### PR TITLE
refactor(frontend): decompose TeacherDashboard into section components

### DIFF
--- a/frontend/src/pages/Teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.tsx
@@ -1,40 +1,51 @@
 import { useEffect, useMemo, useState } from "react"
-import { Link, useNavigate, useSearchParams } from "react-router-dom"
-import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import PageSpinner from "@/components/ui/PageSpinner"
+import { useNavigate, useSearchParams } from "react-router-dom"
+import { BookOpen, Plus, Search } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Badge } from "@/components/ui/badge"
-import { coursesService } from "@/services/courses"
-import { courseSchema, type CourseFormData } from "@/lib/validations/course"
-import type { Course, Certificate } from "@/types"
-import { toast } from "@/lib/toast"
-import { Plus, Pencil, Trash2, BookOpen, Layers, BarChart3, Eye, EyeOff, ClipboardList, Users, Clock, CheckCircle, XCircle, Award, Search, Copy, RotateCcw, Archive } from "lucide-react"
-import { getErrorDetail } from "@/lib/errorDetail"
-import { toProxyImage } from "@/lib/images"
+import PageSpinner from "@/components/ui/PageSpinner"
 import { useConfirm } from "@/components/ui/alert-dialog"
+import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
+import { courseSchema, type CourseFormData } from "@/lib/validations/course"
+import { getErrorDetail } from "@/lib/errorDetail"
+import { coursesService } from "@/services/courses"
+import { toast } from "@/lib/toast"
+import type { Course } from "@/types"
+import {
+  CourseCard,
+  CreateCourseForm,
+  EmptyCoursesCard,
+  PendingCertsCard,
+  TrashSection,
+  type PendingCert,
+} from "./dashboard"
 
 export default function TeacherDashboard() {
   const navigate = useNavigate()
   const confirm = useConfirm()
   const [params, setParams] = useSearchParams()
   const showTrash = params.get("trash") === "1"
-  const { input: searchInput, setInput: setSearchInput, value: urlQuery, maxLength: MAX_SEARCH_LEN } = useDebouncedSearchParam()
+  const {
+    input: searchInput,
+    setInput: setSearchInput,
+    value: urlQuery,
+    maxLength: MAX_SEARCH_LEN,
+  } = useDebouncedSearchParam()
   const [courses, setCourses] = useState<Course[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [showCreate, setShowCreate] = useState(false)
-  const [form, setForm] = useState<CourseFormData>({ title: "", description: "", image_url: "" })
+  const [form, setForm] = useState<CourseFormData>({
+    title: "",
+    description: "",
+    image_url: "",
+  })
   const [errors, setErrors] = useState<Partial<Record<string, string>>>({})
   const [saving, setSaving] = useState(false)
   const [togglingId, setTogglingId] = useState<string | null>(null)
   const [cloningId, setCloningId] = useState<string | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [trashedCourses, setTrashedCourses] = useState<Course[]>([])
-  const [trashLoading, setTrashLoading] = useState(false)
-  const [restoringId, setRestoringId] = useState<string | null>(null)
-  const [pendingCerts, setPendingCerts] = useState<(Certificate & { student_name?: string; course_title?: string })[]>([])
+  const [pendingCerts, setPendingCerts] = useState<PendingCert[]>([])
   const [certActionId, setCertActionId] = useState<string | null>(null)
 
   const filteredCourses = useMemo(() => {
@@ -42,48 +53,6 @@ export default function TeacherDashboard() {
     if (!q) return courses
     return courses.filter((c) => c.title.toLowerCase().includes(q))
   }, [courses, urlQuery])
-
-  const handleApproveCert = async (certId: string) => {
-    setCertActionId(certId)
-    try {
-      await coursesService.teacherApproveCert(certId)
-      setPendingCerts((prev) => prev.filter((c) => c.id !== certId))
-      toast({ title: "Certificate approved", variant: "success" })
-    } catch (err) {
-      toast({ title: getErrorDetail(err, "Failed to approve certificate"), variant: "destructive" })
-    } finally {
-      setCertActionId(null)
-    }
-  }
-
-  const handleRejectCert = async (certId: string) => {
-    setCertActionId(certId)
-    try {
-      await coursesService.rejectCert(certId)
-      setPendingCerts((prev) => prev.filter((c) => c.id !== certId))
-      toast({ title: "Certificate request declined" })
-    } catch (err) {
-      toast({ title: getErrorDetail(err, "Failed to reject certificate"), variant: "destructive" })
-    } finally {
-      setCertActionId(null)
-    }
-  }
-
-  const handleToggleStatus = async (course: Course) => {
-    const newStatus = course.status === "published" ? "draft" : "published"
-    setTogglingId(course.id)
-    try {
-      await coursesService.updateCourse(course.id, { status: newStatus })
-      setCourses((prev) =>
-        prev.map((c) => (c.id === course.id ? { ...c, status: newStatus } : c)),
-      )
-      toast({ title: `Course ${newStatus === "published" ? "published" : "unpublished"}`, variant: "success" })
-    } catch (err) {
-      toast({ title: getErrorDetail(err, "Failed to update status"), variant: "destructive" })
-    } finally {
-      setTogglingId(null)
-    }
-  }
 
   const load = async (signal?: { cancelled: boolean }) => {
     setLoading(true)
@@ -97,7 +66,8 @@ export default function TeacherDashboard() {
       setCourses(data)
       setPendingCerts(certs)
     } catch {
-      if (!signal?.cancelled) setError("Failed to load your courses. Please try again.")
+      if (!signal?.cancelled)
+        setError("Failed to load your courses. Please try again.")
     } finally {
       if (!signal?.cancelled) setLoading(false)
     }
@@ -105,9 +75,65 @@ export default function TeacherDashboard() {
 
   useEffect(() => {
     const signal = { cancelled: false }
-    load(signal)
-    return () => { signal.cancelled = true }
+    void load(signal)
+    return () => {
+      signal.cancelled = true
+    }
   }, [])
+
+  const handleApproveCert = async (certId: string) => {
+    setCertActionId(certId)
+    try {
+      await coursesService.teacherApproveCert(certId)
+      setPendingCerts((prev) => prev.filter((c) => c.id !== certId))
+      toast({ title: "Certificate approved", variant: "success" })
+    } catch (err) {
+      toast({
+        title: getErrorDetail(err, "Failed to approve certificate"),
+        variant: "destructive",
+      })
+    } finally {
+      setCertActionId(null)
+    }
+  }
+
+  const handleRejectCert = async (certId: string) => {
+    setCertActionId(certId)
+    try {
+      await coursesService.rejectCert(certId)
+      setPendingCerts((prev) => prev.filter((c) => c.id !== certId))
+      toast({ title: "Certificate request declined" })
+    } catch (err) {
+      toast({
+        title: getErrorDetail(err, "Failed to reject certificate"),
+        variant: "destructive",
+      })
+    } finally {
+      setCertActionId(null)
+    }
+  }
+
+  const handleToggleStatus = async (course: Course) => {
+    const newStatus = course.status === "published" ? "draft" : "published"
+    setTogglingId(course.id)
+    try {
+      await coursesService.updateCourse(course.id, { status: newStatus })
+      setCourses((prev) =>
+        prev.map((c) => (c.id === course.id ? { ...c, status: newStatus } : c)),
+      )
+      toast({
+        title: `Course ${newStatus === "published" ? "published" : "unpublished"}`,
+        variant: "success",
+      })
+    } catch (err) {
+      toast({
+        title: getErrorDetail(err, "Failed to update status"),
+        variant: "destructive",
+      })
+    } finally {
+      setTogglingId(null)
+    }
+  }
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -153,58 +179,10 @@ export default function TeacherDashboard() {
       setCourses((prev) => prev.filter((c) => c.id !== id))
       toast({ title: "Course moved to trash", variant: "success" })
     } catch (err) {
-      toast({ title: getErrorDetail(err, "Failed to delete course"), variant: "destructive" })
-    }
-  }
-
-  useEffect(() => {
-    if (!showTrash) return
-    const signal = { cancelled: false }
-    setTrashLoading(true)
-    coursesService
-      .getTrashedCourses()
-      .then((data) => { if (!signal.cancelled) setTrashedCourses(data) })
-      .catch(() => { if (!signal.cancelled) toast({ title: "Failed to load trash", variant: "destructive" }) })
-      .finally(() => { if (!signal.cancelled) setTrashLoading(false) })
-    return () => { signal.cancelled = true }
-  }, [showTrash])
-
-  const toggleTrash = () => {
-    const next = new URLSearchParams(params)
-    if (showTrash) next.delete("trash")
-    else next.set("trash", "1")
-    setParams(next, { replace: true })
-  }
-
-  const handleRestore = async (id: string) => {
-    setRestoringId(id)
-    try {
-      const restored = await coursesService.restoreCourse(id)
-      setTrashedCourses((prev) => prev.filter((c) => c.id !== id))
-      setCourses((prev) => [restored, ...prev])
-      toast({ title: "Course restored", variant: "success" })
-    } catch (err) {
-      toast({ title: getErrorDetail(err, "Failed to restore course"), variant: "destructive" })
-    } finally {
-      setRestoringId(null)
-    }
-  }
-
-  const handlePermanentDelete = async (id: string) => {
-    const ok = await confirm({
-      title: "Permanently delete this course?",
-      description:
-        "This will permanently delete the course and all its data (modules, chapters, enrollments, grades). This action cannot be undone.",
-      confirmLabel: "Delete permanently",
-      tone: "destructive",
-    })
-    if (!ok) return
-    try {
-      await coursesService.permanentlyDeleteCourse(id)
-      setTrashedCourses((prev) => prev.filter((c) => c.id !== id))
-      toast({ title: "Course permanently deleted" })
-    } catch (err) {
-      toast({ title: getErrorDetail(err, "Failed to delete course"), variant: "destructive" })
+      toast({
+        title: getErrorDetail(err, "Failed to delete course"),
+        variant: "destructive",
+      })
     }
   }
 
@@ -215,10 +193,20 @@ export default function TeacherDashboard() {
       toast({ title: "Course cloned successfully", variant: "success" })
       navigate(`/teacher/courses/${cloned.id}`)
     } catch (err) {
-      toast({ title: getErrorDetail(err, "Failed to clone course"), variant: "destructive" })
+      toast({
+        title: getErrorDetail(err, "Failed to clone course"),
+        variant: "destructive",
+      })
     } finally {
       setCloningId(null)
     }
+  }
+
+  const toggleTrash = () => {
+    const next = new URLSearchParams(params)
+    if (showTrash) next.delete("trash")
+    else next.set("trash", "1")
+    setParams(next, { replace: true })
   }
 
   return (
@@ -226,7 +214,9 @@ export default function TeacherDashboard() {
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">My Courses</h1>
-          <p className="text-muted-foreground mt-1">Create and manage your course content</p>
+          <p className="text-muted-foreground mt-1">
+            Create and manage your course content
+          </p>
         </div>
         <Button onClick={() => setShowCreate(!showCreate)} size="sm">
           <Plus className="h-4 w-4 mr-1.5" />
@@ -235,110 +225,23 @@ export default function TeacherDashboard() {
       </div>
 
       {showCreate && (
-        <Card className="mb-8 border-dashed">
-          <CardHeader>
-            <CardTitle className="text-lg">Create New Course</CardTitle>
-          </CardHeader>
-          <form onSubmit={handleCreate}>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="title">Title</Label>
-                <Input
-                  id="title"
-                  value={form.title}
-                  onChange={(e) => {
-                    setForm((p) => ({ ...p, title: e.target.value }))
-                    setErrors((p) => ({ ...p, title: undefined }))
-                  }}
-                  placeholder="Introduction to Theology"
-                />
-                {errors.title && <p className="text-sm text-destructive">{errors.title}</p>}
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="desc">Description</Label>
-                <textarea
-                  id="desc"
-                  className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  value={form.description}
-                  onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
-                  placeholder="A brief description of the course..."
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="img">Cover Image URL (optional — or upload after creating)</Label>
-                <Input
-                  id="img"
-                  value={form.image_url}
-                  onChange={(e) => setForm((p) => ({ ...p, image_url: e.target.value }))}
-                  placeholder="https://... (you can upload in the editor)"
-                />
-                {errors.image_url && <p className="text-sm text-destructive">{errors.image_url}</p>}
-              </div>
-              <div className="flex gap-2 pt-2">
-                <Button type="submit" disabled={saving}>
-                  {saving ? "Creating..." : "Create Course"}
-                </Button>
-                <Button type="button" variant="ghost" onClick={() => setShowCreate(false)}>
-                  Cancel
-                </Button>
-              </div>
-            </CardContent>
-          </form>
-        </Card>
+        <CreateCourseForm
+          form={form}
+          setForm={setForm}
+          errors={errors}
+          setErrors={setErrors}
+          saving={saving}
+          onSubmit={handleCreate}
+          onCancel={() => setShowCreate(false)}
+        />
       )}
 
-      {pendingCerts.length > 0 && (
-        <Card className="mb-8 border-l-[3px] border-l-warning">
-          <CardHeader>
-            <CardTitle className="text-xl flex items-center gap-2">
-              <Award className="h-5 w-5 text-warning" />
-              Pending Certificates
-              <Badge variant="warning" className="font-normal">
-                {pendingCerts.length}
-              </Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {pendingCerts.map((cert) => (
-                <div
-                  key={cert.id}
-                  className="flex items-center justify-between rounded-md border border-l-[3px] border-l-warning/60 bg-warning/5 p-4"
-                >
-                  <div className="min-w-0">
-                    <p className="font-medium truncate">{cert.student_name || "Student"}</p>
-                    <p className="text-sm text-muted-foreground truncate">{cert.course_title || "Course"}</p>
-                    <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
-                      <Clock className="h-3 w-3" />
-                      Requested {cert.requested_at ? new Date(cert.requested_at).toLocaleDateString() : "Unknown"}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2 shrink-0 ml-4">
-                    <Button
-                      size="sm"
-                      onClick={() => handleApproveCert(cert.id)}
-                      disabled={certActionId === cert.id}
-                    >
-                      <CheckCircle className="h-4 w-4 mr-1.5" />
-                      Approve
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => handleRejectCert(cert.id)}
-                      disabled={certActionId === cert.id}
-                      className="text-destructive hover:text-destructive"
-                    >
-                      <XCircle className="h-4 w-4 mr-1.5" />
-                      Reject
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      <PendingCertsCard
+        certs={pendingCerts}
+        actionId={certActionId}
+        onApprove={handleApproveCert}
+        onReject={handleRejectCert}
+      />
 
       {loading ? (
         <PageSpinner />
@@ -354,19 +257,7 @@ export default function TeacherDashboard() {
           </CardContent>
         </Card>
       ) : courses.length === 0 ? (
-        <Card className="border-dashed">
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-            <BookOpen className="h-12 w-12 text-muted-foreground/50 mb-4" />
-            <h3 className="text-lg font-medium mb-1">No courses yet</h3>
-            <p className="text-sm text-muted-foreground mb-4">
-              Create your first course to start teaching
-            </p>
-            <Button onClick={() => setShowCreate(true)} size="sm">
-              <Plus className="h-4 w-4 mr-1.5" />
-              Create Course
-            </Button>
-          </CardContent>
-        </Card>
+        <EmptyCoursesCard onCreate={() => setShowCreate(true)} />
       ) : (
         <>
           {courses.length > 3 && (
@@ -375,175 +266,35 @@ export default function TeacherDashboard() {
               <Input
                 placeholder="Search courses..."
                 value={searchInput}
-                onChange={(e) => setSearchInput(e.target.value.slice(0, MAX_SEARCH_LEN))}
+                onChange={(e) =>
+                  setSearchInput(e.target.value.slice(0, MAX_SEARCH_LEN))
+                }
                 maxLength={MAX_SEARCH_LEN}
                 className="max-w-sm pl-9"
               />
             </div>
           )}
           <div className="space-y-4">
-          {filteredCourses.map((course) => (
-            <Card key={course.id} className="group hover:shadow-md transition-shadow">
-              <div className="flex items-start gap-4 p-6">
-                {course.image_url ? (
-                  <img
-                    src={toProxyImage(course.image_url)}
-                    alt={`${course.title} thumbnail`}
-                    loading="lazy"
-                    className="w-20 h-20 rounded-lg object-cover shrink-0"
-                  />
-                ) : (
-                  <div className="w-20 h-20 rounded-lg bg-muted flex items-center justify-center shrink-0">
-                    <BookOpen className="h-8 w-8 text-muted-foreground/40" />
-                  </div>
-                )}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h3 className="font-semibold text-lg truncate">{course.title}</h3>
-                    <Badge variant={course.status === "published" ? "success" : "warning"}>
-                      {course.status === "published" ? "Published" : "Draft"}
-                    </Badge>
-                  </div>
-                  {course.description && (
-                    <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
-                      {course.description}
-                    </p>
-                  )}
-                  <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
-                    <span className="flex items-center gap-1">
-                      <Layers className="h-3.5 w-3.5" />
-                      {course.modules?.length ?? 0} modules
-                    </span>
-                    <span>
-                      Created {new Date(course.created_at).toLocaleDateString()}
-                    </span>
-                  </div>
-                </div>
-                <div className="flex items-center gap-1 shrink-0">
-                  <Link to={`/teacher/courses/${course.id}/analytics`}>
-                    <Button variant="ghost" size="sm" title="Analytics">
-                      <BarChart3 className="h-4 w-4" />
-                      <span className="sr-only">Analytics</span>
-                    </Button>
-                  </Link>
-                  <Link to={`/teacher/courses/${course.id}/gradebook`}>
-                    <Button variant="ghost" size="sm" title="Gradebook">
-                      <ClipboardList className="h-4 w-4" />
-                      <span className="sr-only">Gradebook</span>
-                    </Button>
-                  </Link>
-                  <Link to={`/teacher/courses/${course.id}/progress`}>
-                    <Button variant="ghost" size="sm" title="Student Progress">
-                      <Users className="h-4 w-4" />
-                      <span className="sr-only">Progress</span>
-                    </Button>
-                  </Link>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    title={course.status === "published" ? "Unpublish" : "Publish"}
-                    disabled={togglingId === course.id}
-                    onClick={() => handleToggleStatus(course)}
-                  >
-                    {course.status === "published" ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                    <span className="sr-only">{course.status === "published" ? "Unpublish" : "Publish"}</span>
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    title="Clone course"
-                    disabled={cloningId === course.id}
-                    onClick={() => handleClone(course.id)}
-                  >
-                    {cloningId === course.id ? (
-                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
-                    <span className="sr-only">Clone</span>
-                  </Button>
-                  <Link to={`/teacher/courses/${course.id}`}>
-                    <Button variant="ghost" size="sm" aria-label="Edit course">
-                      <Pencil className="h-4 w-4" />
-                      <span className="hidden sm:inline">Edit</span>
-                    </Button>
-                  </Link>
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => handleDelete(course.id)}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    Delete
-                  </Button>
-                </div>
-              </div>
-            </Card>
-          ))}
-        </div>
+            {filteredCourses.map((course) => (
+              <CourseCard
+                key={course.id}
+                course={course}
+                togglingId={togglingId}
+                cloningId={cloningId}
+                onToggleStatus={handleToggleStatus}
+                onClone={handleClone}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
         </>
       )}
 
-      {/* Trash Section */}
-      <div className="mt-12 border-t pt-8">
-        <button
-          onClick={toggleTrash}
-          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <Archive className="h-4 w-4" />
-          {showTrash ? "Hide Trash" : "Show Trash"}
-        </button>
-
-        {showTrash && (
-          <div className="mt-4">
-            {trashLoading ? (
-              <PageSpinner variant="section" />
-            ) : trashedCourses.length === 0 ? (
-              <p className="text-sm text-muted-foreground py-4">Trash is empty.</p>
-            ) : (
-              <div className="space-y-3">
-                {trashedCourses.map((course) => (
-                  <Card key={course.id} className="opacity-70 border-dashed">
-                    <div className="flex items-center gap-4 p-4">
-                      <div className="flex-1 min-w-0">
-                        <h4 className="text-sm font-medium truncate">{course.title}</h4>
-                        {course.deleted_at && (
-                          <p className="text-xs text-muted-foreground">
-                            Deleted {new Date(course.deleted_at).toLocaleDateString()}
-                          </p>
-                        )}
-                      </div>
-                      <div className="flex items-center gap-2 shrink-0">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleRestore(course.id)}
-                          disabled={restoringId === course.id}
-                        >
-                          <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
-                          Restore
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          onClick={() => handlePermanentDelete(course.id)}
-                        >
-                          <Trash2 className="h-3.5 w-3.5 mr-1.5" />
-                          Delete Forever
-                        </Button>
-                      </div>
-                    </div>
-                  </Card>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      <TrashSection
+        visible={showTrash}
+        onToggle={toggleTrash}
+        onRestore={(restored) => setCourses((prev) => [restored, ...prev])}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
@@ -1,0 +1,135 @@
+import { Link } from "react-router-dom"
+import {
+  BarChart3,
+  BookOpen,
+  ClipboardList,
+  Copy,
+  Eye,
+  EyeOff,
+  Layers,
+  Pencil,
+  Trash2,
+  Users,
+} from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { toProxyImage } from "@/lib/images"
+import type { Course } from "@/types"
+
+interface Props {
+  course: Course
+  togglingId: string | null
+  cloningId: string | null
+  onToggleStatus: (course: Course) => void
+  onClone: (id: string) => void
+  onDelete: (id: string) => void
+}
+
+export function CourseCard({
+  course,
+  togglingId,
+  cloningId,
+  onToggleStatus,
+  onClone,
+  onDelete,
+}: Props) {
+  return (
+    <Card className="group hover:shadow-md transition-shadow">
+      <div className="flex items-start gap-4 p-6">
+        {course.image_url ? (
+          <img
+            src={toProxyImage(course.image_url)}
+            alt={`${course.title} thumbnail`}
+            loading="lazy"
+            className="w-20 h-20 rounded-lg object-cover shrink-0"
+          />
+        ) : (
+          <div className="w-20 h-20 rounded-lg bg-muted flex items-center justify-center shrink-0">
+            <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-lg truncate">{course.title}</h3>
+            <Badge variant={course.status === "published" ? "success" : "warning"}>
+              {course.status === "published" ? "Published" : "Draft"}
+            </Badge>
+          </div>
+          {course.description && (
+            <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+              {course.description}
+            </p>
+          )}
+          <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Layers className="h-3.5 w-3.5" />
+              {course.modules?.length ?? 0} modules
+            </span>
+            <span>Created {new Date(course.created_at).toLocaleDateString()}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <Link to={`/teacher/courses/${course.id}/analytics`}>
+            <Button variant="ghost" size="sm" title="Analytics">
+              <BarChart3 className="h-4 w-4" />
+              <span className="sr-only">Analytics</span>
+            </Button>
+          </Link>
+          <Link to={`/teacher/courses/${course.id}/gradebook`}>
+            <Button variant="ghost" size="sm" title="Gradebook">
+              <ClipboardList className="h-4 w-4" />
+              <span className="sr-only">Gradebook</span>
+            </Button>
+          </Link>
+          <Link to={`/teacher/courses/${course.id}/progress`}>
+            <Button variant="ghost" size="sm" title="Student Progress">
+              <Users className="h-4 w-4" />
+              <span className="sr-only">Progress</span>
+            </Button>
+          </Link>
+          <Button
+            variant="ghost"
+            size="sm"
+            title={course.status === "published" ? "Unpublish" : "Publish"}
+            disabled={togglingId === course.id}
+            onClick={() => onToggleStatus(course)}
+          >
+            {course.status === "published" ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+            <span className="sr-only">
+              {course.status === "published" ? "Unpublish" : "Publish"}
+            </span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            title="Clone course"
+            disabled={cloningId === course.id}
+            onClick={() => onClone(course.id)}
+          >
+            {cloningId === course.id ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+            <span className="sr-only">Clone</span>
+          </Button>
+          <Link to={`/teacher/courses/${course.id}`}>
+            <Button variant="ghost" size="sm" aria-label="Edit course">
+              <Pencil className="h-4 w-4" />
+              <span className="hidden sm:inline">Edit</span>
+            </Button>
+          </Link>
+          <Button variant="destructive" size="sm" onClick={() => onDelete(course.id)}>
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
@@ -1,0 +1,82 @@
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { CourseFormData } from "@/lib/validations/course"
+
+interface Props {
+  form: CourseFormData
+  setForm: React.Dispatch<React.SetStateAction<CourseFormData>>
+  errors: Partial<Record<string, string>>
+  setErrors: React.Dispatch<React.SetStateAction<Partial<Record<string, string>>>>
+  saving: boolean
+  onSubmit: (e: React.FormEvent) => void
+  onCancel: () => void
+}
+
+export function CreateCourseForm({
+  form,
+  setForm,
+  errors,
+  setErrors,
+  saving,
+  onSubmit,
+  onCancel,
+}: Props) {
+  return (
+    <Card className="mb-8 border-dashed">
+      <CardHeader>
+        <CardTitle className="text-lg">Create New Course</CardTitle>
+      </CardHeader>
+      <form onSubmit={onSubmit}>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={form.title}
+              onChange={(e) => {
+                setForm((p) => ({ ...p, title: e.target.value }))
+                setErrors((p) => ({ ...p, title: undefined }))
+              }}
+              placeholder="Introduction to Theology"
+            />
+            {errors.title && <p className="text-sm text-destructive">{errors.title}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="desc">Description</Label>
+            <textarea
+              id="desc"
+              className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              value={form.description}
+              onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
+              placeholder="A brief description of the course..."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="img">
+              Cover Image URL (optional — or upload after creating)
+            </Label>
+            <Input
+              id="img"
+              value={form.image_url}
+              onChange={(e) => setForm((p) => ({ ...p, image_url: e.target.value }))}
+              placeholder="https://... (you can upload in the editor)"
+            />
+            {errors.image_url && (
+              <p className="text-sm text-destructive">{errors.image_url}</p>
+            )}
+          </div>
+          <div className="flex gap-2 pt-2">
+            <Button type="submit" disabled={saving}>
+              {saving ? "Creating..." : "Create Course"}
+            </Button>
+            <Button type="button" variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+          </div>
+        </CardContent>
+      </form>
+    </Card>
+  )
+}

--- a/frontend/src/pages/Teacher/dashboard/EmptyCoursesCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/EmptyCoursesCard.tsx
@@ -1,0 +1,25 @@
+import { BookOpen, Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+interface Props {
+  onCreate: () => void
+}
+
+export function EmptyCoursesCard({ onCreate }: Props) {
+  return (
+    <Card className="border-dashed">
+      <CardContent className="flex flex-col items-center justify-center py-16 text-center">
+        <BookOpen className="h-12 w-12 text-muted-foreground/50 mb-4" />
+        <h3 className="text-lg font-medium mb-1">No courses yet</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          Create your first course to start teaching
+        </p>
+        <Button onClick={onCreate} size="sm">
+          <Plus className="h-4 w-4 mr-1.5" />
+          Create Course
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
@@ -1,0 +1,73 @@
+import { Award, CheckCircle, Clock, XCircle } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { PendingCert } from "./types"
+
+interface Props {
+  certs: PendingCert[]
+  actionId: string | null
+  onApprove: (id: string) => void
+  onReject: (id: string) => void
+}
+
+export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props) {
+  if (certs.length === 0) return null
+  return (
+    <Card className="mb-8 border-l-[3px] border-l-warning">
+      <CardHeader>
+        <CardTitle className="text-xl flex items-center gap-2">
+          <Award className="h-5 w-5 text-warning" />
+          Pending Certificates
+          <Badge variant="warning" className="font-normal">
+            {certs.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {certs.map((cert) => (
+            <div
+              key={cert.id}
+              className="flex items-center justify-between rounded-md border border-l-[3px] border-l-warning/60 bg-warning/5 p-4"
+            >
+              <div className="min-w-0">
+                <p className="font-medium truncate">{cert.student_name || "Student"}</p>
+                <p className="text-sm text-muted-foreground truncate">
+                  {cert.course_title || "Course"}
+                </p>
+                <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
+                  <Clock className="h-3 w-3" />
+                  Requested{" "}
+                  {cert.requested_at
+                    ? new Date(cert.requested_at).toLocaleDateString()
+                    : "Unknown"}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0 ml-4">
+                <Button
+                  size="sm"
+                  onClick={() => onApprove(cert.id)}
+                  disabled={actionId === cert.id}
+                >
+                  <CheckCircle className="h-4 w-4 mr-1.5" />
+                  Approve
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onReject(cert.id)}
+                  disabled={actionId === cert.id}
+                  className="text-destructive hover:text-destructive"
+                >
+                  <XCircle className="h-4 w-4 mr-1.5" />
+                  Reject
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/Teacher/dashboard/TrashSection.tsx
+++ b/frontend/src/pages/Teacher/dashboard/TrashSection.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react"
+import { Archive, RotateCcw, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import PageSpinner from "@/components/ui/PageSpinner"
+import { useConfirm } from "@/components/ui/alert-dialog"
+import { coursesService } from "@/services/courses"
+import { getErrorDetail } from "@/lib/errorDetail"
+import { toast } from "@/lib/toast"
+import type { Course } from "@/types"
+
+interface Props {
+  visible: boolean
+  onToggle: () => void
+  onRestore: (restored: Course) => void
+}
+
+export function TrashSection({ visible, onToggle, onRestore }: Props) {
+  const confirm = useConfirm()
+  const [trashedCourses, setTrashedCourses] = useState<Course[]>([])
+  const [loading, setLoading] = useState(false)
+  const [restoringId, setRestoringId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!visible) return
+    const signal = { cancelled: false }
+    setLoading(true)
+    coursesService
+      .getTrashedCourses()
+      .then((data) => {
+        if (!signal.cancelled) setTrashedCourses(data)
+      })
+      .catch(() => {
+        if (!signal.cancelled)
+          toast({ title: "Failed to load trash", variant: "destructive" })
+      })
+      .finally(() => {
+        if (!signal.cancelled) setLoading(false)
+      })
+    return () => {
+      signal.cancelled = true
+    }
+  }, [visible])
+
+  const handleRestore = async (id: string) => {
+    setRestoringId(id)
+    try {
+      const restored = await coursesService.restoreCourse(id)
+      setTrashedCourses((prev) => prev.filter((c) => c.id !== id))
+      onRestore(restored)
+      toast({ title: "Course restored", variant: "success" })
+    } catch (err) {
+      toast({
+        title: getErrorDetail(err, "Failed to restore course"),
+        variant: "destructive",
+      })
+    } finally {
+      setRestoringId(null)
+    }
+  }
+
+  const handlePermanentDelete = async (id: string) => {
+    const ok = await confirm({
+      title: "Permanently delete this course?",
+      description:
+        "This will permanently delete the course and all its data (modules, chapters, enrollments, grades). This action cannot be undone.",
+      confirmLabel: "Delete permanently",
+      tone: "destructive",
+    })
+    if (!ok) return
+    try {
+      await coursesService.permanentlyDeleteCourse(id)
+      setTrashedCourses((prev) => prev.filter((c) => c.id !== id))
+      toast({ title: "Course permanently deleted" })
+    } catch (err) {
+      toast({
+        title: getErrorDetail(err, "Failed to delete course"),
+        variant: "destructive",
+      })
+    }
+  }
+
+  return (
+    <div className="mt-12 border-t pt-8">
+      <button
+        onClick={onToggle}
+        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <Archive className="h-4 w-4" />
+        {visible ? "Hide Trash" : "Show Trash"}
+      </button>
+
+      {visible && (
+        <div className="mt-4">
+          {loading ? (
+            <PageSpinner variant="section" />
+          ) : trashedCourses.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4">Trash is empty.</p>
+          ) : (
+            <div className="space-y-3">
+              {trashedCourses.map((course) => (
+                <Card key={course.id} className="opacity-70 border-dashed">
+                  <div className="flex items-center gap-4 p-4">
+                    <div className="flex-1 min-w-0">
+                      <h4 className="text-sm font-medium truncate">{course.title}</h4>
+                      {course.deleted_at && (
+                        <p className="text-xs text-muted-foreground">
+                          Deleted {new Date(course.deleted_at).toLocaleDateString()}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleRestore(course.id)}
+                        disabled={restoringId === course.id}
+                      >
+                        <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+                        Restore
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => handlePermanentDelete(course.id)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                        Delete Forever
+                      </Button>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Teacher/dashboard/index.ts
+++ b/frontend/src/pages/Teacher/dashboard/index.ts
@@ -1,0 +1,6 @@
+export { CourseCard } from "./CourseCard"
+export { CreateCourseForm } from "./CreateCourseForm"
+export { EmptyCoursesCard } from "./EmptyCoursesCard"
+export { PendingCertsCard } from "./PendingCertsCard"
+export { TrashSection } from "./TrashSection"
+export type { PendingCert } from "./types"

--- a/frontend/src/pages/Teacher/dashboard/types.ts
+++ b/frontend/src/pages/Teacher/dashboard/types.ts
@@ -1,0 +1,6 @@
+import type { Certificate } from "@/types"
+
+export type PendingCert = Certificate & {
+  student_name?: string
+  course_title?: string
+}


### PR DESCRIPTION
## Summary

- Decomposes the 529-line `frontend/src/pages/Teacher/TeacherDashboard.tsx` into a **284-line orchestrator** plus a focused `pages/Teacher/dashboard/` module.
- The orchestrator now only owns cross-cutting state (course list, search, trash toggle) and CRUD callbacks; every visual section lives in its own component:
  - `CreateCourseForm` — inline create-course form card (title / description / image URL)
  - `PendingCertsCard` — pending certificate approve/reject list (returns `null` when empty)
  - `CourseCard` — single course row with the full action bar (analytics / gradebook / progress / publish / clone / edit / delete)
  - `EmptyCoursesCard` — empty-state CTA when no courses exist
  - `TrashSection` — now self-contained: owns its own fetch + restore/permanent-delete lifecycle, and notifies the parent via an `onRestore(Course)` callback so restored courses re-appear in the main list
  - `types.ts` — `PendingCert` alias
- No behavioral changes — purely structural refactor.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint` on touched paths — clean
- [x] `vitest run` — 85/85 tests pass
- [x] `npm run build` — succeeds
- [ ] Manual smoke test against Vercel preview (create course, toggle publish, clone, delete, search filter, pending certs approve/reject, trash show/restore/permanent delete)
