### PR TITLE
chore(frontend): untrack .env.production

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,0 @@
-VITE_API_URL=


### PR DESCRIPTION
## Summary
- `frontend/.env.production` was tracked in git despite `.env*` being in `.gitignore`. It contained only `VITE_API_URL=` (no real secret), but leaving it tracked invited a contributor to fill it in and push real credentials. Production values belong in Vercel's env-var store.
- `.env.example` templates (`backend/.env.example`, `frontend/.env.example`) remain as the source of truth for contributors.

## Why safe
- File had no production secret (empty value).
- Previous PR (#29) already relaxed `pr-check` so legitimate deletions of env files are allowed.
- Vercel reads env vars from its own store, not from this file, so no deploy breakage.

## Test plan
- `pr-check` passes (deletion is not blocked now).
- Backend/Frontend CI are not path-triggered by this change but Vercel preview deploy continues to build.
- Grep confirms no remaining references to `frontend/.env.production` in source or configs.
