### PR TITLE
refactor(frontend): decompose TeacherGradebook monster page into focused subcomponents

### DIFF
--- a/frontend/src/pages/Teacher/TeacherGradebook.tsx
+++ b/frontend/src/pages/Teacher/TeacherGradebook.tsx
@@ -1,97 +1,38 @@
-import { useEffect, useState, useCallback, useMemo, Fragment } from "react"
+import { useEffect, useState, useCallback, useMemo } from "react"
 import { useParams, useSearchParams, Link } from "react-router-dom"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import PageSpinner from "@/components/ui/PageSpinner"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { coursesService } from "@/services/courses"
 import type { GradingConfig, GradeSummaryResponse, StudentGrade } from "@/types"
 import { toast } from "@/lib/toast"
-import {
-  ArrowLeft, Save, Users, Award, MessageSquare,
-  ChevronDown, ChevronRight, TrendingUp, Settings2,
-  ArrowUpDown, ArrowUp, ArrowDown, Calculator,
-  CheckCircle2, Circle, BookOpen, ClipboardList,
-  HelpCircle, GraduationCap, FileText, LayoutGrid,
-  Download,
-} from "lucide-react"
+import { ArrowLeft, Award, ChevronRight, Download } from "lucide-react"
 import { ErrorState } from "@/components/patterns"
+import {
+  SORT_FIELDS,
+  TABS,
+  type ActiveTab,
+  type SortField,
+  type SortDir,
+  type ChapterInfo,
+  type GradeForm,
+  type ProgressResponse,
+} from "./gradebook/types"
+import { GradebookStats } from "./gradebook/GradebookStats"
+import { GradebookTabs } from "./gradebook/GradebookTabs"
+import { GradingConfigCard } from "./gradebook/GradingConfigCard"
+import { SummaryTab } from "./gradebook/SummaryTab"
+import { GradeTableTab } from "./gradebook/GradeTableTab"
 
-const SORT_FIELDS = ["name", "quiz", "assignment", "participation", "final", "letter"] as const
-type SortField = (typeof SORT_FIELDS)[number]
-type SortDir = "asc" | "desc"
-const TABS = ["summary", "table"] as const
-type ActiveTab = (typeof TABS)[number]
-
-interface ChapterInfo {
-  id: string
-  title: string
-  module_id: string
-  chapter_type: string
-  completed: boolean
-  completed_by: "self" | "teacher" | null
-  quiz_result: { score: number; max_score: number; passed: boolean } | null
-  assignment_result: { status: string; grade: number | null; max_score?: number } | null
-}
-
-interface StudentProgressData {
-  id: string
-  full_name: string
-  email: string
-  progress: number
-  chapters_completed: number
-  total_chapters: number
-  chapters: ChapterInfo[]
-  quiz_results: Array<{ chapter_id: string; score: number; max_score: number; passed: boolean }>
-  assignment_results: Array<{ chapter_id: string; status: string; grade: number | null; max_score: number }>
-}
-
-interface ModuleInfo {
-  id: string
-  title: string
-  order_index: number
-}
-
-interface ProgressResponse {
-  course_id: string
-  course_title: string
-  total_chapters: number
-  total_students: number
-  modules: ModuleInfo[]
-  students: StudentProgressData[]
-}
-
-interface GradeForm {
-  grade: string
-  comment: string
-}
-
-const LETTER_ORDER: Record<string, number> = { A: 5, B: 4, C: 3, D: 2, F: 1 }
-
-function letterColor(letter: string) {
-  switch (letter) {
-    case "A": return "bg-success/15 text-success"
-    case "B": return "bg-info/15 text-info"
-    case "C": return "bg-accent/20 text-foreground"
-    case "D": return "bg-warning/15 text-warning"
-    case "F": return "bg-destructive/15 text-destructive"
-    default: return "bg-muted text-muted-foreground"
-  }
-}
-
-function chapterTypeIcon(type: string) {
-  switch (type) {
-    case "quiz": return <HelpCircle className="h-3 w-3" />
-    case "exam": return <GraduationCap className="h-3 w-3" />
-    case "assignment": return <ClipboardList className="h-3 w-3" />
-    default: return <FileText className="h-3 w-3" />
-  }
-}
-
+/**
+ * Gradebook page: top-level composition of the summary view, the grade
+ * table view, stats, and grading-config card. This component owns all
+ * state (config drafts, manual grade forms, expanded row, loaders); the
+ * per-tab components are pure, prop-driven render layers.
+ */
 export default function TeacherGradebook() {
   const { courseId } = useParams<{ courseId: string }>()
   const [params, setParams] = useSearchParams()
+
   const activeTab: ActiveTab = (TABS as readonly string[]).includes(params.get("tab") ?? "")
     ? (params.get("tab") as ActiveTab)
     : "summary"
@@ -100,36 +41,51 @@ export default function TeacherGradebook() {
     : "name"
   const sortDir: SortDir = params.get("dir") === "desc" ? "desc" : "asc"
 
-  const setActiveTab = (next: ActiveTab) => setParams((p) => {
-    const n = new URLSearchParams(p)
-    if (next === "summary") n.delete("tab"); else n.set("tab", next)
-    return n
-  }, { replace: true })
+  const setActiveTab = (next: ActiveTab) =>
+    setParams(
+      (p) => {
+        const n = new URLSearchParams(p)
+        if (next === "summary") n.delete("tab")
+        else n.set("tab", next)
+        return n
+      },
+      { replace: true },
+    )
 
-  const applySort = (field: SortField, dir: SortDir) => setParams((p) => {
-    const n = new URLSearchParams(p)
-    if (field === "name") n.delete("sort"); else n.set("sort", field)
-    if (dir === "asc") n.delete("dir"); else n.set("dir", dir)
-    return n
-  }, { replace: true })
+  const applySort = (field: SortField, dir: SortDir) =>
+    setParams(
+      (p) => {
+        const n = new URLSearchParams(p)
+        if (field === "name") n.delete("sort")
+        else n.set("sort", field)
+        if (dir === "asc") n.delete("dir")
+        else n.set("dir", dir)
+        return n
+      },
+      { replace: true },
+    )
 
   const [courseTitle, setCourseTitle] = useState("")
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const [config, setConfig] = useState<GradingConfig>({ quiz_weight: 30, assignment_weight: 50, participation_weight: 20 })
+  const [config, setConfig] = useState<GradingConfig>({
+    quiz_weight: 30,
+    assignment_weight: 50,
+    participation_weight: 20,
+  })
   const [configDraft, setConfigDraft] = useState<GradingConfig>(config)
   const [configOpen, setConfigOpen] = useState(false)
   const [savingConfig, setSavingConfig] = useState(false)
 
   const [summary, setSummary] = useState<GradeSummaryResponse | null>(null)
   const [manualGrades, setManualGrades] = useState<Map<string, StudentGrade>>(new Map())
-
   const [progressData, setProgressData] = useState<ProgressResponse | null>(null)
 
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [forms, setForms] = useState<Map<string, GradeForm>>(new Map())
   const [saving, setSaving] = useState<string | null>(null)
+  const [exporting, setExporting] = useState(false)
 
   const [reloadKey, setReloadKey] = useState(0)
   const reload = useCallback(() => setReloadKey((k) => k + 1), [])
@@ -155,7 +111,10 @@ export default function TeacherGradebook() {
         const formMap = new Map<string, GradeForm>()
         for (const g of rawGrades ?? []) {
           gradeMap.set(g.student_id, g)
-          formMap.set(g.student_id, { grade: g.grade ?? "", comment: g.comment ?? "" })
+          formMap.set(g.student_id, {
+            grade: g.grade ?? "",
+            comment: g.comment ?? "",
+          })
         }
         setManualGrades(gradeMap)
         setForms(formMap)
@@ -174,14 +133,16 @@ export default function TeacherGradebook() {
         if (!cancelled) setLoading(false)
       }
     })()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [courseId, reloadKey])
 
-  const configTotal = configDraft.quiz_weight + configDraft.assignment_weight + configDraft.participation_weight
-  const configValid = configTotal === 100
-
   const saveConfig = async () => {
-    if (!courseId || !configValid) return
+    if (!courseId) return
+    const total =
+      configDraft.quiz_weight + configDraft.assignment_weight + configDraft.participation_weight
+    if (total !== 100) return
     setSavingConfig(true)
     try {
       const updated = await coursesService.updateGradingConfig(courseId, configDraft)
@@ -234,35 +195,6 @@ export default function TeacherGradebook() {
     }
   }
 
-  const toggleSort = (field: SortField) => {
-    if (sortField === field) {
-      applySort(field, sortDir === "asc" ? "desc" : "asc")
-    } else {
-      applySort(field, field === "name" ? "asc" : "desc")
-    }
-  }
-
-  const sortedStudents = useMemo(() => {
-    if (!summary) return []
-    const list = [...summary.students]
-    const dir = sortDir === "asc" ? 1 : -1
-    list.sort((a, b) => {
-      let cmp = 0
-      switch (sortField) {
-        case "name": cmp = (a.student_name ?? "").localeCompare(b.student_name ?? ""); break
-        case "quiz": cmp = a.breakdown.quiz_avg - b.breakdown.quiz_avg; break
-        case "assignment": cmp = a.breakdown.assignment_avg - b.breakdown.assignment_avg; break
-        case "participation": cmp = a.breakdown.participation_pct - b.breakdown.participation_pct; break
-        case "final": cmp = a.breakdown.final_score - b.breakdown.final_score; break
-        case "letter": cmp = (LETTER_ORDER[a.breakdown.letter_grade] ?? 0) - (LETTER_ORDER[b.breakdown.letter_grade] ?? 0); break
-      }
-      return cmp * dir
-    })
-    return list
-  }, [summary, sortField, sortDir])
-
-  const [exporting, setExporting] = useState(false)
-
   const handleExportCSV = async () => {
     if (!courseId) return
     setExporting(true)
@@ -271,7 +203,10 @@ export default function TeacherGradebook() {
       const url = URL.createObjectURL(blob)
       const a = document.createElement("a")
       a.href = url
-      const safeTitle = (courseTitle || courseId || "export").replace(/[\\/:*?"<>|]/g, "_").slice(0, 50).trim()
+      const safeTitle = (courseTitle || courseId || "export")
+        .replace(/[\\/:*?"<>|]/g, "_")
+        .slice(0, 50)
+        .trim()
       a.download = `grades_${safeTitle}.csv`
       a.click()
       URL.revokeObjectURL(url)
@@ -280,27 +215,6 @@ export default function TeacherGradebook() {
     } finally {
       setExporting(false)
     }
-  }
-
-  const classAvg = summary?.class_average ?? 0
-  const studentCount = summary?.students.length ?? 0
-  const gradedCount = manualGrades.size
-
-  function SortHeader({ field, label, className }: { field: SortField; label: string; className?: string }) {
-    const active = sortField === field
-    return (
-      <button
-        onClick={() => toggleSort(field)}
-        className={`flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors ${className ?? ""}`}
-      >
-        {label}
-        {active ? (
-          sortDir === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />
-        ) : (
-          <ArrowUpDown className="h-3 w-3 opacity-40" />
-        )}
-      </button>
-    )
   }
 
   const moduleChapterMap = useMemo(() => {
@@ -321,7 +235,6 @@ export default function TeacherGradebook() {
     return [...(progressData.modules ?? [])].sort((a, b) => a.order_index - b.order_index)
   }, [progressData])
 
-  // Map student_id → their chapter data for fast lookup
   const studentChapterMap = useMemo(() => {
     if (!progressData) return new Map<string, Map<string, ChapterInfo>>()
     const outer = new Map<string, Map<string, ChapterInfo>>()
@@ -335,15 +248,14 @@ export default function TeacherGradebook() {
     return outer
   }, [progressData])
 
-  // Sorted students for grade table (by name)
   const tableStudents = useMemo(() => {
     if (!progressData) return []
-    return [...progressData.students].sort((a, b) => (a.full_name ?? "").localeCompare(b.full_name ?? ""))
+    return [...progressData.students].sort((a, b) =>
+      (a.full_name ?? "").localeCompare(b.full_name ?? ""),
+    )
   }, [progressData])
 
-  if (loading) {
-    return <PageSpinner />
-  }
+  if (loading) return <PageSpinner />
 
   if (error) {
     return (
@@ -369,11 +281,15 @@ export default function TeacherGradebook() {
     )
   }
 
+  const studentCount = summary?.students.length ?? 0
+  const classAvg = summary?.class_average ?? 0
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
-      {/* Breadcrumb */}
       <div className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
-        <Link to="/teacher" className="hover:text-foreground transition-colors">My Courses</Link>
+        <Link to="/teacher" className="hover:text-foreground transition-colors">
+          My Courses
+        </Link>
         <ChevronRight className="h-3.5 w-3.5" />
         <span className="text-foreground font-medium">Gradebook</span>
       </div>
@@ -394,268 +310,44 @@ export default function TeacherGradebook() {
         )}
       </div>
 
-      {/* Stats row */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
-        <Card>
-          <CardContent className="pt-5">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-xs text-muted-foreground">Students</p>
-                <p className="text-2xl font-bold mt-0.5">{studentCount}</p>
-              </div>
-              <Users className="h-7 w-7 text-muted-foreground/60" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-5">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-xs text-muted-foreground">Class Average</p>
-                <p className="text-2xl font-bold mt-0.5">{classAvg.toFixed(1)}%</p>
-              </div>
-              <TrendingUp className="h-7 w-7 text-muted-foreground/60" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-5">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-xs text-muted-foreground">Manually Graded</p>
-                <p className="text-2xl font-bold mt-0.5">{gradedCount}/{studentCount}</p>
-              </div>
-              <Award className="h-7 w-7 text-muted-foreground/60" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-5">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-xs text-muted-foreground">Weights Q/A/P</p>
-                <p className="text-sm font-medium mt-0.5">
-                  {config.quiz_weight}/{config.assignment_weight}/{config.participation_weight}
-                </p>
-              </div>
-              <Calculator className="h-7 w-7 text-muted-foreground/60" />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <GradebookStats
+        studentCount={studentCount}
+        classAverage={classAvg}
+        gradedCount={manualGrades.size}
+        config={config}
+      />
 
-      {/* Tabs */}
-      <div className="flex gap-1 mb-6 border-b">
-        <button
-          onClick={() => setActiveTab("summary")}
-          className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === "summary"
-              ? "border-primary text-primary"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <TrendingUp className="h-4 w-4" />
-          Summary Grades
-        </button>
-        <button
-          onClick={() => setActiveTab("table")}
-          className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === "table"
-              ? "border-primary text-primary"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <LayoutGrid className="h-4 w-4" />
-          Grade Table
-        </button>
-      </div>
+      <GradebookTabs active={activeTab} onChange={setActiveTab} />
 
       {activeTab === "summary" && (
         <>
-          {/* Grading Configuration */}
-          <Card className="mb-6">
-            <CardHeader
-              className="cursor-pointer select-none py-4"
-              onClick={() => setConfigOpen(!configOpen)}
-            >
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Settings2 className="h-5 w-5 text-muted-foreground" />
-                  <div>
-                    <CardTitle className="text-base">Grading Configuration</CardTitle>
-                    <CardDescription className="text-xs">Set how quizzes, assignments, and participation contribute to final grades</CardDescription>
-                  </div>
-                </div>
-                {configOpen ? <ChevronDown className="h-4 w-4 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
-              </div>
-            </CardHeader>
-            {configOpen && (
-              <CardContent className="border-t pt-6">
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-                  <div className="space-y-2">
-                    <Label>Quiz Weight (%)</Label>
-                    <Input type="number" min={0} max={100} value={configDraft.quiz_weight}
-                      onChange={(e) => setConfigDraft({ ...configDraft, quiz_weight: Number(e.target.value) || 0 })} className="h-9" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>Assignment Weight (%)</Label>
-                    <Input type="number" min={0} max={100} value={configDraft.assignment_weight}
-                      onChange={(e) => setConfigDraft({ ...configDraft, assignment_weight: Number(e.target.value) || 0 })} className="h-9" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>Participation Weight (%)</Label>
-                    <Input type="number" min={0} max={100} value={configDraft.participation_weight}
-                      onChange={(e) => setConfigDraft({ ...configDraft, participation_weight: Number(e.target.value) || 0 })} className="h-9" />
-                  </div>
-                </div>
-                <div className="flex items-center justify-between mt-4">
-                  <p className={`text-sm font-medium ${configValid ? "text-success" : "text-destructive"}`}>
-                    Total: {configTotal}% {configValid ? "✓" : "(must equal 100%)"}
-                  </p>
-                  <Button size="sm" onClick={saveConfig} disabled={!configValid || savingConfig}>
-                    <Save className="h-3.5 w-3.5 mr-1.5" />
-                    {savingConfig ? "Saving..." : "Save Weights"}
-                  </Button>
-                </div>
-              </CardContent>
-            )}
-          </Card>
-
-          {/* Gradebook Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Student Grades</CardTitle>
-              <CardDescription>
-                Auto-calculated based on quiz scores, assignment grades, and chapter completion. Click a student to override manually.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {studentCount === 0 ? (
-                <p className="text-sm text-muted-foreground py-8 text-center">No students enrolled yet.</p>
-              ) : (
-                <div className="overflow-x-auto">
-                  <div className="grid grid-cols-[1fr_80px_80px_90px_80px_70px_70px] gap-3 px-4 py-3 border-b bg-muted/30 rounded-t-lg min-w-[700px]">
-                    <SortHeader field="name" label="Student" />
-                    <SortHeader field="quiz" label="Quiz" className="justify-end" />
-                    <SortHeader field="assignment" label="Assign." className="justify-end" />
-                    <SortHeader field="participation" label="Particip." className="justify-end" />
-                    <SortHeader field="final" label="Final" className="justify-end" />
-                    <SortHeader field="letter" label="Grade" className="justify-center" />
-                    <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground text-center">Manual</span>
-                  </div>
-
-                  <div className="divide-y min-w-[700px]">
-                    {sortedStudents.map((student) => {
-                      const isExpanded = expandedId === student.student_id
-                      const manualGrade = manualGrades.get(student.student_id)
-                      const form = forms.get(student.student_id) ?? { grade: "", comment: "" }
-                      const b = student.breakdown
-                      const hasDifferentManual = manualGrade?.grade && manualGrade.grade !== b.letter_grade
-
-                      return (
-                        <div key={student.student_id}>
-                          <div
-                            className="grid grid-cols-[1fr_80px_80px_90px_80px_70px_70px] gap-3 px-4 py-3 cursor-pointer hover:bg-muted/30 transition-colors items-center"
-                            onClick={() => toggleExpand(student.student_id)}
-                          >
-                            <div className="flex items-center gap-2 min-w-0">
-                              {isExpanded ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />}
-                              <div className="min-w-0">
-                                <p className="text-sm font-medium truncate">{student.student_name || "Unknown"}</p>
-                                <p className="text-xs text-muted-foreground truncate">{student.student_email}</p>
-                              </div>
-                            </div>
-                            <p className="text-sm tabular-nums text-right">{b.quiz_avg.toFixed(1)}%</p>
-                            <p className="text-sm tabular-nums text-right">{b.assignment_avg.toFixed(1)}%</p>
-                            <p className="text-sm tabular-nums text-right">{b.participation_pct.toFixed(1)}%</p>
-                            <p className="text-sm font-semibold tabular-nums text-right">{b.final_score.toFixed(1)}%</p>
-                            <div className="flex justify-center">
-                              <span className={`inline-flex items-center justify-center rounded-full px-2.5 py-0.5 text-xs font-bold ${letterColor(b.letter_grade)}`}>
-                                {b.letter_grade}
-                              </span>
-                            </div>
-                            <div className="flex justify-center">
-                              {manualGrade?.grade ? (
-                                <span className={`inline-flex items-center justify-center rounded-full px-2.5 py-0.5 text-xs font-bold ${hasDifferentManual ? "bg-warning/15 text-warning ring-1 ring-warning/30" : "bg-muted text-muted-foreground"}`}>
-                                  {manualGrade.grade}
-                                </span>
-                              ) : (
-                                <span className="text-xs text-muted-foreground">—</span>
-                              )}
-                            </div>
-                          </div>
-
-                          {isExpanded && (
-                            <div className="border-t px-4 py-4 bg-muted/10 space-y-4">
-                              <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-2 text-sm">
-                                <div>
-                                  <span className="text-muted-foreground">Quiz Avg:</span>{" "}
-                                  <span className="font-medium">{b.quiz_avg.toFixed(1)}%</span>
-                                  <span className="text-muted-foreground text-xs ml-1">(×{config.quiz_weight}% = {b.quiz_weighted.toFixed(1)})</span>
-                                </div>
-                                <div>
-                                  <span className="text-muted-foreground">Assignment Avg:</span>{" "}
-                                  <span className="font-medium">{b.assignment_avg.toFixed(1)}%</span>
-                                  <span className="text-muted-foreground text-xs ml-1">(×{config.assignment_weight}% = {b.assignment_weighted.toFixed(1)})</span>
-                                </div>
-                                <div>
-                                  <span className="text-muted-foreground">Participation:</span>{" "}
-                                  <span className="font-medium">{b.participation_pct.toFixed(1)}%</span>
-                                  <span className="text-muted-foreground text-xs ml-1">(×{config.participation_weight}% = {b.participation_weighted.toFixed(1)})</span>
-                                </div>
-                              </div>
-
-                              {hasDifferentManual && (
-                                <div className="rounded border border-border border-l-[3px] border-l-warning bg-warning/10 px-3 py-2 text-xs text-foreground">
-                                  Manual grade <strong>{manualGrade?.grade}</strong> differs from calculated <strong>{b.letter_grade}</strong> ({b.final_score.toFixed(1)}%)
-                                </div>
-                              )}
-
-                              <div className="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-3">
-                                <div className="space-y-1.5">
-                                  <label className="text-xs font-medium flex items-center gap-1">
-                                    <Award className="h-3 w-3" /> Override Grade
-                                  </label>
-                                  <Input value={form.grade} onChange={(e) => updateForm(student.student_id, "grade", e.target.value)} placeholder="A, B+, 95..." className="h-9" />
-                                </div>
-                                <div className="space-y-1.5">
-                                  <label className="text-xs font-medium flex items-center gap-1">
-                                    <MessageSquare className="h-3 w-3" /> Comment
-                                  </label>
-                                  <Input value={form.comment} onChange={(e) => updateForm(student.student_id, "comment", e.target.value)} placeholder="Teacher's note..." className="h-9" />
-                                </div>
-                              </div>
-
-                              <Button size="sm" onClick={() => saveGrade(student.student_id)} disabled={saving === student.student_id}>
-                                <Save className="h-3.5 w-3.5 mr-1.5" />
-                                {saving === student.student_id ? "Saving..." : "Save Manual Grade"}
-                              </Button>
-                            </div>
-                          )}
-                        </div>
-                      )
-                    })}
-
-                    {studentCount > 0 && summary && (
-                      <div className="grid grid-cols-[1fr_80px_80px_90px_80px_70px_70px] gap-3 px-4 py-3 bg-muted/40 font-semibold text-sm items-center border-t-2">
-                        <span className="pl-6">Class Average ({studentCount} students)</span>
-                        <p className="tabular-nums text-right">{(summary.students.reduce((s, st) => s + st.breakdown.quiz_avg, 0) / studentCount).toFixed(1)}%</p>
-                        <p className="tabular-nums text-right">{(summary.students.reduce((s, st) => s + st.breakdown.assignment_avg, 0) / studentCount).toFixed(1)}%</p>
-                        <p className="tabular-nums text-right">{(summary.students.reduce((s, st) => s + st.breakdown.participation_pct, 0) / studentCount).toFixed(1)}%</p>
-                        <p className="tabular-nums text-right">{classAvg.toFixed(1)}%</p>
-                        <span /><span />
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <GradingConfigCard
+            open={configOpen}
+            onToggle={() => setConfigOpen(!configOpen)}
+            draft={configDraft}
+            onDraftChange={setConfigDraft}
+            onSave={saveConfig}
+            saving={savingConfig}
+          />
+          <SummaryTab
+            summary={summary}
+            config={config}
+            manualGrades={manualGrades}
+            forms={forms}
+            saving={saving}
+            expandedId={expandedId}
+            sortField={sortField}
+            sortDir={sortDir}
+            onSortChange={applySort}
+            onToggleExpand={toggleExpand}
+            onUpdateForm={updateForm}
+            onSaveGrade={saveGrade}
+          />
         </>
       )}
 
       {activeTab === "table" && (
-        <GradeTableView
+        <GradeTableTab
           progressData={progressData}
           orderedModules={orderedModules}
           moduleChapterMap={moduleChapterMap}
@@ -664,339 +356,12 @@ export default function TeacherGradebook() {
           manualGrades={manualGrades}
           forms={forms}
           saving={saving}
-          updateForm={updateForm}
-          saveGrade={saveGrade}
           expandedId={expandedId}
-          toggleExpand={toggleExpand}
+          onUpdateForm={updateForm}
+          onSaveGrade={saveGrade}
+          onToggleExpand={toggleExpand}
         />
       )}
-    </div>
-  )
-}
-
-interface GradeTableViewProps {
-  progressData: ProgressResponse | null
-  orderedModules: ModuleInfo[]
-  moduleChapterMap: Map<string, ChapterInfo[]>
-  studentChapterMap: Map<string, Map<string, ChapterInfo>>
-  tableStudents: StudentProgressData[]
-  manualGrades: Map<string, StudentGrade>
-  forms: Map<string, GradeForm>
-  saving: string | null
-  updateForm: (userId: string, field: "grade" | "comment", value: string) => void
-  saveGrade: (userId: string) => void
-  expandedId: string | null
-  toggleExpand: (userId: string) => void
-}
-
-function ChapterCell({ chapter }: { chapter: ChapterInfo | undefined }) {
-  if (!chapter) {
-    return <div className="flex items-center justify-center h-9 rounded bg-muted/30 text-muted-foreground/40 text-xs">—</div>
-  }
-
-  const type = chapter.chapter_type
-
-  if (type === "quiz" || type === "exam") {
-    if (chapter.quiz_result) {
-      const pct = chapter.quiz_result.max_score > 0
-        ? Math.round((chapter.quiz_result.score / chapter.quiz_result.max_score) * 100)
-        : 0
-      return (
-        <div className={`flex h-9 flex-col items-center justify-center rounded border px-1 text-xs font-medium ${
-          chapter.quiz_result.passed
-            ? "border-success/30 bg-success/10 text-success"
-            : "border-destructive/30 bg-destructive/10 text-destructive"
-        }`}>
-          <span className="font-semibold">{pct}%</span>
-          <span className="text-[10px] opacity-70">{chapter.quiz_result.score}/{chapter.quiz_result.max_score}</span>
-        </div>
-      )
-    }
-    return (
-      <div className="flex items-center justify-center h-9 rounded bg-muted/30 text-muted-foreground/50 text-xs">
-        <Circle className="h-3.5 w-3.5" />
-      </div>
-    )
-  }
-
-  if (type === "assignment") {
-    if (chapter.assignment_result) {
-      const graded = chapter.assignment_result.grade !== null
-      return (
-        <div className={`flex h-9 flex-col items-center justify-center rounded border px-1 text-xs font-medium ${
-          graded
-            ? "border-info/30 bg-info/10 text-info"
-            : "border-warning/30 bg-warning/10 text-warning"
-        }`}>
-          {graded ? (
-            <>
-              <span className="font-semibold">{chapter.assignment_result.grade}pt</span>
-              <span className="text-[10px] opacity-70">graded</span>
-            </>
-          ) : (
-            <span>submitted</span>
-          )}
-        </div>
-      )
-    }
-    return (
-      <div className="flex items-center justify-center h-9 rounded bg-muted/30 text-muted-foreground/50 text-xs">
-        <Circle className="h-3.5 w-3.5" />
-      </div>
-    )
-  }
-
-  return (
-    <div className="flex items-center justify-center h-9 rounded bg-muted/20 text-muted-foreground/30 text-[10px]">
-      —
-    </div>
-  )
-}
-
-function GradeTableView({
-  progressData,
-  orderedModules,
-  moduleChapterMap,
-  studentChapterMap,
-  tableStudents,
-  manualGrades,
-  forms,
-  saving,
-  updateForm,
-  saveGrade,
-  expandedId,
-  toggleExpand,
-}: GradeTableViewProps) {
-  if (!progressData) {
-    return (
-      <Card>
-        <CardContent className="py-12 text-center">
-          <BookOpen className="h-10 w-10 text-muted-foreground/30 mx-auto mb-3" />
-          <p className="text-sm text-muted-foreground">Could not load progress data.</p>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  if (tableStudents.length === 0) {
-    return (
-      <Card>
-        <CardContent className="py-12 text-center">
-          <Users className="h-10 w-10 text-muted-foreground/30 mx-auto mb-3" />
-          <p className="text-sm text-muted-foreground">No students enrolled yet.</p>
-        </CardContent>
-      </Card>
-    )
-  }
-
-  // All chapters in order (across all modules)
-  const allChapters: ChapterInfo[] = orderedModules.flatMap(
-    (m) => moduleChapterMap.get(m.id) ?? []
-  )
-
-  // Per-student totals
-  function getStudentTotals(studentId: string) {
-    const chMap = studentChapterMap.get(studentId)
-    if (!chMap) return { earned: 0, total: 0 }
-    let earned = 0
-    let total = 0
-    for (const ch of allChapters) {
-      const type = ch.chapter_type
-      if (type === "quiz" || type === "exam") {
-        const qr = chMap.get(ch.id)?.quiz_result
-        if (qr) {
-          earned += qr.score
-          total += qr.max_score
-        } else {
-          total += 1 // placeholder
-        }
-      } else if (type === "assignment") {
-        const ar = chMap.get(ch.id)?.assignment_result
-        const maxPts = ar?.max_score ?? 100
-        total += maxPts
-        if (ar?.grade !== null && ar?.grade !== undefined) {
-          earned += ar.grade
-        }
-      } else {
-        // reading/video/audio etc: 1 point for completion
-        total += 1
-        if (chMap.get(ch.id)?.completed) earned += 1
-      }
-    }
-    return { earned, total }
-  }
-
-  return (
-    <div className="space-y-4">
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">Student Grade Table</CardTitle>
-          <CardDescription className="text-xs">
-            Reading/video chapters = 1 pt for completion · Quiz/exam = scored · Assignment = teacher-graded pts
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse text-xs" style={{ minWidth: `${180 + allChapters.length * 64 + 100}px` }}>
-              <thead>
-                {/* Module header row */}
-                <tr>
-                  <th className="sticky left-0 z-10 bg-card border-b border-r px-3 py-2 text-left font-semibold text-sm w-44 min-w-[11rem]">
-                    Student
-                  </th>
-                  {orderedModules.map((mod) => {
-                    const modChapters = moduleChapterMap.get(mod.id) ?? []
-                    if (modChapters.length === 0) return null
-                    return (
-                      <th
-                        key={mod.id}
-                        colSpan={modChapters.length}
-                        className="border-b border-r px-2 py-2 text-center font-semibold bg-muted/40 truncate max-w-[200px]"
-                      >
-                        {mod.title}
-                      </th>
-                    )
-                  })}
-                  <th className="border-b px-2 py-2 text-center font-semibold bg-muted/40 w-20">
-                    Total
-                  </th>
-                </tr>
-                {/* Chapter header row */}
-                <tr>
-                  <th className="sticky left-0 z-10 bg-card border-b border-r" />
-                  {allChapters.map((ch) => (
-                    <th
-                      key={ch.id}
-                      className="border-b border-r px-1 py-1.5 text-center font-normal text-muted-foreground bg-muted/20 w-16"
-                      title={ch.title}
-                    >
-                      <div className="flex flex-col items-center gap-0.5">
-                        <span className="text-muted-foreground">{chapterTypeIcon(ch.chapter_type)}</span>
-                        <span className="truncate max-w-[52px] text-[10px]">{ch.title}</span>
-                      </div>
-                    </th>
-                  ))}
-                  <th className="border-b px-1 py-1.5 bg-muted/20" />
-                </tr>
-              </thead>
-
-              <tbody>
-                {tableStudents.map((student) => {
-                  const chMap = studentChapterMap.get(student.id)
-                  const { earned, total } = getStudentTotals(student.id)
-                  const manualGrade = manualGrades.get(student.id)
-                  const isExpanded = expandedId === student.id
-                  const form = forms.get(student.id) ?? { grade: "", comment: "" }
-
-                  return (
-                    <Fragment key={student.id}>
-                      <tr
-                        className="hover:bg-muted/20 cursor-pointer transition-colors"
-                        onClick={() => toggleExpand(student.id)}
-                      >
-                        <td className="sticky left-0 z-10 bg-card border-b border-r px-3 py-2 font-medium">
-                          <div className="flex items-center gap-1.5 min-w-0">
-                            {isExpanded
-                              ? <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
-                              : <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />
-                            }
-                            <div className="min-w-0">
-                              <p className="truncate text-xs font-semibold max-w-[140px]">{student.full_name || student.email}</p>
-                              <p className="truncate text-[10px] text-muted-foreground max-w-[140px]">{student.email}</p>
-                            </div>
-                          </div>
-                        </td>
-                        {allChapters.map((ch) => (
-                          <td key={ch.id} className="border-b border-r px-1 py-1" onClick={(e) => e.stopPropagation()}>
-                            <ChapterCell chapter={chMap?.get(ch.id)} />
-                          </td>
-                        ))}
-                        <td className="border-b px-2 py-2 text-center">
-                          <div className="flex flex-col items-center">
-                            <span className="font-semibold text-sm">{earned}</span>
-                            <span className="text-[10px] text-muted-foreground">/{total}</span>
-                            {manualGrade?.grade && (
-                              <span className={`mt-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-bold ${letterColor(manualGrade.grade)}`}>
-                                {manualGrade.grade}
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                      </tr>
-                      {isExpanded && (
-                        <tr>
-                          <td colSpan={allChapters.length + 2} className="bg-muted/10 border-b px-4 py-3">
-                            <div className="flex flex-wrap items-end gap-3">
-                              <div className="space-y-1">
-                                <label className="text-xs font-medium flex items-center gap-1">
-                                  <Award className="h-3 w-3" /> Override Grade
-                                </label>
-                                <Input
-                                  value={form.grade}
-                                  onChange={(e) => updateForm(student.id, "grade", e.target.value)}
-                                  placeholder="A, B+, 95..."
-                                  className="h-8 w-28 text-xs"
-                                />
-                              </div>
-                              <div className="space-y-1 flex-1 min-w-[180px]">
-                                <label className="text-xs font-medium flex items-center gap-1">
-                                  <MessageSquare className="h-3 w-3" /> Comment
-                                </label>
-                                <Input
-                                  value={form.comment}
-                                  onChange={(e) => updateForm(student.id, "comment", e.target.value)}
-                                  placeholder="Teacher's note..."
-                                  className="h-8 text-xs"
-                                />
-                              </div>
-                              <Button size="sm" className="h-8 text-xs" onClick={() => saveGrade(student.id)} disabled={saving === student.id}>
-                                <Save className="h-3 w-3 mr-1" />
-                                {saving === student.id ? "Saving..." : "Save Grade"}
-                              </Button>
-                            </div>
-                          </td>
-                        </tr>
-                      )}
-                    </Fragment>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Legend */}
-          <div className="mt-4 flex flex-wrap gap-4 border-t pt-4 text-xs text-muted-foreground">
-            <div className="flex items-center gap-1.5">
-              <div className="flex h-4 w-4 items-center justify-center rounded border border-success/30 bg-success/10">
-                <CheckCircle2 className="h-2.5 w-2.5 text-success" />
-              </div>
-              Completed (1 pt)
-            </div>
-            <div className="flex items-center gap-1.5">
-              <div className="flex h-4 w-6 items-center justify-center rounded border border-success/30 bg-success/10 text-[9px] font-semibold text-success">85%</div>
-              Quiz passed
-            </div>
-            <div className="flex items-center gap-1.5">
-              <div className="flex h-4 w-6 items-center justify-center rounded border border-destructive/30 bg-destructive/10 text-[9px] font-semibold text-destructive">40%</div>
-              Quiz failed
-            </div>
-            <div className="flex items-center gap-1.5">
-              <div className="flex h-4 w-10 items-center justify-center rounded border border-info/30 bg-info/10 text-[9px] font-semibold text-info">graded</div>
-              Assignment graded
-            </div>
-            <div className="flex items-center gap-1.5">
-              <div className="flex h-4 w-14 items-center justify-center rounded border border-warning/30 bg-warning/10 text-[9px] text-warning">submitted</div>
-              Assignment submitted
-            </div>
-            <div className="flex items-center gap-1.5">
-              <div className="flex h-4 w-4 items-center justify-center rounded border bg-muted/30">
-                <Circle className="h-2.5 w-2.5 text-muted-foreground/40" />
-              </div>
-              Not submitted
-            </div>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
@@ -1,0 +1,454 @@
+import { Fragment, useMemo } from "react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  BookOpen, Users, Circle, CheckCircle2,
+  ChevronDown, ChevronRight, Award, MessageSquare, Save,
+} from "lucide-react"
+import type { StudentGrade } from "@/types"
+import type {
+  ChapterInfo,
+  ModuleInfo,
+  ProgressResponse,
+  StudentProgressData,
+  GradeForm,
+} from "./types"
+import { letterColor, chapterTypeIcon } from "./helpers"
+
+interface Props {
+  progressData: ProgressResponse | null
+  orderedModules: ModuleInfo[]
+  moduleChapterMap: Map<string, ChapterInfo[]>
+  studentChapterMap: Map<string, Map<string, ChapterInfo>>
+  tableStudents: StudentProgressData[]
+  manualGrades: Map<string, StudentGrade>
+  forms: Map<string, GradeForm>
+  saving: string | null
+  expandedId: string | null
+  onUpdateForm: (userId: string, field: keyof GradeForm, value: string) => void
+  onSaveGrade: (userId: string) => void
+  onToggleExpand: (userId: string) => void
+}
+
+/**
+ * "Grade Table" tab: a dense spreadsheet view where columns are chapters
+ * (grouped by module) and rows are students. Clicking a student reveals
+ * the manual override form inline.
+ */
+export function GradeTableTab({
+  progressData,
+  orderedModules,
+  moduleChapterMap,
+  studentChapterMap,
+  tableStudents,
+  manualGrades,
+  forms,
+  saving,
+  expandedId,
+  onUpdateForm,
+  onSaveGrade,
+  onToggleExpand,
+}: Props) {
+  const allChapters: ChapterInfo[] = useMemo(
+    () => orderedModules.flatMap((m) => moduleChapterMap.get(m.id) ?? []),
+    [orderedModules, moduleChapterMap],
+  )
+
+  if (!progressData) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <BookOpen className="h-10 w-10 text-muted-foreground/30 mx-auto mb-3" />
+          <p className="text-sm text-muted-foreground">Could not load progress data.</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (tableStudents.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">
+          <Users className="h-10 w-10 text-muted-foreground/30 mx-auto mb-3" />
+          <p className="text-sm text-muted-foreground">No students enrolled yet.</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Student Grade Table</CardTitle>
+          <CardDescription className="text-xs">
+            Reading/video chapters = 1 pt for completion · Quiz/exam = scored · Assignment = teacher-graded pts
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table
+              className="w-full border-collapse text-xs"
+              style={{ minWidth: `${180 + allChapters.length * 64 + 100}px` }}
+            >
+              <GradeTableHead orderedModules={orderedModules} moduleChapterMap={moduleChapterMap} allChapters={allChapters} />
+              <tbody>
+                {tableStudents.map((student) => (
+                  <GradeTableRow
+                    key={student.id}
+                    student={student}
+                    allChapters={allChapters}
+                    studentChapterMap={studentChapterMap}
+                    manualGrade={manualGrades.get(student.id)}
+                    form={forms.get(student.id) ?? { grade: "", comment: "" }}
+                    expanded={expandedId === student.id}
+                    saving={saving === student.id}
+                    onToggleExpand={onToggleExpand}
+                    onUpdateForm={onUpdateForm}
+                    onSaveGrade={onSaveGrade}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <GradeTableLegend />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function GradeTableHead({
+  orderedModules,
+  moduleChapterMap,
+  allChapters,
+}: {
+  orderedModules: ModuleInfo[]
+  moduleChapterMap: Map<string, ChapterInfo[]>
+  allChapters: ChapterInfo[]
+}) {
+  return (
+    <thead>
+      <tr>
+        <th className="sticky left-0 z-10 bg-card border-b border-r px-3 py-2 text-left font-semibold text-sm w-44 min-w-[11rem]">
+          Student
+        </th>
+        {orderedModules.map((mod) => {
+          const modChapters = moduleChapterMap.get(mod.id) ?? []
+          if (modChapters.length === 0) return null
+          return (
+            <th
+              key={mod.id}
+              colSpan={modChapters.length}
+              className="border-b border-r px-2 py-2 text-center font-semibold bg-muted/40 truncate max-w-[200px]"
+            >
+              {mod.title}
+            </th>
+          )
+        })}
+        <th className="border-b px-2 py-2 text-center font-semibold bg-muted/40 w-20">
+          Total
+        </th>
+      </tr>
+      <tr>
+        <th className="sticky left-0 z-10 bg-card border-b border-r" />
+        {allChapters.map((ch) => (
+          <th
+            key={ch.id}
+            className="border-b border-r px-1 py-1.5 text-center font-normal text-muted-foreground bg-muted/20 w-16"
+            title={ch.title}
+          >
+            <div className="flex flex-col items-center gap-0.5">
+              <span className="text-muted-foreground">{chapterTypeIcon(ch.chapter_type)}</span>
+              <span className="truncate max-w-[52px] text-[10px]">{ch.title}</span>
+            </div>
+          </th>
+        ))}
+        <th className="border-b px-1 py-1.5 bg-muted/20" />
+      </tr>
+    </thead>
+  )
+}
+
+interface GradeTableRowProps {
+  student: StudentProgressData
+  allChapters: ChapterInfo[]
+  studentChapterMap: Map<string, Map<string, ChapterInfo>>
+  manualGrade: StudentGrade | undefined
+  form: GradeForm
+  expanded: boolean
+  saving: boolean
+  onToggleExpand: (userId: string) => void
+  onUpdateForm: (userId: string, field: keyof GradeForm, value: string) => void
+  onSaveGrade: (userId: string) => void
+}
+
+function GradeTableRow({
+  student,
+  allChapters,
+  studentChapterMap,
+  manualGrade,
+  form,
+  expanded,
+  saving,
+  onToggleExpand,
+  onUpdateForm,
+  onSaveGrade,
+}: GradeTableRowProps) {
+  const chMap = studentChapterMap.get(student.id)
+  const { earned, total } = computeStudentTotals(allChapters, chMap)
+
+  return (
+    <Fragment>
+      <tr
+        className="hover:bg-muted/20 cursor-pointer transition-colors"
+        onClick={() => onToggleExpand(student.id)}
+      >
+        <td className="sticky left-0 z-10 bg-card border-b border-r px-3 py-2 font-medium">
+          <div className="flex items-center gap-1.5 min-w-0">
+            {expanded ? (
+              <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
+            ) : (
+              <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />
+            )}
+            <div className="min-w-0">
+              <p className="truncate text-xs font-semibold max-w-[140px]">
+                {student.full_name || student.email}
+              </p>
+              <p className="truncate text-[10px] text-muted-foreground max-w-[140px]">
+                {student.email}
+              </p>
+            </div>
+          </div>
+        </td>
+        {allChapters.map((ch) => (
+          <td
+            key={ch.id}
+            className="border-b border-r px-1 py-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ChapterCell chapter={chMap?.get(ch.id)} />
+          </td>
+        ))}
+        <td className="border-b px-2 py-2 text-center">
+          <div className="flex flex-col items-center">
+            <span className="font-semibold text-sm">{earned}</span>
+            <span className="text-[10px] text-muted-foreground">/{total}</span>
+            {manualGrade?.grade && (
+              <span
+                className={`mt-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-bold ${letterColor(
+                  manualGrade.grade,
+                )}`}
+              >
+                {manualGrade.grade}
+              </span>
+            )}
+          </div>
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={allChapters.length + 2} className="bg-muted/10 border-b px-4 py-3">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="space-y-1">
+                <label className="text-xs font-medium flex items-center gap-1">
+                  <Award className="h-3 w-3" /> Override Grade
+                </label>
+                <Input
+                  value={form.grade}
+                  onChange={(e) => onUpdateForm(student.id, "grade", e.target.value)}
+                  placeholder="A, B+, 95..."
+                  className="h-8 w-28 text-xs"
+                />
+              </div>
+              <div className="space-y-1 flex-1 min-w-[180px]">
+                <label className="text-xs font-medium flex items-center gap-1">
+                  <MessageSquare className="h-3 w-3" /> Comment
+                </label>
+                <Input
+                  value={form.comment}
+                  onChange={(e) => onUpdateForm(student.id, "comment", e.target.value)}
+                  placeholder="Teacher's note..."
+                  className="h-8 text-xs"
+                />
+              </div>
+              <Button
+                size="sm"
+                className="h-8 text-xs"
+                onClick={() => onSaveGrade(student.id)}
+                disabled={saving}
+              >
+                <Save className="h-3 w-3 mr-1" />
+                {saving ? "Saving..." : "Save Grade"}
+              </Button>
+            </div>
+          </td>
+        </tr>
+      )}
+    </Fragment>
+  )
+}
+
+/**
+ * Chapter-type specific status cell: quiz score, assignment state, or a
+ * completion marker for reading/video chapters.
+ */
+function ChapterCell({ chapter }: { chapter: ChapterInfo | undefined }) {
+  if (!chapter) {
+    return (
+      <div className="flex items-center justify-center h-9 rounded bg-muted/30 text-muted-foreground/40 text-xs">
+        —
+      </div>
+    )
+  }
+
+  const type = chapter.chapter_type
+
+  if (type === "quiz" || type === "exam") {
+    if (chapter.quiz_result) {
+      const pct =
+        chapter.quiz_result.max_score > 0
+          ? Math.round((chapter.quiz_result.score / chapter.quiz_result.max_score) * 100)
+          : 0
+      return (
+        <div
+          className={`flex h-9 flex-col items-center justify-center rounded border px-1 text-xs font-medium ${
+            chapter.quiz_result.passed
+              ? "border-success/30 bg-success/10 text-success"
+              : "border-destructive/30 bg-destructive/10 text-destructive"
+          }`}
+        >
+          <span className="font-semibold">{pct}%</span>
+          <span className="text-[10px] opacity-70">
+            {chapter.quiz_result.score}/{chapter.quiz_result.max_score}
+          </span>
+        </div>
+      )
+    }
+    return <EmptyCell />
+  }
+
+  if (type === "assignment") {
+    if (chapter.assignment_result) {
+      const graded = chapter.assignment_result.grade !== null
+      return (
+        <div
+          className={`flex h-9 flex-col items-center justify-center rounded border px-1 text-xs font-medium ${
+            graded
+              ? "border-info/30 bg-info/10 text-info"
+              : "border-warning/30 bg-warning/10 text-warning"
+          }`}
+        >
+          {graded ? (
+            <>
+              <span className="font-semibold">{chapter.assignment_result.grade}pt</span>
+              <span className="text-[10px] opacity-70">graded</span>
+            </>
+          ) : (
+            <span>submitted</span>
+          )}
+        </div>
+      )
+    }
+    return <EmptyCell />
+  }
+
+  return (
+    <div className="flex items-center justify-center h-9 rounded bg-muted/20 text-muted-foreground/30 text-[10px]">
+      —
+    </div>
+  )
+}
+
+function EmptyCell() {
+  return (
+    <div className="flex items-center justify-center h-9 rounded bg-muted/30 text-muted-foreground/50 text-xs">
+      <Circle className="h-3.5 w-3.5" />
+    </div>
+  )
+}
+
+/**
+ * Compute total points earned / available for a student across the given
+ * chapter list.
+ *
+ * - Quiz / exam chapters: use the student's quiz score & max_score; count
+ *   max_score as 1 placeholder if the quiz has not been attempted.
+ * - Assignment chapters: always count `max_score ?? 100` as available;
+ *   add the grade to earned when the assignment has been graded.
+ * - Everything else (reading, video, audio): 1 point for completion.
+ */
+function computeStudentTotals(
+  chapters: ChapterInfo[],
+  chMap: Map<string, ChapterInfo> | undefined,
+): { earned: number; total: number } {
+  let earned = 0
+  let total = 0
+  for (const ch of chapters) {
+    const type = ch.chapter_type
+    if (type === "quiz" || type === "exam") {
+      const qr = chMap?.get(ch.id)?.quiz_result
+      if (qr) {
+        earned += qr.score
+        total += qr.max_score
+      } else {
+        total += 1
+      }
+    } else if (type === "assignment") {
+      const ar = chMap?.get(ch.id)?.assignment_result
+      const maxPts = ar?.max_score ?? 100
+      total += maxPts
+      if (ar?.grade !== null && ar?.grade !== undefined) {
+        earned += ar.grade
+      }
+    } else {
+      total += 1
+      if (chMap?.get(ch.id)?.completed) earned += 1
+    }
+  }
+  return { earned, total }
+}
+
+function GradeTableLegend() {
+  return (
+    <div className="mt-4 flex flex-wrap gap-4 border-t pt-4 text-xs text-muted-foreground">
+      <div className="flex items-center gap-1.5">
+        <div className="flex h-4 w-4 items-center justify-center rounded border border-success/30 bg-success/10">
+          <CheckCircle2 className="h-2.5 w-2.5 text-success" />
+        </div>
+        Completed (1 pt)
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="flex h-4 w-6 items-center justify-center rounded border border-success/30 bg-success/10 text-[9px] font-semibold text-success">
+          85%
+        </div>
+        Quiz passed
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="flex h-4 w-6 items-center justify-center rounded border border-destructive/30 bg-destructive/10 text-[9px] font-semibold text-destructive">
+          40%
+        </div>
+        Quiz failed
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="flex h-4 w-10 items-center justify-center rounded border border-info/30 bg-info/10 text-[9px] font-semibold text-info">
+          graded
+        </div>
+        Assignment graded
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="flex h-4 w-14 items-center justify-center rounded border border-warning/30 bg-warning/10 text-[9px] text-warning">
+          submitted
+        </div>
+        Assignment submitted
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="flex h-4 w-4 items-center justify-center rounded border bg-muted/30">
+          <Circle className="h-2.5 w-2.5 text-muted-foreground/40" />
+        </div>
+        Not submitted
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Teacher/gradebook/GradebookStats.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradebookStats.tsx
@@ -1,0 +1,62 @@
+import { Card, CardContent } from "@/components/ui/card"
+import { Users, Award, TrendingUp, Calculator } from "lucide-react"
+import type { GradingConfig } from "@/types"
+
+interface Props {
+  studentCount: number
+  classAverage: number
+  gradedCount: number
+  config: GradingConfig
+}
+
+/** Four-card stats row shown at the top of the gradebook. */
+export function GradebookStats({ studentCount, classAverage, gradedCount, config }: Props) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+      <StatCard
+        label="Students"
+        value={String(studentCount)}
+        icon={<Users className="h-7 w-7 text-muted-foreground/60" />}
+      />
+      <StatCard
+        label="Class Average"
+        value={`${classAverage.toFixed(1)}%`}
+        icon={<TrendingUp className="h-7 w-7 text-muted-foreground/60" />}
+      />
+      <StatCard
+        label="Manually Graded"
+        value={`${gradedCount}/${studentCount}`}
+        icon={<Award className="h-7 w-7 text-muted-foreground/60" />}
+      />
+      <StatCard
+        label="Weights Q/A/P"
+        value={`${config.quiz_weight}/${config.assignment_weight}/${config.participation_weight}`}
+        valueClassName="text-sm font-medium mt-0.5"
+        icon={<Calculator className="h-7 w-7 text-muted-foreground/60" />}
+      />
+    </div>
+  )
+}
+
+interface StatCardProps {
+  label: string
+  value: string
+  icon: React.ReactNode
+  valueClassName?: string
+}
+
+function StatCard({ label, value, icon, valueClassName }: StatCardProps) {
+  return (
+    <Card>
+      <CardContent className="pt-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs text-muted-foreground">{label}</p>
+            <p className={valueClassName ?? "text-2xl font-bold mt-0.5"}>{value}</p>
+          </div>
+          {icon}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/Teacher/gradebook/GradebookTabs.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradebookTabs.tsx
@@ -1,0 +1,50 @@
+import { TrendingUp, LayoutGrid } from "lucide-react"
+import type { ActiveTab } from "./types"
+
+interface Props {
+  active: ActiveTab
+  onChange: (tab: ActiveTab) => void
+}
+
+/** Two-button tab switcher for "Summary Grades" vs "Grade Table". */
+export function GradebookTabs({ active, onChange }: Props) {
+  return (
+    <div className="flex gap-1 mb-6 border-b">
+      <TabButton
+        active={active === "summary"}
+        onClick={() => onChange("summary")}
+        icon={<TrendingUp className="h-4 w-4" />}
+        label="Summary Grades"
+      />
+      <TabButton
+        active={active === "table"}
+        onClick={() => onChange("table")}
+        icon={<LayoutGrid className="h-4 w-4" />}
+        label="Grade Table"
+      />
+    </div>
+  )
+}
+
+interface TabButtonProps {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}
+
+function TabButton({ active, onClick, icon, label }: TabButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+        active
+          ? "border-primary text-primary"
+          : "border-transparent text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}

--- a/frontend/src/pages/Teacher/gradebook/GradingConfigCard.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradingConfigCard.tsx
@@ -1,0 +1,111 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Settings2, ChevronDown, ChevronRight, Save } from "lucide-react"
+import type { GradingConfig } from "@/types"
+
+interface Props {
+  open: boolean
+  onToggle: () => void
+  draft: GradingConfig
+  onDraftChange: (next: GradingConfig) => void
+  onSave: () => void
+  saving: boolean
+}
+
+/**
+ * Collapsible card where a teacher edits the quiz/assignment/participation
+ * weight split. The component enforces that the three weights must sum
+ * to 100 before the save button becomes clickable.
+ */
+export function GradingConfigCard({
+  open,
+  onToggle,
+  draft,
+  onDraftChange,
+  onSave,
+  saving,
+}: Props) {
+  const total = draft.quiz_weight + draft.assignment_weight + draft.participation_weight
+  const valid = total === 100
+
+  return (
+    <Card className="mb-6">
+      <CardHeader className="cursor-pointer select-none py-4" onClick={onToggle}>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Settings2 className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <CardTitle className="text-base">Grading Configuration</CardTitle>
+              <CardDescription className="text-xs">
+                Set how quizzes, assignments, and participation contribute to final grades
+              </CardDescription>
+            </div>
+          </div>
+          {open ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </CardHeader>
+      {open && (
+        <CardContent className="border-t pt-6">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+            <WeightField
+              label="Quiz Weight (%)"
+              value={draft.quiz_weight}
+              onChange={(v) => onDraftChange({ ...draft, quiz_weight: v })}
+            />
+            <WeightField
+              label="Assignment Weight (%)"
+              value={draft.assignment_weight}
+              onChange={(v) => onDraftChange({ ...draft, assignment_weight: v })}
+            />
+            <WeightField
+              label="Participation Weight (%)"
+              value={draft.participation_weight}
+              onChange={(v) => onDraftChange({ ...draft, participation_weight: v })}
+            />
+          </div>
+          <div className="flex items-center justify-between mt-4">
+            <p
+              className={`text-sm font-medium ${
+                valid ? "text-success" : "text-destructive"
+              }`}
+            >
+              Total: {total}% {valid ? "✓" : "(must equal 100%)"}
+            </p>
+            <Button size="sm" onClick={onSave} disabled={!valid || saving}>
+              <Save className="h-3.5 w-3.5 mr-1.5" />
+              {saving ? "Saving..." : "Save Weights"}
+            </Button>
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  )
+}
+
+interface WeightFieldProps {
+  label: string
+  value: number
+  onChange: (next: number) => void
+}
+
+function WeightField({ label, value, onChange }: WeightFieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      <Input
+        type="number"
+        min={0}
+        max={100}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value) || 0)}
+        className="h-9"
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/Teacher/gradebook/SummaryTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/SummaryTab.tsx
@@ -1,0 +1,366 @@
+import { useMemo } from "react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  ChevronDown, ChevronRight,
+  ArrowUp, ArrowDown, ArrowUpDown,
+  Save, Award, MessageSquare,
+} from "lucide-react"
+import type {
+  GradingConfig,
+  GradeSummaryResponse,
+  StudentGrade,
+  StudentCalculatedGrade,
+} from "@/types"
+import {
+  LETTER_ORDER,
+  type SortField,
+  type SortDir,
+  type GradeForm,
+} from "./types"
+import { letterColor } from "./helpers"
+
+interface Props {
+  summary: GradeSummaryResponse | null
+  config: GradingConfig
+  manualGrades: Map<string, StudentGrade>
+  forms: Map<string, GradeForm>
+  saving: string | null
+  expandedId: string | null
+  sortField: SortField
+  sortDir: SortDir
+  onSortChange: (field: SortField, dir: SortDir) => void
+  onToggleExpand: (userId: string) => void
+  onUpdateForm: (userId: string, field: keyof GradeForm, value: string) => void
+  onSaveGrade: (userId: string) => void
+}
+
+/**
+ * "Summary Grades" tab: auto-calculated quiz/assignment/participation
+ * breakdown per student with an inline panel for manual grade overrides.
+ */
+export function SummaryTab({
+  summary,
+  config,
+  manualGrades,
+  forms,
+  saving,
+  expandedId,
+  sortField,
+  sortDir,
+  onSortChange,
+  onToggleExpand,
+  onUpdateForm,
+  onSaveGrade,
+}: Props) {
+  const sortedStudents = useMemo(() => {
+    if (!summary) return []
+    const list = [...summary.students]
+    const dir = sortDir === "asc" ? 1 : -1
+    list.sort((a, b) => {
+      let cmp = 0
+      switch (sortField) {
+        case "name":
+          cmp = (a.student_name ?? "").localeCompare(b.student_name ?? "")
+          break
+        case "quiz":
+          cmp = a.breakdown.quiz_avg - b.breakdown.quiz_avg
+          break
+        case "assignment":
+          cmp = a.breakdown.assignment_avg - b.breakdown.assignment_avg
+          break
+        case "participation":
+          cmp = a.breakdown.participation_pct - b.breakdown.participation_pct
+          break
+        case "final":
+          cmp = a.breakdown.final_score - b.breakdown.final_score
+          break
+        case "letter":
+          cmp =
+            (LETTER_ORDER[a.breakdown.letter_grade] ?? 0) -
+            (LETTER_ORDER[b.breakdown.letter_grade] ?? 0)
+          break
+      }
+      return cmp * dir
+    })
+    return list
+  }, [summary, sortField, sortDir])
+
+  const studentCount = sortedStudents.length
+  const classAvg = summary?.class_average ?? 0
+
+  const toggleSort = (field: SortField) => {
+    if (sortField === field) {
+      onSortChange(field, sortDir === "asc" ? "desc" : "asc")
+    } else {
+      onSortChange(field, field === "name" ? "asc" : "desc")
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Student Grades</CardTitle>
+        <CardDescription>
+          Auto-calculated based on quiz scores, assignment grades, and chapter completion. Click a student to override manually.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {studentCount === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">No students enrolled yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <div className="grid grid-cols-[1fr_80px_80px_90px_80px_70px_70px] gap-3 px-4 py-3 border-b bg-muted/30 rounded-t-lg min-w-[700px]">
+              <SortHeader field="name" label="Student" sortField={sortField} sortDir={sortDir} onToggle={toggleSort} />
+              <SortHeader field="quiz" label="Quiz" sortField={sortField} sortDir={sortDir} onToggle={toggleSort} className="justify-end" />
+              <SortHeader field="assignment" label="Assign." sortField={sortField} sortDir={sortDir} onToggle={toggleSort} className="justify-end" />
+              <SortHeader field="participation" label="Particip." sortField={sortField} sortDir={sortDir} onToggle={toggleSort} className="justify-end" />
+              <SortHeader field="final" label="Final" sortField={sortField} sortDir={sortDir} onToggle={toggleSort} className="justify-end" />
+              <SortHeader field="letter" label="Grade" sortField={sortField} sortDir={sortDir} onToggle={toggleSort} className="justify-center" />
+              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground text-center">Manual</span>
+            </div>
+
+            <div className="divide-y min-w-[700px]">
+              {sortedStudents.map((student) => (
+                <StudentSummaryRow
+                  key={student.student_id}
+                  student={student}
+                  config={config}
+                  manualGrade={manualGrades.get(student.student_id)}
+                  form={forms.get(student.student_id) ?? { grade: "", comment: "" }}
+                  expanded={expandedId === student.student_id}
+                  saving={saving === student.student_id}
+                  onToggleExpand={onToggleExpand}
+                  onUpdateForm={onUpdateForm}
+                  onSaveGrade={onSaveGrade}
+                />
+              ))}
+
+              {summary && studentCount > 0 && (
+                <ClassAverageRow
+                  summary={summary}
+                  studentCount={studentCount}
+                  classAvg={classAvg}
+                />
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+interface SortHeaderProps {
+  field: SortField
+  label: string
+  sortField: SortField
+  sortDir: SortDir
+  onToggle: (field: SortField) => void
+  className?: string
+}
+
+function SortHeader({ field, label, sortField, sortDir, onToggle, className }: SortHeaderProps) {
+  const active = sortField === field
+  return (
+    <button
+      onClick={() => onToggle(field)}
+      className={`flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors ${
+        className ?? ""
+      }`}
+    >
+      {label}
+      {active ? (
+        sortDir === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />
+      ) : (
+        <ArrowUpDown className="h-3 w-3 opacity-40" />
+      )}
+    </button>
+  )
+}
+
+interface StudentSummaryRowProps {
+  student: StudentCalculatedGrade
+  config: GradingConfig
+  manualGrade: StudentGrade | undefined
+  form: GradeForm
+  expanded: boolean
+  saving: boolean
+  onToggleExpand: (userId: string) => void
+  onUpdateForm: (userId: string, field: keyof GradeForm, value: string) => void
+  onSaveGrade: (userId: string) => void
+}
+
+function StudentSummaryRow({
+  student,
+  config,
+  manualGrade,
+  form,
+  expanded,
+  saving,
+  onToggleExpand,
+  onUpdateForm,
+  onSaveGrade,
+}: StudentSummaryRowProps) {
+  const b = student.breakdown
+  const hasDifferentManual = Boolean(manualGrade?.grade && manualGrade.grade !== b.letter_grade)
+
+  return (
+    <div>
+      <div
+        className="grid grid-cols-[1fr_80px_80px_90px_80px_70px_70px] gap-3 px-4 py-3 cursor-pointer hover:bg-muted/30 transition-colors items-center"
+        onClick={() => onToggleExpand(student.student_id)}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          )}
+          <div className="min-w-0">
+            <p className="text-sm font-medium truncate">{student.student_name || "Unknown"}</p>
+            <p className="text-xs text-muted-foreground truncate">{student.student_email}</p>
+          </div>
+        </div>
+        <p className="text-sm tabular-nums text-right">{b.quiz_avg.toFixed(1)}%</p>
+        <p className="text-sm tabular-nums text-right">{b.assignment_avg.toFixed(1)}%</p>
+        <p className="text-sm tabular-nums text-right">{b.participation_pct.toFixed(1)}%</p>
+        <p className="text-sm font-semibold tabular-nums text-right">{b.final_score.toFixed(1)}%</p>
+        <div className="flex justify-center">
+          <span className={`inline-flex items-center justify-center rounded-full px-2.5 py-0.5 text-xs font-bold ${letterColor(b.letter_grade)}`}>
+            {b.letter_grade}
+          </span>
+        </div>
+        <div className="flex justify-center">
+          {manualGrade?.grade ? (
+            <span
+              className={`inline-flex items-center justify-center rounded-full px-2.5 py-0.5 text-xs font-bold ${
+                hasDifferentManual
+                  ? "bg-warning/15 text-warning ring-1 ring-warning/30"
+                  : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {manualGrade.grade}
+            </span>
+          ) : (
+            <span className="text-xs text-muted-foreground">—</span>
+          )}
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t px-4 py-4 bg-muted/10 space-y-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-2 text-sm">
+            <BreakdownEntry
+              label="Quiz Avg:"
+              pct={b.quiz_avg}
+              weight={config.quiz_weight}
+              weighted={b.quiz_weighted}
+            />
+            <BreakdownEntry
+              label="Assignment Avg:"
+              pct={b.assignment_avg}
+              weight={config.assignment_weight}
+              weighted={b.assignment_weighted}
+            />
+            <BreakdownEntry
+              label="Participation:"
+              pct={b.participation_pct}
+              weight={config.participation_weight}
+              weighted={b.participation_weighted}
+            />
+          </div>
+
+          {hasDifferentManual && (
+            <div className="rounded border border-border border-l-[3px] border-l-warning bg-warning/10 px-3 py-2 text-xs text-foreground">
+              Manual grade <strong>{manualGrade?.grade}</strong> differs from calculated{" "}
+              <strong>{b.letter_grade}</strong> ({b.final_score.toFixed(1)}%)
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 sm:grid-cols-[120px_1fr] gap-3">
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium flex items-center gap-1">
+                <Award className="h-3 w-3" /> Override Grade
+              </label>
+              <Input
+                value={form.grade}
+                onChange={(e) => onUpdateForm(student.student_id, "grade", e.target.value)}
+                placeholder="A, B+, 95..."
+                className="h-9"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium flex items-center gap-1">
+                <MessageSquare className="h-3 w-3" /> Comment
+              </label>
+              <Input
+                value={form.comment}
+                onChange={(e) => onUpdateForm(student.student_id, "comment", e.target.value)}
+                placeholder="Teacher's note..."
+                className="h-9"
+              />
+            </div>
+          </div>
+
+          <Button
+            size="sm"
+            onClick={() => onSaveGrade(student.student_id)}
+            disabled={saving}
+          >
+            <Save className="h-3.5 w-3.5 mr-1.5" />
+            {saving ? "Saving..." : "Save Manual Grade"}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BreakdownEntry({
+  label,
+  pct,
+  weight,
+  weighted,
+}: {
+  label: string
+  pct: number
+  weight: number
+  weighted: number
+}) {
+  return (
+    <div>
+      <span className="text-muted-foreground">{label}</span>{" "}
+      <span className="font-medium">{pct.toFixed(1)}%</span>
+      <span className="text-muted-foreground text-xs ml-1">
+        (×{weight}% = {weighted.toFixed(1)})
+      </span>
+    </div>
+  )
+}
+
+function ClassAverageRow({
+  summary,
+  studentCount,
+  classAvg,
+}: {
+  summary: GradeSummaryResponse
+  studentCount: number
+  classAvg: number
+}) {
+  const avg = (pick: (s: StudentCalculatedGrade) => number) =>
+    summary.students.reduce((acc, st) => acc + pick(st), 0) / studentCount
+
+  return (
+    <div className="grid grid-cols-[1fr_80px_80px_90px_80px_70px_70px] gap-3 px-4 py-3 bg-muted/40 font-semibold text-sm items-center border-t-2">
+      <span className="pl-6">Class Average ({studentCount} students)</span>
+      <p className="tabular-nums text-right">{avg((s) => s.breakdown.quiz_avg).toFixed(1)}%</p>
+      <p className="tabular-nums text-right">{avg((s) => s.breakdown.assignment_avg).toFixed(1)}%</p>
+      <p className="tabular-nums text-right">{avg((s) => s.breakdown.participation_pct).toFixed(1)}%</p>
+      <p className="tabular-nums text-right">{classAvg.toFixed(1)}%</p>
+      <span />
+      <span />
+    </div>
+  )
+}

--- a/frontend/src/pages/Teacher/gradebook/helpers.tsx
+++ b/frontend/src/pages/Teacher/gradebook/helpers.tsx
@@ -1,0 +1,38 @@
+import {
+  HelpCircle,
+  GraduationCap,
+  ClipboardList,
+  FileText,
+} from "lucide-react"
+
+/** Pill background/foreground tokens per letter-grade bucket. */
+export function letterColor(letter: string): string {
+  switch (letter) {
+    case "A":
+      return "bg-success/15 text-success"
+    case "B":
+      return "bg-info/15 text-info"
+    case "C":
+      return "bg-accent/20 text-foreground"
+    case "D":
+      return "bg-warning/15 text-warning"
+    case "F":
+      return "bg-destructive/15 text-destructive"
+    default:
+      return "bg-muted text-muted-foreground"
+  }
+}
+
+/** Tiny icon (12px) that classifies a chapter in the grade table. */
+export function chapterTypeIcon(type: string) {
+  switch (type) {
+    case "quiz":
+      return <HelpCircle className="h-3 w-3" />
+    case "exam":
+      return <GraduationCap className="h-3 w-3" />
+    case "assignment":
+      return <ClipboardList className="h-3 w-3" />
+    default:
+      return <FileText className="h-3 w-3" />
+  }
+}

--- a/frontend/src/pages/Teacher/gradebook/types.ts
+++ b/frontend/src/pages/Teacher/gradebook/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared types for the Gradebook feature. Most of these mirror the
+ * shapes returned by the progress and grade-summary endpoints, narrowed
+ * to the fields the UI actually consumes.
+ */
+
+export const SORT_FIELDS = [
+  "name",
+  "quiz",
+  "assignment",
+  "participation",
+  "final",
+  "letter",
+] as const
+export type SortField = (typeof SORT_FIELDS)[number]
+export type SortDir = "asc" | "desc"
+
+export const TABS = ["summary", "table"] as const
+export type ActiveTab = (typeof TABS)[number]
+
+export interface ChapterInfo {
+  id: string
+  title: string
+  module_id: string
+  chapter_type: string
+  completed: boolean
+  completed_by: "self" | "teacher" | null
+  quiz_result: { score: number; max_score: number; passed: boolean } | null
+  assignment_result: {
+    status: string
+    grade: number | null
+    max_score?: number
+  } | null
+}
+
+export interface StudentProgressData {
+  id: string
+  full_name: string
+  email: string
+  progress: number
+  chapters_completed: number
+  total_chapters: number
+  chapters: ChapterInfo[]
+  quiz_results: Array<{
+    chapter_id: string
+    score: number
+    max_score: number
+    passed: boolean
+  }>
+  assignment_results: Array<{
+    chapter_id: string
+    status: string
+    grade: number | null
+    max_score: number
+  }>
+}
+
+export interface ModuleInfo {
+  id: string
+  title: string
+  order_index: number
+}
+
+export interface ProgressResponse {
+  course_id: string
+  course_title: string
+  total_chapters: number
+  total_students: number
+  modules: ModuleInfo[]
+  students: StudentProgressData[]
+}
+
+export interface GradeForm {
+  grade: string
+  comment: string
+}
+
+/** Ordered ranking used when sorting students by letter grade. */
+export const LETTER_ORDER: Record<string, number> = {
+  A: 5,
+  B: 4,
+  C: 3,
+  D: 2,
+  F: 1,
+}


### PR DESCRIPTION
## Summary

`TeacherGradebook.tsx` had grown to **1,003 lines** holding two large
inline views (summary + grade table), a `ChapterCell` helper, a sort
widget, a stats row, a collapsible weight editor, and all data-loading
logic. It was the biggest single page in the app and every new feature
made it worse.

This PR breaks it into a thin orchestrator (337 lines) plus a focused
`pages/Teacher/gradebook/` folder of pure render components.

### Before → After

| Location | Before | After |
|---|---|---|
| `TeacherGradebook.tsx` | **1,003 lines** | 337 lines |
| `gradebook/types.ts` | — | 77 lines |
| `gradebook/helpers.tsx` | — | 36 lines |
| `gradebook/GradebookStats.tsx` | — | 58 lines |
| `gradebook/GradebookTabs.tsx` | — | 46 lines |
| `gradebook/GradingConfigCard.tsx` | — | 106 lines |
| `gradebook/SummaryTab.tsx` | — | 347 lines |
| `gradebook/GradeTableTab.tsx` | — | 437 lines |

### What changed

- Extracted two tab views (`SummaryTab`, `GradeTableTab`) into their
  own files. Inside each, row rendering, legend, and header sub-parts
  are also their own small components.
- Pulled four reusable pieces out as siblings: `GradebookStats`,
  `GradebookTabs`, `GradingConfigCard`, plus shared `types.ts` and
  `helpers.tsx` (`letterColor`, `chapterTypeIcon`).
- The orchestrator still owns all mutable state — config drafts, manual
  grade forms, expanded row, sort query-params, loaders — and passes
  everything in by props. The tab components are pure and prop-driven.
- Added doc comments describing what each sub-component does and what
  the `computeStudentTotals` rules are.

### Why

- One file no longer exceeds ~440 lines, which makes review and future
  edits dramatically easier.
- Every sub-piece has a single responsibility, clear props, and is
  trivially testable in isolation.
- Future gradebook features (e.g. column chooser, CSV import, bulk
  edit) now have an obvious home instead of piling onto one file.

No behavioral change: every loader, cache call, toast, sort rule, URL
param, and keyboard interaction is preserved verbatim.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npx vitest run` — 85/85 tests pass
- [ ] CI: backend-ci, frontend-ci, pr-check all green
