### PR TITLE
chore: add .editorconfig for consistent indentation and encoding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig helps maintain consistent coding styles across editors.
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+max_line_length = 100
+
+[*.{md,mdc}]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Adds `.editorconfig` with sane defaults for a polyglot repo:

- **UTF-8** + **LF** + final newline + trim trailing whitespace
- **Python**: 4-space indent, 100-char line limit (matches `ruff`/`mypy`)
- **TS / JS / CSS / JSON**: 2-space indent
- **Makefile**: tabs (required)
- **Markdown**: preserves trailing whitespace (needed for hard line breaks)

EditorConfig is automatically respected by VS Code, Cursor, JetBrains, and most editors. Harmless config-only addition, no runtime impact.