### PR TITLE
refactor(calendar): split CalendarPage into hooks + view modules

### DIFF
--- a/frontend/src/pages/Calendar/CalendarPage.tsx
+++ b/frontend/src/pages/Calendar/CalendarPage.tsx
@@ -1,185 +1,42 @@
-import { useEffect, useState, useMemo } from "react"
-import { Link, useSearchParams } from "react-router-dom"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import PageSpinner from "@/components/ui/PageSpinner"
-import { Button } from "@/components/ui/button"
-import { coursesService } from "@/services/courses"
-import type { CalendarEvent, Enrollment } from "@/types"
-import {
-  ChevronLeft,
-  ChevronRight,
-  CalendarDays,
-  Clock,
-  BookOpen,
-  Filter,
-  RefreshCw,
-} from "lucide-react"
-import { ErrorState } from "@/components/patterns"
+import { CalendarDays, Filter, RefreshCw } from "lucide-react";
 
-const EVENT_COLORS: Record<string, { dot: string; bg: string; text: string; border: string }> = {
-  deadline: {
-    dot: "bg-destructive",
-    bg: "bg-destructive/10",
-    text: "text-destructive",
-    border: "border-destructive/30",
-  },
-  live_session: {
-    dot: "bg-info",
-    bg: "bg-info/10",
-    text: "text-info",
-    border: "border-info/30",
-  },
-  exam: {
-    dot: "bg-warning",
-    bg: "bg-warning/10",
-    text: "text-warning",
-    border: "border-warning/30",
-  },
-  other: {
-    dot: "bg-muted-foreground/50",
-    bg: "bg-muted",
-    text: "text-muted-foreground",
-    border: "border-border",
-  },
-}
+import { Button } from "@/components/ui/button";
+import PageSpinner from "@/components/ui/PageSpinner";
+import { ErrorState } from "@/components/patterns";
 
-const FALLBACK_EVENT_COLOR = {
-  dot: "bg-muted-foreground/50",
-  bg: "bg-muted",
-  text: "text-muted-foreground",
-  border: "border-border",
-}
-
-function getEventColor(type: string) {
-  return EVENT_COLORS[type] ?? FALLBACK_EVENT_COLOR
-}
-
-const MONTH_NAMES = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
-]
-
-const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-
-function isSameDay(a: Date, b: Date) {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
-}
-
-function formatTime(dateStr: string) {
-  return new Date(dateStr).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
-}
-
-function formatShortDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString(undefined, { month: "short", day: "numeric" })
-}
-
-function isOverdue(dateStr: string) {
-  return new Date(dateStr) < new Date()
-}
+import { MonthGrid } from "./MonthGrid";
+import { SelectedDayPanel } from "./SelectedDayPanel";
+import { UpcomingEventsPanel } from "./UpcomingEventsPanel";
+import { useCalendarData } from "./useCalendarData";
+import { useMonthGrid } from "./useMonthGrid";
 
 export default function CalendarPage() {
-  const [events, setEvents] = useState<CalendarEvent[]>([])
-  const [enrollments, setEnrollments] = useState<Enrollment[]>([])
-  const [loading, setLoading] = useState(true)
-  const [fetchError, setFetchError] = useState<string | null>(null)
-  const [retryCount, setRetryCount] = useState(0)
-  const [currentDate, setCurrentDate] = useState(() => new Date())
-  const [selectedDay, setSelectedDay] = useState<Date | null>(() => new Date())
-  const [params, setParams] = useSearchParams()
-  const filterCourseId = (params.get("course") ?? "").slice(0, 64)
-  const setFilterCourseId = (id: string) => {
-    const next = new URLSearchParams(params)
-    if (id) next.set("course", id.slice(0, 64))
-    else next.delete("course")
-    setParams(next, { replace: true })
-  }
+  const {
+    events,
+    enrollments,
+    loading,
+    fetchError,
+    retry,
+    filterCourseId,
+    setFilterCourseId,
+  } = useCalendarData();
 
-  useEffect(() => {
-    let cancelled = false
-    setLoading(true)
-    setFetchError(null)
-    const load = async () => {
-      try {
-        const [evts, enrolls] = await Promise.all([
-          coursesService.getCalendarEvents(filterCourseId || undefined),
-          coursesService.getMyCourses().catch(() => []),
-        ])
-        if (cancelled) return
-        setEvents(evts)
-        setEnrollments(enrolls)
-      } catch {
-        if (!cancelled) setFetchError("Failed to load calendar events. Please try again.")
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    }
-    load()
-    return () => { cancelled = true }
-  }, [filterCourseId, retryCount])
-
-  const year = currentDate.getFullYear()
-  const month = currentDate.getMonth()
-
-  const calendarDays = useMemo(() => {
-    const firstDay = new Date(year, month, 1)
-    const lastDay = new Date(year, month + 1, 0)
-    const startOffset = firstDay.getDay()
-    const days: Array<{ date: Date; inMonth: boolean }> = []
-
-    for (let i = startOffset - 1; i >= 0; i--) {
-      const d = new Date(year, month, -i)
-      days.push({ date: d, inMonth: false })
-    }
-    for (let i = 1; i <= lastDay.getDate(); i++) {
-      days.push({ date: new Date(year, month, i), inMonth: true })
-    }
-    const remaining = 7 - (days.length % 7)
-    if (remaining < 7) {
-      for (let i = 1; i <= remaining; i++) {
-        days.push({ date: new Date(year, month + 1, i), inMonth: false })
-      }
-    }
-    return days
-  }, [year, month])
-
-  const eventsByDate = useMemo(() => {
-    const map = new Map<string, CalendarEvent[]>()
-    for (const evt of events) {
-      if (!evt.event_date) continue
-      const d = new Date(evt.event_date)
-      if (Number.isNaN(d.getTime())) continue
-      const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
-      if (!map.has(key)) map.set(key, [])
-      map.get(key)!.push(evt)
-    }
-    return map
-  }, [events])
-
-  const selectedDayEvents = useMemo(() => {
-    if (!selectedDay) return []
-    const key = `${selectedDay.getFullYear()}-${selectedDay.getMonth()}-${selectedDay.getDate()}`
-    return eventsByDate.get(key) ?? []
-  }, [selectedDay, eventsByDate])
-
-  const upcomingEvents = useMemo(() => {
-    const now = new Date()
-    const twoWeeks = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000)
-    return events.filter((e) => {
-      if (!e.event_date) return false
-      const d = new Date(e.event_date)
-      if (Number.isNaN(d.getTime())) return false
-      return d >= now && d <= twoWeeks
-    })
-  }, [events])
-
-  const today = new Date()
-
-  const prevMonth = () => setCurrentDate(new Date(year, month - 1, 1))
-  const nextMonth = () => setCurrentDate(new Date(year, month + 1, 1))
-  const goToday = () => setCurrentDate(new Date())
+  const {
+    year,
+    month,
+    calendarDays,
+    eventsByDate,
+    selectedDay,
+    setSelectedDay,
+    selectedDayEvents,
+    upcomingEvents,
+    prevMonth,
+    nextMonth,
+    goToday,
+  } = useMonthGrid(events);
 
   if (loading) {
-    return <PageSpinner />
+    return <PageSpinner />;
   }
 
   if (fetchError) {
@@ -188,14 +45,14 @@ export default function CalendarPage() {
         <ErrorState
           description={fetchError}
           action={
-            <Button variant="outline" size="sm" onClick={() => setRetryCount((c) => c + 1)}>
+            <Button variant="outline" size="sm" onClick={retry}>
               <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
               Retry
             </Button>
           }
         />
       </div>
-    )
+    );
   }
 
   return (
@@ -232,210 +89,28 @@ export default function CalendarPage() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Calendar Grid */}
         <div className="lg:col-span-2">
-          <Card>
-            <CardHeader className="pb-2">
-              <div className="flex items-center justify-between">
-                <CardTitle className="font-serif text-lg">
-                  {MONTH_NAMES[month]} {year}
-                </CardTitle>
-                <div className="flex items-center gap-1">
-                  <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={prevMonth} aria-label="Previous month">
-                    <ChevronLeft className="h-4 w-4" />
-                  </Button>
-                  <Button variant="outline" size="sm" className="h-8 text-xs" onClick={goToday}>
-                    Today
-                  </Button>
-                  <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={nextMonth} aria-label="Next month">
-                    <ChevronRight className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="pt-2">
-              {/* Day headers */}
-              <div className="grid grid-cols-7 mb-1">
-                {DAY_NAMES.map((d) => (
-                  <div key={d} className="text-center text-[10px] font-medium text-muted-foreground uppercase tracking-wider py-1">
-                    {d}
-                  </div>
-                ))}
-              </div>
-
-              {/* Day cells */}
-              <div className="grid grid-cols-7 border-t border-l">
-                {calendarDays.map(({ date, inMonth }) => {
-                  const key = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
-                  const dayEvents = eventsByDate.get(key) ?? []
-                  const isToday = isSameDay(date, today)
-                  const isSelected = selectedDay && isSameDay(date, selectedDay)
-
-                  return (
-                    <button
-                      key={key}
-                      onClick={() => setSelectedDay(date)}
-                      className={`
-                        relative min-h-[72px] sm:min-h-[80px] p-1 border-r border-b text-left transition-colors
-                        ${inMonth ? "bg-background" : "bg-muted/30"}
-                        ${isSelected ? "ring-2 ring-primary ring-inset" : "hover:bg-muted/50"}
-                      `}
-                    >
-                      <span
-                        className={`
-                          inline-flex items-center justify-center w-6 h-6 text-xs font-medium rounded-full
-                          ${isToday ? "bg-primary text-primary-foreground" : ""}
-                          ${!inMonth ? "text-muted-foreground/40" : ""}
-                        `}
-                      >
-                        {date.getDate()}
-                      </span>
-
-                      {dayEvents.length > 0 && (
-                        <div className="flex flex-wrap gap-0.5 mt-0.5">
-                          {dayEvents.slice(0, 3).map((evt) => {
-                            const color = getEventColor(evt.event_type)
-                            return (
-                              <span
-                                key={evt.id}
-                                className={`block w-full rounded px-1 py-0.5 text-[9px] leading-tight truncate ${color.bg} ${color.text}`}
-                                title={evt.title}
-                              >
-                                {evt.title}
-                              </span>
-                            )
-                          })}
-                          {dayEvents.length > 3 && (
-                            <span className="text-[9px] text-muted-foreground pl-1">
-                              +{dayEvents.length - 3} more
-                            </span>
-                          )}
-                        </div>
-                      )}
-                    </button>
-                  )
-                })}
-              </div>
-
-              {/* Legend */}
-              <div className="flex flex-wrap items-center gap-3 mt-3 text-[10px]">
-                {Object.entries(EVENT_COLORS).map(([type, color]) => (
-                  <span key={type} className="flex items-center gap-1">
-                    <span className={`w-2 h-2 rounded-full ${color.dot}`} />
-                    <span className="capitalize text-muted-foreground">{type.replace("_", " ")}</span>
-                  </span>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+          <MonthGrid
+            year={year}
+            month={month}
+            today={new Date()}
+            calendarDays={calendarDays}
+            eventsByDate={eventsByDate}
+            selectedDay={selectedDay}
+            onSelectDay={setSelectedDay}
+            onPrevMonth={prevMonth}
+            onNextMonth={nextMonth}
+            onGoToday={goToday}
+          />
         </div>
 
-        {/* Side Panel */}
         <div className="space-y-4">
-          {/* Selected Day Events */}
           {selectedDay && (
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm font-medium flex items-center gap-2">
-                  <CalendarDays className="h-4 w-4 text-primary" />
-                  {selectedDay.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" })}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                {selectedDayEvents.length === 0 ? (
-                  <p className="text-sm text-muted-foreground py-3 text-center">No events on this day</p>
-                ) : (
-                  <div className="space-y-2">
-                    {selectedDayEvents.map((evt) => {
-                      const color = getEventColor(evt.event_type)
-                      return (
-                        <div key={evt.id} className={`rounded-lg border p-2.5 ${color.border} ${color.bg}`}>
-                          <div className="flex items-start gap-2">
-                            <span className={`mt-1 w-2 h-2 rounded-full shrink-0 ${color.dot}`} />
-                            <div className="flex-1 min-w-0">
-                              <p className={`text-sm font-medium ${color.text}`}>{evt.title}</p>
-                              <div className="flex items-center gap-2 mt-0.5 text-[10px] text-muted-foreground">
-                                <span className="flex items-center gap-0.5">
-                                  <Clock className="h-2.5 w-2.5" />
-                                  {formatTime(evt.event_date)}
-                                </span>
-                                <span className="capitalize">{evt.event_type.replace("_", " ")}</span>
-                              </div>
-                              {evt.course_title && (
-                                <Link
-                                  to={`/courses/${evt.course_id}`}
-                                  className="flex items-center gap-1 mt-1 text-[10px] text-primary hover:underline"
-                                >
-                                  <BookOpen className="h-2.5 w-2.5" />
-                                  {evt.course_title}
-                                </Link>
-                              )}
-                              {evt.description && (
-                                <p className="text-[10px] text-muted-foreground mt-1 line-clamp-2">{evt.description}</p>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
+            <SelectedDayPanel selectedDay={selectedDay} events={selectedDayEvents} />
           )}
-
-          {/* Upcoming 14 days */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium flex items-center gap-2">
-                <Clock className="h-4 w-4 text-muted-foreground" />
-                Upcoming (14 days)
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {upcomingEvents.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4 text-center">
-                  No upcoming events
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {upcomingEvents.map((evt) => {
-                    const color = getEventColor(evt.event_type)
-                    const overdue = evt.event_type === "deadline" && isOverdue(evt.event_date)
-                    return (
-                      <div
-                        key={evt.id}
-                        className={`flex items-start gap-2 rounded-md border p-2 transition-colors ${
-                          overdue ? "border-destructive/30 bg-destructive/5" : "hover:bg-muted/50"
-                        }`}
-                      >
-                        <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${color.dot}`} />
-                        <div className="min-w-0 flex-1">
-                          <p className={`truncate text-xs font-medium ${overdue ? "text-destructive" : ""}`}>
-                            {evt.title}
-                          </p>
-                          <div className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
-                            <span>{formatShortDate(evt.event_date)}</span>
-                            <span>{formatTime(evt.event_date)}</span>
-                            {overdue && (
-                              <span className="font-medium text-destructive">Overdue</span>
-                            )}
-                          </div>
-                          {evt.course_title && (
-                            <p className="text-[10px] text-muted-foreground/70 truncate mt-0.5">
-                              {evt.course_title}
-                            </p>
-                          )}
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <UpcomingEventsPanel events={upcomingEvents} />
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Calendar/MonthGrid.tsx
+++ b/frontend/src/pages/Calendar/MonthGrid.tsx
@@ -1,0 +1,148 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import type { CalendarEvent } from "@/types";
+import { DAY_NAMES, EVENT_COLORS, MONTH_NAMES, getEventColor } from "./constants";
+import { calendarDayKey, isSameDay } from "./utils";
+
+interface MonthGridProps {
+  year: number;
+  month: number;
+  today: Date;
+  calendarDays: Array<{ date: Date; inMonth: boolean }>;
+  eventsByDate: Map<string, CalendarEvent[]>;
+  selectedDay: Date | null;
+  onSelectDay: (date: Date) => void;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+  onGoToday: () => void;
+}
+
+/**
+ * Calendar grid with month navigation and legend. All events come in
+ * pre-bucketed by day via `eventsByDate` so this component stays pure.
+ */
+export function MonthGrid({
+  year,
+  month,
+  today,
+  calendarDays,
+  eventsByDate,
+  selectedDay,
+  onSelectDay,
+  onPrevMonth,
+  onNextMonth,
+  onGoToday,
+}: MonthGridProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="font-serif text-lg">
+            {MONTH_NAMES[month]} {year}
+          </CardTitle>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              onClick={onPrevMonth}
+              aria-label="Previous month"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="sm" className="h-8 text-xs" onClick={onGoToday}>
+              Today
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              onClick={onNextMonth}
+              aria-label="Next month"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-2">
+        <div className="grid grid-cols-7 mb-1">
+          {DAY_NAMES.map((d) => (
+            <div
+              key={d}
+              className="text-center text-[10px] font-medium text-muted-foreground uppercase tracking-wider py-1"
+            >
+              {d}
+            </div>
+          ))}
+        </div>
+
+        <div className="grid grid-cols-7 border-t border-l">
+          {calendarDays.map(({ date, inMonth }) => {
+            const key = calendarDayKey(date);
+            const dayEvents = eventsByDate.get(key) ?? [];
+            const isToday = isSameDay(date, today);
+            const isSelected = selectedDay != null && isSameDay(date, selectedDay);
+
+            return (
+              <button
+                key={key}
+                onClick={() => onSelectDay(date)}
+                className={`
+                  relative min-h-[72px] sm:min-h-[80px] p-1 border-r border-b text-left transition-colors
+                  ${inMonth ? "bg-background" : "bg-muted/30"}
+                  ${isSelected ? "ring-2 ring-primary ring-inset" : "hover:bg-muted/50"}
+                `}
+              >
+                <span
+                  className={`
+                    inline-flex items-center justify-center w-6 h-6 text-xs font-medium rounded-full
+                    ${isToday ? "bg-primary text-primary-foreground" : ""}
+                    ${!inMonth ? "text-muted-foreground/40" : ""}
+                  `}
+                >
+                  {date.getDate()}
+                </span>
+
+                {dayEvents.length > 0 && (
+                  <div className="flex flex-wrap gap-0.5 mt-0.5">
+                    {dayEvents.slice(0, 3).map((evt) => {
+                      const color = getEventColor(evt.event_type);
+                      return (
+                        <span
+                          key={evt.id}
+                          className={`block w-full rounded px-1 py-0.5 text-[9px] leading-tight truncate ${color.bg} ${color.text}`}
+                          title={evt.title}
+                        >
+                          {evt.title}
+                        </span>
+                      );
+                    })}
+                    {dayEvents.length > 3 && (
+                      <span className="text-[9px] text-muted-foreground pl-1">
+                        +{dayEvents.length - 3} more
+                      </span>
+                    )}
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 mt-3 text-[10px]">
+          {Object.entries(EVENT_COLORS).map(([type, color]) => (
+            <span key={type} className="flex items-center gap-1">
+              <span className={`w-2 h-2 rounded-full ${color.dot}`} />
+              <span className="capitalize text-muted-foreground">
+                {type.replace("_", " ")}
+              </span>
+            </span>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Calendar/SelectedDayPanel.tsx
+++ b/frontend/src/pages/Calendar/SelectedDayPanel.tsx
@@ -1,0 +1,76 @@
+import { Link } from "react-router-dom";
+import { BookOpen, CalendarDays, Clock } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CalendarEvent } from "@/types";
+import { getEventColor } from "./constants";
+import { formatTime } from "./utils";
+
+interface SelectedDayPanelProps {
+  selectedDay: Date;
+  events: CalendarEvent[];
+}
+
+export function SelectedDayPanel({ selectedDay, events }: SelectedDayPanelProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <CalendarDays className="h-4 w-4 text-primary" />
+          {selectedDay.toLocaleDateString(undefined, {
+            weekday: "long",
+            month: "long",
+            day: "numeric",
+          })}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {events.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-3 text-center">
+            No events on this day
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {events.map((evt) => {
+              const color = getEventColor(evt.event_type);
+              return (
+                <div
+                  key={evt.id}
+                  className={`rounded-lg border p-2.5 ${color.border} ${color.bg}`}
+                >
+                  <div className="flex items-start gap-2">
+                    <span className={`mt-1 w-2 h-2 rounded-full shrink-0 ${color.dot}`} />
+                    <div className="flex-1 min-w-0">
+                      <p className={`text-sm font-medium ${color.text}`}>{evt.title}</p>
+                      <div className="flex items-center gap-2 mt-0.5 text-[10px] text-muted-foreground">
+                        <span className="flex items-center gap-0.5">
+                          <Clock className="h-2.5 w-2.5" />
+                          {formatTime(evt.event_date)}
+                        </span>
+                        <span className="capitalize">{evt.event_type.replace("_", " ")}</span>
+                      </div>
+                      {evt.course_title && (
+                        <Link
+                          to={`/courses/${evt.course_id}`}
+                          className="flex items-center gap-1 mt-1 text-[10px] text-primary hover:underline"
+                        >
+                          <BookOpen className="h-2.5 w-2.5" />
+                          {evt.course_title}
+                        </Link>
+                      )}
+                      {evt.description && (
+                        <p className="text-[10px] text-muted-foreground mt-1 line-clamp-2">
+                          {evt.description}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
+++ b/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
@@ -1,0 +1,72 @@
+import { Clock } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CalendarEvent } from "@/types";
+import { getEventColor } from "./constants";
+import { formatShortDate, formatTime, isOverdue } from "./utils";
+
+interface UpcomingEventsPanelProps {
+  events: CalendarEvent[];
+}
+
+/**
+ * Sidebar list of events happening in the next 14 days. Past deadlines
+ * get flagged as overdue so the student can act on them.
+ */
+export function UpcomingEventsPanel({ events }: UpcomingEventsPanelProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <Clock className="h-4 w-4 text-muted-foreground" />
+          Upcoming (14 days)
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {events.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">No upcoming events</p>
+        ) : (
+          <div className="space-y-2">
+            {events.map((evt) => {
+              const color = getEventColor(evt.event_type);
+              const overdue = evt.event_type === "deadline" && isOverdue(evt.event_date);
+              return (
+                <div
+                  key={evt.id}
+                  className={`flex items-start gap-2 rounded-md border p-2 transition-colors ${
+                    overdue
+                      ? "border-destructive/30 bg-destructive/5"
+                      : "hover:bg-muted/50"
+                  }`}
+                >
+                  <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${color.dot}`} />
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={`truncate text-xs font-medium ${
+                        overdue ? "text-destructive" : ""
+                      }`}
+                    >
+                      {evt.title}
+                    </p>
+                    <div className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
+                      <span>{formatShortDate(evt.event_date)}</span>
+                      <span>{formatTime(evt.event_date)}</span>
+                      {overdue && (
+                        <span className="font-medium text-destructive">Overdue</span>
+                      )}
+                    </div>
+                    {evt.course_title && (
+                      <p className="text-[10px] text-muted-foreground/70 truncate mt-0.5">
+                        {evt.course_title}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Calendar/constants.ts
+++ b/frontend/src/pages/Calendar/constants.ts
@@ -1,0 +1,61 @@
+export type EventColorPalette = {
+  dot: string;
+  bg: string;
+  text: string;
+  border: string;
+};
+
+export const EVENT_COLORS: Record<string, EventColorPalette> = {
+  deadline: {
+    dot: "bg-destructive",
+    bg: "bg-destructive/10",
+    text: "text-destructive",
+    border: "border-destructive/30",
+  },
+  live_session: {
+    dot: "bg-info",
+    bg: "bg-info/10",
+    text: "text-info",
+    border: "border-info/30",
+  },
+  exam: {
+    dot: "bg-warning",
+    bg: "bg-warning/10",
+    text: "text-warning",
+    border: "border-warning/30",
+  },
+  other: {
+    dot: "bg-muted-foreground/50",
+    bg: "bg-muted",
+    text: "text-muted-foreground",
+    border: "border-border",
+  },
+};
+
+export const FALLBACK_EVENT_COLOR: EventColorPalette = {
+  dot: "bg-muted-foreground/50",
+  bg: "bg-muted",
+  text: "text-muted-foreground",
+  border: "border-border",
+};
+
+export function getEventColor(type: string): EventColorPalette {
+  return EVENT_COLORS[type] ?? FALLBACK_EVENT_COLOR;
+}
+
+export const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+export const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];

--- a/frontend/src/pages/Calendar/useCalendarData.ts
+++ b/frontend/src/pages/Calendar/useCalendarData.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { coursesService } from "@/services/courses";
+import type { CalendarEvent, Enrollment } from "@/types";
+
+interface CalendarData {
+  events: CalendarEvent[];
+  enrollments: Enrollment[];
+  loading: boolean;
+  fetchError: string | null;
+  retry: () => void;
+  filterCourseId: string;
+  setFilterCourseId: (id: string) => void;
+}
+
+/**
+ * Owns data loading + URL-bound course filter for the calendar page.
+ *
+ * The filter is mirrored into `?course=` so a student sharing a link
+ * lands on the same filtered view. `retry` bumps a counter to force a
+ * reload after a transient fetch failure.
+ */
+export function useCalendarData(): CalendarData {
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const [params, setParams] = useSearchParams();
+
+  // Hard cap the query-string value so a crafted URL can't blow up any
+  // downstream storage / logging. 64 chars is plenty for a UUID.
+  const filterCourseId = (params.get("course") ?? "").slice(0, 64);
+
+  const setFilterCourseId = (id: string) => {
+    const next = new URLSearchParams(params);
+    if (id) next.set("course", id.slice(0, 64));
+    else next.delete("course");
+    setParams(next, { replace: true });
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setFetchError(null);
+    const load = async () => {
+      try {
+        const [evts, enrolls] = await Promise.all([
+          coursesService.getCalendarEvents(filterCourseId || undefined),
+          coursesService.getMyCourses().catch(() => []),
+        ]);
+        if (cancelled) return;
+        setEvents(evts);
+        setEnrollments(enrolls);
+      } catch {
+        if (!cancelled) setFetchError("Failed to load calendar events. Please try again.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [filterCourseId, retryCount]);
+
+  return {
+    events,
+    enrollments,
+    loading,
+    fetchError,
+    retry: () => setRetryCount((c) => c + 1),
+    filterCourseId,
+    setFilterCourseId,
+  };
+}

--- a/frontend/src/pages/Calendar/useMonthGrid.ts
+++ b/frontend/src/pages/Calendar/useMonthGrid.ts
@@ -1,0 +1,91 @@
+import { useMemo, useState } from "react";
+
+import type { CalendarEvent } from "@/types";
+import { calendarDayKey } from "./utils";
+
+interface DayCell {
+  date: Date;
+  inMonth: boolean;
+}
+
+/**
+ * Derives everything the calendar UI needs to render a month at a time:
+ * the Sunday-padded grid of day cells, a `Map` of events keyed by day,
+ * the events for the currently-selected day, and the next 14 days of
+ * upcoming events.
+ *
+ * Everything is memoised so re-rendering on selection doesn't rebuild
+ * the grid or the bucket.
+ */
+export function useMonthGrid(events: CalendarEvent[]) {
+  const [currentDate, setCurrentDate] = useState(() => new Date());
+  const [selectedDay, setSelectedDay] = useState<Date | null>(() => new Date());
+
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
+  const calendarDays = useMemo<DayCell[]>(() => {
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+    const startOffset = firstDay.getDay();
+    const days: DayCell[] = [];
+
+    for (let i = startOffset - 1; i >= 0; i--) {
+      days.push({ date: new Date(year, month, -i), inMonth: false });
+    }
+    for (let i = 1; i <= lastDay.getDate(); i++) {
+      days.push({ date: new Date(year, month, i), inMonth: true });
+    }
+    const remaining = 7 - (days.length % 7);
+    if (remaining < 7) {
+      for (let i = 1; i <= remaining; i++) {
+        days.push({ date: new Date(year, month + 1, i), inMonth: false });
+      }
+    }
+    return days;
+  }, [year, month]);
+
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, CalendarEvent[]>();
+    for (const evt of events) {
+      if (!evt.event_date) continue;
+      const d = new Date(evt.event_date);
+      if (Number.isNaN(d.getTime())) continue;
+      const key = calendarDayKey(d);
+      const bucket = map.get(key);
+      if (bucket) bucket.push(evt);
+      else map.set(key, [evt]);
+    }
+    return map;
+  }, [events]);
+
+  const selectedDayEvents = useMemo(() => {
+    if (!selectedDay) return [];
+    return eventsByDate.get(calendarDayKey(selectedDay)) ?? [];
+  }, [selectedDay, eventsByDate]);
+
+  const upcomingEvents = useMemo(() => {
+    const now = new Date();
+    const twoWeeks = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
+    return events.filter((e) => {
+      if (!e.event_date) return false;
+      const d = new Date(e.event_date);
+      if (Number.isNaN(d.getTime())) return false;
+      return d >= now && d <= twoWeeks;
+    });
+  }, [events]);
+
+  return {
+    year,
+    month,
+    calendarDays,
+    eventsByDate,
+    selectedDay,
+    setSelectedDay,
+    selectedDayEvents,
+    upcomingEvents,
+    prevMonth: () => setCurrentDate(new Date(year, month - 1, 1)),
+    nextMonth: () => setCurrentDate(new Date(year, month + 1, 1)),
+    goToday: () => setCurrentDate(new Date()),
+  };
+}

--- a/frontend/src/pages/Calendar/utils.ts
+++ b/frontend/src/pages/Calendar/utils.ts
@@ -1,0 +1,34 @@
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export function formatTime(dateStr: string): string {
+  return new Date(dateStr).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function formatShortDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function isOverdue(dateStr: string): boolean {
+  return new Date(dateStr) < new Date();
+}
+
+/**
+ * Stable "YYYY-M-D" key used to bucket events by day and to match the
+ * currently-selected day. We intentionally don't zero-pad since the
+ * same format is used on both sides.
+ */
+export function calendarDayKey(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+}


### PR DESCRIPTION
## Summary

`CalendarPage.tsx` was 441 lines and carried data loading, URL-filter state, date math, month-grid rendering, two side panels, color palettes, and formatters — one file doing everything. Split it into a focused folder under `pages/Calendar/`:

- `constants.ts` — `EVENT_COLORS` palette and month/day labels.
- `utils.ts` — `isSameDay`, `formatTime`, `formatShortDate`, `isOverdue`, shared `calendarDayKey` generator.
- `useCalendarData` — fetches events + enrollments, owns retry, mirrors the filter to `?course=…` (with length cap).
- `useMonthGrid` — derives the grid, event-by-day map, selected-day events, and the 14-day upcoming list; owns the month cursor + selection.
- `MonthGrid` — pure grid view.
- `SelectedDayPanel` / `UpcomingEventsPanel` — presentational panels.
- `CalendarPage` — thin orchestrator (~110 lines).

## Why

- Each concern now lives next to code of the same shape and can be tested or tweaked in isolation.
- Extracting `calendarDayKey` into a helper removes a duplicated key formula that existed in three places.
- Future changes (e.g. adding a teacher-only event-create dialog) no longer need to touch the whole file.

## Behavior

No visible change: same layout, same URL param, same month nav, same event colors, same overdue rules, same empty/loading/error paths.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes (zero warnings)
- [x] `npm run test:run` — 85 passed / 10 files
- [x] `npm run build` succeeds
