### PR TITLE
refactor(frontend): split god service into per-domain modules

### DIFF
--- a/frontend/src/services/adminUsers.ts
+++ b/frontend/src/services/adminUsers.ts
@@ -1,0 +1,33 @@
+import api from "./api"
+import type { User } from "@/types"
+
+/**
+ * Admin-only user management endpoints exposed at /users/admin/*.
+ * Kept separate from usersService (which handles the current user's profile)
+ * because the authorisation scope and risk profile are very different.
+ */
+export const adminUsersService = {
+  async getAllUsers(): Promise<User[]> {
+    const response = await api.get<User[]>("/users/admin/users")
+    return response.data
+  },
+
+  async updateUserRole(userId: string, role: string): Promise<void> {
+    await api.put(`/users/admin/users/${userId}/role`, null, { params: { role } })
+  },
+
+  async bulkUpdateUserRoles(
+    userIds: string[],
+    role: string,
+  ): Promise<{ updated: number; role: string }> {
+    const response = await api.put<{ updated: number; role: string }>(
+      "/users/admin/users/bulk-role",
+      { user_ids: userIds, role },
+    )
+    return response.data
+  },
+
+  async adminDeleteUser(userId: string): Promise<void> {
+    await api.delete(`/users/admin/users/${userId}`)
+  },
+}

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -1,0 +1,31 @@
+import api from "./api"
+import { cacheGet, cacheSet } from "@/lib/cache"
+
+export interface CourseAnalyticsEnrollment {
+  enrollment_id: string
+  user_id: string
+  full_name: string | null
+  email: string
+  progress: number
+  enrolled_at: string | null
+}
+
+export interface CourseAnalytics {
+  course_id: string
+  course_title: string
+  total_students: number
+  avg_progress: number
+  completion_count: number
+  enrollments: CourseAnalyticsEnrollment[]
+}
+
+export const analyticsService = {
+  async getCourseAnalyticsAPI(courseId: string): Promise<CourseAnalytics> {
+    const key = `analytics:course:${courseId}`
+    const cached = cacheGet<CourseAnalytics>(key)
+    if (cached) return cached
+    const response = await api.get<CourseAnalytics>(`/analytics/course/${courseId}`)
+    cacheSet(key, response.data, 30 * 1000)
+    return response.data
+  },
+}

--- a/frontend/src/services/announcements.ts
+++ b/frontend/src/services/announcements.ts
@@ -1,0 +1,31 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import type { Announcement } from "@/types"
+
+export const announcementsService = {
+  async getAnnouncements(courseId?: string): Promise<Announcement[]> {
+    const key = courseId ? `announcements:course:${courseId}` : `announcements:global`
+    const cached = cacheGet<Announcement[]>(key)
+    if (cached) return cached
+    const params = courseId ? { course_id: courseId } : undefined
+    const response = await api.get<Announcement[]>("/announcements", { params })
+    cacheSet(key, response.data, 2 * 60 * 1000)
+    return response.data
+  },
+
+  async createAnnouncement(data: {
+    title: string
+    content: string
+    course_id?: string
+  }): Promise<Announcement> {
+    const response = await api.post<Announcement>("/announcements", data)
+    cacheInvalidate(`announcements:global`)
+    if (data.course_id) cacheInvalidate(`announcements:course:${data.course_id}`)
+    return response.data
+  },
+
+  async deleteAnnouncement(id: string): Promise<void> {
+    await api.delete(`/announcements/${id}`)
+    cacheInvalidatePrefix(`announcements:`)
+  },
+}

--- a/frontend/src/services/assignments.ts
+++ b/frontend/src/services/assignments.ts
@@ -1,0 +1,74 @@
+import api from "./api"
+import { cacheInvalidatePrefix } from "@/lib/cache"
+import type { Assignment, AssignmentSubmission } from "@/types"
+
+export type AssignmentCreateData = {
+  chapter_id: string
+  title: string
+  description?: string | null
+  max_score?: number
+  due_date?: string | null
+}
+
+export const assignmentsService = {
+  async getChapterAssignments(chapterId: string): Promise<Assignment[]> {
+    const response = await api.get<Assignment[]>(`/assignments/chapter/${chapterId}`)
+    return response.data
+  },
+
+  async createAssignment(data: AssignmentCreateData): Promise<Assignment> {
+    const response = await api.post<Assignment>("/assignments", data)
+    return response.data
+  },
+
+  async updateAssignment(
+    id: string,
+    data: Partial<AssignmentCreateData>,
+  ): Promise<Assignment> {
+    const response = await api.put<Assignment>(`/assignments/${id}`, data)
+    return response.data
+  },
+
+  async deleteAssignment(id: string): Promise<void> {
+    await api.delete(`/assignments/${id}`)
+  },
+
+  async submitAssignment(
+    id: string,
+    data: { content?: string; file_url?: string },
+  ): Promise<AssignmentSubmission> {
+    const response = await api.post<AssignmentSubmission>(`/assignments/${id}/submit`, data)
+    cacheInvalidatePrefix("progress:my:")
+    return response.data
+  },
+
+  async getSubmissions(assignmentId: string): Promise<AssignmentSubmission[]> {
+    const response = await api.get<AssignmentSubmission[]>(
+      `/assignments/${assignmentId}/submissions`,
+    )
+    return response.data
+  },
+
+  async getMySubmissions(assignmentId: string): Promise<AssignmentSubmission[]> {
+    const response = await api.get<AssignmentSubmission[]>(
+      `/assignments/${assignmentId}/my-submissions`,
+    )
+    return response.data
+  },
+
+  async gradeSubmission(
+    submissionId: string,
+    data: { grade: number; feedback?: string; status: string },
+  ): Promise<AssignmentSubmission> {
+    const response = await api.put<AssignmentSubmission>(
+      `/assignments/submissions/${submissionId}/grade`,
+      data,
+    )
+    cacheInvalidatePrefix("grades:course:")
+    cacheInvalidatePrefix("grades:summary:")
+    cacheInvalidatePrefix("grades:my")
+    cacheInvalidatePrefix("analytics:course:")
+    cacheInvalidatePrefix("progress:students:")
+    return response.data
+  },
+}

--- a/frontend/src/services/audit.ts
+++ b/frontend/src/services/audit.ts
@@ -1,0 +1,19 @@
+import api from "./api"
+import type { AuditLogPage } from "@/types"
+
+export type AuditLogQuery = {
+  page?: number
+  page_size?: number
+  user_id?: string
+  resource_type?: string
+  action?: string
+  date_from?: string
+  date_to?: string
+}
+
+export const auditService = {
+  async getAuditLogs(params: AuditLogQuery = {}): Promise<AuditLogPage> {
+    const response = await api.get<AuditLogPage>("/audit", { params })
+    return response.data
+  },
+}

--- a/frontend/src/services/blocks.ts
+++ b/frontend/src/services/blocks.ts
@@ -1,0 +1,54 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import type { ChapterBlock, BlockType } from "@/types"
+
+export type ChapterBlockCreateData = {
+  block_type: BlockType
+  order_index?: number
+  content?: string | null
+  quiz_id?: string | null
+  assignment_id?: string | null
+  file_bucket?: string | null
+  file_path?: string | null
+  file_name?: string | null
+}
+
+export type ChapterBlockUpdateData = Partial<Omit<ChapterBlockCreateData, "block_type">> & {
+  block_type?: BlockType
+}
+
+export const blocksService = {
+  async getChapterBlocks(chapterId: string): Promise<ChapterBlock[]> {
+    const key = `blocks:chapter:${chapterId}`
+    const cached = cacheGet<ChapterBlock[]>(key)
+    if (cached) return cached
+    const response = await api.get<ChapterBlock[]>(`/blocks/chapter/${chapterId}`)
+    cacheSet(key, response.data, 2 * 60 * 1000)
+    return response.data
+  },
+
+  async createBlock(chapterId: string, data: ChapterBlockCreateData): Promise<ChapterBlock> {
+    const response = await api.post<ChapterBlock>(`/blocks/chapter/${chapterId}`, data)
+    cacheInvalidate(`blocks:chapter:${chapterId}`)
+    return response.data
+  },
+
+  async updateBlock(blockId: string, data: ChapterBlockUpdateData): Promise<ChapterBlock> {
+    const response = await api.put<ChapterBlock>(`/blocks/${blockId}`, data)
+    cacheInvalidatePrefix("blocks:chapter:")
+    return response.data
+  },
+
+  async deleteBlock(blockId: string): Promise<void> {
+    await api.delete(`/blocks/${blockId}`)
+    cacheInvalidatePrefix("blocks:chapter:")
+  },
+
+  async reorderBlocks(
+    chapterId: string,
+    blocks: { id: string; order_index: number }[],
+  ): Promise<void> {
+    await api.put(`/blocks/chapter/${chapterId}/reorder`, blocks)
+    cacheInvalidate(`blocks:chapter:${chapterId}`)
+  },
+}

--- a/frontend/src/services/calendar.ts
+++ b/frontend/src/services/calendar.ts
@@ -1,0 +1,64 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import type { CalendarEvent, CourseEvent } from "@/types"
+
+export const calendarService = {
+  async getCalendarEvents(courseId?: string): Promise<CalendarEvent[]> {
+    const key = `calendar:events:${courseId ?? "all"}`
+    const cached = cacheGet<CalendarEvent[]>(key)
+    if (cached) return cached
+    const params = courseId ? { course_id: courseId } : undefined
+    const response = await api.get<CalendarEvent[]>("/calendar/events", { params })
+    cacheSet(key, response.data, 60 * 1000)
+    return response.data
+  },
+
+  async getCourseEvents(courseId: string): Promise<CourseEvent[]> {
+    const key = `calendar:course-events:${courseId}`
+    const cached = cacheGet<CourseEvent[]>(key)
+    if (cached) return cached
+    const response = await api.get<CourseEvent[]>(`/courses/${courseId}/events`)
+    cacheSet(key, response.data, 2 * 60 * 1000)
+    return response.data
+  },
+
+  async createCourseEvent(
+    courseId: string,
+    data: {
+      title: string
+      description?: string
+      event_type?: string
+      event_date: string
+    },
+  ): Promise<CourseEvent> {
+    const response = await api.post<CourseEvent>(`/courses/${courseId}/events`, data)
+    cacheInvalidate(`calendar:course-events:${courseId}`)
+    cacheInvalidatePrefix("calendar:events:")
+    return response.data
+  },
+
+  async updateCourseEvent(
+    courseId: string,
+    eventId: string,
+    data: {
+      title?: string
+      description?: string
+      event_type?: string
+      event_date?: string
+    },
+  ): Promise<CourseEvent> {
+    const response = await api.put<CourseEvent>(
+      `/courses/${courseId}/events/${eventId}`,
+      data,
+    )
+    cacheInvalidate(`calendar:course-events:${courseId}`)
+    cacheInvalidatePrefix("calendar:events:")
+    return response.data
+  },
+
+  async deleteCourseEvent(courseId: string, eventId: string): Promise<void> {
+    await api.delete(`/courses/${courseId}/events/${eventId}`)
+    cacheInvalidate(`calendar:course-events:${courseId}`)
+    cacheInvalidatePrefix("calendar:events:")
+  },
+}

--- a/frontend/src/services/certificates.ts
+++ b/frontend/src/services/certificates.ts
@@ -1,0 +1,47 @@
+import api from "./api"
+import { isAxiosError } from "axios"
+import type { Certificate } from "@/types"
+
+export const certificatesService = {
+  async getCourseCertificate(courseId: string): Promise<Certificate | null> {
+    try {
+      const response = await api.get<Certificate>(`/certificates/course/${courseId}`)
+      return response.data
+    } catch (err: unknown) {
+      if (isAxiosError(err) && err.response?.status === 404) return null
+      throw err
+    }
+  },
+
+  async requestCertificate(courseId: string): Promise<Certificate> {
+    const response = await api.post<Certificate>(`/certificates/course/${courseId}`)
+    return response.data
+  },
+
+  async getMyCertificates(): Promise<Certificate[]> {
+    const response = await api.get<Certificate[]>("/certificates/my")
+    return response.data
+  },
+
+  async getPendingCertificates(): Promise<Certificate[]> {
+    const response = await api.get<Certificate[]>("/certificates/pending")
+    return response.data
+  },
+
+  async teacherApproveCert(certId: string): Promise<void> {
+    await api.put(`/certificates/${certId}/teacher-approve`)
+  },
+
+  async adminApproveCert(certId: string): Promise<void> {
+    await api.put(`/certificates/${certId}/admin-approve`)
+  },
+
+  async rejectCert(certId: string): Promise<void> {
+    await api.put(`/certificates/${certId}/reject`)
+  },
+
+  async getAdminPendingCerts(): Promise<Certificate[]> {
+    const response = await api.get<Certificate[]>("/certificates/admin/pending")
+    return response.data
+  },
+}

--- a/frontend/src/services/cohorts.ts
+++ b/frontend/src/services/cohorts.ts
@@ -1,0 +1,46 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import type { Cohort } from "@/types"
+
+export type CohortMutation = {
+  name: string
+  start_date: string
+  end_date: string
+  enrollment_start?: string | null
+  enrollment_end?: string | null
+  max_students?: number | null
+  status?: Cohort["status"]
+}
+
+export const cohortsService = {
+  async getCourseCohorts(courseId: string): Promise<Cohort[]> {
+    const key = `cohorts:course:${courseId}`
+    const cached = cacheGet<Cohort[]>(key)
+    if (cached) return cached
+    const response = await api.get<Cohort[]>(`/cohorts/course/${courseId}`)
+    cacheSet(key, response.data, 2 * 60 * 1000)
+    return response.data
+  },
+
+  async createCohort(courseId: string, data: CohortMutation): Promise<Cohort> {
+    const response = await api.post<Cohort>(`/cohorts/course/${courseId}`, data)
+    cacheInvalidate(`cohorts:course:${courseId}`)
+    return response.data
+  },
+
+  async updateCohort(cohortId: string, data: Partial<CohortMutation>): Promise<Cohort> {
+    const response = await api.put<Cohort>(`/cohorts/${cohortId}`, data)
+    cacheInvalidatePrefix("cohorts:course:")
+    return response.data
+  },
+
+  async deleteCohort(cohortId: string): Promise<void> {
+    await api.delete(`/cohorts/${cohortId}`)
+    cacheInvalidatePrefix("cohorts:course:")
+  },
+
+  async completeCohort(cohortId: string): Promise<void> {
+    await api.post(`/cohorts/${cohortId}/complete`)
+    cacheInvalidatePrefix("cohorts:course:")
+  },
+}

--- a/frontend/src/services/courses.ts
+++ b/frontend/src/services/courses.ts
@@ -1,51 +1,35 @@
 import api from "./api"
 import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
-import { isAxiosError } from "axios"
-import type {
-  User, Course, Module, Chapter, Enrollment, Announcement, StudentGrade,
-  Quiz, QuizAttempt, QuizAnswerResult, QuizQuestionType, PendingAnswer,
-  Assignment, AssignmentSubmission, Certificate, CourseReview, ChapterBlock, BlockType, Cohort,
-  Notification, NotificationListResponse,
-  AuditLogPage,
-  GradingConfig, GradeSummaryResponse,
-  CalendarEvent, CourseEvent,
-  StudentProgressResponse,
-} from "../types"
+import type { Course, Module, Chapter } from "@/types"
 
-type CohortMutation = {
-  name: string
-  start_date: string
-  end_date: string
-  enrollment_start?: string | null
-  enrollment_end?: string | null
-  max_students?: number | null
-  status?: Cohort["status"]
-}
+import { adminUsersService } from "./adminUsers"
+import { announcementsService } from "./announcements"
+import { assignmentsService } from "./assignments"
+import { auditService } from "./audit"
+import { blocksService } from "./blocks"
+import { calendarService } from "./calendar"
+import { certificatesService } from "./certificates"
+import { cohortsService } from "./cohorts"
+import { enrollmentsService } from "./enrollments"
+import { gradesService } from "./grades"
+import { notificationsService } from "./notifications"
+import { progressService } from "./progress"
+import { quizzesService } from "./quizzes"
+import { reviewsService } from "./reviews"
+import { analyticsService } from "./analytics"
 
-type AssignmentCreateData = {
-  chapter_id: string
-  title: string
-  description?: string | null
-  max_score?: number
-  due_date?: string | null
-}
-
-type ChapterBlockCreateData = {
-  block_type: BlockType
-  order_index?: number
-  content?: string | null
-  quiz_id?: string | null
-  assignment_id?: string | null
-  file_bucket?: string | null
-  file_path?: string | null
-  file_name?: string | null
-}
-
-type ChapterBlockUpdateData = Partial<Omit<ChapterBlockCreateData, "block_type">> & {
-  block_type?: BlockType
-}
-
-export const coursesService = {
+/**
+ * Course, module, and chapter CRUD. These three entities share the same
+ * nested URL structure (`/courses/:id/modules/:mid/chapters/:cid`) and the
+ * same cache-invalidation graph (`courses:detail:*`, `courses:module:*`),
+ * so they stay together. Every other domain lives in its own service file.
+ *
+ * `coursesService` is also re-exported as a facade that spreads every
+ * domain service so legacy call sites like `coursesService.getChapterQuiz`
+ * keep working during migration. New code should import the specific
+ * per-domain service (e.g. `import { quizzesService } from "./quizzes"`).
+ */
+const courseCrud = {
   async getCourses(search?: string): Promise<Course[]> {
     const key = `courses:list:${search ?? ""}`
     const cached = cacheGet<Course[]>(key)
@@ -65,96 +49,6 @@ export const coursesService = {
     return response.data
   },
 
-  async getModule(courseId: string, moduleId: string): Promise<Module> {
-    const key = `courses:module:${courseId}:${moduleId}`
-    const cached = cacheGet<Module>(key)
-    if (cached) return cached
-    const response = await api.get<Module>(`/courses/${courseId}/modules/${moduleId}`)
-    cacheSet(key, response.data, 3 * 60 * 1000)
-    return response.data
-  },
-
-  async getCourseCohorts(courseId: string): Promise<Cohort[]> {
-    const key = `cohorts:course:${courseId}`
-    const cached = cacheGet<Cohort[]>(key)
-    if (cached) return cached
-    const response = await api.get<Cohort[]>(`/cohorts/course/${courseId}`)
-    cacheSet(key, response.data, 2 * 60 * 1000)
-    return response.data
-  },
-  async createCohort(courseId: string, data: CohortMutation): Promise<Cohort> {
-    const response = await api.post<Cohort>(`/cohorts/course/${courseId}`, data)
-    cacheInvalidate(`cohorts:course:${courseId}`)
-    return response.data
-  },
-  async updateCohort(cohortId: string, data: Partial<CohortMutation>): Promise<Cohort> {
-    const response = await api.put<Cohort>(`/cohorts/${cohortId}`, data)
-    cacheInvalidatePrefix("cohorts:course:")
-    return response.data
-  },
-  async deleteCohort(cohortId: string): Promise<void> {
-    await api.delete(`/cohorts/${cohortId}`)
-    cacheInvalidatePrefix("cohorts:course:")
-  },
-
-  async completeCohort(cohortId: string): Promise<void> {
-    await api.post(`/cohorts/${cohortId}/complete`)
-    cacheInvalidatePrefix("cohorts:course:")
-  },
-
-  async enrollInCourse(courseId: string, cohortId?: string): Promise<Enrollment> {
-    const response = await api.post<Enrollment>(
-      `/courses/${courseId}/enroll`,
-      cohortId ? { cohort_id: cohortId } : {},
-    )
-    cacheInvalidate("courses:my")
-    cacheInvalidate(`courses:enrollment-status:${courseId}`)
-    cacheInvalidatePrefix("calendar:events:")
-    cacheInvalidatePrefix("progress:my:")
-    return response.data
-  },
-
-  async getMyCourses(): Promise<Enrollment[]> {
-    // Cached per-session. HomePage, ProfilePage, CalendarPage, and
-    // CertificatesPage all call this on mount, so without a small TTL we'd
-    // hit `/users/me/courses` four times during a normal navigation.
-    const key = "courses:my"
-    const cached = cacheGet<Enrollment[]>(key)
-    if (cached) return cached
-    const response = await api.get<Enrollment[]>("/users/me/courses")
-    cacheSet(key, response.data, 60 * 1000)
-    return response.data
-  },
-
-  async getEnrollmentStatus(courseId: string): Promise<{ enrolled: boolean; enrollment: Enrollment | null }> {
-    const key = `courses:enrollment-status:${courseId}`
-    const cached = cacheGet<{ enrolled: boolean; enrollment: Enrollment | null }>(key)
-    if (cached) return cached
-    const response = await api.get<{ enrolled: boolean; enrollment: Enrollment | null }>(
-      `/courses/${courseId}/enrollment-status`,
-    )
-    cacheSet(key, response.data, 60 * 1000)
-    return response.data
-  },
-
-  async getAllUsers(): Promise<User[]> {
-    const response = await api.get<User[]>("/users/admin/users")
-    return response.data
-  },
-
-  async updateUserRole(userId: string, role: string): Promise<void> {
-    await api.put(`/users/admin/users/${userId}/role`, null, { params: { role } })
-  },
-
-  async bulkUpdateUserRoles(userIds: string[], role: string): Promise<{ updated: number; role: string }> {
-    const response = await api.put<{ updated: number; role: string }>("/users/admin/users/bulk-role", { user_ids: userIds, role })
-    return response.data
-  },
-
-  async adminDeleteUser(userId: string): Promise<void> {
-    await api.delete(`/users/admin/users/${userId}`)
-  },
-
   async getTeacherCourses(): Promise<Course[]> {
     const key = "courses:teacher"
     const cached = cacheGet<Course[]>(key)
@@ -164,7 +58,9 @@ export const coursesService = {
     return response.data
   },
 
-  async createCourse(data: { title: string; description?: string; image_url?: string }): Promise<Course> {
+  async createCourse(
+    data: { title: string; description?: string; image_url?: string },
+  ): Promise<Course> {
     const response = await api.post<Course>("/courses", data)
     cacheInvalidatePrefix("courses:list:")
     cacheInvalidate("courses:teacher")
@@ -224,6 +120,15 @@ export const coursesService = {
     return response.data
   },
 
+  async getModule(courseId: string, moduleId: string): Promise<Module> {
+    const key = `courses:module:${courseId}:${moduleId}`
+    const cached = cacheGet<Module>(key)
+    if (cached) return cached
+    const response = await api.get<Module>(`/courses/${courseId}/modules/${moduleId}`)
+    cacheSet(key, response.data, 3 * 60 * 1000)
+    return response.data
+  },
+
   async createModule(
     courseId: string,
     data: { title: string; description?: string; order_index?: number },
@@ -237,9 +142,17 @@ export const coursesService = {
   async updateModule(
     courseId: string,
     moduleId: string,
-    data: { title?: string; description?: string; order_index?: number; due_date?: string | null },
+    data: {
+      title?: string
+      description?: string
+      order_index?: number
+      due_date?: string | null
+    },
   ): Promise<Module> {
-    const response = await api.put<Module>(`/courses/${courseId}/modules/${moduleId}`, data)
+    const response = await api.put<Module>(
+      `/courses/${courseId}/modules/${moduleId}`,
+      data,
+    )
     cacheInvalidate(`courses:detail:${courseId}`)
     cacheInvalidate(`courses:module:${courseId}:${moduleId}`)
     return response.data
@@ -269,7 +182,13 @@ export const coursesService = {
     courseId: string,
     moduleId: string,
     chapterId: string,
-    data: { title?: string; order_index?: number; chapter_type?: string; requires_completion?: boolean; is_locked?: boolean },
+    data: {
+      title?: string
+      order_index?: number
+      chapter_type?: string
+      requires_completion?: boolean
+      is_locked?: boolean
+    },
   ): Promise<Chapter> {
     const response = await api.put<Chapter>(
       `/courses/${courseId}/modules/${moduleId}/chapters/${chapterId}`,
@@ -285,426 +204,52 @@ export const coursesService = {
     moduleId: string,
     chapterId: string,
   ): Promise<void> {
-    await api.delete(`/courses/${courseId}/modules/${moduleId}/chapters/${chapterId}`)
+    await api.delete(
+      `/courses/${courseId}/modules/${moduleId}/chapters/${chapterId}`,
+    )
     cacheInvalidate(`courses:detail:${courseId}`)
     cacheInvalidate(`courses:module:${courseId}:${moduleId}`)
   },
+}
 
-  async getAnnouncements(courseId?: string): Promise<Announcement[]> {
-    const key = courseId ? `announcements:course:${courseId}` : `announcements:global`
-    const cached = cacheGet<Announcement[]>(key)
-    if (cached) return cached
-    const params = courseId ? { course_id: courseId } : undefined
-    const response = await api.get<Announcement[]>("/announcements", { params })
-    cacheSet(key, response.data, 2 * 60 * 1000)
-    return response.data
-  },
+/**
+ * Backwards-compatible aggregate. Prefer the per-domain services for new code
+ * — this facade exists solely so the long-lived `coursesService.*` call sites
+ * across the app keep working while we migrate them file-by-file.
+ */
+export const coursesService = {
+  ...courseCrud,
+  ...adminUsersService,
+  ...announcementsService,
+  ...assignmentsService,
+  ...auditService,
+  ...blocksService,
+  ...calendarService,
+  ...certificatesService,
+  ...cohortsService,
+  ...enrollmentsService,
+  ...gradesService,
+  ...notificationsService,
+  ...progressService,
+  ...quizzesService,
+  ...reviewsService,
+  ...analyticsService,
+}
 
-  async createAnnouncement(data: { title: string; content: string; course_id?: string }): Promise<Announcement> {
-    const response = await api.post<Announcement>("/announcements", data)
-    cacheInvalidate(`announcements:global`)
-    if (data.course_id) cacheInvalidate(`announcements:course:${data.course_id}`)
-    return response.data
-  },
-
-  async deleteAnnouncement(id: string): Promise<void> {
-    await api.delete(`/announcements/${id}`)
-    cacheInvalidatePrefix(`announcements:`)
-  },
-
-  async getCourseGrades(courseId: string): Promise<StudentGrade[]> {
-    const key = `grades:course:${courseId}`
-    const cached = cacheGet<StudentGrade[]>(key)
-    if (cached) return cached
-    const response = await api.get<StudentGrade[]>(`/grades/course/${courseId}`)
-    cacheSet(key, response.data, 60 * 1000)
-    return response.data
-  },
-
-  async upsertGrade(courseId: string, studentId: string, data: { grade?: string; comment?: string }): Promise<StudentGrade> {
-    const response = await api.put<StudentGrade>(`/grades/course/${courseId}/student/${studentId}`, data)
-    cacheInvalidate(`grades:course:${courseId}`)
-    cacheInvalidate(`grades:summary:${courseId}`)
-    cacheInvalidatePrefix("grades:my")
-    return response.data
-  },
-
-  async getMyGrades(): Promise<StudentGrade[]> {
-    const key = "grades:my"
-    const cached = cacheGet<StudentGrade[]>(key)
-    if (cached) return cached
-    const response = await api.get<StudentGrade[]>("/grades/my")
-    cacheSet(key, response.data, 60 * 1000)
-    return response.data
-  },
-
-  async updateGradingConfig(courseId: string, data: GradingConfig): Promise<GradingConfig> {
-    const response = await api.put<GradingConfig>(`/grades/course/${courseId}/config`, data)
-    cacheInvalidate(`grades:summary:${courseId}`)
-    cacheInvalidate(`grades:course:${courseId}`)
-    cacheInvalidate(`analytics:course:${courseId}`)
-    return response.data
-  },
-
-  async getGradeSummary(courseId: string): Promise<GradeSummaryResponse> {
-    const key = `grades:summary:${courseId}`
-    const cached = cacheGet<GradeSummaryResponse>(key)
-    if (cached) return cached
-    const response = await api.get<GradeSummaryResponse>(`/grades/course/${courseId}/summary`)
-    cacheSet(key, response.data, 60 * 1000)
-    return response.data
-  },
-
-  async exportGradesCSV(courseId: string): Promise<Blob> {
-    const response = await api.get(`/grades/course/${courseId}/export-csv`, { responseType: "blob" })
-    return response.data
-  },
-
-  async getCourseAnalyticsAPI(courseId: string): Promise<{
-    course_id: string
-    course_title: string
-    total_students: number
-    avg_progress: number
-    completion_count: number
-    enrollments: Array<{
-      enrollment_id: string
-      user_id: string
-      full_name: string | null
-      email: string
-      progress: number
-      enrolled_at: string | null
-    }>
-  }> {
-    const key = `analytics:course:${courseId}`
-    const cached = cacheGet<{
-      course_id: string
-      course_title: string
-      total_students: number
-      avg_progress: number
-      completion_count: number
-      enrollments: Array<{
-        enrollment_id: string
-        user_id: string
-        full_name: string | null
-        email: string
-        progress: number
-        enrolled_at: string | null
-      }>
-    }>(key)
-    if (cached) return cached
-    const response = await api.get(`/analytics/course/${courseId}`)
-    cacheSet(key, response.data, 30 * 1000)
-    return response.data
-  },
-
-  async getChapterQuiz(chapterId: string): Promise<Quiz | null> {
-    const key = `quiz:chapter:${chapterId}`
-    const cached = cacheGet<Quiz | null>(key)
-    if (cached !== undefined) return cached
-    try {
-      const response = await api.get<Quiz | null>(`/quizzes/chapter/${chapterId}`)
-      cacheSet(key, response.data, 2 * 60 * 1000)
-      return response.data
-    } catch (err: unknown) {
-      if (isAxiosError(err) && err.response?.status === 404) {
-        cacheSet(key, null, 2 * 60 * 1000)
-        return null
-      }
-      throw err
-    }
-  },
-  async createQuiz(data: {
-    chapter_id: string
-    title: string
-    description?: string | null
-    quiz_type?: "quiz" | "exam"
-    max_attempts?: number | null
-    passing_score: number
-    questions: Array<{
-      question_text: string
-      question_type: QuizQuestionType
-      order_index: number
-      points: number
-      min_words?: number | null
-      options: Array<{
-        option_text: string
-        is_correct: boolean
-        order_index: number
-      }>
-    }>
-  }): Promise<Quiz> {
-    const response = await api.post<Quiz>("/quizzes", data)
-    cacheInvalidate(`quiz:chapter:${data.chapter_id}`)
-    return response.data
-  },
-  async deleteQuiz(quizId: string, chapterId?: string): Promise<void> {
-    await api.delete(`/quizzes/${quizId}`)
-    if (chapterId) {
-      cacheInvalidate(`quiz:chapter:${chapterId}`)
-    } else {
-      cacheInvalidatePrefix("quiz:chapter:")
-    }
-  },
-  async submitQuiz(quizId: string, answers: { question_id: string; selected_option_id?: string; text_answer?: string }[]): Promise<QuizAttempt> {
-    const response = await api.post<QuizAttempt>(`/quizzes/${quizId}/submit`, { answers })
-    cacheInvalidatePrefix("progress:my:")
-    return response.data
-  },
-  async getMyQuizAttempts(quizId: string): Promise<QuizAttempt[]> {
-    const response = await api.get<QuizAttempt[]>(`/quizzes/${quizId}/my-attempts`)
-    return response.data
-  },
-  async getPendingAnswers(quizId: string, includeGraded = false): Promise<PendingAnswer[]> {
-    const response = await api.get<PendingAnswer[]>(
-      `/quizzes/${quizId}/pending-answers`,
-      { params: { include_graded: includeGraded } },
-    )
-    return response.data
-  },
-  async gradeQuizAnswer(
-    answerId: string,
-    pointsEarned: number,
-    graderComment?: string | null,
-  ): Promise<QuizAnswerResult> {
-    const response = await api.patch<QuizAnswerResult>(`/quizzes/answers/${answerId}`, {
-      points_earned: pointsEarned,
-      grader_comment: graderComment ?? null,
-    })
-    return response.data
-  },
-  async grantExtraAttempts(quizId: string, userId: string, extraAttempts: number): Promise<void> {
-    await api.post(`/quizzes/${quizId}/extra-attempts`, {
-      user_id: userId,
-      extra_attempts: extraAttempts,
-    })
-  },
-
-  async getChapterAssignments(chapterId: string): Promise<Assignment[]> {
-    const response = await api.get<Assignment[]>(`/assignments/chapter/${chapterId}`)
-    return response.data
-  },
-  async createAssignment(data: AssignmentCreateData): Promise<Assignment> {
-    const response = await api.post<Assignment>("/assignments", data)
-    return response.data
-  },
-  async updateAssignment(id: string, data: Partial<AssignmentCreateData>): Promise<Assignment> {
-    const response = await api.put<Assignment>(`/assignments/${id}`, data)
-    return response.data
-  },
-  async deleteAssignment(id: string): Promise<void> {
-    await api.delete(`/assignments/${id}`)
-  },
-  async submitAssignment(id: string, data: { content?: string; file_url?: string }): Promise<AssignmentSubmission> {
-    const response = await api.post<AssignmentSubmission>(`/assignments/${id}/submit`, data)
-    cacheInvalidatePrefix("progress:my:")
-    return response.data
-  },
-  async getSubmissions(assignmentId: string): Promise<AssignmentSubmission[]> {
-    const response = await api.get<AssignmentSubmission[]>(`/assignments/${assignmentId}/submissions`)
-    return response.data
-  },
-  async getMySubmissions(assignmentId: string): Promise<AssignmentSubmission[]> {
-    const response = await api.get<AssignmentSubmission[]>(`/assignments/${assignmentId}/my-submissions`)
-    return response.data
-  },
-  async gradeSubmission(submissionId: string, data: { grade: number; feedback?: string; status: string }): Promise<AssignmentSubmission> {
-    const response = await api.put<AssignmentSubmission>(`/assignments/submissions/${submissionId}/grade`, data)
-    cacheInvalidatePrefix("grades:course:")
-    cacheInvalidatePrefix("grades:summary:")
-    cacheInvalidatePrefix("grades:my")
-    cacheInvalidatePrefix("analytics:course:")
-    cacheInvalidatePrefix("progress:students:")
-    return response.data
-  },
-
-  async getChapterBlocks(chapterId: string): Promise<ChapterBlock[]> {
-    const key = `blocks:chapter:${chapterId}`
-    const cached = cacheGet<ChapterBlock[]>(key)
-    if (cached) return cached
-    const response = await api.get<ChapterBlock[]>(`/blocks/chapter/${chapterId}`)
-    cacheSet(key, response.data, 2 * 60 * 1000)
-    return response.data
-  },
-  async createBlock(chapterId: string, data: ChapterBlockCreateData): Promise<ChapterBlock> {
-    const response = await api.post<ChapterBlock>(`/blocks/chapter/${chapterId}`, data)
-    cacheInvalidate(`blocks:chapter:${chapterId}`)
-    return response.data
-  },
-  async updateBlock(blockId: string, data: ChapterBlockUpdateData): Promise<ChapterBlock> {
-    const response = await api.put<ChapterBlock>(`/blocks/${blockId}`, data)
-    cacheInvalidatePrefix("blocks:chapter:")
-    return response.data
-  },
-  async deleteBlock(blockId: string): Promise<void> {
-    await api.delete(`/blocks/${blockId}`)
-    cacheInvalidatePrefix("blocks:chapter:")
-  },
-  async reorderBlocks(chapterId: string, blocks: { id: string; order_index: number }[]): Promise<void> {
-    await api.put(`/blocks/chapter/${chapterId}/reorder`, blocks)
-    cacheInvalidate(`blocks:chapter:${chapterId}`)
-  },
-
-  async getCourseCertificate(courseId: string): Promise<Certificate | null> {
-    try {
-      const response = await api.get<Certificate>(`/certificates/course/${courseId}`)
-      return response.data
-    } catch (err: unknown) {
-      if (isAxiosError(err) && err.response?.status === 404) return null
-      throw err
-    }
-  },
-  async requestCertificate(courseId: string): Promise<Certificate> {
-    const response = await api.post<Certificate>(`/certificates/course/${courseId}`)
-    return response.data
-  },
-  async getMyCertificates(): Promise<Certificate[]> {
-    const response = await api.get<Certificate[]>("/certificates/my")
-    return response.data
-  },
-  async getPendingCertificates(): Promise<Certificate[]> {
-    const response = await api.get<Certificate[]>("/certificates/pending")
-    return response.data
-  },
-  async teacherApproveCert(certId: string): Promise<void> {
-    await api.put(`/certificates/${certId}/teacher-approve`)
-  },
-  async adminApproveCert(certId: string): Promise<void> {
-    await api.put(`/certificates/${certId}/admin-approve`)
-  },
-  async rejectCert(certId: string): Promise<void> {
-    await api.put(`/certificates/${certId}/reject`)
-  },
-  async getAdminPendingCerts(): Promise<Certificate[]> {
-    const response = await api.get<Certificate[]>("/certificates/admin/pending")
-    return response.data
-  },
-
-  async teacherMarkComplete(chapterId: string, studentId: string): Promise<void> {
-    await api.put(`/progress/chapter/${chapterId}/student/${studentId}/complete`)
-    cacheInvalidatePrefix("progress:students:")
-    cacheInvalidatePrefix("analytics:course:")
-  },
-  async teacherMarkIncomplete(chapterId: string, studentId: string): Promise<void> {
-    await api.put(`/progress/chapter/${chapterId}/student/${studentId}/incomplete`)
-    cacheInvalidatePrefix("progress:students:")
-    cacheInvalidatePrefix("analytics:course:")
-  },
-
-  async getCourseReviews(courseId: string): Promise<CourseReview[]> {
-    const key = `reviews:course:${courseId}`
-    const cached = cacheGet<CourseReview[]>(key)
-    if (cached) return cached
-    const response = await api.get<CourseReview[]>(`/reviews/course/${courseId}`)
-    cacheSet(key, response.data, 2 * 60 * 1000)
-    return response.data
-  },
-  async submitReview(courseId: string, data: { rating: number; comment?: string }): Promise<CourseReview> {
-    const response = await api.post<CourseReview>(`/reviews/course/${courseId}`, data)
-    cacheInvalidate(`reviews:course:${courseId}`)
-    return response.data
-  },
-
-  async deleteReview(id: string): Promise<void> {
-    await api.delete(`/reviews/${id}`)
-    cacheInvalidatePrefix("reviews:course:")
-  },
-
-  async getMyChapterProgress(courseId: string): Promise<string[]> {
-    const key = `progress:my:${courseId}`
-    const cached = cacheGet<string[]>(key)
-    if (cached) return cached
-    const response = await api.get<string[]>(`/progress/course/${courseId}/my-progress`)
-    cacheSet(key, response.data, 60 * 1000)
-    return response.data
-  },
-
-  async getStudentProgress(courseId: string): Promise<StudentProgressResponse> {
-    const key = `progress:students:${courseId}`
-    const cached = cacheGet<StudentProgressResponse>(key)
-    if (cached) return cached
-    const response = await api.get<StudentProgressResponse>(`/progress/course/${courseId}/students`)
-    cacheSet(key, response.data, 30 * 1000)
-    return response.data
-  },
-
-  async getNotifications(page: number = 1): Promise<NotificationListResponse> {
-    const response = await api.get<NotificationListResponse>("/notifications", { params: { page } })
-    return response.data
-  },
-  async getUnreadCount(): Promise<number> {
-    const response = await api.get<{ count: number }>("/notifications/unread-count")
-    return response.data.count
-  },
-  async markAsRead(id: string): Promise<Notification> {
-    const response = await api.patch<Notification>(`/notifications/${id}/read`)
-    return response.data
-  },
-  async markAllAsRead(): Promise<void> {
-    await api.post("/notifications/read-all")
-  },
-  async deleteNotification(id: string): Promise<void> {
-    await api.delete(`/notifications/${id}`)
-  },
-
-  async getAuditLogs(params: {
-    page?: number
-    page_size?: number
-    user_id?: string
-    resource_type?: string
-    action?: string
-    date_from?: string
-    date_to?: string
-  } = {}): Promise<AuditLogPage> {
-    const response = await api.get<AuditLogPage>("/audit", { params })
-    return response.data
-  },
-
-  async getCalendarEvents(courseId?: string): Promise<CalendarEvent[]> {
-    const key = `calendar:events:${courseId ?? "all"}`
-    const cached = cacheGet<CalendarEvent[]>(key)
-    if (cached) return cached
-    const params = courseId ? { course_id: courseId } : undefined
-    const response = await api.get<CalendarEvent[]>("/calendar/events", { params })
-    cacheSet(key, response.data, 60 * 1000)
-    return response.data
-  },
-
-  async getCourseEvents(courseId: string): Promise<CourseEvent[]> {
-    const key = `calendar:course-events:${courseId}`
-    const cached = cacheGet<CourseEvent[]>(key)
-    if (cached) return cached
-    const response = await api.get<CourseEvent[]>(`/courses/${courseId}/events`)
-    cacheSet(key, response.data, 2 * 60 * 1000)
-    return response.data
-  },
-
-  async createCourseEvent(courseId: string, data: {
-    title: string
-    description?: string
-    event_type?: string
-    event_date: string
-  }): Promise<CourseEvent> {
-    const response = await api.post<CourseEvent>(`/courses/${courseId}/events`, data)
-    cacheInvalidate(`calendar:course-events:${courseId}`)
-    cacheInvalidatePrefix("calendar:events:")
-    return response.data
-  },
-
-  async updateCourseEvent(courseId: string, eventId: string, data: {
-    title?: string
-    description?: string
-    event_type?: string
-    event_date?: string
-  }): Promise<CourseEvent> {
-    const response = await api.put<CourseEvent>(`/courses/${courseId}/events/${eventId}`, data)
-    cacheInvalidate(`calendar:course-events:${courseId}`)
-    cacheInvalidatePrefix("calendar:events:")
-    return response.data
-  },
-
-  async deleteCourseEvent(courseId: string, eventId: string): Promise<void> {
-    await api.delete(`/courses/${courseId}/events/${eventId}`)
-    cacheInvalidate(`calendar:course-events:${courseId}`)
-    cacheInvalidatePrefix("calendar:events:")
-  },
+export {
+  adminUsersService,
+  announcementsService,
+  assignmentsService,
+  auditService,
+  blocksService,
+  calendarService,
+  certificatesService,
+  cohortsService,
+  enrollmentsService,
+  gradesService,
+  notificationsService,
+  progressService,
+  quizzesService,
+  reviewsService,
+  analyticsService,
 }

--- a/frontend/src/services/enrollments.ts
+++ b/frontend/src/services/enrollments.ts
@@ -1,0 +1,42 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import type { Enrollment } from "@/types"
+
+export const enrollmentsService = {
+  async enrollInCourse(courseId: string, cohortId?: string): Promise<Enrollment> {
+    const response = await api.post<Enrollment>(
+      `/courses/${courseId}/enroll`,
+      cohortId ? { cohort_id: cohortId } : {},
+    )
+    cacheInvalidate("courses:my")
+    cacheInvalidate(`courses:enrollment-status:${courseId}`)
+    cacheInvalidatePrefix("calendar:events:")
+    cacheInvalidatePrefix("progress:my:")
+    return response.data
+  },
+
+  async getMyCourses(): Promise<Enrollment[]> {
+    // HomePage, ProfilePage, CalendarPage, and CertificatesPage all call this
+    // on mount. Without the short TTL we'd issue four identical requests for
+    // /users/me/courses during a routine navigation.
+    const key = "courses:my"
+    const cached = cacheGet<Enrollment[]>(key)
+    if (cached) return cached
+    const response = await api.get<Enrollment[]>("/users/me/courses")
+    cacheSet(key, response.data, 60 * 1000)
+    return response.data
+  },
+
+  async getEnrollmentStatus(
+    courseId: string,
+  ): Promise<{ enrolled: boolean; enrollment: Enrollment | null }> {
+    const key = `courses:enrollment-status:${courseId}`
+    const cached = cacheGet<{ enrolled: boolean; enrollment: Enrollment | null }>(key)
+    if (cached) return cached
+    const response = await api.get<{ enrolled: boolean; enrollment: Enrollment | null }>(
+      `/courses/${courseId}/enrollment-status`,
+    )
+    cacheSet(key, response.data, 60 * 1000)
+    return response.data
+  },
+}

--- a/frontend/src/services/grades.ts
+++ b/frontend/src/services/grades.ts
@@ -1,0 +1,64 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import type { GradingConfig, GradeSummaryResponse, StudentGrade } from "@/types"
+
+export const gradesService = {
+  async getCourseGrades(courseId: string): Promise<StudentGrade[]> {
+    const key = `grades:course:${courseId}`
+    const cached = cacheGet<StudentGrade[]>(key)
+    if (cached) return cached
+    const response = await api.get<StudentGrade[]>(`/grades/course/${courseId}`)
+    cacheSet(key, response.data, 60 * 1000)
+    return response.data
+  },
+
+  async upsertGrade(
+    courseId: string,
+    studentId: string,
+    data: { grade?: string; comment?: string },
+  ): Promise<StudentGrade> {
+    const response = await api.put<StudentGrade>(
+      `/grades/course/${courseId}/student/${studentId}`,
+      data,
+    )
+    cacheInvalidate(`grades:course:${courseId}`)
+    cacheInvalidate(`grades:summary:${courseId}`)
+    cacheInvalidatePrefix("grades:my")
+    return response.data
+  },
+
+  async getMyGrades(): Promise<StudentGrade[]> {
+    const key = "grades:my"
+    const cached = cacheGet<StudentGrade[]>(key)
+    if (cached) return cached
+    const response = await api.get<StudentGrade[]>("/grades/my")
+    cacheSet(key, response.data, 60 * 1000)
+    return response.data
+  },
+
+  async updateGradingConfig(courseId: string, data: GradingConfig): Promise<GradingConfig> {
+    const response = await api.put<GradingConfig>(`/grades/course/${courseId}/config`, data)
+    cacheInvalidate(`grades:summary:${courseId}`)
+    cacheInvalidate(`grades:course:${courseId}`)
+    cacheInvalidate(`analytics:course:${courseId}`)
+    return response.data
+  },
+
+  async getGradeSummary(courseId: string): Promise<GradeSummaryResponse> {
+    const key = `grades:summary:${courseId}`
+    const cached = cacheGet<GradeSummaryResponse>(key)
+    if (cached) return cached
+    const response = await api.get<GradeSummaryResponse>(
+      `/grades/course/${courseId}/summary`,
+    )
+    cacheSet(key, response.data, 60 * 1000)
+    return response.data
+  },
+
+  async exportGradesCSV(courseId: string): Promise<Blob> {
+    const response = await api.get(`/grades/course/${courseId}/export-csv`, {
+      responseType: "blob",
+    })
+    return response.data
+  },
+}

--- a/frontend/src/services/notifications.ts
+++ b/frontend/src/services/notifications.ts
@@ -1,0 +1,29 @@
+import api from "./api"
+import type { Notification, NotificationListResponse } from "@/types"
+
+export const notificationsService = {
+  async getNotifications(page: number = 1): Promise<NotificationListResponse> {
+    const response = await api.get<NotificationListResponse>("/notifications", {
+      params: { page },
+    })
+    return response.data
+  },
+
+  async getUnreadCount(): Promise<number> {
+    const response = await api.get<{ count: number }>("/notifications/unread-count")
+    return response.data.count
+  },
+
+  async markAsRead(id: string): Promise<Notification> {
+    const response = await api.patch<Notification>(`/notifications/${id}/read`)
+    return response.data
+  },
+
+  async markAllAsRead(): Promise<void> {
+    await api.post("/notifications/read-all")
+  },
+
+  async deleteNotification(id: string): Promise<void> {
+    await api.delete(`/notifications/${id}`)
+  },
+}

--- a/frontend/src/services/progress.ts
+++ b/frontend/src/services/progress.ts
@@ -1,0 +1,37 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidatePrefix } from "@/lib/cache"
+import type { StudentProgressResponse } from "@/types"
+
+export const progressService = {
+  async teacherMarkComplete(chapterId: string, studentId: string): Promise<void> {
+    await api.put(`/progress/chapter/${chapterId}/student/${studentId}/complete`)
+    cacheInvalidatePrefix("progress:students:")
+    cacheInvalidatePrefix("analytics:course:")
+  },
+
+  async teacherMarkIncomplete(chapterId: string, studentId: string): Promise<void> {
+    await api.put(`/progress/chapter/${chapterId}/student/${studentId}/incomplete`)
+    cacheInvalidatePrefix("progress:students:")
+    cacheInvalidatePrefix("analytics:course:")
+  },
+
+  async getMyChapterProgress(courseId: string): Promise<string[]> {
+    const key = `progress:my:${courseId}`
+    const cached = cacheGet<string[]>(key)
+    if (cached) return cached
+    const response = await api.get<string[]>(`/progress/course/${courseId}/my-progress`)
+    cacheSet(key, response.data, 60 * 1000)
+    return response.data
+  },
+
+  async getStudentProgress(courseId: string): Promise<StudentProgressResponse> {
+    const key = `progress:students:${courseId}`
+    const cached = cacheGet<StudentProgressResponse>(key)
+    if (cached) return cached
+    const response = await api.get<StudentProgressResponse>(
+      `/progress/course/${courseId}/students`,
+    )
+    cacheSet(key, response.data, 30 * 1000)
+    return response.data
+  },
+}

--- a/frontend/src/services/quizzes.ts
+++ b/frontend/src/services/quizzes.ts
@@ -1,0 +1,113 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import { isAxiosError } from "axios"
+import type {
+  Quiz,
+  QuizAttempt,
+  QuizAnswerResult,
+  QuizQuestionType,
+  PendingAnswer,
+} from "@/types"
+
+export type QuizCreateData = {
+  chapter_id: string
+  title: string
+  description?: string | null
+  quiz_type?: "quiz" | "exam"
+  max_attempts?: number | null
+  passing_score: number
+  questions: Array<{
+    question_text: string
+    question_type: QuizQuestionType
+    order_index: number
+    points: number
+    min_words?: number | null
+    options: Array<{
+      option_text: string
+      is_correct: boolean
+      order_index: number
+    }>
+  }>
+}
+
+export type QuizSubmissionAnswer = {
+  question_id: string
+  selected_option_id?: string
+  text_answer?: string
+}
+
+export const quizzesService = {
+  async getChapterQuiz(chapterId: string): Promise<Quiz | null> {
+    const key = `quiz:chapter:${chapterId}`
+    const cached = cacheGet<Quiz | null>(key)
+    if (cached !== undefined) return cached
+    try {
+      const response = await api.get<Quiz | null>(`/quizzes/chapter/${chapterId}`)
+      cacheSet(key, response.data, 2 * 60 * 1000)
+      return response.data
+    } catch (err: unknown) {
+      if (isAxiosError(err) && err.response?.status === 404) {
+        cacheSet(key, null, 2 * 60 * 1000)
+        return null
+      }
+      throw err
+    }
+  },
+
+  async createQuiz(data: QuizCreateData): Promise<Quiz> {
+    const response = await api.post<Quiz>("/quizzes", data)
+    cacheInvalidate(`quiz:chapter:${data.chapter_id}`)
+    return response.data
+  },
+
+  async deleteQuiz(quizId: string, chapterId?: string): Promise<void> {
+    await api.delete(`/quizzes/${quizId}`)
+    if (chapterId) {
+      cacheInvalidate(`quiz:chapter:${chapterId}`)
+    } else {
+      cacheInvalidatePrefix("quiz:chapter:")
+    }
+  },
+
+  async submitQuiz(quizId: string, answers: QuizSubmissionAnswer[]): Promise<QuizAttempt> {
+    const response = await api.post<QuizAttempt>(`/quizzes/${quizId}/submit`, { answers })
+    cacheInvalidatePrefix("progress:my:")
+    return response.data
+  },
+
+  async getMyQuizAttempts(quizId: string): Promise<QuizAttempt[]> {
+    const response = await api.get<QuizAttempt[]>(`/quizzes/${quizId}/my-attempts`)
+    return response.data
+  },
+
+  async getPendingAnswers(quizId: string, includeGraded = false): Promise<PendingAnswer[]> {
+    const response = await api.get<PendingAnswer[]>(
+      `/quizzes/${quizId}/pending-answers`,
+      { params: { include_graded: includeGraded } },
+    )
+    return response.data
+  },
+
+  async gradeQuizAnswer(
+    answerId: string,
+    pointsEarned: number,
+    graderComment?: string | null,
+  ): Promise<QuizAnswerResult> {
+    const response = await api.patch<QuizAnswerResult>(`/quizzes/answers/${answerId}`, {
+      points_earned: pointsEarned,
+      grader_comment: graderComment ?? null,
+    })
+    return response.data
+  },
+
+  async grantExtraAttempts(
+    quizId: string,
+    userId: string,
+    extraAttempts: number,
+  ): Promise<void> {
+    await api.post(`/quizzes/${quizId}/extra-attempts`, {
+      user_id: userId,
+      extra_attempts: extraAttempts,
+    })
+  },
+}

--- a/frontend/src/services/reviews.ts
+++ b/frontend/src/services/reviews.ts
@@ -1,0 +1,28 @@
+import api from "./api"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import type { CourseReview } from "@/types"
+
+export const reviewsService = {
+  async getCourseReviews(courseId: string): Promise<CourseReview[]> {
+    const key = `reviews:course:${courseId}`
+    const cached = cacheGet<CourseReview[]>(key)
+    if (cached) return cached
+    const response = await api.get<CourseReview[]>(`/reviews/course/${courseId}`)
+    cacheSet(key, response.data, 2 * 60 * 1000)
+    return response.data
+  },
+
+  async submitReview(
+    courseId: string,
+    data: { rating: number; comment?: string },
+  ): Promise<CourseReview> {
+    const response = await api.post<CourseReview>(`/reviews/course/${courseId}`, data)
+    cacheInvalidate(`reviews:course:${courseId}`)
+    return response.data
+  },
+
+  async deleteReview(id: string): Promise<void> {
+    await api.delete(`/reviews/${id}`)
+    cacheInvalidatePrefix("reviews:course:")
+  },
+}


### PR DESCRIPTION
## Summary

`frontend/src/services/courses.ts` had grown into an unmistakable god
service: one 711-line file with ~60 methods spanning 15 different
domains (courses, modules, chapters, cohorts, enrollments, grades,
quizzes, assignments, blocks, certificates, progress, notifications,
audit, calendar, reviews, analytics, admin-user management). Every
new feature added another clause to the same overgrown object and the
cache-invalidation logic was scattered across unrelated methods.

This PR decomposes it into a clean per-domain layout while preserving
full backwards compatibility.

### What changed

- Extracted 14 new focused service files under `frontend/src/services/`:
  - `adminUsers.ts`, `announcements.ts`, `assignments.ts`, `audit.ts`,
    `blocks.ts`, `calendar.ts`, `certificates.ts`, `cohorts.ts`,
    `enrollments.ts`, `grades.ts`, `notifications.ts`, `progress.ts`,
    `quizzes.ts`, `reviews.ts`, `analytics.ts`.
- `courses.ts` now contains only course / module / chapter CRUD (the
  three entities that share the nested URL structure and cache graph)
  and re-exports all per-domain services.
- `coursesService` is kept as a spread-facade of every domain service,
  so every `coursesService.foo()` call site in the app (roughly 28
  files) continues to work unchanged during the incremental migration.
- Every method signature, cache key, TTL, and `cacheInvalidate*` call
  is preserved verbatim — this is a pure restructuring.

### Why

- Single-responsibility modules are easier to review, test, and
  navigate.
- New features naturally target their domain (`quizzesService.submit`)
  instead of piling onto one object.
- Cache keys now live next to the methods that own them.
- The facade lets us migrate call sites in small follow-up PRs rather
  than as part of this diff.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npx vitest run` — 85/85 tests pass
- [ ] CI: backend-ci, frontend-ci, pr-check all green
