### PR TITLE
chore: add .gitattributes to normalize line endings (LF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Normalize line endings to LF across all platforms to avoid noisy diffs.
+* text=auto eol=lf
+
+# Source code — explicit LF.
+*.py    text eol=lf
+*.ts    text eol=lf
+*.tsx   text eol=lf
+*.js    text eol=lf
+*.jsx   text eol=lf
+*.json  text eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+*.md    text eol=lf
+*.mdc   text eol=lf
+*.sql   text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+*.toml  text eol=lf
+*.sh    text eol=lf
+
+# Binary assets — never modify.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.webp  binary
+*.svg   binary
+*.woff  binary
+*.woff2 binary
+*.pdf   binary
+*.zip   binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project does not yet follow [Semantic Versioning](https://semver.org/) but
+will adopt it starting with v1.0.0.
+
+## [Unreleased]
+
+_Nothing yet — see the [ROADMAP](ROADMAP.md) for what's next._
+
+## [0.1.0] - 2026-04-24
+
+First public release as an open-source project. Everything below was built
+over the preceding months and is now available under the MIT license.
+
+### Core platform
+
+- **Role-based access control** — admin, teacher, and student roles with
+  fine-grained API and UI guards.
+- **Course authoring** — courses, modules, chapters, and rich content blocks
+  via a TipTap editor (text, images, YouTube embeds, callouts, audio).
+- **Quiz system** — `multiple_choice`, `true_false`, `short_answer`, and
+  `essay` question types with per-quiz attempt limits and teacher-granted
+  extra attempts.
+- **Assignments** — submission, teacher grading queue, and automatic chapter
+  completion on submission.
+- **Enrollment and progress** — student enrollment, chapter-level progress
+  tracking, and module/course completion.
+- **Certificates** — automatic generation with teacher approval flow.
+- **Cohorts** — group students for batch management and analytics.
+- **Announcements** — admin/teacher broadcast system with banner display.
+- **Calendar** — course and cohort event management.
+- **Notifications** — in-app notification bell with read/unread state.
+- **Teacher tools** — gradebook, analytics dashboard, pending-answers queue
+  for essay/short-answer grading.
+- **Admin tools** — user management, bulk operations, CSV export, soft
+  delete, course cloning, full-text search.
+
+### Design and UX
+
+- **Design system** — editorial aesthetic (Fraunces + Inter), OKLCH semantic
+  tokens, dark/light theme, responsive down to 360px.
+- **UI primitives** — shadcn/ui + Radix (AlertDialog, DropdownMenu, Popover,
+  Tooltip, Sheet, Tabs, Accordion, ScrollArea, Avatar, Badge).
+- **Patterns** — InlineEdit, InlineEditCover, PageHeader, EmptyState,
+  ErrorState, loading skeletons, error boundaries.
+- **Inline editing** — course and module headers edit in place (no modals).
+
+### Infrastructure
+
+- **Backend** — Python 3.12, FastAPI, SQLAlchemy 2.0 (Mapped style),
+  Pydantic 2, deployed as Vercel serverless functions.
+- **Frontend** — React 18, TypeScript, Vite 8, Tailwind CSS 3, deployed as
+  Vercel static site.
+- **Database** — PostgreSQL via Supabase with RLS on every table; migrations
+  managed via Supabase CLI.
+- **Auth** — Supabase Auth (Google OAuth + email/password), JWTs verified
+  server-side.
+- **CI/CD** — GitHub Actions (lint, typecheck, test, Postgres schema smoke,
+  `npm audit`, `pip-audit`), Dependabot for weekly dependency updates.
+- **Monitoring** — Datadog RUM + Session Replay (opt-in).
+
+### Security
+
+- RLS enabled on all tables with per-role policies.
+- Server-side HTML sanitization on content create/update.
+- CORS locked to known origins with regex for Vercel previews.
+- Pydantic `max_length` on all user-facing string fields.
+- `pip-audit` and `npm audit` in CI.
+- Production API docs disabled.
+- `FOR UPDATE` + `IntegrityError` handling for race conditions.
+
+### Content
+
+- "Deyaniya Apostolov" (Acts of the Apostles) — 4 modules, ~5 hours,
+  100-question final exam + per-module quizzes.
+- "Bibliya kak istoricheskiy dokument" (Bible as a Historical Document) —
+  mini-course with Bible Project video chapters and module quiz.
+
+[Unreleased]: https://github.com/ArVaViT/biblie-school/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ArVaViT/biblie-school/releases/tag/v0.1.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,116 @@
+# Roadmap
+
+This document outlines the planned direction for Bible School LMS. It is a
+living document — priorities may shift based on community feedback and
+contributor interest.
+
+Have an idea? Open a
+[feature request](https://github.com/ArVaViT/biblie-school/issues/new?template=feature_request.yml)
+or start a [discussion](https://github.com/ArVaViT/biblie-school/discussions).
+
+## Legend
+
+| Status | Meaning |
+|--------|---------|
+| :white_check_mark: Done | Shipped and available |
+| :construction: In progress | Actively being worked on |
+| :bulb: Planned | Accepted, not yet started |
+| :thought_balloon: Exploring | Under consideration |
+
+---
+
+## v0.1 — Foundation (current)
+
+:white_check_mark: Core LMS (courses, modules, chapters, blocks, quizzes,
+assignments, certificates, enrollment, progress)
+
+:white_check_mark: Role-based access (admin, teacher, student)
+
+:white_check_mark: Design system (editorial aesthetic, dark/light theme,
+responsive)
+
+:white_check_mark: CI/CD (GitHub Actions, Dependabot, Vercel auto-deploy)
+
+:white_check_mark: Open-source community health files (LICENSE, CoC,
+CONTRIBUTING, SECURITY, templates)
+
+---
+
+## v0.2 — Quality and polish
+
+:construction: **Visual overhaul v2** — Tailwind v4, shadcn CSS-first config,
+OKLCH tokens refresh, ~10 implementation waves (design direction documented
+internally).
+
+:bulb: **Accessibility audit** — WCAG 2.1 AA compliance, screen reader
+testing, keyboard navigation for all interactive elements.
+
+:bulb: **i18n framework** — extract hardcoded Russian strings into a
+translation system (likely `react-i18next`) so the platform can serve
+English, Ukrainian, and other language communities.
+
+:bulb: **Comprehensive test coverage** — push backend above 95%, add
+Playwright E2E tests for critical student and teacher flows.
+
+---
+
+## v0.3 — Teacher experience
+
+:bulb: **Bulk grading** — select multiple essay/short-answer submissions and
+grade them in a batch view.
+
+:bulb: **Rubric builder** — define grading rubrics per assignment/quiz and
+apply them consistently.
+
+:bulb: **Discussion forums** — threaded per-chapter discussions for student
+Q&A (teacher-moderated).
+
+:bulb: **Attendance tracking** — optional per-cohort attendance records for
+in-person or hybrid programs.
+
+---
+
+## v0.4 — Student experience
+
+:bulb: **Offline reading** — PWA with service worker caching for chapter
+content (critical for areas with unreliable internet).
+
+:bulb: **Mobile app** — React Native or Capacitor wrapper for iOS/Android.
+
+:bulb: **Gamification** — optional streaks, badges, and leaderboards to
+encourage daily study habits.
+
+:bulb: **Student portfolio** — collect completed assignments and certificates
+into a shareable profile page.
+
+---
+
+## v0.5 — Platform and scale
+
+:thought_balloon: **Multi-tenancy** — allow multiple independent Bible
+schools to share one deployment with isolated data.
+
+:thought_balloon: **Plugin/extension system** — let nonprofits add custom
+block types, grading logic, or integrations without forking.
+
+:thought_balloon: **API v2** — GraphQL or tRPC for more efficient data
+fetching as the feature set grows.
+
+:thought_balloon: **Self-hosted installer** — one-command Docker Compose
+setup for organizations that want to run their own instance.
+
+---
+
+## How to contribute to the roadmap
+
+1. **Pick a :bulb: Planned item** and open an issue to discuss your approach.
+2. **Propose a new item** via a feature request issue — if accepted, it gets
+   added here.
+3. **Tackle a `good first issue`** — smaller tasks that build toward roadmap
+   goals are labeled in the issue tracker.
+
+We especially welcome contributions from:
+- **Nonprofit Bible schools** who can share their real-world needs.
+- **Designers** who want to improve the student/teacher experience.
+- **Translators** who can help make the platform multilingual.
+- **QA testers** who can help us find and fix bugs.


### PR DESCRIPTION
Adds `.gitattributes` with `* text=auto eol=lf` and explicit LF rules for all source extensions (Python, TS/JS, JSON, CSS, SQL, YAML, Markdown, shell).

Prevents CRLF/LF inconsistencies when contributors work on Windows (CRLF) vs macOS/Linux (LF), which otherwise show up as spurious whole-file diffs in CI.

Also marks common binary extensions (PNG/JPG/ICO/WOFF/PDF) as `binary` so Git never attempts text normalization on them.

Config-only, no runtime or build impact.