### PR TITLE
ci(pr-check): allow deletions of committed env files

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -66,7 +66,10 @@ jobs:
         run: |
           set -euo pipefail
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" pr-head || true)
+          # --diff-filter=d excludes deletions: we want to forbid *adding* or
+          # *modifying* secret files, not removing previously committed ones
+          # (removal is strictly a cleanup action and must stay easy).
+          CHANGED_FILES=$(git diff --name-only --diff-filter=d "$BASE_SHA" pr-head || true)
           FOUND=0
           while IFS= read -r f; do
             [ -z "$f" ] && continue


### PR DESCRIPTION
## Summary
- `pr-check.yml` refuses any PR whose diff mentions `.env.production`, `.env`, credential JSON files, etc. That is right for *additions/modifications* but it also blocks us from *removing* a file that was committed by mistake — which is exactly the situation we have with `frontend/.env.production` (tracked but empty).
- Switch the forbidden-file scan to `git diff --name-only --diff-filter=d` so deletions no longer match, while additions, modifications, copies and renames are still checked.

## Why this is a prerequisite
The next PR needs to `git rm frontend/.env.production`. Without this change, that PR would fail the `Block secret and environment files in diff` step and could not merge through the normal flow.

## Test plan
- Merge this PR first; `pr-check` workflow must pass on the diff itself (this file is not in the forbidden list).
- Subsequent PR that deletes `frontend/.env.production` should now pass the guard.
