### PR TITLE
refactor(frontend): extract AdminDashboard state into tab-scoped hooks

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -1,45 +1,25 @@
-import { useEffect, useState, useMemo, useCallback } from "react"
 import { Navigate, useSearchParams } from "react-router-dom"
-import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
-import { useAuth } from "@/context/useAuth"
-import { coursesService } from "@/services/courses"
-import type { AuditLogQuery } from "@/services/audit"
-import { getErrorDetail } from "@/lib/errorDetail"
-import { supabase } from "@/lib/supabase"
-import type { UserRole, AuditLogEntry } from "@/types"
-import { Button } from "@/components/ui/button"
-import { toast } from "@/lib/toast"
 import { Shield } from "lucide-react"
-import { useConfirm } from "@/components/ui/alert-dialog"
+import { useAuth } from "@/context/useAuth"
+import { Button } from "@/components/ui/button"
 import { ErrorState } from "@/components/patterns"
-import {
-  ADMIN_TABS,
-  ISO_DATE_REGEX,
-  ACTION_OPTIONS,
-  RESOURCE_OPTIONS,
-  type AdminTab,
-  type ProfileRow,
-  type AdminStats,
-} from "./dashboard/constants"
+import { ADMIN_TABS, type AdminTab } from "./dashboard/constants"
 import { AdminTabs } from "./dashboard/AdminTabs"
 import { OverviewStats } from "./dashboard/OverviewStats"
 import { PendingTeachersCard } from "./dashboard/PendingTeachersCard"
-import { PendingCertsCard, type AdminCert } from "./dashboard/PendingCertsCard"
+import { PendingCertsCard } from "./dashboard/PendingCertsCard"
 import { UsersCard } from "./dashboard/UsersCard"
 import { AuditLogTab } from "./dashboard/AuditLogTab"
-
-const AUDIT_PAGE_SIZE = 25
+import { useAdminOverview } from "./dashboard/useAdminOverview"
+import { useAdminAudit } from "./dashboard/useAdminAudit"
 
 /**
- * Admin dashboard orchestrator. Owns every piece of mutable state
- * (users, stats, certs, audit filters, selection set, loaders) and
- * passes pure-presentation children in `dashboard/` the props they
- * need. The CSS here is intentionally minimal — the real UI work lives
- * in `dashboard/` tab-scoped components.
+ * Admin dashboard orchestrator. Delegates every piece of state to
+ * tab-scoped hooks (`useAdminOverview`, `useAdminAudit`) and renders
+ * the matching section for the active tab. This file is layout-only.
  */
 export default function AdminDashboard() {
   const { user } = useAuth()
-  const confirm = useConfirm()
   const [params, setParams] = useSearchParams()
 
   const rawTab = params.get("tab")
@@ -47,125 +27,10 @@ export default function AdminDashboard() {
     ? (rawTab as AdminTab)
     : "overview"
 
-  const {
-    input: searchInput,
-    setInput: setSearchInput,
-    value: urlQuery,
-    maxLength: MAX_SEARCH_LEN,
-  } = useDebouncedSearchParam()
+  const overview = useAdminOverview({ currentUserId: user?.id })
+  const audit = useAdminAudit({ enabled: tab === "audit" })
 
-  const [users, setUsers] = useState<ProfileRow[]>([])
-  const [stats, setStats] = useState<AdminStats>({ users: 0, courses: 0, enrollments: 0 })
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [updatingId, setUpdatingId] = useState<string | null>(null)
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [bulkRole, setBulkRole] = useState<UserRole>("student")
-  const [bulkUpdating, setBulkUpdating] = useState(false)
-  const [adminCerts, setAdminCerts] = useState<AdminCert[]>([])
-  const [certActionId, setCertActionId] = useState<string | null>(null)
-
-  const [auditLogs, setAuditLogs] = useState<AuditLogEntry[]>([])
-  const [auditTotal, setAuditTotal] = useState(0)
-  const [auditLoading, setAuditLoading] = useState(false)
-
-  const pickOption = <T extends readonly string[]>(
-    val: string | null,
-    opts: T,
-  ): T[number] | "" =>
-    val && (opts as readonly string[]).includes(val) ? (val as T[number]) : ""
-
-  const auditAction = pickOption(params.get("ax"), ACTION_OPTIONS)
-  const auditResource = pickOption(params.get("ar"), RESOURCE_OPTIONS)
-  const auditDateFrom = ISO_DATE_REGEX.test(params.get("af") ?? "") ? params.get("af")! : ""
-  const auditDateTo = ISO_DATE_REGEX.test(params.get("at") ?? "") ? params.get("at")! : ""
-  const rawPage = Number.parseInt(params.get("ap") ?? "1", 10)
-  const auditPage = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1
-
-  const updateAudit = useCallback(
-    (patch: Record<string, string | null>, opts: { resetPage?: boolean } = {}) =>
-      setParams(
-        (prev) => {
-          const n = new URLSearchParams(prev)
-          for (const [k, v] of Object.entries(patch)) {
-            if (v) n.set(k, v)
-            else n.delete(k)
-          }
-          if (opts.resetPage) n.delete("ap")
-          return n
-        },
-        { replace: true },
-      ),
-    [setParams],
-  )
-
-  const [reloadKey, setReloadKey] = useState(0)
-  const reload = useCallback(() => setReloadKey((k) => k + 1), [])
-
-  useEffect(() => {
-    let cancelled = false
-    setLoading(true)
-    setError(null)
-    ;(async () => {
-      try {
-        const [allUsers, coursesCount, enrollmentsCount, certs] = await Promise.all([
-          coursesService.getAllUsers(),
-          supabase.from("courses").select("id", { count: "exact", head: true }),
-          supabase.from("enrollments").select("id", { count: "exact", head: true }),
-          coursesService.getAdminPendingCerts().catch(() => []),
-        ])
-        if (cancelled) return
-        setUsers(allUsers as ProfileRow[])
-        setStats({
-          users: allUsers.length,
-          courses: coursesCount.count ?? 0,
-          enrollments: enrollmentsCount.count ?? 0,
-        })
-        setAdminCerts(certs)
-      } catch {
-        if (!cancelled) setError("Failed to load admin data. Please try again.")
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [reloadKey])
-
-  useEffect(() => {
-    if (tab !== "audit") return
-    let cancelled = false
-    setAuditLoading(true)
-    ;(async () => {
-      try {
-        const query: AuditLogQuery = {
-          page: auditPage,
-          page_size: AUDIT_PAGE_SIZE,
-        }
-        if (auditAction) query.action = auditAction
-        if (auditResource) query.resource_type = auditResource
-        if (auditDateFrom) query.date_from = new Date(auditDateFrom).toISOString()
-        if (auditDateTo) query.date_to = new Date(auditDateTo + "T23:59:59").toISOString()
-
-        const data = await coursesService.getAuditLogs(query)
-        if (cancelled) return
-        setAuditLogs(data.items ?? [])
-        setAuditTotal(data.total ?? 0)
-      } catch (err: unknown) {
-        if (cancelled) return
-        const detail =
-          getErrorDetail(err) ||
-          "The audit_logs table may not exist yet. Deploy the latest migration."
-        toast({ title: `Audit log error: ${detail}`, variant: "destructive" })
-      } finally {
-        if (!cancelled) setAuditLoading(false)
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [tab, auditPage, auditAction, auditResource, auditDateFrom, auditDateTo])
+  if (user?.role !== "admin") return <Navigate to="/" replace />
 
   const setTab = (nextTab: AdminTab) => {
     const next = new URLSearchParams(params)
@@ -173,203 +38,6 @@ export default function AdminDashboard() {
     else next.set("tab", nextTab)
     setParams(next, { replace: true })
   }
-
-  const filtered = useMemo(() => {
-    const q = urlQuery.trim().toLowerCase()
-    if (!q) return users
-    return users.filter(
-      (u) => u.full_name?.toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
-    )
-  }, [users, urlQuery])
-
-  const userMap = useMemo(() => {
-    const map: Record<string, string> = {}
-    for (const u of users) map[u.id] = u.full_name || u.email
-    return map
-  }, [users])
-
-  const filteredIds = useMemo(() => new Set(filtered.map((u) => u.id)), [filtered])
-
-  useEffect(() => {
-    setSelectedIds((prev) => {
-      const narrowed = new Set([...prev].filter((id) => filteredIds.has(id)))
-      return narrowed.size === prev.size ? prev : narrowed
-    })
-  }, [filteredIds])
-
-  if (user?.role !== "admin") return <Navigate to="/" replace />
-
-  const handleRoleChange = async (userId: string, newRole: UserRole) => {
-    setUpdatingId(userId)
-    try {
-      await coursesService.updateUserRole(userId, newRole)
-      setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, role: newRole } : u)))
-      toast({ title: "Role updated", variant: "success" })
-    } catch {
-      toast({ title: "Failed to update role", variant: "destructive" })
-    } finally {
-      setUpdatingId(null)
-    }
-  }
-
-  const handleDeleteUser = async (target: ProfileRow) => {
-    const ok = await confirm({
-      title: `Delete ${target.full_name || target.email}?`,
-      description:
-        "This permanently removes their account, enrollments, submissions, grades, certificates, and notifications. Courses they created will be kept but disassociated. This cannot be undone.",
-      confirmLabel: "Delete account",
-      tone: "destructive",
-    })
-    if (!ok) return
-    setUpdatingId(target.id)
-    try {
-      await coursesService.adminDeleteUser(target.id)
-      setUsers((prev) => prev.filter((u) => u.id !== target.id))
-      setSelectedIds((prev) => {
-        if (!prev.has(target.id)) return prev
-        const next = new Set(prev)
-        next.delete(target.id)
-        return next
-      })
-      toast({ title: "User deleted", variant: "success" })
-    } catch (err) {
-      toast({
-        title: getErrorDetail(err, "Failed to delete user"),
-        variant: "destructive",
-      })
-    } finally {
-      setUpdatingId(null)
-    }
-  }
-
-  const toggleSelectAll = () => {
-    const allFilteredSelected =
-      filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
-    if (allFilteredSelected) {
-      setSelectedIds(new Set())
-    } else {
-      setSelectedIds(new Set(filtered.map((u) => u.id)))
-    }
-  }
-
-  const toggleSelect = (id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
-
-  const handleBulkRoleChange = async () => {
-    const ids = [...selectedIds].filter((id) => id !== user?.id)
-    if (ids.length === 0) return
-    const ok = await confirm({
-      title: "Change role for selected users?",
-      description: `${ids.length} user(s) will be set to role "${bulkRole}".`,
-      confirmLabel: "Apply",
-    })
-    if (!ok) return
-    setBulkUpdating(true)
-    try {
-      const result = await coursesService.bulkUpdateUserRoles(ids, bulkRole)
-      setUsers((prev) =>
-        prev.map((u) => (ids.includes(u.id) ? { ...u, role: bulkRole } : u)),
-      )
-      setSelectedIds(new Set())
-      toast({
-        title: `Updated ${result.updated} user(s) to ${bulkRole}`,
-        variant: "success",
-      })
-    } catch (err) {
-      toast({
-        title: getErrorDetail(err, "Bulk update failed"),
-        variant: "destructive",
-      })
-    } finally {
-      setBulkUpdating(false)
-    }
-  }
-
-  const pendingTeachers = users.filter((u) => u.role === "pending_teacher")
-
-  const handleApproveTeacherRaw = async (userId: string) => {
-    setUpdatingId(userId)
-    try {
-      await coursesService.updateUserRole(userId, "teacher")
-      setUsers((prev) =>
-        prev.map((u) => (u.id === userId ? { ...u, role: "teacher" as UserRole } : u)),
-      )
-      toast({ title: "Teacher approved", variant: "success" })
-    } catch {
-      toast({ title: "Failed to approve teacher", variant: "destructive" })
-    } finally {
-      setUpdatingId(null)
-    }
-  }
-
-  const handleDenyTeacherRaw = async (userId: string) => {
-    setUpdatingId(userId)
-    try {
-      await coursesService.updateUserRole(userId, "student")
-      setUsers((prev) =>
-        prev.map((u) => (u.id === userId ? { ...u, role: "student" as UserRole } : u)),
-      )
-      toast({ title: "Teacher denied", variant: "success" })
-    } catch {
-      toast({ title: "Failed to deny teacher", variant: "destructive" })
-    } finally {
-      setUpdatingId(null)
-    }
-  }
-
-  const approvePendingTeacher = async (u: ProfileRow) => {
-    const ok = await confirm({
-      title: "Approve this teacher?",
-      description: `${u.full_name || u.email} will gain access to teacher features.`,
-      confirmLabel: "Approve",
-    })
-    if (ok) handleApproveTeacherRaw(u.id)
-  }
-
-  const denyPendingTeacher = async (u: ProfileRow) => {
-    const ok = await confirm({
-      title: "Deny this teacher?",
-      description: `${u.full_name || u.email}'s teacher request will be rejected.`,
-      confirmLabel: "Deny",
-      tone: "destructive",
-    })
-    if (ok) handleDenyTeacherRaw(u.id)
-  }
-
-  const handleFinalApproveCert = async (certId: string) => {
-    setCertActionId(certId)
-    try {
-      await coursesService.adminApproveCert(certId)
-      setAdminCerts((prev) => prev.filter((c) => c.id !== certId))
-      toast({ title: "Certificate approved", variant: "success" })
-    } catch {
-      toast({ title: "Failed to approve certificate", variant: "destructive" })
-    } finally {
-      setCertActionId(null)
-    }
-  }
-
-  const handleRejectCert = async (certId: string) => {
-    setCertActionId(certId)
-    try {
-      await coursesService.rejectCert(certId)
-      setAdminCerts((prev) => prev.filter((c) => c.id !== certId))
-      toast({ title: "Certificate rejected", variant: "success" })
-    } catch {
-      toast({ title: "Failed to reject certificate", variant: "destructive" })
-    } finally {
-      setCertActionId(null)
-    }
-  }
-
-  const resetAuditFilters = () =>
-    updateAudit({ ax: null, ar: null, af: null, at: null, ap: null })
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-6xl">
@@ -387,12 +55,12 @@ export default function AdminDashboard() {
 
       <AdminTabs active={tab} onChange={setTab} />
 
-      {error && (
+      {overview.error && (
         <ErrorState
           icon={<Shield />}
-          description={error}
+          description={overview.error}
           action={
-            <Button onClick={reload} size="sm" variant="outline">
+            <Button onClick={overview.reload} size="sm" variant="outline">
               Try again
             </Button>
           }
@@ -400,65 +68,63 @@ export default function AdminDashboard() {
         />
       )}
 
-      {!error && tab === "overview" && (
+      {!overview.error && tab === "overview" && (
         <>
-          <OverviewStats stats={stats} loading={loading} />
+          <OverviewStats stats={overview.stats} loading={overview.loading} />
           <PendingTeachersCard
-            pending={pendingTeachers}
-            updatingId={updatingId}
-            onApprove={approvePendingTeacher}
-            onDeny={denyPendingTeacher}
+            pending={overview.pendingTeachers}
+            updatingId={overview.updatingId}
+            onApprove={overview.approvePendingTeacher}
+            onDeny={overview.denyPendingTeacher}
           />
           <PendingCertsCard
-            certs={adminCerts}
-            actionId={certActionId}
-            onApprove={handleFinalApproveCert}
-            onReject={handleRejectCert}
+            certs={overview.adminCerts}
+            actionId={overview.certActionId}
+            onApprove={overview.handleFinalApproveCert}
+            onReject={overview.handleRejectCert}
           />
           <UsersCard
-            users={users}
-            filtered={filtered}
-            loading={loading}
-            searchInput={searchInput}
-            searchMaxLength={MAX_SEARCH_LEN}
-            urlQuery={urlQuery}
-            selectedIds={selectedIds}
-            bulkRole={bulkRole}
-            bulkUpdating={bulkUpdating}
-            updatingId={updatingId}
+            users={overview.users}
+            filtered={overview.filtered}
+            loading={overview.loading}
+            searchInput={overview.searchInput}
+            searchMaxLength={overview.searchMaxLength}
+            urlQuery={overview.urlQuery}
+            selectedIds={overview.selectedIds}
+            bulkRole={overview.bulkRole}
+            bulkUpdating={overview.bulkUpdating}
+            updatingId={overview.updatingId}
             currentUserId={user?.id}
-            onSearchInputChange={setSearchInput}
-            onBulkRoleChange={setBulkRole}
-            onApplyBulkRole={handleBulkRoleChange}
-            onClearSelection={() => setSelectedIds(new Set())}
-            onToggleSelectAll={toggleSelectAll}
-            onToggleSelect={toggleSelect}
-            onRoleChange={handleRoleChange}
-            onDeleteUser={handleDeleteUser}
+            onSearchInputChange={overview.setSearchInput}
+            onBulkRoleChange={overview.setBulkRole}
+            onApplyBulkRole={overview.handleBulkRoleChange}
+            onClearSelection={overview.clearSelection}
+            onToggleSelectAll={overview.toggleSelectAll}
+            onToggleSelect={overview.toggleSelect}
+            onRoleChange={overview.handleRoleChange}
+            onDeleteUser={overview.handleDeleteUser}
           />
         </>
       )}
 
-      {!error && tab === "audit" && (
+      {!overview.error && tab === "audit" && (
         <AuditLogTab
-          logs={auditLogs}
-          total={auditTotal}
-          loading={auditLoading}
-          page={auditPage}
-          pageSize={AUDIT_PAGE_SIZE}
-          userMap={userMap}
-          action={auditAction}
-          resource={auditResource}
-          dateFrom={auditDateFrom}
-          dateTo={auditDateTo}
-          onAction={(v) => updateAudit({ ax: v || null }, { resetPage: true })}
-          onResource={(v) => updateAudit({ ar: v || null }, { resetPage: true })}
-          onDateFrom={(v) => updateAudit({ af: v || null }, { resetPage: true })}
-          onDateTo={(v) => updateAudit({ at: v || null }, { resetPage: true })}
-          onReset={resetAuditFilters}
-          onPageChange={(next) =>
-            updateAudit({ ap: next <= 1 ? null : String(next) })
-          }
+          logs={audit.logs}
+          total={audit.total}
+          loading={audit.loading}
+          page={audit.page}
+          pageSize={audit.pageSize}
+          userMap={overview.userMap}
+          action={audit.action}
+          resource={audit.resource}
+          dateFrom={audit.dateFrom}
+          dateTo={audit.dateTo}
+          onAction={audit.setAction}
+          onResource={audit.setResource}
+          onDateFrom={audit.setDateFrom}
+          onDateTo={audit.setDateTo}
+          onReset={audit.resetFilters}
+          onPageChange={audit.setPage}
         />
       )}
     </div>

--- a/frontend/src/pages/Admin/dashboard/useAdminAudit.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminAudit.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+import { coursesService } from "@/services/courses"
+import type { AuditLogQuery } from "@/services/audit"
+import { toast } from "@/lib/toast"
+import { getErrorDetail } from "@/lib/errorDetail"
+import type { AuditLogEntry } from "@/types"
+import {
+  ACTION_OPTIONS,
+  ISO_DATE_REGEX,
+  RESOURCE_OPTIONS,
+} from "./constants"
+
+export const AUDIT_PAGE_SIZE = 25
+
+interface UseAdminAuditArgs {
+  /** When `false` the hook skips fetching — used to avoid loading the
+   *  audit log while the user is on another tab. */
+  enabled: boolean
+}
+
+const pickOption = <T extends readonly string[]>(
+  val: string | null,
+  opts: T,
+): T[number] | "" =>
+  val && (opts as readonly string[]).includes(val) ? (val as T[number]) : ""
+
+/**
+ * Manages the audit-log tab: URL-driven filter state, paging, and
+ * network loading. All filter state is synced to the URL so the tab
+ * is bookmarkable and survives navigation.
+ */
+export function useAdminAudit({ enabled }: UseAdminAuditArgs) {
+  const [params, setParams] = useSearchParams()
+
+  const action = pickOption(params.get("ax"), ACTION_OPTIONS)
+  const resource = pickOption(params.get("ar"), RESOURCE_OPTIONS)
+  const dateFrom = ISO_DATE_REGEX.test(params.get("af") ?? "") ? params.get("af")! : ""
+  const dateTo = ISO_DATE_REGEX.test(params.get("at") ?? "") ? params.get("at")! : ""
+  const rawPage = Number.parseInt(params.get("ap") ?? "1", 10)
+  const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1
+
+  const [logs, setLogs] = useState<AuditLogEntry[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(false)
+
+  const updateAudit = useCallback(
+    (patch: Record<string, string | null>, opts: { resetPage?: boolean } = {}) =>
+      setParams(
+        (prev) => {
+          const n = new URLSearchParams(prev)
+          for (const [k, v] of Object.entries(patch)) {
+            if (v) n.set(k, v)
+            else n.delete(k)
+          }
+          if (opts.resetPage) n.delete("ap")
+          return n
+        },
+        { replace: true },
+      ),
+    [setParams],
+  )
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    setLoading(true)
+    ;(async () => {
+      try {
+        const query: AuditLogQuery = { page, page_size: AUDIT_PAGE_SIZE }
+        if (action) query.action = action
+        if (resource) query.resource_type = resource
+        if (dateFrom) query.date_from = new Date(dateFrom).toISOString()
+        // Treat the "to" filter as the full day: everything up to
+        // 23:59:59 of that calendar date.
+        if (dateTo) query.date_to = new Date(dateTo + "T23:59:59").toISOString()
+
+        const data = await coursesService.getAuditLogs(query)
+        if (cancelled) return
+        setLogs(data.items ?? [])
+        setTotal(data.total ?? 0)
+      } catch (err: unknown) {
+        if (cancelled) return
+        const detail =
+          getErrorDetail(err) ||
+          "The audit_logs table may not exist yet. Deploy the latest migration."
+        toast({ title: `Audit log error: ${detail}`, variant: "destructive" })
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, page, action, resource, dateFrom, dateTo])
+
+  const resetFilters = () =>
+    updateAudit({ ax: null, ar: null, af: null, at: null, ap: null })
+
+  return {
+    logs,
+    total,
+    loading,
+    page,
+    pageSize: AUDIT_PAGE_SIZE,
+    action,
+    resource,
+    dateFrom,
+    dateTo,
+    setAction: (v: string) => updateAudit({ ax: v || null }, { resetPage: true }),
+    setResource: (v: string) => updateAudit({ ar: v || null }, { resetPage: true }),
+    setDateFrom: (v: string) => updateAudit({ af: v || null }, { resetPage: true }),
+    setDateTo: (v: string) => updateAudit({ at: v || null }, { resetPage: true }),
+    setPage: (next: number) => updateAudit({ ap: next <= 1 ? null : String(next) }),
+    resetFilters,
+  }
+}

--- a/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
+import { coursesService } from "@/services/courses"
+import { supabase } from "@/lib/supabase"
+import { toast } from "@/lib/toast"
+import { getErrorDetail } from "@/lib/errorDetail"
+import { useConfirm } from "@/components/ui/alert-dialog"
+import type { UserRole } from "@/types"
+import type { AdminCert } from "./PendingCertsCard"
+import type { AdminStats, ProfileRow } from "./constants"
+
+interface UseAdminOverviewArgs {
+  /** Current signed-in user id — excluded from bulk operations and delete confirmations. */
+  currentUserId: string | undefined
+}
+
+/**
+ * Owns every piece of state rendered by the Overview tab:
+ * users list, stats counters, pending-teacher approvals, pending-
+ * certificate approvals, the row-selection set, and all bulk/row
+ * handlers. Split out of `AdminDashboard` so the page component stays
+ * focused on layout and tab routing.
+ */
+export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
+  const confirm = useConfirm()
+
+  const {
+    input: searchInput,
+    setInput: setSearchInput,
+    value: urlQuery,
+    maxLength: searchMaxLength,
+  } = useDebouncedSearchParam()
+
+  const [users, setUsers] = useState<ProfileRow[]>([])
+  const [stats, setStats] = useState<AdminStats>({ users: 0, courses: 0, enrollments: 0 })
+  const [adminCerts, setAdminCerts] = useState<AdminCert[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [updatingId, setUpdatingId] = useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [bulkRole, setBulkRole] = useState<UserRole>("student")
+  const [bulkUpdating, setBulkUpdating] = useState(false)
+  const [certActionId, setCertActionId] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    ;(async () => {
+      try {
+        const [allUsers, coursesCount, enrollmentsCount, certs] = await Promise.all([
+          coursesService.getAllUsers(),
+          supabase.from("courses").select("id", { count: "exact", head: true }),
+          supabase.from("enrollments").select("id", { count: "exact", head: true }),
+          coursesService.getAdminPendingCerts().catch(() => []),
+        ])
+        if (cancelled) return
+        setUsers(allUsers as ProfileRow[])
+        setStats({
+          users: allUsers.length,
+          courses: coursesCount.count ?? 0,
+          enrollments: enrollmentsCount.count ?? 0,
+        })
+        setAdminCerts(certs)
+      } catch {
+        if (!cancelled) setError("Failed to load admin data. Please try again.")
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [reloadKey])
+
+  const filtered = useMemo(() => {
+    const q = urlQuery.trim().toLowerCase()
+    if (!q) return users
+    return users.filter(
+      (u) => u.full_name?.toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
+    )
+  }, [users, urlQuery])
+
+  const userMap = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const u of users) map[u.id] = u.full_name || u.email
+    return map
+  }, [users])
+
+  // When a filter hides rows, drop them from the selection so
+  // "Apply to N selected" counts only visible rows.
+  const filteredIds = useMemo(() => new Set(filtered.map((u) => u.id)), [filtered])
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const narrowed = new Set([...prev].filter((id) => filteredIds.has(id)))
+      return narrowed.size === prev.size ? prev : narrowed
+    })
+  }, [filteredIds])
+
+  const handleRoleChange = async (userId: string, newRole: UserRole) => {
+    setUpdatingId(userId)
+    try {
+      await coursesService.updateUserRole(userId, newRole)
+      setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, role: newRole } : u)))
+      toast({ title: "Role updated", variant: "success" })
+    } catch {
+      toast({ title: "Failed to update role", variant: "destructive" })
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  const handleDeleteUser = async (target: ProfileRow) => {
+    const ok = await confirm({
+      title: `Delete ${target.full_name || target.email}?`,
+      description:
+        "This permanently removes their account, enrollments, submissions, grades, certificates, and notifications. Courses they created will be kept but disassociated. This cannot be undone.",
+      confirmLabel: "Delete account",
+      tone: "destructive",
+    })
+    if (!ok) return
+    setUpdatingId(target.id)
+    try {
+      await coursesService.adminDeleteUser(target.id)
+      setUsers((prev) => prev.filter((u) => u.id !== target.id))
+      setSelectedIds((prev) => {
+        if (!prev.has(target.id)) return prev
+        const next = new Set(prev)
+        next.delete(target.id)
+        return next
+      })
+      toast({ title: "User deleted", variant: "success" })
+    } catch (err) {
+      toast({ title: getErrorDetail(err, "Failed to delete user"), variant: "destructive" })
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleSelectAll = () => {
+    const allFilteredSelected =
+      filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
+    if (allFilteredSelected) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(filtered.map((u) => u.id)))
+    }
+  }
+
+  const clearSelection = () => setSelectedIds(new Set())
+
+  const handleBulkRoleChange = async () => {
+    // Never flip our own role in a bulk update — an admin deselecting
+    // themselves mid-action would lock them out.
+    const ids = [...selectedIds].filter((id) => id !== currentUserId)
+    if (ids.length === 0) return
+    const ok = await confirm({
+      title: "Change role for selected users?",
+      description: `${ids.length} user(s) will be set to role "${bulkRole}".`,
+      confirmLabel: "Apply",
+    })
+    if (!ok) return
+    setBulkUpdating(true)
+    try {
+      const result = await coursesService.bulkUpdateUserRoles(ids, bulkRole)
+      setUsers((prev) =>
+        prev.map((u) => (ids.includes(u.id) ? { ...u, role: bulkRole } : u)),
+      )
+      setSelectedIds(new Set())
+      toast({ title: `Updated ${result.updated} user(s) to ${bulkRole}`, variant: "success" })
+    } catch (err) {
+      toast({ title: getErrorDetail(err, "Bulk update failed"), variant: "destructive" })
+    } finally {
+      setBulkUpdating(false)
+    }
+  }
+
+  const pendingTeachers = useMemo(
+    () => users.filter((u) => u.role === "pending_teacher"),
+    [users],
+  )
+
+  const setTeacherRole = async (userId: string, nextRole: UserRole, okMsg: string, failMsg: string) => {
+    setUpdatingId(userId)
+    try {
+      await coursesService.updateUserRole(userId, nextRole)
+      setUsers((prev) =>
+        prev.map((u) => (u.id === userId ? { ...u, role: nextRole } : u)),
+      )
+      toast({ title: okMsg, variant: "success" })
+    } catch {
+      toast({ title: failMsg, variant: "destructive" })
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  const approvePendingTeacher = async (u: ProfileRow) => {
+    const ok = await confirm({
+      title: "Approve this teacher?",
+      description: `${u.full_name || u.email} will gain access to teacher features.`,
+      confirmLabel: "Approve",
+    })
+    if (ok) await setTeacherRole(u.id, "teacher", "Teacher approved", "Failed to approve teacher")
+  }
+
+  const denyPendingTeacher = async (u: ProfileRow) => {
+    const ok = await confirm({
+      title: "Deny this teacher?",
+      description: `${u.full_name || u.email}'s teacher request will be rejected.`,
+      confirmLabel: "Deny",
+      tone: "destructive",
+    })
+    if (ok) await setTeacherRole(u.id, "student", "Teacher denied", "Failed to deny teacher")
+  }
+
+  const handleCertDecision = async (
+    certId: string,
+    call: () => Promise<unknown>,
+    okMsg: string,
+    failMsg: string,
+  ) => {
+    setCertActionId(certId)
+    try {
+      await call()
+      setAdminCerts((prev) => prev.filter((c) => c.id !== certId))
+      toast({ title: okMsg, variant: "success" })
+    } catch {
+      toast({ title: failMsg, variant: "destructive" })
+    } finally {
+      setCertActionId(null)
+    }
+  }
+
+  const handleFinalApproveCert = (certId: string) =>
+    handleCertDecision(
+      certId,
+      () => coursesService.adminApproveCert(certId),
+      "Certificate approved",
+      "Failed to approve certificate",
+    )
+
+  const handleRejectCert = (certId: string) =>
+    handleCertDecision(
+      certId,
+      () => coursesService.rejectCert(certId),
+      "Certificate rejected",
+      "Failed to reject certificate",
+    )
+
+  return {
+    users,
+    filtered,
+    userMap,
+    stats,
+    adminCerts,
+    pendingTeachers,
+    loading,
+    error,
+    updatingId,
+    selectedIds,
+    bulkRole,
+    bulkUpdating,
+    certActionId,
+    searchInput,
+    setSearchInput,
+    urlQuery,
+    searchMaxLength,
+    reload,
+    setBulkRole,
+    handleRoleChange,
+    handleDeleteUser,
+    toggleSelect,
+    toggleSelectAll,
+    clearSelection,
+    handleBulkRoleChange,
+    approvePendingTeacher,
+    denyPendingTeacher,
+    handleFinalApproveCert,
+    handleRejectCert,
+  }
+}


### PR DESCRIPTION
## Summary

Extract `AdminDashboard.tsx` state into two tab-scoped hooks so the page component becomes layout-only.

- **`dashboard/useAdminOverview.ts`** (new, 294 LOC) — loads users + stats + admin pending certs in one roundtrip, owns the row-selection set, bulk-role state, filter derivation, and every Overview tab handler (role change, delete, bulk update, pending-teacher approve/deny, cert approve/reject).
- **`dashboard/useAdminAudit.ts`** (new, 117 LOC) — owns the audit-log URL query (action / resource / dateFrom / dateTo / page), fetches when enabled, exposes a setter API and a `resetFilters()` helper. Skips loading while the user is on another tab via the `enabled` flag.
- **`AdminDashboard.tsx`** trimmed from **466 → 132 lines**; now just reads `tab` from the URL, calls the two hooks, and renders the matching section.

Behavioural parity:
- Same routes, same URL query params (`?tab`, `?ax`, `?ar`, `?af`, `?at`, `?ap`), same page size (25).
- Same "don't flip your own role in bulk" guard.
- Same empty-filter normalization (out-of-range date / unknown action / bad page number → empty string / page 1).

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint src/pages/Admin` — clean
- [x] `vitest run` — **85 passed**
- [x] `vite build` — green
