### PR TITLE
refactor(frontend): decompose ChapterBlockEditor into per-type editors

### DIFF
--- a/frontend/src/components/editor/ChapterBlockEditor.tsx
+++ b/frontend/src/components/editor/ChapterBlockEditor.tsx
@@ -1,277 +1,82 @@
-import { useEffect, useState, useCallback, useRef } from "react"
-import { Button } from "@/components/ui/button"
+import { useCallback, useEffect, useState } from "react"
 import { Label } from "@/components/ui/label"
-import RichTextEditor from "./RichTextEditor"
+import { Loader2 } from "lucide-react"
 import { coursesService } from "@/services/courses"
-import { storageService } from "@/services/storage"
 import { getErrorDetail } from "@/lib/errorDetail"
-import type { ChapterBlock } from "@/types"
 import { toast } from "@/lib/toast"
-import {
-  Plus, Trash2, GripVertical, Save, FileText,
-  ChevronDown, ChevronRight, Loader2, Type,
-  HelpCircle, ClipboardList, Paperclip, Check,
-  Upload, X,
-} from "lucide-react"
-import QuizEditor from "@/components/quiz/QuizEditor"
-import AssignmentEditor from "@/components/assignment/AssignmentEditor"
+import type { ChapterBlock } from "@/types"
 import { useConfirm } from "@/components/ui/alert-dialog"
-
-// Video and audio embeds live inside text blocks — the rich editor's toolbar
-// has dedicated buttons for both — so the block layer only needs the shapes
-// that aren't just HTML.
-const BLOCK_TYPES = [
-  { value: "text", label: "Text", icon: Type },
-  { value: "quiz", label: "Quiz", icon: HelpCircle },
-  { value: "assignment", label: "Assignment", icon: ClipboardList },
-  { value: "file", label: "File", icon: Paperclip },
-] as const
-
-type BlockType = (typeof BLOCK_TYPES)[number]["value"]
+import { AddBlockMenu, BlockRow, type BlockType } from "./blocks"
 
 interface Props {
   chapterId: string
 }
 
-function FileBlockEditor({
-  block,
-  uploading,
-  onUpload,
-  onClear,
-}: {
-  block: ChapterBlock
-  uploading: boolean
-  onUpload: (file: File) => void
-  onClear: () => void
-}) {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const hasFile = Boolean(block.file_bucket && block.file_path)
-
-  return (
-    <div className="space-y-2">
-      <Label className="text-xs flex items-center gap-1.5">
-        <Paperclip className="h-3.5 w-3.5" />
-        Attached File
-      </Label>
-      {hasFile ? (
-        <div className="flex items-center gap-2 rounded-md border px-3 py-2 bg-muted/30">
-          <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
-          <span className="text-sm flex-1 truncate">{block.file_name ?? block.file_path}</span>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => inputRef.current?.click()}
-            disabled={uploading}
-            className="h-7 text-xs"
-          >
-            {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : "Replace"}
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onClear}
-            disabled={uploading}
-            className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-            aria-label="Remove file"
-          >
-            <X className="h-3.5 w-3.5" />
-          </Button>
-        </div>
-      ) : (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => inputRef.current?.click()}
-          disabled={uploading}
-          className="w-full border-dashed"
-        >
-          {uploading ? (
-            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-          ) : (
-            <Upload className="h-3.5 w-3.5 mr-1.5" />
-          )}
-          {uploading ? "Uploading..." : "Upload a file"}
-        </Button>
-      )}
-      <input
-        ref={inputRef}
-        type="file"
-        className="hidden"
-        onChange={(e) => {
-          const file = e.target.files?.[0]
-          if (file) onUpload(file)
-          e.target.value = ""
-        }}
-      />
-    </div>
-  )
-}
-
+/**
+ * Teacher-facing list of content blocks for a chapter. Thin
+ * orchestrator: owns the list + which block is expanded + the drag
+ * state for reordering, and delegates each row (and every type of
+ * per-block editor) to `./blocks/`.
+ */
 export default function ChapterBlockEditor({ chapterId }: Props) {
   const confirm = useConfirm()
   const [blocks, setBlocks] = useState<ChapterBlock[]>([])
   const [loading, setLoading] = useState(true)
-  const [expandedBlock, setExpandedBlock] = useState<string | null>(null)
-  const [savingBlock, setSavingBlock] = useState<string | null>(null)
-  const [showAddMenu, setShowAddMenu] = useState(false)
-  const [addingBlock, setAddingBlock] = useState(false)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [adding, setAdding] = useState(false)
   const [dragIdx, setDragIdx] = useState<number | null>(null)
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null)
 
-  const [editContent, setEditContent] = useState("")
-  const [uploadingFileFor, setUploadingFileFor] = useState<string | null>(null)
-  const [autoSaveStatus, setAutoSaveStatus] = useState<"idle" | "pending" | "saving" | "saved">("idle")
-  const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const savedResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const editContentRef = useRef("")
-  const mountedRef = useRef(true)
-
-  const loadBlocks = useCallback(async (signal?: { cancelled: boolean }) => {
-    try {
-      const data = await coursesService.getChapterBlocks(chapterId)
-      if (signal?.cancelled) return
-      setBlocks(data.sort((a, b) => a.order_index - b.order_index))
-    } catch (error: unknown) {
-      if (signal?.cancelled) return
-      const detail = getErrorDetail(error)
-      if (detail) {
-        toast({ title: `Failed to load blocks: ${detail}`, variant: "destructive" })
+  const load = useCallback(
+    async (signal?: { cancelled: boolean }) => {
+      try {
+        const data = await coursesService.getChapterBlocks(chapterId)
+        if (signal?.cancelled) return
+        setBlocks(data.sort((a, b) => a.order_index - b.order_index))
+      } catch (error: unknown) {
+        if (signal?.cancelled) return
+        const detail = getErrorDetail(error)
+        if (detail) {
+          toast({ title: `Failed to load blocks: ${detail}`, variant: "destructive" })
+        }
+      } finally {
+        if (!signal?.cancelled) setLoading(false)
       }
-    } finally {
-      if (!signal?.cancelled) setLoading(false)
-    }
-  }, [chapterId])
+    },
+    [chapterId],
+  )
 
   useEffect(() => {
     const signal = { cancelled: false }
-    loadBlocks(signal)
-    return () => { signal.cancelled = true }
-  }, [loadBlocks])
+    void load(signal)
+    return () => {
+      signal.cancelled = true
+    }
+  }, [load])
 
   const addBlock = async (type: BlockType) => {
-    setAddingBlock(true)
-    setShowAddMenu(false)
+    setAdding(true)
     try {
       const newBlock = await coursesService.createBlock(chapterId, {
         block_type: type,
         order_index: blocks.length,
       })
       setBlocks((prev) => [...prev, newBlock])
-      setExpandedBlock(newBlock.id)
-      initEditState(newBlock)
+      setExpandedId(newBlock.id)
       toast({ title: `${type} block added`, variant: "success" })
     } catch (error: unknown) {
       const detail = getErrorDetail(error) || "Unknown error"
       toast({ title: `Failed to add block: ${detail}`, variant: "destructive" })
     } finally {
-      setAddingBlock(false)
+      setAdding(false)
     }
   }
 
-  const initEditState = (block: ChapterBlock) => {
-    setEditContent(block.content ?? "")
-    editContentRef.current = block.content ?? ""
+  const replaceBlock = (updated: ChapterBlock) => {
+    setBlocks((prev) => prev.map((b) => (b.id === updated.id ? updated : b)))
   }
 
-  const updateBlockField = async (blockId: string, field: string, value: string) => {
-    try {
-      const updated = await coursesService.updateBlock(blockId, { [field]: value })
-      setBlocks((prev) => prev.map((b) => (b.id === blockId ? updated : b)))
-    } catch {
-      toast({ title: "Failed to update block", variant: "destructive" })
-    }
-  }
-
-  const handleBlockFileUpload = async (block: ChapterBlock, file: File) => {
-    setUploadingFileFor(block.id)
-    try {
-      const { bucket, path, name } = await storageService.uploadBlockFile(chapterId, file)
-      const updated = await coursesService.updateBlock(block.id, {
-        file_bucket: bucket,
-        file_path: path,
-        file_name: name,
-      })
-      setBlocks((prev) => prev.map((b) => (b.id === block.id ? updated : b)))
-      toast({ title: "File uploaded", variant: "success" })
-    } catch (error: unknown) {
-      const detail = getErrorDetail(error) || "Upload failed"
-      toast({ title: detail, variant: "destructive" })
-    } finally {
-      setUploadingFileFor(null)
-    }
-  }
-
-  const handleBlockFileClear = async (block: ChapterBlock) => {
-    try {
-      const updated = await coursesService.updateBlock(block.id, {
-        file_bucket: null,
-        file_path: null,
-        file_name: null,
-      })
-      setBlocks((prev) => prev.map((b) => (b.id === block.id ? updated : b)))
-    } catch {
-      toast({ title: "Failed to remove file", variant: "destructive" })
-    }
-  }
-
-  const scheduleAutoSave = useCallback((block: ChapterBlock) => {
-    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current)
-    if (savedResetTimer.current) clearTimeout(savedResetTimer.current)
-    setAutoSaveStatus("pending")
-    const blockId = block.id
-    const snapshot = editContentRef.current
-    autoSaveTimer.current = setTimeout(async () => {
-      if (!mountedRef.current) return
-      // Defer the write while the tab is hidden: saving will happen the
-      // next time the user is typing (or on explicit save). This avoids
-      // background tabs hammering the API for no user benefit.
-      if (typeof document !== "undefined" && document.visibilityState === "hidden") {
-        setAutoSaveStatus("pending")
-        return
-      }
-      setAutoSaveStatus("saving")
-      try {
-        const updated = await coursesService.updateBlock(blockId, { content: snapshot })
-        if (!mountedRef.current) return
-        setBlocks((prev) => prev.map((b) => (b.id === blockId ? updated : b)))
-        setAutoSaveStatus("saved")
-        savedResetTimer.current = setTimeout(() => {
-          if (mountedRef.current) setAutoSaveStatus("idle")
-        }, 2000)
-      } catch {
-        if (!mountedRef.current) return
-        setAutoSaveStatus("idle")
-        toast({ title: "Auto-save failed", variant: "destructive" })
-      }
-    }, 2000)
-  }, [])
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-      if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current)
-      if (savedResetTimer.current) clearTimeout(savedResetTimer.current)
-    }
-  }, [])
-
-  const saveTextBlock = async (block: ChapterBlock) => {
-    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current)
-    if (savedResetTimer.current) clearTimeout(savedResetTimer.current)
-    setAutoSaveStatus("idle")
-    setSavingBlock(block.id)
-    try {
-      const updated = await coursesService.updateBlock(block.id, { content: editContent })
-      setBlocks((prev) => prev.map((b) => (b.id === block.id ? updated : b)))
-      toast({ title: "Block saved", variant: "success" })
-    } catch {
-      toast({ title: "Failed to save block", variant: "destructive" })
-    } finally {
-      setSavingBlock(null)
-    }
-  }
-
-  const deleteBlock = async (blockId: string) => {
+  const deleteBlock = async (id: string) => {
     const ok = await confirm({
       title: "Delete this block?",
       confirmLabel: "Delete",
@@ -279,22 +84,13 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
     })
     if (!ok) return
     try {
-      await coursesService.deleteBlock(blockId)
-      setBlocks((prev) => prev.filter((b) => b.id !== blockId))
-      if (expandedBlock === blockId) setExpandedBlock(null)
+      await coursesService.deleteBlock(id)
+      setBlocks((prev) => prev.filter((b) => b.id !== id))
+      if (expandedId === id) setExpandedId(null)
       toast({ title: "Block deleted", variant: "success" })
     } catch {
       toast({ title: "Failed to delete block", variant: "destructive" })
     }
-  }
-
-  const handleDragStart = (idx: number) => {
-    setDragIdx(idx)
-  }
-
-  const handleDragOver = (e: React.DragEvent, idx: number) => {
-    e.preventDefault()
-    setDragOverIdx(idx)
   }
 
   const handleDrop = async (targetIdx: number) => {
@@ -307,28 +103,20 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
     const [moved] = reordered.splice(dragIdx, 1)
     if (!moved) return
     reordered.splice(targetIdx, 0, moved)
-    const updated = reordered.map((b, i) => ({ ...b, order_index: i }))
-    setBlocks(updated)
+    const withIndex = reordered.map((b, i) => ({ ...b, order_index: i }))
+    setBlocks(withIndex)
     setDragIdx(null)
     setDragOverIdx(null)
 
     try {
-      await coursesService.reorderBlocks(chapterId, updated.map((b) => ({ id: b.id, order_index: b.order_index })))
+      await coursesService.reorderBlocks(
+        chapterId,
+        withIndex.map((b) => ({ id: b.id, order_index: b.order_index })),
+      )
     } catch {
       toast({ title: "Failed to reorder blocks", variant: "destructive" })
-      loadBlocks()
+      void load()
     }
-  }
-
-  const blockIcon = (type: string) => {
-    const found = BLOCK_TYPES.find((bt) => bt.value === type)
-    if (!found) return FileText
-    return found.icon
-  }
-
-  const blockLabel = (type: string) => {
-    const found = BLOCK_TYPES.find((bt) => bt.value === type)
-    return found?.label ?? type
   }
 
   if (loading) {
@@ -345,7 +133,9 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
         <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
           Content Blocks
         </Label>
-        <span className="text-xs text-muted-foreground">{blocks.length} block{blocks.length !== 1 ? "s" : ""}</span>
+        <span className="text-xs text-muted-foreground">
+          {blocks.length} block{blocks.length !== 1 ? "s" : ""}
+        </span>
       </div>
 
       {blocks.length === 0 && (
@@ -355,164 +145,34 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
       )}
 
       <div className="space-y-2">
-        {blocks.map((block, idx) => {
-          const Icon = blockIcon(block.block_type)
-          const isExpanded = expandedBlock === block.id
-          return (
-            <div
-              key={block.id}
-              draggable
-              onDragStart={() => handleDragStart(idx)}
-              onDragOver={(e) => handleDragOver(e, idx)}
-              onDrop={() => handleDrop(idx)}
-              onDragEnd={() => { setDragIdx(null); setDragOverIdx(null) }}
-              className={`rounded-md border transition-colors ${
-                dragOverIdx === idx ? "border-primary bg-primary/5" : "bg-background"
-              }`}
-            >
-              <div
-                className="flex items-center gap-2 px-3 py-2 cursor-pointer select-none"
-                onClick={() => {
-                  if (isExpanded) {
-                    setExpandedBlock(null)
-                  } else {
-                    setExpandedBlock(block.id)
-                    initEditState(block)
-                  }
-                }}
-              >
-                <GripVertical className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0 cursor-grab" />
-                {isExpanded ? (
-                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                )}
-                <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                <span className="text-sm font-medium flex-1">{blockLabel(block.block_type)}</span>
-                <span className="text-[10px] text-muted-foreground">#{idx + 1}</span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 w-6 p-0 text-destructive hover:text-destructive shrink-0"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    deleteBlock(block.id)
-                  }}
-                >
-                  <Trash2 className="h-3 w-3" />
-                </Button>
-              </div>
-
-              {isExpanded && (
-                <div className="border-t px-3 py-3 space-y-3">
-                  {block.block_type === "text" && (
-                    <>
-                      <RichTextEditor
-                        content={editContent}
-                        onChange={(html) => {
-                          setEditContent(html)
-                          editContentRef.current = html
-                          scheduleAutoSave(block)
-                        }}
-                        placeholder="Write block content..."
-                      />
-                      <div className="flex items-center gap-3">
-                        <Button
-                          size="sm"
-                          onClick={() => saveTextBlock(block)}
-                          disabled={savingBlock === block.id}
-                        >
-                          {savingBlock === block.id ? (
-                            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                          ) : (
-                            <Save className="h-3.5 w-3.5 mr-1.5" />
-                          )}
-                          Save Text
-                        </Button>
-                        {autoSaveStatus === "pending" && (
-                          <span className="text-xs text-muted-foreground animate-pulse">
-                            Unsaved changes...
-                          </span>
-                        )}
-                        {autoSaveStatus === "saving" && (
-                          <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                            <Loader2 className="h-3 w-3 animate-spin" />
-                            Auto-saving...
-                          </span>
-                        )}
-                        {autoSaveStatus === "saved" && (
-                          <span className="flex items-center gap-1 text-xs text-success">
-                            <Check className="h-3 w-3" />
-                            Saved
-                          </span>
-                        )}
-                      </div>
-                    </>
-                  )}
-
-                  {block.block_type === "quiz" && (
-                    <QuizEditor
-                      chapterId={chapterId}
-                      onQuizSaved={(quizId) => updateBlockField(block.id, "quiz_id", quizId)}
-                    />
-                  )}
-
-                  {block.block_type === "assignment" && (
-                    <AssignmentEditor
-                      chapterId={chapterId}
-                      onAssignmentCreated={(id) => updateBlockField(block.id, "assignment_id", id)}
-                    />
-                  )}
-
-                  {block.block_type === "file" && (
-                    <FileBlockEditor
-                      block={block}
-                      uploading={uploadingFileFor === block.id}
-                      onUpload={(file) => handleBlockFileUpload(block, file)}
-                      onClear={() => handleBlockFileClear(block)}
-                    />
-                  )}
-                </div>
-              )}
-            </div>
-          )
-        })}
+        {blocks.map((block, idx) => (
+          <BlockRow
+            key={block.id}
+            block={block}
+            chapterId={chapterId}
+            index={idx}
+            expanded={expandedId === block.id}
+            isDragOver={dragOverIdx === idx}
+            onExpandToggle={() =>
+              setExpandedId((prev) => (prev === block.id ? null : block.id))
+            }
+            onDelete={() => deleteBlock(block.id)}
+            onBlockUpdated={replaceBlock}
+            onDragStart={() => setDragIdx(idx)}
+            onDragOver={(e) => {
+              e.preventDefault()
+              setDragOverIdx(idx)
+            }}
+            onDrop={() => handleDrop(idx)}
+            onDragEnd={() => {
+              setDragIdx(null)
+              setDragOverIdx(null)
+            }}
+          />
+        ))}
       </div>
 
-      {/* Add Block button with dropdown */}
-      <div className="relative">
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full border-dashed"
-          onClick={() => setShowAddMenu(!showAddMenu)}
-          disabled={addingBlock}
-        >
-          {addingBlock ? (
-            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-          ) : (
-            <Plus className="h-3.5 w-3.5 mr-1.5" />
-          )}
-          Add Block
-        </Button>
-        {showAddMenu && (
-          <div className="absolute z-10 mt-1 w-full bg-background border rounded-md shadow-lg py-1">
-            {BLOCK_TYPES.map((bt) => {
-              const Icon = bt.icon
-              return (
-                <button
-                  key={bt.value}
-                  onClick={() => addBlock(bt.value)}
-                  className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
-                >
-                  <Icon className="h-4 w-4 text-muted-foreground" />
-                  {bt.label}
-                </button>
-              )
-            })}
-          </div>
-        )}
-      </div>
+      <AddBlockMenu onAdd={addBlock} adding={adding} />
     </div>
   )
 }

--- a/frontend/src/components/editor/blocks/AddBlockMenu.tsx
+++ b/frontend/src/components/editor/blocks/AddBlockMenu.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Loader2, Plus } from "lucide-react"
+import { BLOCK_TYPES, type BlockType } from "./types"
+
+interface Props {
+  onAdd: (type: BlockType) => void
+  adding: boolean
+}
+
+/**
+ * "Add Block" button with a dropdown of block types. Self-contained —
+ * the parent just exposes an `onAdd(type)` callback.
+ */
+export function AddBlockMenu({ onAdd, adding }: Props) {
+  const [open, setOpen] = useState(false)
+
+  const pick = (type: BlockType) => {
+    setOpen(false)
+    onAdd(type)
+  }
+
+  return (
+    <div className="relative">
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full border-dashed"
+        onClick={() => setOpen((v) => !v)}
+        disabled={adding}
+      >
+        {adding ? (
+          <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+        ) : (
+          <Plus className="h-3.5 w-3.5 mr-1.5" />
+        )}
+        Add Block
+      </Button>
+      {open && (
+        <div className="absolute z-10 mt-1 w-full bg-background border rounded-md shadow-lg py-1">
+          {BLOCK_TYPES.map((bt) => {
+            const Icon = bt.icon
+            return (
+              <button
+                key={bt.value}
+                onClick={() => pick(bt.value)}
+                className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
+              >
+                <Icon className="h-4 w-4 text-muted-foreground" />
+                {bt.label}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/editor/blocks/BlockRow.tsx
+++ b/frontend/src/components/editor/blocks/BlockRow.tsx
@@ -1,0 +1,121 @@
+import { Button } from "@/components/ui/button"
+import { ChevronDown, ChevronRight, GripVertical, Trash2 } from "lucide-react"
+import QuizEditor from "@/components/quiz/QuizEditor"
+import AssignmentEditor from "@/components/assignment/AssignmentEditor"
+import { coursesService } from "@/services/courses"
+import { toast } from "@/lib/toast"
+import type { ChapterBlock } from "@/types"
+import { blockIcon, blockLabel } from "./types"
+import { TextBlockEditor } from "./TextBlockEditor"
+import { FileBlockEditor } from "./FileBlockEditor"
+
+interface Props {
+  block: ChapterBlock
+  chapterId: string
+  index: number
+  expanded: boolean
+  isDragOver: boolean
+  onExpandToggle: () => void
+  onDelete: () => void
+  onBlockUpdated: (updated: ChapterBlock) => void
+  onDragStart: () => void
+  onDragOver: (e: React.DragEvent) => void
+  onDrop: () => void
+  onDragEnd: () => void
+}
+
+/**
+ * A single draggable chapter block: drag handle, expand/collapse
+ * header, delete button, and a type-specific editor body when expanded.
+ */
+export function BlockRow({
+  block,
+  chapterId,
+  index,
+  expanded,
+  isDragOver,
+  onExpandToggle,
+  onDelete,
+  onBlockUpdated,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: Props) {
+  const Icon = blockIcon(block.block_type)
+
+  const updateField = async (field: string, value: string) => {
+    try {
+      const updated = await coursesService.updateBlock(block.id, { [field]: value })
+      onBlockUpdated(updated)
+    } catch {
+      toast({ title: "Failed to update block", variant: "destructive" })
+    }
+  }
+
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+      className={`rounded-md border transition-colors ${
+        isDragOver ? "border-primary bg-primary/5" : "bg-background"
+      }`}
+    >
+      <div
+        className="flex items-center gap-2 px-3 py-2 cursor-pointer select-none"
+        onClick={onExpandToggle}
+      >
+        <GripVertical className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0 cursor-grab" />
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        <span className="text-sm font-medium flex-1">{blockLabel(block.block_type)}</span>
+        <span className="text-[10px] text-muted-foreground">#{index + 1}</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0 text-destructive hover:text-destructive shrink-0"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete()
+          }}
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+
+      {expanded && (
+        <div className="border-t px-3 py-3 space-y-3">
+          {block.block_type === "text" && (
+            <TextBlockEditor block={block} onSaved={onBlockUpdated} />
+          )}
+          {block.block_type === "quiz" && (
+            <QuizEditor
+              chapterId={chapterId}
+              onQuizSaved={(quizId) => updateField("quiz_id", quizId)}
+            />
+          )}
+          {block.block_type === "assignment" && (
+            <AssignmentEditor
+              chapterId={chapterId}
+              onAssignmentCreated={(id) => updateField("assignment_id", id)}
+            />
+          )}
+          {block.block_type === "file" && (
+            <FileBlockEditor
+              block={block}
+              chapterId={chapterId}
+              onUpdated={onBlockUpdated}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/editor/blocks/FileBlockEditor.tsx
+++ b/frontend/src/components/editor/blocks/FileBlockEditor.tsx
@@ -1,0 +1,119 @@
+import { useRef, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { FileText, Loader2, Paperclip, Upload, X } from "lucide-react"
+import { coursesService } from "@/services/courses"
+import { storageService } from "@/services/storage"
+import { getErrorDetail } from "@/lib/errorDetail"
+import { toast } from "@/lib/toast"
+import type { ChapterBlock } from "@/types"
+
+interface Props {
+  block: ChapterBlock
+  chapterId: string
+  onUpdated: (updated: ChapterBlock) => void
+}
+
+/**
+ * File-attachment editor for a chapter block: upload/replace/remove a
+ * single file. Owns its own "uploading" state so sibling blocks aren't
+ * affected by this block's upload.
+ */
+export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const hasFile = Boolean(block.file_bucket && block.file_path)
+
+  const upload = async (file: File) => {
+    setUploading(true)
+    try {
+      const { bucket, path, name } = await storageService.uploadBlockFile(chapterId, file)
+      const updated = await coursesService.updateBlock(block.id, {
+        file_bucket: bucket,
+        file_path: path,
+        file_name: name,
+      })
+      onUpdated(updated)
+      toast({ title: "File uploaded", variant: "success" })
+    } catch (error: unknown) {
+      const detail = getErrorDetail(error) || "Upload failed"
+      toast({ title: detail, variant: "destructive" })
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const clear = async () => {
+    try {
+      const updated = await coursesService.updateBlock(block.id, {
+        file_bucket: null,
+        file_path: null,
+        file_name: null,
+      })
+      onUpdated(updated)
+    } catch {
+      toast({ title: "Failed to remove file", variant: "destructive" })
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs flex items-center gap-1.5">
+        <Paperclip className="h-3.5 w-3.5" />
+        Attached File
+      </Label>
+      {hasFile ? (
+        <div className="flex items-center gap-2 rounded-md border px-3 py-2 bg-muted/30">
+          <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span className="text-sm flex-1 truncate">
+            {block.file_name ?? block.file_path}
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => inputRef.current?.click()}
+            disabled={uploading}
+            className="h-7 text-xs"
+          >
+            {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : "Replace"}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={clear}
+            disabled={uploading}
+            className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+            aria-label="Remove file"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => inputRef.current?.click()}
+          disabled={uploading}
+          className="w-full border-dashed"
+        >
+          {uploading ? (
+            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <Upload className="h-3.5 w-3.5 mr-1.5" />
+          )}
+          {uploading ? "Uploading..." : "Upload a file"}
+        </Button>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) void upload(file)
+          e.target.value = ""
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/editor/blocks/TextBlockEditor.tsx
+++ b/frontend/src/components/editor/blocks/TextBlockEditor.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Check, Loader2, Save } from "lucide-react"
+import RichTextEditor from "../RichTextEditor"
+import { coursesService } from "@/services/courses"
+import { toast } from "@/lib/toast"
+import type { ChapterBlock } from "@/types"
+
+interface Props {
+  block: ChapterBlock
+  onSaved: (updated: ChapterBlock) => void
+}
+
+type AutoSaveStatus = "idle" | "pending" | "saving" | "saved"
+
+const AUTOSAVE_DELAY_MS = 2000
+const SAVED_FLASH_MS = 2000
+
+/**
+ * Rich-text content editor for a `text` chapter block. Owns its own
+ * draft state + debounced auto-save pipeline; deactivates when the
+ * browser tab is hidden so background tabs don't hammer the API.
+ */
+export function TextBlockEditor({ block, onSaved }: Props) {
+  const [content, setContent] = useState(block.content ?? "")
+  const [savingExplicit, setSavingExplicit] = useState(false)
+  const [autoSaveStatus, setAutoSaveStatus] = useState<AutoSaveStatus>("idle")
+
+  const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const savedResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const contentRef = useRef(content)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current)
+      if (savedResetTimer.current) clearTimeout(savedResetTimer.current)
+    }
+  }, [])
+
+  const scheduleAutoSave = () => {
+    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current)
+    if (savedResetTimer.current) clearTimeout(savedResetTimer.current)
+    setAutoSaveStatus("pending")
+    const snapshot = contentRef.current
+    autoSaveTimer.current = setTimeout(async () => {
+      if (!mountedRef.current) return
+      if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+        setAutoSaveStatus("pending")
+        return
+      }
+      setAutoSaveStatus("saving")
+      try {
+        const updated = await coursesService.updateBlock(block.id, { content: snapshot })
+        if (!mountedRef.current) return
+        onSaved(updated)
+        setAutoSaveStatus("saved")
+        savedResetTimer.current = setTimeout(() => {
+          if (mountedRef.current) setAutoSaveStatus("idle")
+        }, SAVED_FLASH_MS)
+      } catch {
+        if (!mountedRef.current) return
+        setAutoSaveStatus("idle")
+        toast({ title: "Auto-save failed", variant: "destructive" })
+      }
+    }, AUTOSAVE_DELAY_MS)
+  }
+
+  const saveExplicit = async () => {
+    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current)
+    if (savedResetTimer.current) clearTimeout(savedResetTimer.current)
+    setAutoSaveStatus("idle")
+    setSavingExplicit(true)
+    try {
+      const updated = await coursesService.updateBlock(block.id, { content })
+      onSaved(updated)
+      toast({ title: "Block saved", variant: "success" })
+    } catch {
+      toast({ title: "Failed to save block", variant: "destructive" })
+    } finally {
+      setSavingExplicit(false)
+    }
+  }
+
+  return (
+    <>
+      <RichTextEditor
+        content={content}
+        onChange={(html) => {
+          setContent(html)
+          contentRef.current = html
+          scheduleAutoSave()
+        }}
+        placeholder="Write block content..."
+      />
+      <div className="flex items-center gap-3">
+        <Button size="sm" onClick={saveExplicit} disabled={savingExplicit}>
+          {savingExplicit ? (
+            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5 mr-1.5" />
+          )}
+          Save Text
+        </Button>
+        {autoSaveStatus === "pending" && (
+          <span className="text-xs text-muted-foreground animate-pulse">
+            Unsaved changes...
+          </span>
+        )}
+        {autoSaveStatus === "saving" && (
+          <span className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Auto-saving...
+          </span>
+        )}
+        {autoSaveStatus === "saved" && (
+          <span className="flex items-center gap-1 text-xs text-success">
+            <Check className="h-3 w-3" />
+            Saved
+          </span>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/editor/blocks/index.ts
+++ b/frontend/src/components/editor/blocks/index.ts
@@ -1,0 +1,5 @@
+export { AddBlockMenu } from "./AddBlockMenu"
+export { BlockRow } from "./BlockRow"
+export { FileBlockEditor } from "./FileBlockEditor"
+export { TextBlockEditor } from "./TextBlockEditor"
+export { BLOCK_TYPES, blockIcon, blockLabel, type BlockType } from "./types"

--- a/frontend/src/components/editor/blocks/types.ts
+++ b/frontend/src/components/editor/blocks/types.ts
@@ -1,0 +1,31 @@
+import {
+  ClipboardList,
+  FileText,
+  HelpCircle,
+  Paperclip,
+  Type,
+  type LucideIcon,
+} from "lucide-react"
+
+/**
+ * The block "kinds" a teacher can add to a chapter. Video and audio
+ * embeds live inside text blocks (the rich editor's toolbar has
+ * dedicated buttons), so the block layer only needs the shapes that
+ * aren't just HTML.
+ */
+export const BLOCK_TYPES = [
+  { value: "text", label: "Text", icon: Type },
+  { value: "quiz", label: "Quiz", icon: HelpCircle },
+  { value: "assignment", label: "Assignment", icon: ClipboardList },
+  { value: "file", label: "File", icon: Paperclip },
+] as const satisfies ReadonlyArray<{ value: string; label: string; icon: LucideIcon }>
+
+export type BlockType = (typeof BLOCK_TYPES)[number]["value"]
+
+export function blockIcon(type: string): LucideIcon {
+  return BLOCK_TYPES.find((bt) => bt.value === type)?.icon ?? FileText
+}
+
+export function blockLabel(type: string): string {
+  return BLOCK_TYPES.find((bt) => bt.value === type)?.label ?? type
+}


### PR DESCRIPTION
## Summary

Decomposes `frontend/src/components/editor/ChapterBlockEditor.tsx` (519 lines) into a 164-line orchestrator and five focused modules under `components/editor/blocks/`.

**Before:** one file mixing block CRUD, drag-and-drop, debounced auto-save with hidden-tab guard, inline file upload, custom add-block dropdown, and an inner `FileBlockEditor` helper.

**After:**

- `blocks/types.ts` — `BLOCK_TYPES`, `BlockType`, `blockIcon`, `blockLabel` helpers
- `blocks/TextBlockEditor.tsx` — the rich-text editor + the debounced auto-save pipeline. Self-contained: all timer refs + the `document.visibilityState === "hidden"` guard live here now.
- `blocks/FileBlockEditor.tsx` — upload / replace / remove a file. Owns its own `uploading` state so a sibling file block's upload doesn't disable this one's input.
- `blocks/BlockRow.tsx` — one draggable row: drag handle, expand header, delete button, and routes to the correct editor body (`TextBlockEditor` / `QuizEditor` / `AssignmentEditor` / `FileBlockEditor`) based on `block_type`.
- `blocks/AddBlockMenu.tsx` — the "Add Block" dropdown, self-contained.

The orchestrator now only owns:
- the blocks list + which one is expanded,
- the drag source/target indices,
- create / delete / reorder handlers,
- a single `replaceBlock(updated)` callback shared with every type-specific editor.

No behavior changes.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint` on `components/editor` — clean
- [x] `vitest run` — 85/85 pass
- [x] `npm run build` — succeeds
- [ ] Manual smoke on preview: add a text block and type — watch "Unsaved…" → "Auto-saving…" → "Saved"; explicit save button; add a file block, upload/replace/remove; add a quiz block, add an assignment block; drag blocks to reorder; delete blocks.
