### PR TITLE
chore(backend): remove dead rate-limit rule, export QuizExtraAttempt

### DIFF
--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -42,7 +42,6 @@ from app.core.http import get_client_ip
 
 ENDPOINT_LIMITS: dict[str, tuple[int, int]] = {
     "/api/v1/auth/": (10, 60),
-    "/api/v1/files": (20, 60),
 }
 
 MAX_BUCKETS = 10_000

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,7 +10,14 @@ from app.models.course_event import CourseEvent
 from app.models.enrollment import Enrollment
 from app.models.notification import Notification
 from app.models.prerequisite import CoursePrerequisite
-from app.models.quiz import Quiz, QuizAnswer, QuizAttempt, QuizOption, QuizQuestion
+from app.models.quiz import (
+    Quiz,
+    QuizAnswer,
+    QuizAttempt,
+    QuizExtraAttempt,
+    QuizOption,
+    QuizQuestion,
+)
 from app.models.review import CourseReview
 from app.models.student_grade import StudentGrade
 from app.models.user import User, UserRole
@@ -35,6 +42,7 @@ __all__ = [
     "Quiz",
     "QuizAnswer",
     "QuizAttempt",
+    "QuizExtraAttempt",
     "QuizOption",
     "QuizQuestion",
     "StudentGrade",


### PR DESCRIPTION
## Summary
Two unrelated but tiny backend cleanups, kept together to minimise CI churn:

1. **Remove dead `/api/v1/files` rule from `RateLimitMiddleware`.** `ENDPOINT_LIMITS` still listed a 20/60s override for `/api/v1/files`, but there is no `files` router mounted in `app/main.py` and no endpoint anywhere in the code starts with that prefix. The entry is pure dead code and misleads anyone reading the middleware.
2. **Re-export `QuizExtraAttempt` from `app.models.__init__`.** It's defined in `app/models/quiz.py` and used by `app/api/v1/quizzes.py` (plus tests), but was the only model missing from the package `__all__`. Every other quiz-related class is exported; this brings the package API to a consistent state.

## Test plan
- `ruff check app tests` — clean
- `ruff format --check` — clean
- `mypy --config-file mypy.ini` — `Success: no issues found in 69 source files`
- `pytest tests -q` — 396 passed (baseline)
- CI: `backend-ci` (lint + tests + Postgres schema smoke) must stay green.
