### PR TITLE
refactor(frontend): decompose AdminDashboard into tab-scoped components

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -1,107 +1,103 @@
 import { useEffect, useState, useMemo, useCallback } from "react"
 import { Navigate, useSearchParams } from "react-router-dom"
 import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
 import { useAuth } from "@/context/useAuth"
 import { coursesService } from "@/services/courses"
+import type { AuditLogQuery } from "@/services/audit"
 import { getErrorDetail } from "@/lib/errorDetail"
 import { supabase } from "@/lib/supabase"
-import type { UserRole, Certificate, AuditLogEntry } from "@/types"
+import type { UserRole, AuditLogEntry } from "@/types"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { toast } from "@/lib/toast"
-import {
-  Users, BookOpen, GraduationCap, Shield, Search, Clock,
-  CheckCircle, XCircle, Award, FileText, ChevronLeft, ChevronRight,
-  Trash2,
-} from "lucide-react"
-import { toProxyImage } from "@/lib/images"
+import { Shield } from "lucide-react"
 import { useConfirm } from "@/components/ui/alert-dialog"
-import VirtualAdminUsers from "./VirtualAdminUsers"
-import PageSpinner from "@/components/ui/PageSpinner"
+import { ErrorState } from "@/components/patterns"
+import {
+  ADMIN_TABS,
+  ISO_DATE_REGEX,
+  ACTION_OPTIONS,
+  RESOURCE_OPTIONS,
+  type AdminTab,
+  type ProfileRow,
+  type AdminStats,
+} from "./dashboard/constants"
+import { AdminTabs } from "./dashboard/AdminTabs"
+import { OverviewStats } from "./dashboard/OverviewStats"
+import { PendingTeachersCard } from "./dashboard/PendingTeachersCard"
+import { PendingCertsCard, type AdminCert } from "./dashboard/PendingCertsCard"
+import { UsersCard } from "./dashboard/UsersCard"
+import { AuditLogTab } from "./dashboard/AuditLogTab"
 
-// Above this row count we swap the full <table> render for a react-window list.
-// Small tenants keep the familiar semantic table; large tenants avoid paying
-// 500 avatar images + 500 <select> elements worth of DOM on mount.
-const USERS_VIRTUAL_THRESHOLD = 50
+const AUDIT_PAGE_SIZE = 25
 
-interface ProfileRow {
-  id: string
-  email: string
-  full_name: string | null
-  role: UserRole
-  created_at: string
-  avatar_url: string | null
-}
-
-interface Stats {
-  users: number
-  courses: number
-  enrollments: number
-}
-
-type Tab = "overview" | "audit"
-
-const TABS: readonly Tab[] = ["overview", "audit"]
-
-const ACTION_OPTIONS = ["create", "update", "delete", "publish", "enroll", "approve", "reject", "grade"] as const
-const RESOURCE_OPTIONS = ["course", "module", "chapter", "enrollment", "certificate", "assignment_submission", "user"] as const
-const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
-
-const actionBadgeClass: Record<string, string> = {
-  create: "bg-success/15 text-success",
-  update: "bg-info/15 text-info",
-  delete: "bg-destructive/15 text-destructive",
-  publish: "bg-primary/15 text-primary",
-  enroll: "bg-info/15 text-info",
-  approve: "bg-success/15 text-success",
-  reject: "bg-destructive/15 text-destructive",
-  grade: "bg-warning/15 text-warning",
-}
-
+/**
+ * Admin dashboard orchestrator. Owns every piece of mutable state
+ * (users, stats, certs, audit filters, selection set, loaders) and
+ * passes pure-presentation children in `dashboard/` the props they
+ * need. The CSS here is intentionally minimal — the real UI work lives
+ * in `dashboard/` tab-scoped components.
+ */
 export default function AdminDashboard() {
   const { user } = useAuth()
   const confirm = useConfirm()
   const [params, setParams] = useSearchParams()
+
   const rawTab = params.get("tab")
-  const tab: Tab = TABS.includes(rawTab as Tab) ? (rawTab as Tab) : "overview"
-  const { input: searchInput, setInput: setSearchInput, value: urlQuery, maxLength: MAX_SEARCH_LEN } = useDebouncedSearchParam()
+  const tab: AdminTab = ADMIN_TABS.includes(rawTab as AdminTab)
+    ? (rawTab as AdminTab)
+    : "overview"
+
+  const {
+    input: searchInput,
+    setInput: setSearchInput,
+    value: urlQuery,
+    maxLength: MAX_SEARCH_LEN,
+  } = useDebouncedSearchParam()
+
   const [users, setUsers] = useState<ProfileRow[]>([])
-  const [stats, setStats] = useState<Stats>({ users: 0, courses: 0, enrollments: 0 })
+  const [stats, setStats] = useState<AdminStats>({ users: 0, courses: 0, enrollments: 0 })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [updatingId, setUpdatingId] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [bulkRole, setBulkRole] = useState<UserRole>("student")
   const [bulkUpdating, setBulkUpdating] = useState(false)
-  const [adminCerts, setAdminCerts] = useState<(Certificate & { student_name?: string; course_title?: string; approved_by_name?: string; approved_at?: string })[]>([])
+  const [adminCerts, setAdminCerts] = useState<AdminCert[]>([])
   const [certActionId, setCertActionId] = useState<string | null>(null)
 
   const [auditLogs, setAuditLogs] = useState<AuditLogEntry[]>([])
   const [auditTotal, setAuditTotal] = useState(0)
   const [auditLoading, setAuditLoading] = useState(false)
-  const auditPageSize = 25
 
-  const pickOption = <T extends readonly string[]>(val: string | null, opts: T): T[number] | "" =>
+  const pickOption = <T extends readonly string[]>(
+    val: string | null,
+    opts: T,
+  ): T[number] | "" =>
     val && (opts as readonly string[]).includes(val) ? (val as T[number]) : ""
 
   const auditAction = pickOption(params.get("ax"), ACTION_OPTIONS)
   const auditResource = pickOption(params.get("ar"), RESOURCE_OPTIONS)
-  const auditDateFrom = ISO_DATE.test(params.get("af") ?? "") ? params.get("af")! : ""
-  const auditDateTo = ISO_DATE.test(params.get("at") ?? "") ? params.get("at")! : ""
+  const auditDateFrom = ISO_DATE_REGEX.test(params.get("af") ?? "") ? params.get("af")! : ""
+  const auditDateTo = ISO_DATE_REGEX.test(params.get("at") ?? "") ? params.get("at")! : ""
   const rawPage = Number.parseInt(params.get("ap") ?? "1", 10)
   const auditPage = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1
 
-  const updateAudit = (patch: Record<string, string | null>, opts: { resetPage?: boolean } = {}) =>
-    setParams((prev) => {
-      const n = new URLSearchParams(prev)
-      for (const [k, v] of Object.entries(patch)) {
-        if (v) n.set(k, v); else n.delete(k)
-      }
-      if (opts.resetPage) n.delete("ap")
-      return n
-    }, { replace: true })
+  const updateAudit = useCallback(
+    (patch: Record<string, string | null>, opts: { resetPage?: boolean } = {}) =>
+      setParams(
+        (prev) => {
+          const n = new URLSearchParams(prev)
+          for (const [k, v] of Object.entries(patch)) {
+            if (v) n.set(k, v)
+            else n.delete(k)
+          }
+          if (opts.resetPage) n.delete("ap")
+          return n
+        },
+        { replace: true },
+      ),
+    [setParams],
+  )
 
   const [reloadKey, setReloadKey] = useState(0)
   const reload = useCallback(() => setReloadKey((k) => k + 1), [])
@@ -132,7 +128,9 @@ export default function AdminDashboard() {
         if (!cancelled) setLoading(false)
       }
     })()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [reloadKey])
 
   useEffect(() => {
@@ -141,9 +139,9 @@ export default function AdminDashboard() {
     setAuditLoading(true)
     ;(async () => {
       try {
-        const query: Record<string, string | number> = {
+        const query: AuditLogQuery = {
           page: auditPage,
-          page_size: auditPageSize,
+          page_size: AUDIT_PAGE_SIZE,
         }
         if (auditAction) query.action = auditAction
         if (auditResource) query.resource_type = auditResource
@@ -154,18 +152,22 @@ export default function AdminDashboard() {
         if (cancelled) return
         setAuditLogs(data.items ?? [])
         setAuditTotal(data.total ?? 0)
-      } catch (error: unknown) {
+      } catch (err: unknown) {
         if (cancelled) return
-        const detail = getErrorDetail(error) || "The audit_logs table may not exist yet. Deploy the latest migration."
+        const detail =
+          getErrorDetail(err) ||
+          "The audit_logs table may not exist yet. Deploy the latest migration."
         toast({ title: `Audit log error: ${detail}`, variant: "destructive" })
       } finally {
         if (!cancelled) setAuditLoading(false)
       }
     })()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [tab, auditPage, auditAction, auditResource, auditDateFrom, auditDateTo])
 
-  const setTab = (nextTab: Tab) => {
+  const setTab = (nextTab: AdminTab) => {
     const next = new URLSearchParams(params)
     if (nextTab === "overview") next.delete("tab")
     else next.set("tab", nextTab)
@@ -176,38 +178,32 @@ export default function AdminDashboard() {
     const q = urlQuery.trim().toLowerCase()
     if (!q) return users
     return users.filter(
-      (u) =>
-        u.full_name?.toLowerCase().includes(q) ||
-        u.email.toLowerCase().includes(q),
+      (u) => u.full_name?.toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
     )
   }, [users, urlQuery])
+
   const userMap = useMemo(() => {
     const map: Record<string, string> = {}
     for (const u of users) map[u.id] = u.full_name || u.email
     return map
   }, [users])
-  const totalAuditPages = Math.max(1, Math.ceil(auditTotal / auditPageSize))
 
   const filteredIds = useMemo(() => new Set(filtered.map((u) => u.id)), [filtered])
 
   useEffect(() => {
-    setSelectedIds(prev => {
-      const narrowed = new Set([...prev].filter(id => filteredIds.has(id)))
+    setSelectedIds((prev) => {
+      const narrowed = new Set([...prev].filter((id) => filteredIds.has(id)))
       return narrowed.size === prev.size ? prev : narrowed
     })
   }, [filteredIds])
 
-  if (user?.role !== "admin") {
-    return <Navigate to="/" replace />
-  }
+  if (user?.role !== "admin") return <Navigate to="/" replace />
 
   const handleRoleChange = async (userId: string, newRole: UserRole) => {
     setUpdatingId(userId)
     try {
       await coursesService.updateUserRole(userId, newRole)
-      setUsers((prev) =>
-        prev.map((u) => (u.id === userId ? { ...u, role: newRole } : u)),
-      )
+      setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, role: newRole } : u)))
       toast({ title: "Role updated", variant: "success" })
     } catch {
       toast({ title: "Failed to update role", variant: "destructive" })
@@ -237,14 +233,18 @@ export default function AdminDashboard() {
       })
       toast({ title: "User deleted", variant: "success" })
     } catch (err) {
-      toast({ title: getErrorDetail(err, "Failed to delete user"), variant: "destructive" })
+      toast({
+        title: getErrorDetail(err, "Failed to delete user"),
+        variant: "destructive",
+      })
     } finally {
       setUpdatingId(null)
     }
   }
 
   const toggleSelectAll = () => {
-    const allFilteredSelected = filtered.length > 0 && filtered.every(u => selectedIds.has(u.id))
+    const allFilteredSelected =
+      filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
     if (allFilteredSelected) {
       setSelectedIds(new Set())
     } else {
@@ -277,23 +277,23 @@ export default function AdminDashboard() {
         prev.map((u) => (ids.includes(u.id) ? { ...u, role: bulkRole } : u)),
       )
       setSelectedIds(new Set())
-      toast({ title: `Updated ${result.updated} user(s) to ${bulkRole}`, variant: "success" })
+      toast({
+        title: `Updated ${result.updated} user(s) to ${bulkRole}`,
+        variant: "success",
+      })
     } catch (err) {
-      toast({ title: getErrorDetail(err, "Bulk update failed"), variant: "destructive" })
+      toast({
+        title: getErrorDetail(err, "Bulk update failed"),
+        variant: "destructive",
+      })
     } finally {
       setBulkUpdating(false)
     }
   }
 
-  const statCards = [
-    { label: "Total Users", value: stats.users, icon: Users },
-    { label: "Total Courses", value: stats.courses, icon: BookOpen },
-    { label: "Total Enrollments", value: stats.enrollments, icon: GraduationCap },
-  ]
-
   const pendingTeachers = users.filter((u) => u.role === "pending_teacher")
 
-  const handleApproveTeacher = async (userId: string) => {
+  const handleApproveTeacherRaw = async (userId: string) => {
     setUpdatingId(userId)
     try {
       await coursesService.updateUserRole(userId, "teacher")
@@ -308,7 +308,7 @@ export default function AdminDashboard() {
     }
   }
 
-  const handleDenyTeacher = async (userId: string) => {
+  const handleDenyTeacherRaw = async (userId: string) => {
     setUpdatingId(userId)
     try {
       await coursesService.updateUserRole(userId, "student")
@@ -321,6 +321,25 @@ export default function AdminDashboard() {
     } finally {
       setUpdatingId(null)
     }
+  }
+
+  const approvePendingTeacher = async (u: ProfileRow) => {
+    const ok = await confirm({
+      title: "Approve this teacher?",
+      description: `${u.full_name || u.email} will gain access to teacher features.`,
+      confirmLabel: "Approve",
+    })
+    if (ok) handleApproveTeacherRaw(u.id)
+  }
+
+  const denyPendingTeacher = async (u: ProfileRow) => {
+    const ok = await confirm({
+      title: "Deny this teacher?",
+      description: `${u.full_name || u.email}'s teacher request will be rejected.`,
+      confirmLabel: "Deny",
+      tone: "destructive",
+    })
+    if (ok) handleDenyTeacherRaw(u.id)
   }
 
   const handleFinalApproveCert = async (certId: string) => {
@@ -349,20 +368,6 @@ export default function AdminDashboard() {
     }
   }
 
-  const roleDisplayNames: Record<UserRole, string> = {
-    student: "Student",
-    pending_teacher: "Pending Teacher",
-    teacher: "Teacher",
-    admin: "Admin",
-  }
-
-  const roleBadgeClass: Record<UserRole, string> = {
-    admin: "bg-destructive/15 text-destructive",
-    teacher: "bg-primary/15 text-primary",
-    pending_teacher: "bg-warning/15 text-warning",
-    student: "bg-info/15 text-info",
-  }
-
   const resetAuditFilters = () =>
     updateAudit({ ax: null, ar: null, af: null, at: null, ap: null })
 
@@ -374,538 +379,87 @@ export default function AdminDashboard() {
         </div>
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Admin Dashboard</h1>
-          <p className="text-muted-foreground mt-0.5">Manage users, roles, and monitor platform activity</p>
+          <p className="text-muted-foreground mt-0.5">
+            Manage users, roles, and monitor platform activity
+          </p>
         </div>
       </div>
 
-      {/* Tabs */}
-      <div className="flex gap-1 mb-8 border-b">
-        <button
-          onClick={() => setTab("overview")}
-          className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
-            tab === "overview"
-              ? "text-primary"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <div className="flex items-center gap-2">
-            <Users className="h-4 w-4" />
-            Overview
-          </div>
-          {tab === "overview" && (
-            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-t" />
-          )}
-        </button>
-        <button
-          onClick={() => setTab("audit")}
-          className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
-            tab === "audit"
-              ? "text-primary"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <div className="flex items-center gap-2">
-            <FileText className="h-4 w-4" />
-            Audit Log
-          </div>
-          {tab === "audit" && (
-            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-t" />
-          )}
-        </button>
-      </div>
+      <AdminTabs active={tab} onChange={setTab} />
 
       {error && (
-        <Card className="mb-8 border-destructive/30">
-          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-            <Shield className="h-12 w-12 text-destructive/40 mb-4" />
-            <h3 className="text-lg font-medium mb-1">Something went wrong</h3>
-            <p className="text-sm text-muted-foreground mb-4">{error}</p>
+        <ErrorState
+          icon={<Shield />}
+          description={error}
+          action={
             <Button onClick={reload} size="sm" variant="outline">
               Try again
             </Button>
-          </CardContent>
-        </Card>
+          }
+          className="mb-8"
+        />
       )}
 
-      {!error && tab === "overview" && <>
-      {/* Stats */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-        {statCards.map((s) => (
-          <Card key={s.label}>
-            <CardContent className="flex items-center gap-4 p-6">
-              <div className="rounded-md bg-muted p-3">
-                <s.icon className="h-6 w-6 text-muted-foreground" />
-              </div>
-              <div>
-                <p className="text-sm text-muted-foreground">{s.label}</p>
-                <p className="text-2xl font-bold">
-                  {loading ? "—" : s.value.toLocaleString()}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {/* Pending Teacher Approvals */}
-      {pendingTeachers.length > 0 && (
-        <Card className="mb-8 border-l-[3px] border-l-warning">
-          <CardHeader>
-            <CardTitle className="text-xl flex items-center gap-2">
-              <Clock className="h-5 w-5 text-warning" />
-              Pending Teacher Approvals
-              <Badge variant="warning" className="font-normal">
-                {pendingTeachers.length}
-              </Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {pendingTeachers.map((u) => (
-                <div
-                  key={u.id}
-                  className="flex items-center justify-between rounded-md border border-l-[3px] border-l-warning/60 bg-warning/5 p-4"
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    {u.avatar_url ? (
-                      <img src={toProxyImage(u.avatar_url)} alt={`${u.full_name ?? u.email} avatar`} className="h-10 w-10 rounded-full object-cover" />
-                    ) : (
-                      <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center text-sm font-medium text-muted-foreground">
-                        {(u.full_name?.[0] ?? u.email[0] ?? "?").toUpperCase()}
-                      </div>
-                    )}
-                    <div className="min-w-0">
-                      <p className="font-medium truncate">{u.full_name || "No name"}</p>
-                      <p className="text-sm text-muted-foreground truncate">{u.email}</p>
-                      <p className="text-xs text-muted-foreground">
-                        Registered {new Date(u.created_at).toLocaleDateString()}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2 shrink-0 ml-4">
-                    <Button
-                      size="sm"
-                      onClick={async () => {
-                        const ok = await confirm({
-                          title: "Approve this teacher?",
-                          description: `${u.full_name || u.email} will gain access to teacher features.`,
-                          confirmLabel: "Approve",
-                        })
-                        if (ok) handleApproveTeacher(u.id)
-                      }}
-                      disabled={updatingId === u.id}
-                    >
-                      <CheckCircle className="h-4 w-4 mr-1.5" />
-                      Approve
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={async () => {
-                        const ok = await confirm({
-                          title: "Deny this teacher?",
-                          description: `${u.full_name || u.email}'s teacher request will be rejected.`,
-                          confirmLabel: "Deny",
-                          tone: "destructive",
-                        })
-                        if (ok) handleDenyTeacher(u.id)
-                      }}
-                      disabled={updatingId === u.id}
-                      className="text-destructive hover:text-destructive"
-                    >
-                      <XCircle className="h-4 w-4 mr-1.5" />
-                      Deny
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+      {!error && tab === "overview" && (
+        <>
+          <OverviewStats stats={stats} loading={loading} />
+          <PendingTeachersCard
+            pending={pendingTeachers}
+            updatingId={updatingId}
+            onApprove={approvePendingTeacher}
+            onDeny={denyPendingTeacher}
+          />
+          <PendingCertsCard
+            certs={adminCerts}
+            actionId={certActionId}
+            onApprove={handleFinalApproveCert}
+            onReject={handleRejectCert}
+          />
+          <UsersCard
+            users={users}
+            filtered={filtered}
+            loading={loading}
+            searchInput={searchInput}
+            searchMaxLength={MAX_SEARCH_LEN}
+            urlQuery={urlQuery}
+            selectedIds={selectedIds}
+            bulkRole={bulkRole}
+            bulkUpdating={bulkUpdating}
+            updatingId={updatingId}
+            currentUserId={user?.id}
+            onSearchInputChange={setSearchInput}
+            onBulkRoleChange={setBulkRole}
+            onApplyBulkRole={handleBulkRoleChange}
+            onClearSelection={() => setSelectedIds(new Set())}
+            onToggleSelectAll={toggleSelectAll}
+            onToggleSelect={toggleSelect}
+            onRoleChange={handleRoleChange}
+            onDeleteUser={handleDeleteUser}
+          />
+        </>
       )}
 
-      {/* Certificate Approvals */}
-      {adminCerts.length > 0 && (
-        <Card className="mb-8 border-l-[3px] border-l-primary">
-          <CardHeader>
-            <CardTitle className="text-xl flex items-center gap-2">
-              <Award className="h-5 w-5 text-primary" />
-              Certificate Approvals
-              <Badge variant="default" className="font-normal">
-                {adminCerts.length}
-              </Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {adminCerts.map((cert) => (
-                <div
-                  key={cert.id}
-                  className="flex items-center justify-between rounded-md border border-l-[3px] border-l-primary/60 bg-primary/5 p-4"
-                >
-                  <div className="min-w-0">
-                    <p className="font-medium truncate">{cert.student_name || "Student"}</p>
-                    <p className="text-sm text-muted-foreground truncate">{cert.course_title || "Course"}</p>
-                    <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
-                      {cert.approved_by_name && (
-                        <span className="flex items-center gap-1">
-                          <CheckCircle className="h-3 w-3 text-success" />
-                          Approved by {cert.approved_by_name}
-                        </span>
-                      )}
-                      {cert.approved_at && (
-                        <span className="flex items-center gap-1">
-                          <Clock className="h-3 w-3" />
-                          {new Date(cert.approved_at).toLocaleDateString()}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2 shrink-0 ml-4">
-                    <Button
-                      size="sm"
-                      onClick={() => handleFinalApproveCert(cert.id)}
-                      disabled={certActionId === cert.id}
-                    >
-                      <CheckCircle className="h-4 w-4 mr-1.5" />
-                      Approve
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => handleRejectCert(cert.id)}
-                      disabled={certActionId === cert.id}
-                      className="text-destructive hover:text-destructive"
-                    >
-                      <XCircle className="h-4 w-4 mr-1.5" />
-                      Reject
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Users Table */}
-      <Card>
-        <CardHeader className="flex-row items-center justify-between gap-4 space-y-0 flex-wrap">
-          <CardTitle className="text-xl">Users</CardTitle>
-          <div className="flex items-center gap-3 flex-wrap">
-            {selectedIds.size > 0 && (
-              <div className="flex items-center gap-2 bg-primary/5 border border-primary/20 rounded-lg px-3 py-1.5">
-                <span className="text-xs font-medium">{selectedIds.size} selected</span>
-                <select
-                  value={bulkRole}
-                  onChange={(e) => setBulkRole(e.target.value as UserRole)}
-                  className="h-7 rounded border border-input bg-background px-2 text-xs"
-                >
-                  <option value="student">Student</option>
-                  <option value="pending_teacher">Pending Teacher</option>
-                  <option value="teacher">Teacher</option>
-                  <option value="admin">Admin</option>
-                </select>
-                <Button size="sm" className="h-7 text-xs" onClick={handleBulkRoleChange} disabled={bulkUpdating}>
-                  {bulkUpdating ? "Updating..." : "Apply"}
-                </Button>
-                <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={() => setSelectedIds(new Set())}>
-                  Clear
-                </Button>
-              </div>
-            )}
-            <div className="relative w-full max-w-xs">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="Search by name or email…"
-                value={searchInput}
-                onChange={(e) => setSearchInput(e.target.value.slice(0, MAX_SEARCH_LEN))}
-                maxLength={MAX_SEARCH_LEN}
-                className="pl-9"
-              />
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {loading ? (
-            <PageSpinner />
-          ) : filtered.length === 0 ? (
-            <div className="flex flex-col items-center py-16 text-center">
-              <Users className="h-12 w-12 text-muted-foreground/40 mb-3" />
-              <p className="text-muted-foreground">
-                {urlQuery ? "No users match your search" : "No users found"}
-              </p>
-            </div>
-          ) : filtered.length >= USERS_VIRTUAL_THRESHOLD ? (
-            <>
-              <div className="flex items-center gap-3 px-3 pb-2">
-                <input
-                  type="checkbox"
-                  checked={filtered.length > 0 && filtered.every(u => selectedIds.has(u.id))}
-                  onChange={toggleSelectAll}
-                  className="h-4 w-4 rounded border-input"
-                  aria-label="Select all users"
-                />
-                <span className="text-xs text-muted-foreground">Select all {filtered.length}</span>
-              </div>
-              <VirtualAdminUsers
-                users={filtered}
-                selectedIds={selectedIds}
-                updatingId={updatingId}
-                currentUserId={user?.id}
-                roleBadgeClass={roleBadgeClass}
-                roleDisplayNames={roleDisplayNames}
-                onToggleSelect={toggleSelect}
-                onRoleChange={handleRoleChange}
-                onDeleteUser={handleDeleteUser}
-              />
-            </>
-          ) : (
-            <div className="overflow-x-auto -mx-6">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b text-left">
-                    <th className="px-3 py-3 w-10">
-                      <input
-                        type="checkbox"
-                        checked={filtered.length > 0 && filtered.every(u => selectedIds.has(u.id))}
-                        onChange={toggleSelectAll}
-                        className="h-4 w-4 rounded border-input"
-                        aria-label="Select all users"
-                      />
-                    </th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">Name</th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">Email</th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">Role</th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">Joined</th>
-                    <th className="px-6 py-3 w-10" aria-label="Actions" />
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {filtered.map((u) => (
-                    <tr key={u.id} className={`hover:bg-muted/50 transition-colors ${selectedIds.has(u.id) ? "bg-primary/[0.03]" : ""}`}>
-                      <td className="px-3 py-3">
-                        <input
-                          type="checkbox"
-                          checked={selectedIds.has(u.id)}
-                          onChange={() => toggleSelect(u.id)}
-                          className="h-4 w-4 rounded border-input"
-                          aria-label={`Select ${u.full_name || u.email}`}
-                        />
-                      </td>
-                      <td className="px-6 py-3">
-                        <div className="flex items-center gap-3">
-                          {u.avatar_url ? (
-                            <img
-                              src={toProxyImage(u.avatar_url)}
-                              alt={`${u.full_name ?? u.email} avatar`}
-                              className="h-8 w-8 rounded-full object-cover"
-                            />
-                          ) : (
-                            <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-muted-foreground">
-                              {(u.full_name?.[0] ?? u.email[0] ?? "?").toUpperCase()}
-                            </div>
-                          )}
-                          <span className="font-medium">{u.full_name || "—"}</span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-3 text-muted-foreground">{u.email}</td>
-                      <td className="px-6 py-3">
-                        <div className="flex items-center gap-2">
-                          <span className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${roleBadgeClass[u.role]}`}>
-                            {roleDisplayNames[u.role]}
-                          </span>
-                          <select
-                            value={u.role}
-                            disabled={updatingId === u.id || u.id === user?.id}
-                            onChange={(e) => handleRoleChange(u.id, e.target.value as UserRole)}
-                            className="h-8 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-                          >
-                            <option value="student">Student</option>
-                            <option value="pending_teacher">Pending Teacher</option>
-                            <option value="teacher">Teacher</option>
-                            <option value="admin">Admin</option>
-                          </select>
-                        </div>
-                      </td>
-                      <td className="px-6 py-3 text-muted-foreground">
-                        {new Date(u.created_at).toLocaleDateString()}
-                      </td>
-                      <td className="px-3 py-3">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                          disabled={updatingId === u.id || u.id === user?.id}
-                          onClick={() => handleDeleteUser(u)}
-                          aria-label={`Delete ${u.full_name || u.email}`}
-                          title={u.id === user?.id ? "You cannot delete your own account" : "Delete user"}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-          {!loading && filtered.length > 0 && (
-            <p className="text-xs text-muted-foreground mt-4 px-6">
-              Showing {filtered.length} of {users.length} users
-            </p>
-          )}
-        </CardContent>
-      </Card>
-      </>}
-
-      {/* Audit Log Tab */}
       {!error && tab === "audit" && (
-        <div className="space-y-6">
-          {/* Filters */}
-          <Card>
-            <CardContent className="p-4">
-              <div className="flex flex-wrap items-end gap-3">
-                <div className="space-y-1">
-                  <label className="text-xs font-medium text-muted-foreground">Action</label>
-                  <select
-                    value={auditAction}
-                    onChange={(e) => updateAudit({ ax: e.target.value || null }, { resetPage: true })}
-                    className="h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                  >
-                    <option value="">All actions</option>
-                    {ACTION_OPTIONS.map((a) => (
-                      <option key={a} value={a}>{a}</option>
-                    ))}
-                  </select>
-                </div>
-                <div className="space-y-1">
-                  <label className="text-xs font-medium text-muted-foreground">Resource</label>
-                  <select
-                    value={auditResource}
-                    onChange={(e) => updateAudit({ ar: e.target.value || null }, { resetPage: true })}
-                    className="h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                  >
-                    <option value="">All resources</option>
-                    {RESOURCE_OPTIONS.map((r) => (
-                      <option key={r} value={r}>{r}</option>
-                    ))}
-                  </select>
-                </div>
-                <div className="space-y-1">
-                  <label className="text-xs font-medium text-muted-foreground">From</label>
-                  <Input
-                    type="date"
-                    value={auditDateFrom}
-                    onChange={(e) => updateAudit({ af: e.target.value || null }, { resetPage: true })}
-                    className="h-9 w-40"
-                  />
-                </div>
-                <div className="space-y-1">
-                  <label className="text-xs font-medium text-muted-foreground">To</label>
-                  <Input
-                    type="date"
-                    value={auditDateTo}
-                    onChange={(e) => updateAudit({ at: e.target.value || null }, { resetPage: true })}
-                    className="h-9 w-40"
-                  />
-                </div>
-                <Button variant="ghost" size="sm" onClick={resetAuditFilters} className="h-9">
-                  Clear filters
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-xl flex items-center gap-2">
-                <FileText className="h-5 w-5" />
-                Audit Log
-                <span className="text-sm font-normal text-muted-foreground ml-2">
-                  {auditTotal.toLocaleString()} entries
-                </span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {auditLoading ? (
-                <PageSpinner />
-              ) : auditLogs.length === 0 ? (
-                <div className="flex flex-col items-center py-16 text-center">
-                  <FileText className="h-12 w-12 text-muted-foreground/40 mb-3" />
-                  <p className="text-muted-foreground">No audit logs found</p>
-                </div>
-              ) : (
-                <>
-                  <div className="overflow-x-auto -mx-6">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="border-b text-left">
-                          <th className="px-6 py-3 font-medium text-muted-foreground">Date</th>
-                          <th className="px-6 py-3 font-medium text-muted-foreground">User</th>
-                          <th className="px-6 py-3 font-medium text-muted-foreground">Action</th>
-                          <th className="px-6 py-3 font-medium text-muted-foreground">Resource</th>
-                          <th className="px-6 py-3 font-medium text-muted-foreground">Resource ID</th>
-                          <th className="px-6 py-3 font-medium text-muted-foreground">IP</th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
-                        {auditLogs.map((log) => (
-                          <tr key={log.id} className="hover:bg-muted/50 transition-colors">
-                            <td className="px-6 py-3 text-muted-foreground whitespace-nowrap">
-                              {new Date(log.created_at).toLocaleString()}
-                            </td>
-                            <td className="px-6 py-3 max-w-[160px] truncate" title={log.user_id ?? ""}>
-                              {log.user_id ? (userMap[log.user_id] || log.user_id.slice(0, 8) + "…") : "—"}
-                            </td>
-                            <td className="px-6 py-3">
-                              <span className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${actionBadgeClass[log.action] || "bg-muted text-muted-foreground"}`}>
-                                {log.action}
-                              </span>
-                            </td>
-                            <td className="px-6 py-3 text-muted-foreground">{log.resource_type}</td>
-                            <td className="px-6 py-3 font-mono text-xs text-muted-foreground max-w-[120px] truncate" title={log.resource_id}>
-                              {log.resource_id.length > 12 ? log.resource_id.slice(0, 12) + "…" : log.resource_id}
-                            </td>
-                            <td className="px-6 py-3 text-muted-foreground text-xs">
-                              {log.ip_address || "—"}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-
-                  {/* Pagination */}
-                  <div className="flex items-center justify-between pt-4 px-6">
-                    <p className="text-xs text-muted-foreground">
-                      Page {auditPage} of {totalAuditPages}
-                    </p>
-                    <div className="flex items-center gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={auditPage <= 1}
-                        onClick={() => updateAudit({ ap: auditPage - 1 <= 1 ? null : String(auditPage - 1) })}
-                      >
-                        <ChevronLeft className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={auditPage >= totalAuditPages}
-                        onClick={() => updateAudit({ ap: String(auditPage + 1) })}
-                      >
-                        <ChevronRight className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+        <AuditLogTab
+          logs={auditLogs}
+          total={auditTotal}
+          loading={auditLoading}
+          page={auditPage}
+          pageSize={AUDIT_PAGE_SIZE}
+          userMap={userMap}
+          action={auditAction}
+          resource={auditResource}
+          dateFrom={auditDateFrom}
+          dateTo={auditDateTo}
+          onAction={(v) => updateAudit({ ax: v || null }, { resetPage: true })}
+          onResource={(v) => updateAudit({ ar: v || null }, { resetPage: true })}
+          onDateFrom={(v) => updateAudit({ af: v || null }, { resetPage: true })}
+          onDateTo={(v) => updateAudit({ at: v || null }, { resetPage: true })}
+          onReset={resetAuditFilters}
+          onPageChange={(next) =>
+            updateAudit({ ap: next <= 1 ? null : String(next) })
+          }
+        />
       )}
     </div>
   )

--- a/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
+++ b/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
@@ -1,0 +1,53 @@
+import { Users, FileText } from "lucide-react"
+import type { AdminTab } from "./constants"
+
+interface Props {
+  active: AdminTab
+  onChange: (next: AdminTab) => void
+}
+
+/** Underlined tab bar used at the top of the Admin dashboard. */
+export function AdminTabs({ active, onChange }: Props) {
+  return (
+    <div className="flex gap-1 mb-8 border-b">
+      <TabButton
+        active={active === "overview"}
+        onClick={() => onChange("overview")}
+        icon={<Users className="h-4 w-4" />}
+        label="Overview"
+      />
+      <TabButton
+        active={active === "audit"}
+        onClick={() => onChange("audit")}
+        icon={<FileText className="h-4 w-4" />}
+        label="Audit Log"
+      />
+    </div>
+  )
+}
+
+interface TabButtonProps {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}
+
+function TabButton({ active, onClick, icon, label }: TabButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
+        active ? "text-primary" : "text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        {icon}
+        {label}
+      </div>
+      {active && (
+        <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-t" />
+      )}
+    </button>
+  )
+}

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -1,0 +1,229 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import PageSpinner from "@/components/ui/PageSpinner"
+import { FileText, ChevronLeft, ChevronRight } from "lucide-react"
+import type { AuditLogEntry } from "@/types"
+import {
+  ACTION_OPTIONS,
+  RESOURCE_OPTIONS,
+  ACTION_BADGE_CLASS,
+} from "./constants"
+
+interface Props {
+  logs: AuditLogEntry[]
+  total: number
+  loading: boolean
+  page: number
+  pageSize: number
+  userMap: Record<string, string>
+  action: string
+  resource: string
+  dateFrom: string
+  dateTo: string
+  onAction: (next: string) => void
+  onResource: (next: string) => void
+  onDateFrom: (next: string) => void
+  onDateTo: (next: string) => void
+  onReset: () => void
+  onPageChange: (nextPage: number) => void
+}
+
+/** Full audit-log tab: filters, table, and pagination. */
+export function AuditLogTab({
+  logs,
+  total,
+  loading,
+  page,
+  pageSize,
+  userMap,
+  action,
+  resource,
+  dateFrom,
+  dateTo,
+  onAction,
+  onResource,
+  onDateFrom,
+  onDateTo,
+  onReset,
+  onPageChange,
+}: Props) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <FilterSelect label="Action" value={action} onChange={onAction} options={ACTION_OPTIONS} placeholder="All actions" />
+            <FilterSelect label="Resource" value={resource} onChange={onResource} options={RESOURCE_OPTIONS} placeholder="All resources" />
+            <FilterDate label="From" value={dateFrom} onChange={onDateFrom} />
+            <FilterDate label="To" value={dateTo} onChange={onDateTo} />
+            <Button variant="ghost" size="sm" onClick={onReset} className="h-9">
+              Clear filters
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Audit Log
+            <span className="text-sm font-normal text-muted-foreground ml-2">
+              {total.toLocaleString()} entries
+            </span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <PageSpinner />
+          ) : logs.length === 0 ? (
+            <div className="flex flex-col items-center py-16 text-center">
+              <FileText className="h-12 w-12 text-muted-foreground/40 mb-3" />
+              <p className="text-muted-foreground">No audit logs found</p>
+            </div>
+          ) : (
+            <>
+              <AuditTable logs={logs} userMap={userMap} />
+              <div className="flex items-center justify-between pt-4 px-6">
+                <p className="text-xs text-muted-foreground">
+                  Page {page} of {totalPages}
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page <= 1}
+                    onClick={() => onPageChange(page - 1)}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page >= totalPages}
+                    onClick={() => onPageChange(page + 1)}
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+interface FilterSelectProps {
+  label: string
+  value: string
+  onChange: (next: string) => void
+  options: readonly string[]
+  placeholder: string
+}
+
+function FilterSelect({ label, value, onChange, options, placeholder }: FilterSelectProps) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs font-medium text-muted-foreground">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        <option value="">{placeholder}</option>
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+function FilterDate({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (next: string) => void
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs font-medium text-muted-foreground">{label}</label>
+      <Input
+        type="date"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-9 w-40"
+      />
+    </div>
+  )
+}
+
+function AuditTable({
+  logs,
+  userMap,
+}: {
+  logs: AuditLogEntry[]
+  userMap: Record<string, string>
+}) {
+  return (
+    <div className="overflow-x-auto -mx-6">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="px-6 py-3 font-medium text-muted-foreground">Date</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">User</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">Action</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">Resource</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">Resource ID</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">IP</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {logs.map((log) => (
+            <tr key={log.id} className="hover:bg-muted/50 transition-colors">
+              <td className="px-6 py-3 text-muted-foreground whitespace-nowrap">
+                {new Date(log.created_at).toLocaleString()}
+              </td>
+              <td className="px-6 py-3 max-w-[160px] truncate" title={log.user_id ?? ""}>
+                {log.user_id
+                  ? userMap[log.user_id] || log.user_id.slice(0, 8) + "…"
+                  : "—"}
+              </td>
+              <td className="px-6 py-3">
+                <span
+                  className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${
+                    ACTION_BADGE_CLASS[log.action] || "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {log.action}
+                </span>
+              </td>
+              <td className="px-6 py-3 text-muted-foreground">{log.resource_type}</td>
+              <td
+                className="px-6 py-3 font-mono text-xs text-muted-foreground max-w-[120px] truncate"
+                title={log.resource_id}
+              >
+                {log.resource_id.length > 12
+                  ? log.resource_id.slice(0, 12) + "…"
+                  : log.resource_id}
+              </td>
+              <td className="px-6 py-3 text-muted-foreground text-xs">
+                {log.ip_address || "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
+++ b/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent } from "@/components/ui/card"
+import { Users, BookOpen, GraduationCap } from "lucide-react"
+import type { AdminStats } from "./constants"
+
+interface Props {
+  stats: AdminStats
+  loading: boolean
+}
+
+const CARDS = [
+  { key: "users", label: "Total Users", icon: Users },
+  { key: "courses", label: "Total Courses", icon: BookOpen },
+  { key: "enrollments", label: "Total Enrollments", icon: GraduationCap },
+] as const
+
+/** Three-card stats row on the admin overview tab. */
+export function OverviewStats({ stats, loading }: Props) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+      {CARDS.map(({ key, label, icon: Icon }) => (
+        <Card key={label}>
+          <CardContent className="flex items-center gap-4 p-6">
+            <div className="rounded-md bg-muted p-3">
+              <Icon className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">{label}</p>
+              <p className="text-2xl font-bold">
+                {loading ? "—" : stats[key].toLocaleString()}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
@@ -1,0 +1,89 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Award, CheckCircle, XCircle, Clock } from "lucide-react"
+import type { Certificate } from "@/types"
+
+export type AdminCert = Certificate & {
+  student_name?: string
+  course_title?: string
+  approved_by_name?: string
+  approved_at?: string
+}
+
+interface Props {
+  certs: AdminCert[]
+  actionId: string | null
+  onApprove: (certId: string) => void
+  onReject: (certId: string) => void
+}
+
+/** Certificates pending final admin approval after a teacher signed off. */
+export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props) {
+  if (certs.length === 0) return null
+
+  return (
+    <Card className="mb-8 border-l-[3px] border-l-primary">
+      <CardHeader>
+        <CardTitle className="text-xl flex items-center gap-2">
+          <Award className="h-5 w-5 text-primary" />
+          Certificate Approvals
+          <Badge variant="default" className="font-normal">
+            {certs.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {certs.map((cert) => (
+            <div
+              key={cert.id}
+              className="flex items-center justify-between rounded-md border border-l-[3px] border-l-primary/60 bg-primary/5 p-4"
+            >
+              <div className="min-w-0">
+                <p className="font-medium truncate">{cert.student_name || "Student"}</p>
+                <p className="text-sm text-muted-foreground truncate">
+                  {cert.course_title || "Course"}
+                </p>
+                <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+                  {cert.approved_by_name && (
+                    <span className="flex items-center gap-1">
+                      <CheckCircle className="h-3 w-3 text-success" />
+                      Approved by {cert.approved_by_name}
+                    </span>
+                  )}
+                  {cert.approved_at && (
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {new Date(cert.approved_at).toLocaleDateString()}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-2 shrink-0 ml-4">
+                <Button
+                  size="sm"
+                  onClick={() => onApprove(cert.id)}
+                  disabled={actionId === cert.id}
+                >
+                  <CheckCircle className="h-4 w-4 mr-1.5" />
+                  Approve
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onReject(cert.id)}
+                  disabled={actionId === cert.id}
+                  className="text-destructive hover:text-destructive"
+                >
+                  <XCircle className="h-4 w-4 mr-1.5" />
+                  Reject
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/Admin/dashboard/PendingTeachersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingTeachersCard.tsx
@@ -1,0 +1,79 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Clock, CheckCircle, XCircle } from "lucide-react"
+import { toProxyImage } from "@/lib/images"
+import type { ProfileRow } from "./constants"
+
+interface Props {
+  pending: ProfileRow[]
+  updatingId: string | null
+  onApprove: (user: ProfileRow) => void
+  onDeny: (user: ProfileRow) => void
+}
+
+/** Warning-accented list of users whose role is `pending_teacher`. */
+export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: Props) {
+  if (pending.length === 0) return null
+
+  return (
+    <Card className="mb-8 border-l-[3px] border-l-warning">
+      <CardHeader>
+        <CardTitle className="text-xl flex items-center gap-2">
+          <Clock className="h-5 w-5 text-warning" />
+          Pending Teacher Approvals
+          <Badge variant="warning" className="font-normal">
+            {pending.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {pending.map((u) => (
+            <div
+              key={u.id}
+              className="flex items-center justify-between rounded-md border border-l-[3px] border-l-warning/60 bg-warning/5 p-4"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                {u.avatar_url ? (
+                  <img
+                    src={toProxyImage(u.avatar_url)}
+                    alt={`${u.full_name ?? u.email} avatar`}
+                    className="h-10 w-10 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center text-sm font-medium text-muted-foreground">
+                    {(u.full_name?.[0] ?? u.email[0] ?? "?").toUpperCase()}
+                  </div>
+                )}
+                <div className="min-w-0">
+                  <p className="font-medium truncate">{u.full_name || "No name"}</p>
+                  <p className="text-sm text-muted-foreground truncate">{u.email}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Registered {new Date(u.created_at).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 shrink-0 ml-4">
+                <Button size="sm" onClick={() => onApprove(u)} disabled={updatingId === u.id}>
+                  <CheckCircle className="h-4 w-4 mr-1.5" />
+                  Approve
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onDeny(u)}
+                  disabled={updatingId === u.id}
+                  className="text-destructive hover:text-destructive"
+                >
+                  <XCircle className="h-4 w-4 mr-1.5" />
+                  Deny
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -1,0 +1,334 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Users, Search, Trash2 } from "lucide-react"
+import { toProxyImage } from "@/lib/images"
+import PageSpinner from "@/components/ui/PageSpinner"
+import VirtualAdminUsers from "../VirtualAdminUsers"
+import type { UserRole } from "@/types"
+import {
+  type ProfileRow,
+  ROLE_BADGE_CLASS,
+  ROLE_DISPLAY_NAMES,
+} from "./constants"
+
+/**
+ * Above this row count we swap the full <table> render for a react-window
+ * list. Small tenants keep the familiar semantic table; large tenants
+ * avoid paying ~500 avatar images + <select>s worth of DOM on mount.
+ */
+export const USERS_VIRTUAL_THRESHOLD = 50
+
+interface Props {
+  users: ProfileRow[]
+  filtered: ProfileRow[]
+  loading: boolean
+  searchInput: string
+  searchMaxLength: number
+  urlQuery: string
+  selectedIds: Set<string>
+  bulkRole: UserRole
+  bulkUpdating: boolean
+  updatingId: string | null
+  currentUserId: string | undefined
+  onSearchInputChange: (next: string) => void
+  onBulkRoleChange: (next: UserRole) => void
+  onApplyBulkRole: () => void
+  onClearSelection: () => void
+  onToggleSelectAll: () => void
+  onToggleSelect: (id: string) => void
+  onRoleChange: (userId: string, role: UserRole) => void
+  onDeleteUser: (user: ProfileRow) => void
+}
+
+/** Main users table + bulk-action bar + search input. */
+export function UsersCard({
+  users,
+  filtered,
+  loading,
+  searchInput,
+  searchMaxLength,
+  urlQuery,
+  selectedIds,
+  bulkRole,
+  bulkUpdating,
+  updatingId,
+  currentUserId,
+  onSearchInputChange,
+  onBulkRoleChange,
+  onApplyBulkRole,
+  onClearSelection,
+  onToggleSelectAll,
+  onToggleSelect,
+  onRoleChange,
+  onDeleteUser,
+}: Props) {
+  const allFilteredSelected =
+    filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between gap-4 space-y-0 flex-wrap">
+        <CardTitle className="text-xl">Users</CardTitle>
+        <div className="flex items-center gap-3 flex-wrap">
+          {selectedIds.size > 0 && (
+            <div className="flex items-center gap-2 bg-primary/5 border border-primary/20 rounded-lg px-3 py-1.5">
+              <span className="text-xs font-medium">{selectedIds.size} selected</span>
+              <select
+                value={bulkRole}
+                onChange={(e) => onBulkRoleChange(e.target.value as UserRole)}
+                className="h-7 rounded border border-input bg-background px-2 text-xs"
+              >
+                <option value="student">Student</option>
+                <option value="pending_teacher">Pending Teacher</option>
+                <option value="teacher">Teacher</option>
+                <option value="admin">Admin</option>
+              </select>
+              <Button
+                size="sm"
+                className="h-7 text-xs"
+                onClick={onApplyBulkRole}
+                disabled={bulkUpdating}
+              >
+                {bulkUpdating ? "Updating..." : "Apply"}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs"
+                onClick={onClearSelection}
+              >
+                Clear
+              </Button>
+            </div>
+          )}
+          <div className="relative w-full max-w-xs">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search by name or email…"
+              value={searchInput}
+              onChange={(e) => onSearchInputChange(e.target.value.slice(0, searchMaxLength))}
+              maxLength={searchMaxLength}
+              className="pl-9"
+            />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <PageSpinner />
+        ) : filtered.length === 0 ? (
+          <EmptyUsers hasQuery={Boolean(urlQuery)} />
+        ) : filtered.length >= USERS_VIRTUAL_THRESHOLD ? (
+          <>
+            <div className="flex items-center gap-3 px-3 pb-2">
+              <input
+                type="checkbox"
+                checked={allFilteredSelected}
+                onChange={onToggleSelectAll}
+                className="h-4 w-4 rounded border-input"
+                aria-label="Select all users"
+              />
+              <span className="text-xs text-muted-foreground">
+                Select all {filtered.length}
+              </span>
+            </div>
+            <VirtualAdminUsers
+              users={filtered}
+              selectedIds={selectedIds}
+              updatingId={updatingId}
+              currentUserId={currentUserId}
+              roleBadgeClass={ROLE_BADGE_CLASS}
+              roleDisplayNames={ROLE_DISPLAY_NAMES}
+              onToggleSelect={onToggleSelect}
+              onRoleChange={onRoleChange}
+              onDeleteUser={onDeleteUser}
+            />
+          </>
+        ) : (
+          <UsersTable
+            filtered={filtered}
+            selectedIds={selectedIds}
+            updatingId={updatingId}
+            currentUserId={currentUserId}
+            onToggleSelectAll={onToggleSelectAll}
+            onToggleSelect={onToggleSelect}
+            onRoleChange={onRoleChange}
+            onDeleteUser={onDeleteUser}
+          />
+        )}
+        {!loading && filtered.length > 0 && (
+          <p className="text-xs text-muted-foreground mt-4 px-6">
+            Showing {filtered.length} of {users.length} users
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EmptyUsers({ hasQuery }: { hasQuery: boolean }) {
+  return (
+    <div className="flex flex-col items-center py-16 text-center">
+      <Users className="h-12 w-12 text-muted-foreground/40 mb-3" />
+      <p className="text-muted-foreground">
+        {hasQuery ? "No users match your search" : "No users found"}
+      </p>
+    </div>
+  )
+}
+
+interface UsersTableProps {
+  filtered: ProfileRow[]
+  selectedIds: Set<string>
+  updatingId: string | null
+  currentUserId: string | undefined
+  onToggleSelectAll: () => void
+  onToggleSelect: (id: string) => void
+  onRoleChange: (userId: string, role: UserRole) => void
+  onDeleteUser: (user: ProfileRow) => void
+}
+
+function UsersTable({
+  filtered,
+  selectedIds,
+  updatingId,
+  currentUserId,
+  onToggleSelectAll,
+  onToggleSelect,
+  onRoleChange,
+  onDeleteUser,
+}: UsersTableProps) {
+  const allFilteredSelected =
+    filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
+
+  return (
+    <div className="overflow-x-auto -mx-6">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="px-3 py-3 w-10">
+              <input
+                type="checkbox"
+                checked={allFilteredSelected}
+                onChange={onToggleSelectAll}
+                className="h-4 w-4 rounded border-input"
+                aria-label="Select all users"
+              />
+            </th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">Name</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">Email</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">Role</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">Joined</th>
+            <th className="px-6 py-3 w-10" aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {filtered.map((u) => (
+            <UserRow
+              key={u.id}
+              user={u}
+              selected={selectedIds.has(u.id)}
+              updating={updatingId === u.id}
+              isSelf={u.id === currentUserId}
+              onToggleSelect={onToggleSelect}
+              onRoleChange={onRoleChange}
+              onDeleteUser={onDeleteUser}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+interface UserRowProps {
+  user: ProfileRow
+  selected: boolean
+  updating: boolean
+  isSelf: boolean
+  onToggleSelect: (id: string) => void
+  onRoleChange: (userId: string, role: UserRole) => void
+  onDeleteUser: (user: ProfileRow) => void
+}
+
+function UserRow({
+  user,
+  selected,
+  updating,
+  isSelf,
+  onToggleSelect,
+  onRoleChange,
+  onDeleteUser,
+}: UserRowProps) {
+  return (
+    <tr
+      className={`hover:bg-muted/50 transition-colors ${
+        selected ? "bg-primary/[0.03]" : ""
+      }`}
+    >
+      <td className="px-3 py-3">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={() => onToggleSelect(user.id)}
+          className="h-4 w-4 rounded border-input"
+          aria-label={`Select ${user.full_name || user.email}`}
+        />
+      </td>
+      <td className="px-6 py-3">
+        <div className="flex items-center gap-3">
+          {user.avatar_url ? (
+            <img
+              src={toProxyImage(user.avatar_url)}
+              alt={`${user.full_name ?? user.email} avatar`}
+              className="h-8 w-8 rounded-full object-cover"
+            />
+          ) : (
+            <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-muted-foreground">
+              {(user.full_name?.[0] ?? user.email[0] ?? "?").toUpperCase()}
+            </div>
+          )}
+          <span className="font-medium">{user.full_name || "—"}</span>
+        </div>
+      </td>
+      <td className="px-6 py-3 text-muted-foreground">{user.email}</td>
+      <td className="px-6 py-3">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${ROLE_BADGE_CLASS[user.role]}`}
+          >
+            {ROLE_DISPLAY_NAMES[user.role]}
+          </span>
+          <select
+            value={user.role}
+            disabled={updating || isSelf}
+            onChange={(e) => onRoleChange(user.id, e.target.value as UserRole)}
+            className="h-8 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          >
+            <option value="student">Student</option>
+            <option value="pending_teacher">Pending Teacher</option>
+            <option value="teacher">Teacher</option>
+            <option value="admin">Admin</option>
+          </select>
+        </div>
+      </td>
+      <td className="px-6 py-3 text-muted-foreground">
+        {new Date(user.created_at).toLocaleDateString()}
+      </td>
+      <td className="px-3 py-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+          disabled={updating || isSelf}
+          onClick={() => onDeleteUser(user)}
+          aria-label={`Delete ${user.full_name || user.email}`}
+          title={isSelf ? "You cannot delete your own account" : "Delete user"}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </td>
+    </tr>
+  )
+}

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -1,0 +1,70 @@
+import type { UserRole } from "@/types"
+
+export type AdminTab = "overview" | "audit"
+export const ADMIN_TABS: readonly AdminTab[] = ["overview", "audit"]
+
+export const ACTION_OPTIONS = [
+  "create",
+  "update",
+  "delete",
+  "publish",
+  "enroll",
+  "approve",
+  "reject",
+  "grade",
+] as const
+
+export const RESOURCE_OPTIONS = [
+  "course",
+  "module",
+  "chapter",
+  "enrollment",
+  "certificate",
+  "assignment_submission",
+  "user",
+] as const
+
+export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+/** Background/foreground pair used in audit-log action pills. */
+export const ACTION_BADGE_CLASS: Record<string, string> = {
+  create: "bg-success/15 text-success",
+  update: "bg-info/15 text-info",
+  delete: "bg-destructive/15 text-destructive",
+  publish: "bg-primary/15 text-primary",
+  enroll: "bg-info/15 text-info",
+  approve: "bg-success/15 text-success",
+  reject: "bg-destructive/15 text-destructive",
+  grade: "bg-warning/15 text-warning",
+}
+
+/** Human-readable role names for dropdowns and badges. */
+export const ROLE_DISPLAY_NAMES: Record<UserRole, string> = {
+  student: "Student",
+  pending_teacher: "Pending Teacher",
+  teacher: "Teacher",
+  admin: "Admin",
+}
+
+/** Role-pill color classes. */
+export const ROLE_BADGE_CLASS: Record<UserRole, string> = {
+  admin: "bg-destructive/15 text-destructive",
+  teacher: "bg-primary/15 text-primary",
+  pending_teacher: "bg-warning/15 text-warning",
+  student: "bg-info/15 text-info",
+}
+
+export interface ProfileRow {
+  id: string
+  email: string
+  full_name: string | null
+  role: UserRole
+  created_at: string
+  avatar_url: string | null
+}
+
+export interface AdminStats {
+  users: number
+  courses: number
+  enrollments: number
+}


### PR DESCRIPTION
## Summary

Split the 867-line `AdminDashboard.tsx` into a thin orchestrator and per-section components under `pages/Admin/dashboard/`. Same pattern used for `TeacherGradebook` in #35.

Before: one file rendered stats, pending-teacher list, pending-cert list, users table (with search, bulk role change, delete, virtual list fallback), and a separate audit-log tab with its own filters + pagination. Everything lived in the same scope, so every edit diffed the whole page.

After:

- `AdminDashboard.tsx` (429 lines) — orchestrator. Owns mutable state, URL-param derivation, side-effect loaders, and mutation handlers. Passes stateless props to the tab children.
- `dashboard/constants.ts` — shared types (`ProfileRow`, `AdminTab`, `AdminStats`), tab enum, role/action badge maps, ISO-date regex, option lists for audit filters.
- `dashboard/AdminTabs.tsx` — the two-tab bar.
- `dashboard/OverviewStats.tsx` — three stat cards.
- `dashboard/PendingTeachersCard.tsx` — pending teacher approval list.
- `dashboard/PendingCertsCard.tsx` — certificate approval list.
- `dashboard/UsersCard.tsx` — search, bulk action bar, users table + virtualized list fallback (`>= 50` rows).
- `dashboard/AuditLogTab.tsx` — audit filter row, paginated log table.

`VirtualAdminUsers.tsx` and every admin service call is untouched. `AuditLogQuery` is now typed at the call site instead of the old `Record<string, string | number>`.

No behaviour change: same URL params (`tab`, `q`, `ax`, `ar`, `af`, `at`, `ap`), same services, same confirm dialogs, same empty-state copy.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/pages/Admin --max-warnings 0` clean
- [x] `npx vitest run` — 85/85 pass
- [x] `npm run build` clean
- [ ] GitHub Actions green on the PR
