### PR TITLE
refactor(frontend): decompose StudentProgress into table-scoped components

### DIFF
--- a/frontend/src/pages/Teacher/StudentProgress.tsx
+++ b/frontend/src/pages/Teacher/StudentProgress.tsx
@@ -1,78 +1,85 @@
-import { useEffect, useState, useMemo, useCallback } from "react"
-import { useParams, Link } from "react-router-dom"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Link, useParams } from "react-router-dom"
 import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
 import { getErrorDetail } from "@/lib/errorDetail"
-import { isGradableChapterType } from "@/lib/chapterTypes"
-import type {
-  StudentProgressResponse,
-  StudentProgressEntry,
-  StudentQuizResult,
-  StudentAssignmentResult,
-  StudentChapterInfo,
-} from "@/types"
+import type { StudentProgressResponse } from "@/types"
 import {
   ArrowLeft,
-  Users,
-  TrendingUp,
-  Award,
-  Search,
-  ChevronDown,
-  ChevronRight,
-  BookOpen,
-  CheckCircle,
-  XCircle,
-  Clock,
-  ClipboardList,
   BarChart3,
-  FileText,
-  RotateCcw,
-  Loader2,
+  ChevronRight,
+  ClipboardList,
+  Search,
+  Users,
 } from "lucide-react"
 import { ErrorState } from "@/components/patterns"
+import {
+  averageProgress,
+  completionRate,
+  ProgressStats,
+  StudentProgressSkeleton,
+  StudentTable,
+  type SortColumn,
+  type SortDirection,
+} from "./progress"
 
-type ProgressData = StudentProgressResponse
-type StudentData = StudentProgressEntry
-type QuizResult = StudentQuizResult
-type AssignmentResult = StudentAssignmentResult
-type ChapterInfo = StudentChapterInfo
-
+/**
+ * Teacher view of every enrolled student in a course. Owns the fetch,
+ * filter, and sort state; delegates presentation to `progress/*`.
+ *
+ * The table itself stays here as a single derived memo so we can keep
+ * sort/search centralised — each row only knows about its own expansion
+ * and mutation calls.
+ */
 export default function StudentProgress() {
   const { courseId } = useParams<{ courseId: string }>()
-  const { input: searchInput, setInput: setSearchInput, value: search, maxLength } = useDebouncedSearchParam()
-  const [data, setData] = useState<ProgressData | null>(null)
+  const {
+    input: searchInput,
+    setInput: setSearchInput,
+    value: search,
+    maxLength,
+  } = useDebouncedSearchParam()
+
+  const [data, setData] = useState<StudentProgressResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [expandedId, setExpandedId] = useState<string | null>(null)
-  const [sortBy, setSortBy] = useState<"name" | "progress" | "last_activity">("name")
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc")
+  const [sortBy, setSortBy] = useState<SortColumn>("name")
+  const [sortDir, setSortDir] = useState<SortDirection>("asc")
 
-  const load = useCallback(async (signal?: { cancelled: boolean }) => {
-    if (!courseId) return
-    setLoading(true)
-    setData(null)
-    try {
-      const result = await coursesService.getStudentProgress(courseId)
-      if (signal?.cancelled) return
-      setData(result)
-    } catch (err) {
-      if (signal?.cancelled) return
-      toast({ title: getErrorDetail(err, "Failed to load student progress"), variant: "destructive" })
-    } finally {
-      if (!signal?.cancelled) setLoading(false)
-    }
-  }, [courseId])
+  const load = useCallback(
+    async (signal?: { cancelled: boolean }) => {
+      if (!courseId) return
+      setLoading(true)
+      setData(null)
+      try {
+        const result = await coursesService.getStudentProgress(courseId)
+        if (signal?.cancelled) return
+        setData(result)
+      } catch (err) {
+        if (signal?.cancelled) return
+        toast({
+          title: getErrorDetail(err, "Failed to load student progress"),
+          variant: "destructive",
+        })
+      } finally {
+        if (!signal?.cancelled) setLoading(false)
+      }
+    },
+    [courseId],
+  )
 
   useEffect(() => {
     const signal = { cancelled: false }
-    load(signal)
-    return () => { signal.cancelled = true }
+    void load(signal)
+    return () => {
+      signal.cancelled = true
+    }
   }, [load])
 
-  const toggleSort = (col: typeof sortBy) => {
+  const toggleSort = (col: SortColumn) => {
     if (sortBy === col) {
       setSortDir((d) => (d === "asc" ? "desc" : "asc"))
     } else {
@@ -83,110 +90,66 @@ export default function StudentProgress() {
 
   const filtered = useMemo(() => {
     if (!data) return []
-    let list = data.students
-    if (search.trim()) {
-      const q = search.toLowerCase()
-      list = list.filter(
-        (s) =>
-          (s.full_name ?? "").toLowerCase().includes(q) ||
-          (s.email ?? "").toLowerCase().includes(q),
-      )
-    }
-    list = [...list].sort((a, b) => {
+    const q = search.trim().toLowerCase()
+    const list = q
+      ? data.students.filter(
+          (s) =>
+            (s.full_name ?? "").toLowerCase().includes(q) ||
+            (s.email ?? "").toLowerCase().includes(q),
+        )
+      : data.students
+    return [...list].sort((a, b) => {
       const dir = sortDir === "asc" ? 1 : -1
-      if (sortBy === "name") return (a.full_name ?? "").localeCompare(b.full_name ?? "") * dir
-      if (sortBy === "progress") return (a.progress - b.progress) * dir
-      if (sortBy === "last_activity") {
-        const da = a.last_activity ? new Date(a.last_activity).getTime() : 0
-        const db = b.last_activity ? new Date(b.last_activity).getTime() : 0
-        return (da - db) * dir
+      if (sortBy === "name") {
+        return (a.full_name ?? "").localeCompare(b.full_name ?? "") * dir
       }
-      return 0
+      if (sortBy === "progress") {
+        return (a.progress - b.progress) * dir
+      }
+      const da = a.last_activity ? new Date(a.last_activity).getTime() : 0
+      const db = b.last_activity ? new Date(b.last_activity).getTime() : 0
+      return (da - db) * dir
     })
-    return list
   }, [data, search, sortBy, sortDir])
 
-  const avgProgress = useMemo(() => {
-    if (!data || data.students.length === 0) return 0
-    return Math.round(
-      data.students.reduce((sum, s) => sum + s.progress, 0) / data.students.length,
-    )
-  }, [data])
+  const handleStudentChapterUpdate = useCallback(
+    (
+      studentId: string,
+      chapterId: string,
+      completed: boolean,
+      completedBy: "teacher" | "self" | null,
+    ) => {
+      setData((prev) => {
+        if (!prev) return prev
+        return {
+          ...prev,
+          students: prev.students.map((s) => {
+            if (s.id !== studentId) return s
+            const updatedChapters = s.chapters?.map((ch) =>
+              ch.id === chapterId ? { ...ch, completed, completed_by: completedBy } : ch,
+            )
+            const completedCount =
+              updatedChapters?.filter((ch) => ch.completed).length ?? s.chapters_completed
+            return {
+              ...s,
+              chapters: updatedChapters,
+              chapters_completed: completed
+                ? s.chapters_completed + 1
+                : Math.max(0, s.chapters_completed - 1),
+              progress:
+                prev.total_chapters > 0
+                  ? Math.round((completedCount / prev.total_chapters) * 100)
+                  : s.progress,
+            }
+          }),
+        }
+      })
+    },
+    [],
+  )
 
-  const completionRate = useMemo(() => {
-    if (!data || data.students.length === 0) return 0
-    const completed = data.students.filter((s) => s.progress >= 100).length
-    return Math.round((completed / data.students.length) * 100)
-  }, [data])
-
-  const quizAvg = (student: StudentData) => {
-    if (student.quiz_results.length === 0) return null
-    const total = student.quiz_results.reduce((s, q) => s + (q.score / q.max_score) * 100, 0)
-    return Math.round(total / student.quiz_results.length)
-  }
-
-  const assignmentAvg = (student: StudentData) => {
-    const graded = student.assignment_results.filter((a) => a.grade !== null)
-    if (graded.length === 0) return null
-    const total = graded.reduce((s, a) => s + ((a.grade! / a.max_score) * 100), 0)
-    return Math.round(total / graded.length)
-  }
-
-  const overallGrade = (student: StudentData) => {
-    const scores: number[] = []
-    const qAvg = quizAvg(student)
-    const aAvg = assignmentAvg(student)
-    if (qAvg !== null) scores.push(qAvg)
-    if (aAvg !== null) scores.push(aAvg)
-    if (scores.length === 0) return null
-    return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
-  }
-
-  const formatDate = (d: string | null) => {
-    if (!d) return "—"
-    return new Date(d).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    })
-  }
-
-  const relativeTime = (d: string | null) => {
-    if (!d) return "Never"
-    const diff = Date.now() - new Date(d).getTime()
-    const mins = Math.floor(diff / 60000)
-    if (mins < 60) return `${mins}m ago`
-    const hours = Math.floor(mins / 60)
-    if (hours < 24) return `${hours}h ago`
-    const days = Math.floor(hours / 24)
-    if (days < 7) return `${days}d ago`
-    return formatDate(d)
-  }
-
-  if (loading) {
-    return (
-      <div className="container mx-auto px-4 py-8 max-w-6xl">
-        <div className="h-8 w-48 bg-muted rounded animate-pulse mb-6" />
-        <div className="rounded-lg border">
-          <div className="p-4 border-b">
-            <div className="h-9 w-64 bg-muted rounded animate-pulse" />
-          </div>
-          <div className="divide-y">
-            {[1, 2, 3, 4, 5].map(i => (
-              <div key={i} className="p-4 flex items-center gap-4">
-                <div className="h-4 w-4 bg-muted rounded animate-pulse" />
-                <div className="h-4 flex-1 bg-muted rounded animate-pulse" />
-                <div className="h-4 w-24 bg-muted rounded animate-pulse" />
-                <div className="h-4 w-16 bg-muted rounded animate-pulse" />
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  if (!data) {
+  if (loading) return <StudentProgressSkeleton />
+  if (!data)
     return (
       <div className="container mx-auto px-4 py-8 max-w-6xl">
         <ErrorState
@@ -209,45 +172,24 @@ export default function StudentProgress() {
         />
       </div>
     )
-  }
-
-  const handleStudentChapterUpdate = (studentId: string, chapterId: string, completed: boolean, completedBy: "teacher" | "self" | null) => {
-    setData((prev) => {
-      if (!prev) return prev
-      return {
-        ...prev,
-        students: prev.students.map((s) => {
-          if (s.id !== studentId) return s
-          const updatedChapters = s.chapters?.map((ch) =>
-            ch.id === chapterId ? { ...ch, completed, completed_by: completedBy } : ch,
-          )
-          const completedCount = updatedChapters?.filter((ch) => ch.completed).length ?? s.chapters_completed
-          return {
-            ...s,
-            chapters: updatedChapters,
-            chapters_completed: completed ? s.chapters_completed + 1 : Math.max(0, s.chapters_completed - 1),
-            progress: prev.total_chapters > 0 ? Math.round((completedCount / prev.total_chapters) * 100) : s.progress,
-          }
-        }),
-      }
-    })
-  }
-
-  const SortIndicator = ({ col }: { col: typeof sortBy }) => {
-    if (sortBy !== col) return null
-    return <span className="ml-1">{sortDir === "asc" ? "↑" : "↓"}</span>
-  }
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-6xl">
-      {/* Header */}
       <div className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
-        <Link to="/teacher" className="hover:text-foreground transition-colors">My Courses</Link>
+        <Link to="/teacher" className="hover:text-foreground transition-colors">
+          My Courses
+        </Link>
         <ChevronRight className="h-3.5 w-3.5" />
-        <Link to={`/teacher/courses/${courseId}`} className="hover:text-foreground transition-colors">{data.course_title || "Course"}</Link>
+        <Link
+          to={`/teacher/courses/${courseId}`}
+          className="hover:text-foreground transition-colors"
+        >
+          {data.course_title || "Course"}
+        </Link>
         <ChevronRight className="h-3.5 w-3.5" />
         <span className="text-foreground font-medium">Student Progress</span>
       </div>
+
       <div className="flex items-center gap-3 mb-8">
         <div className="flex-1">
           <h1 className="text-3xl font-bold tracking-tight">Student Progress</h1>
@@ -269,44 +211,12 @@ export default function StudentProgress() {
         </div>
       </div>
 
-      {/* Stats Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-muted-foreground">Total Students</p>
-                <p className="text-2xl font-bold mt-1">{data.students.length}</p>
-              </div>
-              <Users className="h-8 w-8 text-muted-foreground/60" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-muted-foreground">Average Progress</p>
-                <p className="text-2xl font-bold mt-1">{avgProgress}%</p>
-              </div>
-              <TrendingUp className="h-8 w-8 text-muted-foreground/60" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-muted-foreground">Completion Rate</p>
-                <p className="text-2xl font-bold mt-1">{completionRate}%</p>
-              </div>
-              <Award className="h-8 w-8 text-muted-foreground/60" />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <ProgressStats
+        totalStudents={data.students.length}
+        averageProgress={averageProgress(data.students)}
+        completionRate={completionRate(data.students)}
+      />
 
-      {/* Search */}
       <div className="relative mb-6">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
@@ -318,392 +228,17 @@ export default function StudentProgress() {
         />
       </div>
 
-      {/* Student Table */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <Users className="h-5 w-5" />
-            Students
-            <span className="text-sm font-normal text-muted-foreground">
-              ({filtered.length})
-            </span>
-          </CardTitle>
-          <CardDescription>Click a row to view detailed breakdown</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {filtered.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <Users className="h-10 w-10 mx-auto mb-3 opacity-30" />
-              <p className="text-sm">
-                {search ? "No students match your search" : "No students enrolled yet"}
-              </p>
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b text-left">
-                    <th className="pb-3 pr-2 w-8" />
-                    <th
-                      className="pb-3 font-medium text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors"
-                      onClick={() => toggleSort("name")}
-                    >
-                      Name <SortIndicator col="name" />
-                    </th>
-                    <th className="pb-3 font-medium text-muted-foreground">Email</th>
-                    <th
-                      className="pb-3 font-medium text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors"
-                      onClick={() => toggleSort("progress")}
-                    >
-                      Progress <SortIndicator col="progress" />
-                    </th>
-                    <th className="pb-3 font-medium text-muted-foreground">Chapters</th>
-                    <th className="pb-3 font-medium text-muted-foreground">Quiz Avg</th>
-                    <th className="pb-3 font-medium text-muted-foreground">Assign. Avg</th>
-                    <th
-                      className="pb-3 font-medium text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors"
-                      onClick={() => toggleSort("last_activity")}
-                    >
-                      Last Active <SortIndicator col="last_activity" />
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filtered.map((student) => {
-                    const isExpanded = expandedId === student.id
-                    const qA = quizAvg(student)
-                    const aA = assignmentAvg(student)
-                    const grade = overallGrade(student)
-
-                    return (
-                      <StudentRow
-                        key={student.id}
-                        student={student}
-                        isExpanded={isExpanded}
-                        onToggle={() => setExpandedId(isExpanded ? null : student.id)}
-                        quizAvg={qA}
-                        assignmentAvg={aA}
-                        overallGrade={grade}
-                        relativeTime={relativeTime}
-                        formatDate={formatDate}
-                        courseId={courseId!}
-                        onStudentUpdate={handleStudentChapterUpdate}
-                      />
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <StudentTable
+        students={filtered}
+        courseId={courseId ?? ""}
+        hasSearch={Boolean(search)}
+        expandedId={expandedId}
+        onExpandToggle={(id) => setExpandedId((prev) => (prev === id ? null : id))}
+        sortBy={sortBy}
+        sortDir={sortDir}
+        onToggleSort={toggleSort}
+        onChapterUpdate={handleStudentChapterUpdate}
+      />
     </div>
-  )
-}
-
-function ProgressBar({ value, className = "" }: { value: number; className?: string }) {
-  const color =
-    value >= 100
-      ? "bg-success"
-      : value >= 60
-        ? "bg-primary"
-        : value >= 30
-          ? "bg-warning"
-          : "bg-destructive"
-
-  return (
-    <div className={`flex items-center gap-2 ${className}`}>
-      <div className="h-2 max-w-[120px] flex-1 rounded-full bg-muted">
-        <div
-          className={`h-full rounded-full transition-all ${color}`}
-          style={{ width: `${Math.min(value, 100)}%` }}
-        />
-      </div>
-      <span className="w-10 text-right text-xs font-medium tabular-nums">
-        {value}%
-      </span>
-    </div>
-  )
-}
-
-function ScoreBadge({ value }: { value: number | null }) {
-  if (value === null) return <span className="text-xs text-muted-foreground">—</span>
-  const color =
-    value >= 90
-      ? "bg-success/15 text-success"
-      : value >= 70
-        ? "bg-info/15 text-info"
-        : value >= 50
-          ? "bg-warning/15 text-warning"
-          : "bg-destructive/15 text-destructive"
-  return (
-    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
-      {value}%
-    </span>
-  )
-}
-
-interface StudentRowProps {
-  student: StudentData
-  isExpanded: boolean
-  onToggle: () => void
-  quizAvg: number | null
-  assignmentAvg: number | null
-  overallGrade: number | null
-  relativeTime: (d: string | null) => string
-  formatDate: (d: string | null) => string
-  courseId: string
-  onStudentUpdate: (studentId: string, chapterId: string, completed: boolean, completedBy: "teacher" | "self" | null) => void
-}
-
-function StudentRow({
-  student,
-  isExpanded,
-  onToggle,
-  quizAvg: qA,
-  assignmentAvg: aA,
-  overallGrade: grade,
-  relativeTime,
-  formatDate,
-  courseId,
-  onStudentUpdate,
-}: StudentRowProps) {
-  const [togglingChapter, setTogglingChapter] = useState<string | null>(null)
-  const [grantingQuiz, setGrantingQuiz] = useState<string | null>(null)
-
-  const allChapters = new Map<string, { quiz?: QuizResult; assignment?: AssignmentResult; chapterInfo?: ChapterInfo }>()
-
-  student.chapters?.forEach((ch) => {
-    const existing = allChapters.get(ch.id) || {}
-    allChapters.set(ch.id, { ...existing, chapterInfo: ch })
-  })
-  student.quiz_results.forEach((q) => {
-    const existing = allChapters.get(q.chapter_id) || {}
-    allChapters.set(q.chapter_id, { ...existing, quiz: q })
-  })
-  student.assignment_results.forEach((a) => {
-    const existing = allChapters.get(a.chapter_id) || {}
-    allChapters.set(a.chapter_id, { ...existing, assignment: a })
-  })
-
-  const handleToggleComplete = async (chapterInfo: ChapterInfo) => {
-    setTogglingChapter(chapterInfo.id)
-    try {
-      if (chapterInfo.completed) {
-        await coursesService.teacherMarkIncomplete(chapterInfo.id, student.id)
-        onStudentUpdate(student.id, chapterInfo.id, false, null)
-        toast({ title: "Marked as incomplete", variant: "success" })
-      } else {
-        await coursesService.teacherMarkComplete(chapterInfo.id, student.id)
-        onStudentUpdate(student.id, chapterInfo.id, true, "teacher")
-        toast({ title: "Marked as complete", variant: "success" })
-      }
-    } catch {
-      toast({ title: "Failed to update completion", variant: "destructive" })
-    } finally {
-      setTogglingChapter(null)
-    }
-  }
-
-  const handleGrantExtraAttempt = async (quizId: string) => {
-    setGrantingQuiz(quizId)
-    try {
-      await coursesService.grantExtraAttempts(quizId, student.id, 1)
-      toast({ title: "Extra attempt granted", variant: "success" })
-    } catch {
-      toast({ title: "Failed to grant extra attempt", variant: "destructive" })
-    } finally {
-      setGrantingQuiz(null)
-    }
-  }
-
-  return (
-    <>
-      <tr
-        className="border-b last:border-0 cursor-pointer hover:bg-muted/50 transition-colors"
-        onClick={onToggle}
-      >
-        <td className="py-3 pr-2">
-          {isExpanded ? (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" />
-          )}
-        </td>
-        <td className="py-3 font-medium">{student.full_name}</td>
-        <td className="py-3 text-muted-foreground">{student.email}</td>
-        <td className="py-3">
-          <ProgressBar value={student.progress} />
-        </td>
-        <td className="py-3 text-center tabular-nums">
-          {student.chapters_completed}/{student.total_chapters}
-        </td>
-        <td className="py-3">
-          <ScoreBadge value={qA} />
-        </td>
-        <td className="py-3">
-          <ScoreBadge value={aA} />
-        </td>
-        <td className="py-3 text-muted-foreground text-xs">
-          {relativeTime(student.last_activity)}
-        </td>
-      </tr>
-      {isExpanded && (
-        <tr>
-          <td colSpan={8} className="p-0">
-            <div className="bg-muted/30 border-y px-6 py-5 space-y-5">
-              {/* Summary row */}
-              <div className="flex flex-wrap gap-6">
-                <div>
-                  <p className="text-xs text-muted-foreground mb-1">Overall Grade</p>
-                  <p className="text-xl font-bold">
-                    {grade !== null ? `${grade}%` : "N/A"}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs text-muted-foreground mb-1">Enrolled</p>
-                  <p className="text-sm font-medium">{formatDate(student.enrolled_at)}</p>
-                </div>
-                <div>
-                  <p className="text-xs text-muted-foreground mb-1">Chapters Completed</p>
-                  <p className="text-sm font-medium">
-                    {student.chapters_completed} of {student.total_chapters}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs text-muted-foreground mb-1">Progress</p>
-                  <ProgressBar value={student.progress} />
-                </div>
-              </div>
-
-              {/* Chapter breakdown */}
-              {allChapters.size > 0 && (
-                <div>
-                  <h4 className="text-sm font-semibold mb-3 flex items-center gap-1.5">
-                    <BookOpen className="h-4 w-4" />
-                    Chapter Breakdown
-                  </h4>
-                  <div className="space-y-2">
-                    {Array.from(allChapters.entries()).map(([chId, { quiz, assignment, chapterInfo }]) => (
-                      <div
-                        key={chId}
-                        className="flex items-center gap-4 bg-background rounded-lg px-4 py-3 border text-sm"
-                      >
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2">
-                            <p className="font-medium truncate">{chapterInfo?.title ?? quiz?.chapter_title ?? assignment?.chapter_title ?? chId}</p>
-                          </div>
-                          {chapterInfo && isGradableChapterType(chapterInfo.chapter_type) && (
-                            <p className="text-xs mt-0.5">
-                              {chapterInfo.completed ? (
-                                <span className={chapterInfo.completed_by === "teacher"
-                                  ? "text-info"
-                                  : "text-success"
-                                }>
-                                  {chapterInfo.completed_by === "teacher"
-                                    ? "Completed by teacher"
-                                    : chapterInfo.completed_by === "quiz"
-                                      ? "Completed via quiz"
-                                      : "Completed via submission"}
-                                </span>
-                              ) : (
-                                <span className="text-muted-foreground">Not completed</span>
-                              )}
-                            </p>
-                          )}
-                        </div>
-                        {quiz && (
-                          <div className="flex items-center gap-1.5 text-xs">
-                            {quiz.passed ? (
-                              <CheckCircle className="h-3.5 w-3.5 text-success" />
-                            ) : (
-                              <XCircle className="h-3.5 w-3.5 text-destructive" />
-                            )}
-                            <span>
-                              Quiz: {quiz.score}/{quiz.max_score}
-                            </span>
-                            {quiz.quiz_id && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-6 px-1.5 text-[10px] text-muted-foreground hover:text-foreground"
-                                disabled={grantingQuiz === quiz.quiz_id}
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleGrantExtraAttempt(quiz.quiz_id!)
-                                }}
-                                title="Grant extra attempt"
-                              >
-                                {grantingQuiz === quiz.quiz_id ? (
-                                  <Loader2 className="h-3 w-3 animate-spin" />
-                                ) : (
-                                  <RotateCcw className="h-3 w-3" />
-                                )}
-                              </Button>
-                            )}
-                          </div>
-                        )}
-                        {assignment && (
-                          <div className="flex items-center gap-1.5 text-xs">
-                            {assignment.status === "graded" ? (
-                              <CheckCircle className="h-3.5 w-3.5 text-success" />
-                            ) : (
-                              <Clock className="h-3.5 w-3.5 text-warning" />
-                            )}
-                            <span>
-                              {assignment.title}:{" "}
-                              {assignment.grade !== null
-                                ? `${assignment.grade}/${assignment.max_score}`
-                                : assignment.status}
-                            </span>
-                          </div>
-                        )}
-                        {chapterInfo && isGradableChapterType(chapterInfo.chapter_type) && (
-                          <Button
-                            variant={chapterInfo.completed ? "outline" : "default"}
-                            size="sm"
-                            className="shrink-0 text-xs h-7"
-                            disabled={togglingChapter === chapterInfo.id}
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              handleToggleComplete(chapterInfo)
-                            }}
-                          >
-                            {togglingChapter === chapterInfo.id ? (
-                              <Clock className="h-3 w-3 mr-1 animate-spin" />
-                            ) : chapterInfo.completed ? (
-                              <XCircle className="h-3 w-3 mr-1" />
-                            ) : (
-                              <CheckCircle className="h-3 w-3 mr-1" />
-                            )}
-                            {chapterInfo.completed ? "Undo" : "Complete"}
-                          </Button>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Actions */}
-              <div className="flex items-center gap-2 pt-1">
-                <Link to={`/teacher/courses/${courseId}/gradebook`}>
-                  <Button size="sm" variant="outline">
-                    <ClipboardList className="h-3.5 w-3.5 mr-1.5" />
-                    Gradebook
-                  </Button>
-                </Link>
-                <Link to={`/teacher/courses/${courseId}/analytics`}>
-                  <Button size="sm" variant="ghost">
-                    <FileText className="h-3.5 w-3.5 mr-1.5" />
-                    View Analytics
-                  </Button>
-                </Link>
-              </div>
-            </div>
-          </td>
-        </tr>
-      )}
-    </>
   )
 }

--- a/frontend/src/pages/Teacher/progress/ChapterBreakdownRow.tsx
+++ b/frontend/src/pages/Teacher/progress/ChapterBreakdownRow.tsx
@@ -1,0 +1,145 @@
+import { Button } from "@/components/ui/button"
+import {
+  CheckCircle,
+  Clock,
+  Loader2,
+  RotateCcw,
+  XCircle,
+} from "lucide-react"
+import { isGradableChapterType } from "@/lib/chapterTypes"
+import type { AssignmentResult, ChapterInfo, QuizResult } from "./helpers"
+
+interface Props {
+  chapterId: string
+  chapterInfo?: ChapterInfo
+  quiz?: QuizResult
+  assignment?: AssignmentResult
+  togglingChapterId: string | null
+  grantingQuizId: string | null
+  onToggleComplete: (chapter: ChapterInfo) => void
+  onGrantExtraAttempt: (quizId: string) => void
+}
+
+/**
+ * One row inside a student's expanded "chapter breakdown" table. Each row
+ * shows the chapter title, quiz status (if any), assignment status (if any),
+ * and for gradable chapters a toggle / grant-extra-attempt affordance.
+ */
+export function ChapterBreakdownRow({
+  chapterId,
+  chapterInfo,
+  quiz,
+  assignment,
+  togglingChapterId,
+  grantingQuizId,
+  onToggleComplete,
+  onGrantExtraAttempt,
+}: Props) {
+  const title =
+    chapterInfo?.title ?? quiz?.chapter_title ?? assignment?.chapter_title ?? chapterId
+  const gradable = chapterInfo ? isGradableChapterType(chapterInfo.chapter_type) : false
+  const completed = chapterInfo?.completed ?? false
+
+  return (
+    <div className="flex items-center gap-4 bg-background rounded-lg px-4 py-3 border text-sm">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <p className="font-medium truncate">{title}</p>
+        </div>
+        {chapterInfo && gradable && (
+          <p className="text-xs mt-0.5">
+            {completed ? (
+              <CompletionLabel completedBy={chapterInfo.completed_by} />
+            ) : (
+              <span className="text-muted-foreground">Not completed</span>
+            )}
+          </p>
+        )}
+      </div>
+
+      {quiz && (
+        <div className="flex items-center gap-1.5 text-xs">
+          {quiz.passed ? (
+            <CheckCircle className="h-3.5 w-3.5 text-success" />
+          ) : (
+            <XCircle className="h-3.5 w-3.5 text-destructive" />
+          )}
+          <span>
+            Quiz: {quiz.score}/{quiz.max_score}
+          </span>
+          {quiz.quiz_id && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1.5 text-[10px] text-muted-foreground hover:text-foreground"
+              disabled={grantingQuizId === quiz.quiz_id}
+              onClick={(e) => {
+                e.stopPropagation()
+                onGrantExtraAttempt(quiz.quiz_id!)
+              }}
+              title="Grant extra attempt"
+            >
+              {grantingQuizId === quiz.quiz_id ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <RotateCcw className="h-3 w-3" />
+              )}
+            </Button>
+          )}
+        </div>
+      )}
+
+      {assignment && (
+        <div className="flex items-center gap-1.5 text-xs">
+          {assignment.status === "graded" ? (
+            <CheckCircle className="h-3.5 w-3.5 text-success" />
+          ) : (
+            <Clock className="h-3.5 w-3.5 text-warning" />
+          )}
+          <span>
+            {assignment.title}:{" "}
+            {assignment.grade !== null
+              ? `${assignment.grade}/${assignment.max_score}`
+              : assignment.status}
+          </span>
+        </div>
+      )}
+
+      {chapterInfo && gradable && (
+        <Button
+          variant={completed ? "outline" : "default"}
+          size="sm"
+          className="shrink-0 text-xs h-7"
+          disabled={togglingChapterId === chapterInfo.id}
+          onClick={(e) => {
+            e.stopPropagation()
+            onToggleComplete(chapterInfo)
+          }}
+        >
+          {togglingChapterId === chapterInfo.id ? (
+            <Clock className="h-3 w-3 mr-1 animate-spin" />
+          ) : completed ? (
+            <XCircle className="h-3 w-3 mr-1" />
+          ) : (
+            <CheckCircle className="h-3 w-3 mr-1" />
+          )}
+          {completed ? "Undo" : "Complete"}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+function CompletionLabel({
+  completedBy,
+}: {
+  completedBy: ChapterInfo["completed_by"]
+}) {
+  if (completedBy === "teacher") {
+    return <span className="text-info">Completed by teacher</span>
+  }
+  if (completedBy === "quiz") {
+    return <span className="text-success">Completed via quiz</span>
+  }
+  return <span className="text-success">Completed via submission</span>
+}

--- a/frontend/src/pages/Teacher/progress/ProgressBar.tsx
+++ b/frontend/src/pages/Teacher/progress/ProgressBar.tsx
@@ -1,0 +1,49 @@
+/** Horizontal progress bar with tone steps (red → amber → primary → green). */
+export function ProgressBar({
+  value,
+  className = "",
+}: {
+  value: number
+  className?: string
+}) {
+  const color =
+    value >= 100
+      ? "bg-success"
+      : value >= 60
+        ? "bg-primary"
+        : value >= 30
+          ? "bg-warning"
+          : "bg-destructive"
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <div className="h-2 max-w-[120px] flex-1 rounded-full bg-muted">
+        <div
+          className={`h-full rounded-full transition-all ${color}`}
+          style={{ width: `${Math.min(value, 100)}%` }}
+        />
+      </div>
+      <span className="w-10 text-right text-xs font-medium tabular-nums">
+        {value}%
+      </span>
+    </div>
+  )
+}
+
+/** Small percentage pill with tone based on score. `null` renders an em-dash. */
+export function ScoreBadge({ value }: { value: number | null }) {
+  if (value === null) return <span className="text-xs text-muted-foreground">—</span>
+  const color =
+    value >= 90
+      ? "bg-success/15 text-success"
+      : value >= 70
+        ? "bg-info/15 text-info"
+        : value >= 50
+          ? "bg-warning/15 text-warning"
+          : "bg-destructive/15 text-destructive"
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
+      {value}%
+    </span>
+  )
+}

--- a/frontend/src/pages/Teacher/progress/ProgressStats.tsx
+++ b/frontend/src/pages/Teacher/progress/ProgressStats.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent } from "@/components/ui/card"
+import { Award, TrendingUp, Users } from "lucide-react"
+
+interface Props {
+  totalStudents: number
+  averageProgress: number
+  completionRate: number
+}
+
+const CARDS = [
+  { key: "total", label: "Total Students", icon: Users },
+  { key: "avg", label: "Average Progress", icon: TrendingUp },
+  { key: "completion", label: "Completion Rate", icon: Award },
+] as const
+
+export function ProgressStats({ totalStudents, averageProgress, completionRate }: Props) {
+  const values: Record<(typeof CARDS)[number]["key"], string> = {
+    total: totalStudents.toString(),
+    avg: `${averageProgress}%`,
+    completion: `${completionRate}%`,
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+      {CARDS.map(({ key, label, icon: Icon }) => (
+        <Card key={key}>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">{label}</p>
+                <p className="text-2xl font-bold mt-1">{values[key]}</p>
+              </div>
+              <Icon className="h-8 w-8 text-muted-foreground/60" />
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/Teacher/progress/StudentRow.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentRow.tsx
@@ -1,0 +1,223 @@
+import { useMemo, useState } from "react"
+import { Link } from "react-router-dom"
+import { Button } from "@/components/ui/button"
+import { toast } from "@/lib/toast"
+import { coursesService } from "@/services/courses"
+import {
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  ClipboardList,
+  FileText,
+} from "lucide-react"
+import { ChapterBreakdownRow } from "./ChapterBreakdownRow"
+import { ProgressBar, ScoreBadge } from "./ProgressBar"
+import {
+  formatDate,
+  relativeTime,
+  type AssignmentResult,
+  type ChapterInfo,
+  type QuizResult,
+  type StudentData,
+} from "./helpers"
+
+interface Props {
+  student: StudentData
+  isExpanded: boolean
+  onToggle: () => void
+  quizAvg: number | null
+  assignmentAvg: number | null
+  overallGrade: number | null
+  courseId: string
+  onChapterUpdate: (
+    studentId: string,
+    chapterId: string,
+    completed: boolean,
+    completedBy: "teacher" | "self" | null,
+  ) => void
+}
+
+type ChapterEntry = {
+  quiz?: QuizResult
+  assignment?: AssignmentResult
+  chapterInfo?: ChapterInfo
+}
+
+/**
+ * Two-row component: the always-visible student summary row, plus the
+ * detail row that appears when expanded (per-chapter breakdown, quick
+ * actions). Uses render-time memo for the merged chapter map so we don't
+ * rebuild it on every keystroke in the outer search input.
+ */
+export function StudentRow({
+  student,
+  isExpanded,
+  onToggle,
+  quizAvg,
+  assignmentAvg,
+  overallGrade,
+  courseId,
+  onChapterUpdate,
+}: Props) {
+  const [togglingChapter, setTogglingChapter] = useState<string | null>(null)
+  const [grantingQuiz, setGrantingQuiz] = useState<string | null>(null)
+
+  const allChapters = useMemo(() => {
+    const map = new Map<string, ChapterEntry>()
+    for (const ch of student.chapters ?? []) {
+      map.set(ch.id, { ...(map.get(ch.id) ?? {}), chapterInfo: ch })
+    }
+    for (const q of student.quiz_results) {
+      map.set(q.chapter_id, { ...(map.get(q.chapter_id) ?? {}), quiz: q })
+    }
+    for (const a of student.assignment_results) {
+      map.set(a.chapter_id, { ...(map.get(a.chapter_id) ?? {}), assignment: a })
+    }
+    return map
+  }, [student.chapters, student.quiz_results, student.assignment_results])
+
+  const handleToggleComplete = async (chapterInfo: ChapterInfo) => {
+    setTogglingChapter(chapterInfo.id)
+    try {
+      if (chapterInfo.completed) {
+        await coursesService.teacherMarkIncomplete(chapterInfo.id, student.id)
+        onChapterUpdate(student.id, chapterInfo.id, false, null)
+        toast({ title: "Marked as incomplete", variant: "success" })
+      } else {
+        await coursesService.teacherMarkComplete(chapterInfo.id, student.id)
+        onChapterUpdate(student.id, chapterInfo.id, true, "teacher")
+        toast({ title: "Marked as complete", variant: "success" })
+      }
+    } catch {
+      toast({ title: "Failed to update completion", variant: "destructive" })
+    } finally {
+      setTogglingChapter(null)
+    }
+  }
+
+  const handleGrantExtraAttempt = async (quizId: string) => {
+    setGrantingQuiz(quizId)
+    try {
+      await coursesService.grantExtraAttempts(quizId, student.id, 1)
+      toast({ title: "Extra attempt granted", variant: "success" })
+    } catch {
+      toast({ title: "Failed to grant extra attempt", variant: "destructive" })
+    } finally {
+      setGrantingQuiz(null)
+    }
+  }
+
+  return (
+    <>
+      <tr
+        className="border-b last:border-0 cursor-pointer hover:bg-muted/50 transition-colors"
+        onClick={onToggle}
+      >
+        <td className="py-3 pr-2">
+          {isExpanded ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </td>
+        <td className="py-3 font-medium">{student.full_name}</td>
+        <td className="py-3 text-muted-foreground">{student.email}</td>
+        <td className="py-3">
+          <ProgressBar value={student.progress} />
+        </td>
+        <td className="py-3 text-center tabular-nums">
+          {student.chapters_completed}/{student.total_chapters}
+        </td>
+        <td className="py-3">
+          <ScoreBadge value={quizAvg} />
+        </td>
+        <td className="py-3">
+          <ScoreBadge value={assignmentAvg} />
+        </td>
+        <td className="py-3 text-muted-foreground text-xs">
+          {relativeTime(student.last_activity)}
+        </td>
+      </tr>
+      {isExpanded && (
+        <tr>
+          <td colSpan={8} className="p-0">
+            <div className="bg-muted/30 border-y px-6 py-5 space-y-5">
+              <div className="flex flex-wrap gap-6">
+                <SummaryStat label="Overall Grade">
+                  <p className="text-xl font-bold">
+                    {overallGrade !== null ? `${overallGrade}%` : "N/A"}
+                  </p>
+                </SummaryStat>
+                <SummaryStat label="Enrolled">
+                  <p className="text-sm font-medium">{formatDate(student.enrolled_at)}</p>
+                </SummaryStat>
+                <SummaryStat label="Chapters Completed">
+                  <p className="text-sm font-medium">
+                    {student.chapters_completed} of {student.total_chapters}
+                  </p>
+                </SummaryStat>
+                <SummaryStat label="Progress">
+                  <ProgressBar value={student.progress} />
+                </SummaryStat>
+              </div>
+
+              {allChapters.size > 0 && (
+                <div>
+                  <h4 className="text-sm font-semibold mb-3 flex items-center gap-1.5">
+                    <BookOpen className="h-4 w-4" />
+                    Chapter Breakdown
+                  </h4>
+                  <div className="space-y-2">
+                    {Array.from(allChapters.entries()).map(([id, entry]) => (
+                      <ChapterBreakdownRow
+                        key={id}
+                        chapterId={id}
+                        chapterInfo={entry.chapterInfo}
+                        quiz={entry.quiz}
+                        assignment={entry.assignment}
+                        togglingChapterId={togglingChapter}
+                        grantingQuizId={grantingQuiz}
+                        onToggleComplete={handleToggleComplete}
+                        onGrantExtraAttempt={handleGrantExtraAttempt}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="flex items-center gap-2 pt-1">
+                <Link to={`/teacher/courses/${courseId}/gradebook`}>
+                  <Button size="sm" variant="outline">
+                    <ClipboardList className="h-3.5 w-3.5 mr-1.5" />
+                    Gradebook
+                  </Button>
+                </Link>
+                <Link to={`/teacher/courses/${courseId}/analytics`}>
+                  <Button size="sm" variant="ghost">
+                    <FileText className="h-3.5 w-3.5 mr-1.5" />
+                    View Analytics
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function SummaryStat({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/pages/Teacher/progress/StudentSkeleton.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentSkeleton.tsx
@@ -1,0 +1,23 @@
+/** Animated placeholder shown while student progress loads. */
+export function StudentProgressSkeleton() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-6xl">
+      <div className="h-8 w-48 bg-muted rounded animate-pulse mb-6" />
+      <div className="rounded-lg border">
+        <div className="p-4 border-b">
+          <div className="h-9 w-64 bg-muted rounded animate-pulse" />
+        </div>
+        <div className="divide-y">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="p-4 flex items-center gap-4">
+              <div className="h-4 w-4 bg-muted rounded animate-pulse" />
+              <div className="h-4 flex-1 bg-muted rounded animate-pulse" />
+              <div className="h-4 w-24 bg-muted rounded animate-pulse" />
+              <div className="h-4 w-16 bg-muted rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Teacher/progress/StudentTable.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentTable.tsx
@@ -1,0 +1,147 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Users } from "lucide-react"
+import { StudentRow } from "./StudentRow"
+import {
+  assignmentAvg,
+  overallGrade,
+  quizAvg,
+  type SortColumn,
+  type SortDirection,
+  type StudentData,
+} from "./helpers"
+
+interface Props {
+  students: StudentData[]
+  courseId: string
+  hasSearch: boolean
+  expandedId: string | null
+  onExpandToggle: (id: string) => void
+  sortBy: SortColumn
+  sortDir: SortDirection
+  onToggleSort: (col: SortColumn) => void
+  onChapterUpdate: (
+    studentId: string,
+    chapterId: string,
+    completed: boolean,
+    completedBy: "teacher" | "self" | null,
+  ) => void
+}
+
+export function StudentTable({
+  students,
+  courseId,
+  hasSearch,
+  expandedId,
+  onExpandToggle,
+  sortBy,
+  sortDir,
+  onToggleSort,
+  onChapterUpdate,
+}: Props) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          Students
+          <span className="text-sm font-normal text-muted-foreground">
+            ({students.length})
+          </span>
+        </CardTitle>
+        <CardDescription>Click a row to view detailed breakdown</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {students.length === 0 ? (
+          <EmptyState hasSearch={hasSearch} />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="pb-3 pr-2 w-8" />
+                  <SortableHeader
+                    label="Name"
+                    col="name"
+                    sortBy={sortBy}
+                    sortDir={sortDir}
+                    onToggle={onToggleSort}
+                  />
+                  <th className="pb-3 font-medium text-muted-foreground">Email</th>
+                  <SortableHeader
+                    label="Progress"
+                    col="progress"
+                    sortBy={sortBy}
+                    sortDir={sortDir}
+                    onToggle={onToggleSort}
+                  />
+                  <th className="pb-3 font-medium text-muted-foreground">Chapters</th>
+                  <th className="pb-3 font-medium text-muted-foreground">Quiz Avg</th>
+                  <th className="pb-3 font-medium text-muted-foreground">Assign. Avg</th>
+                  <SortableHeader
+                    label="Last Active"
+                    col="last_activity"
+                    sortBy={sortBy}
+                    sortDir={sortDir}
+                    onToggle={onToggleSort}
+                  />
+                </tr>
+              </thead>
+              <tbody>
+                {students.map((student) => (
+                  <StudentRow
+                    key={student.id}
+                    student={student}
+                    isExpanded={expandedId === student.id}
+                    onToggle={() => onExpandToggle(student.id)}
+                    quizAvg={quizAvg(student)}
+                    assignmentAvg={assignmentAvg(student)}
+                    overallGrade={overallGrade(student)}
+                    courseId={courseId}
+                    onChapterUpdate={onChapterUpdate}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EmptyState({ hasSearch }: { hasSearch: boolean }) {
+  return (
+    <div className="text-center py-12 text-muted-foreground">
+      <Users className="h-10 w-10 mx-auto mb-3 opacity-30" />
+      <p className="text-sm">
+        {hasSearch ? "No students match your search" : "No students enrolled yet"}
+      </p>
+    </div>
+  )
+}
+
+interface SortableHeaderProps {
+  label: string
+  col: SortColumn
+  sortBy: SortColumn
+  sortDir: SortDirection
+  onToggle: (col: SortColumn) => void
+}
+
+function SortableHeader({ label, col, sortBy, sortDir, onToggle }: SortableHeaderProps) {
+  return (
+    <th
+      className="pb-3 font-medium text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors"
+      onClick={() => onToggle(col)}
+    >
+      {label}
+      {sortBy === col && <span className="ml-1">{sortDir === "asc" ? "↑" : "↓"}</span>}
+    </th>
+  )
+}

--- a/frontend/src/pages/Teacher/progress/helpers.ts
+++ b/frontend/src/pages/Teacher/progress/helpers.ts
@@ -1,0 +1,80 @@
+import type {
+  StudentAssignmentResult,
+  StudentChapterInfo,
+  StudentProgressEntry,
+  StudentQuizResult,
+} from "@/types"
+
+export type StudentData = StudentProgressEntry
+export type QuizResult = StudentQuizResult
+export type AssignmentResult = StudentAssignmentResult
+export type ChapterInfo = StudentChapterInfo
+
+export type SortColumn = "name" | "progress" | "last_activity"
+export type SortDirection = "asc" | "desc"
+
+/** Average quiz percentage, or null if the student has no quiz attempts. */
+export function quizAvg(student: StudentData): number | null {
+  if (student.quiz_results.length === 0) return null
+  const total = student.quiz_results.reduce(
+    (sum, q) => sum + (q.score / q.max_score) * 100,
+    0,
+  )
+  return Math.round(total / student.quiz_results.length)
+}
+
+/** Average graded-assignment percentage, or null if nothing has been graded. */
+export function assignmentAvg(student: StudentData): number | null {
+  const graded = student.assignment_results.filter((a) => a.grade !== null)
+  if (graded.length === 0) return null
+  const total = graded.reduce((sum, a) => sum + (a.grade! / a.max_score) * 100, 0)
+  return Math.round(total / graded.length)
+}
+
+/**
+ * Simple mean of quizAvg and assignmentAvg. We intentionally do NOT weight
+ * by attempt count — a single low quiz shouldn't skew the grade more than
+ * graded assignments would.
+ */
+export function overallGrade(student: StudentData): number | null {
+  const scores: number[] = []
+  const qAvg = quizAvg(student)
+  const aAvg = assignmentAvg(student)
+  if (qAvg !== null) scores.push(qAvg)
+  if (aAvg !== null) scores.push(aAvg)
+  if (scores.length === 0) return null
+  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
+}
+
+export function formatDate(d: string | null): string {
+  if (!d) return "—"
+  return new Date(d).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+/** "3m ago" / "5d ago" / falls back to formatDate after 7 days. */
+export function relativeTime(d: string | null): string {
+  if (!d) return "Never"
+  const diff = Date.now() - new Date(d).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return formatDate(d)
+}
+
+export function averageProgress(students: StudentData[]): number {
+  if (students.length === 0) return 0
+  return Math.round(students.reduce((sum, s) => sum + s.progress, 0) / students.length)
+}
+
+export function completionRate(students: StudentData[]): number {
+  if (students.length === 0) return 0
+  const completed = students.filter((s) => s.progress >= 100).length
+  return Math.round((completed / students.length) * 100)
+}

--- a/frontend/src/pages/Teacher/progress/index.ts
+++ b/frontend/src/pages/Teacher/progress/index.ts
@@ -1,0 +1,10 @@
+export { ProgressStats } from "./ProgressStats"
+export { StudentProgressSkeleton } from "./StudentSkeleton"
+export { StudentTable } from "./StudentTable"
+export {
+  averageProgress,
+  completionRate,
+  type SortColumn,
+  type SortDirection,
+  type StudentData,
+} from "./helpers"


### PR DESCRIPTION
## Summary

Third monster-page cleanup in the series (#35 TeacherGradebook → #36 AdminDashboard → #37 CourseEditor → this).

Splits `StudentProgress.tsx` (previously 675 lines) into a 231-line orchestrator + a `pages/Teacher/progress/` folder of single-purpose children:

- `helpers.ts` — pure math (`quizAvg`, `assignmentAvg`, `overallGrade`, `averageProgress`, `completionRate`), date formatters, sort enums, shared type aliases. No React deps → trivially testable.
- `ProgressBar.tsx` — shared `ProgressBar` and `ScoreBadge`.
- `ProgressStats.tsx` — 3 stat cards driven from one `CARDS` tuple (was three hand-copied `Card/CardContent` blocks).
- `StudentSkeleton.tsx` — loading skeleton.
- `StudentTable.tsx` — table header (with a `SortableHeader` helper), empty state, tbody mapping.
- `StudentRow.tsx` — summary row + expanded detail. Chapter-merge `Map` is now memoised.
- `ChapterBreakdownRow.tsx` — one row of the per-chapter breakdown, including quiz/assignment status, grant-extra-attempt, and toggle-complete. Pulled out of the ~120-line inline block that used to live inside StudentRow.

Incidental improvements:

- The chapter-merge map is now `useMemo`'d on its three inputs — previously it was rebuilt on every render of every row, including on every keystroke in the outer search input.
- A `CompletionLabel` helper replaces a three-way nested ternary inside a `<p>` inside two conditionals.

No behaviour change. Same services, same URL search param, same confirm flows.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/pages/Teacher --max-warnings 0` clean
- [x] `npx vitest run` — 85/85 pass
- [x] `npm run build` clean
- [ ] GitHub Actions green
