### PR TITLE
refactor(backend): drop lying response-type annotations on endpoints

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -26,7 +26,7 @@ def list_announcements(
     limit: int = Query(50, ge=1, le=200),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> list[AnnouncementResponse]:
+) -> list[Announcement]:
     query = db.query(Announcement)
     is_admin = current_user.role in (UserRole.ADMIN.value, "admin")
 
@@ -67,7 +67,7 @@ def list_announcements(
         )
     # Admin without course_id sees all announcements (paginated, capped by limit).
 
-    return query.order_by(Announcement.created_at.desc()).offset(skip).limit(limit).all()  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return query.order_by(Announcement.created_at.desc()).offset(skip).limit(limit).all()
 
 
 @router.post("", response_model=AnnouncementResponse, status_code=status.HTTP_201_CREATED)
@@ -75,7 +75,7 @@ def create_announcement(
     data: AnnouncementCreate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> AnnouncementResponse:
+) -> Announcement:
     if data.course_id:
         course = db.query(Course).filter(Course.id == data.course_id).first()
         if not course:
@@ -119,7 +119,7 @@ def create_announcement(
 
     db.commit()
     db.refresh(announcement)
-    return announcement  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return announcement
 
 
 @router.put("/{announcement_id}", response_model=AnnouncementResponse)
@@ -128,7 +128,7 @@ def update_announcement(
     data: AnnouncementUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> AnnouncementResponse:
+) -> Announcement:
     announcement = db.query(Announcement).filter(Announcement.id == announcement_id).first()
     if not announcement:
         raise HTTPException(
@@ -148,7 +148,7 @@ def update_announcement(
 
     db.commit()
     db.refresh(announcement)
-    return announcement  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return announcement
 
 
 @router.delete("/{announcement_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/audit.py
+++ b/backend/app/api/v1/audit.py
@@ -45,7 +45,7 @@ def list_audit_logs(
     date_to: datetime | None = Query(None),
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
-) -> AuditLogPage:
+) -> dict:
     q = db.query(AuditLog)
 
     if user_id:
@@ -62,4 +62,7 @@ def list_audit_logs(
     total = q.count()
     items = q.order_by(AuditLog.created_at.desc()).offset((page - 1) * page_size).limit(page_size).all()
 
-    return AuditLogPage(items=items, total=total, page=page, page_size=page_size)  # type: ignore[arg-type]  # FastAPI serializes via from_attributes
+    # Return a plain dict so FastAPI hydrates ``AuditLogPage`` via
+    # ``from_attributes``; constructing the Pydantic envelope directly
+    # would need an explicit ``model_validate`` to pass mypy.
+    return {"items": items, "total": total, "page": page, "page_size": page_size}

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -148,7 +148,7 @@ def create_course_event(
     data: CourseEventCreate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> CourseEventResponse:
+) -> CourseEvent:
     verify_course_owner(db, course_id, teacher)
     event = CourseEvent(
         course_id=course_id,
@@ -161,7 +161,7 @@ def create_course_event(
     db.add(event)
     db.commit()
     db.refresh(event)
-    return event  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return event
 
 
 @event_router.get(
@@ -172,7 +172,7 @@ def list_course_events(
     course_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> list[CourseEventResponse]:
+) -> list[CourseEvent]:
     # Narrow probe: only the columns needed for ownership + soft-delete checks.
     course_row = db.query(Course.created_by).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course_row:
@@ -190,7 +190,7 @@ def list_course_events(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You must be enrolled in this course to view events",
             )
-    return db.query(CourseEvent).filter(CourseEvent.course_id == course_id).order_by(CourseEvent.event_date).all()  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return db.query(CourseEvent).filter(CourseEvent.course_id == course_id).order_by(CourseEvent.event_date).all()
 
 
 @event_router.put(
@@ -203,7 +203,7 @@ def update_course_event(
     data: CourseEventUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> CourseEventResponse:
+) -> CourseEvent:
     verify_course_owner(db, course_id, teacher)
     event = (
         db.query(CourseEvent)
@@ -219,7 +219,7 @@ def update_course_event(
         setattr(event, field, value)
     db.commit()
     db.refresh(event)
-    return event  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return event
 
 
 @event_router.delete(

--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_optional_user, require_teacher
 from app.core.database import get_db
-from app.models.course import Course
+from app.models.course import Course, Module
 from app.models.user import User, UserRole
 from app.schemas.course import CourseResponse, CourseSummary, ModuleResponse
 from app.services.course_service import (
@@ -62,7 +62,7 @@ def get_course_detail(
     course_id: str,
     current_user: User | None = Depends(get_optional_user),
     db: Session = Depends(get_db),
-) -> CourseResponse:
+) -> Course:
     course = get_course(db, course_id)
     if not course:
         raise HTTPException(
@@ -77,8 +77,7 @@ def get_course_detail(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Course '{course_id}' not found",
             )
-    # FastAPI serializes via from_attributes.
-    return course  # type: ignore[return-value]
+    return course
 
 
 @router.get("/{course_id}/modules/{module_id}", response_model=ModuleResponse)
@@ -87,7 +86,7 @@ def get_module_detail(
     module_id: str,
     current_user: User | None = Depends(get_optional_user),
     db: Session = Depends(get_db),
-) -> ModuleResponse:
+) -> Module:
     # Lightweight access probe — avoids loading the whole course→modules→chapters
     # tree just to check publication state.
     course_row = (
@@ -113,5 +112,4 @@ def get_module_detail(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Module '{module_id}' not found in course '{course_id}'",
         )
-    # FastAPI serializes via from_attributes.
-    return module  # type: ignore[return-value]
+    return module

--- a/backend/app/api/v1/courses/chapters.py
+++ b/backend/app/api/v1/courses/chapters.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import require_teacher, verify_course_owner
 from app.core.database import get_db
 from app.core.sanitize import sanitize_string
+from app.models.course import Chapter
 from app.models.user import User
 from app.schemas.course import ChapterCreate, ChapterResponse, ChapterUpdate
 from app.services.course_service import (
@@ -30,7 +31,7 @@ def create_new_chapter(
     data: ChapterCreate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> ChapterResponse:
+) -> Chapter:
     verify_course_owner(db, course_id, teacher.id, allow_admin=False)
     module = get_module(db, course_id, module_id)
     if not module:
@@ -40,8 +41,7 @@ def create_new_chapter(
         )
     if data.title:
         data.title = sanitize_string(data.title)
-    # FastAPI serializes via from_attributes.
-    return create_chapter(db, module_id, data)  # type: ignore[return-value]
+    return create_chapter(db, module_id, data)
 
 
 @router.put(
@@ -55,7 +55,7 @@ def update_existing_chapter(
     data: ChapterUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> ChapterResponse:
+) -> Chapter:
     verify_course_owner(db, course_id, teacher.id, allow_admin=False)
     chapter = get_chapter(db, course_id, module_id, chapter_id)
     if not chapter:
@@ -65,8 +65,7 @@ def update_existing_chapter(
         )
     if data.title:
         data.title = sanitize_string(data.title)
-    # FastAPI serializes via from_attributes.
-    return update_chapter(db, chapter, data)  # type: ignore[return-value]
+    return update_chapter(db, chapter, data)
 
 
 @router.delete(

--- a/backend/app/api/v1/courses/crud.py
+++ b/backend/app/api/v1/courses/crud.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import assert_course_owner, require_teacher
 from app.core.database import get_db
 from app.core.sanitize import sanitize_string
+from app.models.course import Course
 from app.models.user import User
 from app.schemas.course import CourseCreate, CourseResponse, CourseUpdate
 from app.services.audit_service import log_action
@@ -28,13 +29,12 @@ def create_new_course(
     request: Request,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> CourseResponse:
+) -> Course:
     if data.title:
         data.title = sanitize_string(data.title)
     course = create_course(db, data, teacher.id)
     log_action(db, teacher.id, "create", "course", course.id, request=request)
-    # FastAPI serializes via from_attributes.
-    return course  # type: ignore[return-value]
+    return course
 
 
 @router.put("/{course_id}", response_model=CourseResponse)
@@ -44,7 +44,7 @@ def update_existing_course(
     request: Request,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> CourseResponse:
+) -> Course:
     course = get_course(db, course_id)
     if not course:
         raise HTTPException(
@@ -63,7 +63,7 @@ def update_existing_course(
     # publication event from a generic update.
     action = "publish" if data.status == "published" and old_status != "published" else "update"
     log_action(db, teacher.id, action, "course", course_id, details=details or None, request=request)
-    return result  # type: ignore[return-value]
+    return result
 
 
 @router.delete("/{course_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -93,7 +93,7 @@ def clone_existing_course(
     course_id: str,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> CourseResponse:
+) -> Course:
     course = get_course(db, course_id)
     if not course:
         raise HTTPException(
@@ -114,7 +114,7 @@ def clone_existing_course(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to clone course",
         )
-    return new_course  # type: ignore[return-value]
+    return new_course
 
 
 @router.post("/{course_id}/restore", response_model=CourseResponse)
@@ -123,7 +123,7 @@ def restore_deleted_course(
     request: Request,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> CourseResponse:
+) -> Course:
     course = get_course(db, course_id, include_deleted=True)
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
@@ -132,7 +132,7 @@ def restore_deleted_course(
     assert_course_owner(course, teacher, allow_admin=False)
     result = restore_course(db, course)
     log_action(db, teacher.id, "restore", "course", course_id, request=request)
-    return result  # type: ignore[return-value]
+    return result
 
 
 @router.delete("/{course_id}/permanent", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/courses/enrollment.py
+++ b/backend/app/api/v1/courses/enrollment.py
@@ -91,7 +91,7 @@ def enroll_course(
     body: EnrollRequest = EnrollRequest(),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> EnrollmentResponse:
+) -> Enrollment:
     course = get_course(db, course_id)
     if not course:
         raise HTTPException(
@@ -132,5 +132,4 @@ def enroll_course(
         details={"course_id": course_id},
         request=request,
     )
-    # FastAPI serializes via from_attributes.
-    return enrollment  # type: ignore[return-value]
+    return enrollment

--- a/backend/app/api/v1/courses/modules.py
+++ b/backend/app/api/v1/courses/modules.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import require_teacher, verify_course_owner
 from app.core.database import get_db
+from app.models.course import Module
 from app.models.user import User
 from app.schemas.course import ModuleCreate, ModuleResponse, ModuleUpdate
 from app.services.course_service import (
@@ -27,10 +28,9 @@ def create_new_module(
     data: ModuleCreate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> ModuleResponse:
+) -> Module:
     verify_course_owner(db, course_id, teacher.id, allow_admin=False)
-    # FastAPI serializes via from_attributes.
-    return create_module(db, course_id, data)  # type: ignore[return-value]
+    return create_module(db, course_id, data)
 
 
 @router.put("/{course_id}/modules/{module_id}", response_model=ModuleResponse)
@@ -40,7 +40,7 @@ def update_existing_module(
     data: ModuleUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> ModuleResponse:
+) -> Module:
     verify_course_owner(db, course_id, teacher.id, allow_admin=False)
     module = get_module(db, course_id, module_id)
     if not module:
@@ -48,8 +48,7 @@ def update_existing_module(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Module '{module_id}' not found in course '{course_id}'",
         )
-    # FastAPI serializes via from_attributes.
-    return update_module(db, module, data)  # type: ignore[return-value]
+    return update_module(db, module, data)
 
 
 @router.delete("/{course_id}/modules/{module_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/grades.py
+++ b/backend/app/api/v1/grades.py
@@ -220,9 +220,9 @@ def list_my_grades(
     limit: int = Query(100, ge=1, le=500),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> list[GradeResponse]:
+) -> list[StudentGrade]:
     return (
-        db.query(StudentGrade)  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+        db.query(StudentGrade)
         .filter(StudentGrade.student_id == current_user.id)
         .order_by(StudentGrade.graded_at.desc())
         .offset(skip)
@@ -236,7 +236,7 @@ def get_my_grade_for_course(
     course_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> GradeResponse:
+) -> StudentGrade:
     grade = (
         db.query(StudentGrade)
         .filter(
@@ -250,7 +250,7 @@ def get_my_grade_for_course(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No grade found for course '{course_id}'",
         )
-    return grade  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return grade
 
 
 @router.get("/course/{course_id}", response_model=list[GradeResponse])
@@ -261,12 +261,12 @@ def list_course_grades(
     limit: int = Query(100, ge=1, le=500),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> list[GradeResponse]:
+) -> list[StudentGrade]:
     verify_course_owner(db, course_id, teacher)
     query = db.query(StudentGrade).filter(StudentGrade.course_id == course_id)
     if cohort_id is not None:
         query = query.filter(StudentGrade.cohort_id == cohort_id)
-    return query.order_by(StudentGrade.graded_at.desc()).offset(skip).limit(limit).all()  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return query.order_by(StudentGrade.graded_at.desc()).offset(skip).limit(limit).all()
 
 
 @router.get("/course/{course_id}/student/{student_id}", response_model=GradeResponse)
@@ -276,7 +276,7 @@ def get_student_grade(
     cohort_id: str | None = Query(None),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> GradeResponse:
+) -> StudentGrade:
     verify_course_owner(db, course_id, teacher)
     query = db.query(StudentGrade).filter(
         StudentGrade.student_id == student_id,
@@ -290,7 +290,7 @@ def get_student_grade(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No grade found for student '{student_id}' in course '{course_id}'",
         )
-    return grade  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return grade
 
 
 @router.put("/course/{course_id}/student/{student_id}", response_model=GradeResponse)
@@ -301,7 +301,7 @@ def upsert_student_grade(
     cohort_id: str | None = Query(None),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> GradeResponse:
+) -> StudentGrade:
     verify_course_owner(db, course_id, teacher)
 
     enrolled = db.query(Enrollment).filter(Enrollment.user_id == student_id, Enrollment.course_id == course_id).first()
@@ -337,4 +337,4 @@ def upsert_student_grade(
 
     db.commit()
     db.refresh(grade)
-    return grade  # type: ignore[return-value]  # FastAPI serializes via from_attributes
+    return grade

--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -35,12 +35,16 @@ def list_notifications(
         .all()
     )
 
-    return NotificationListResponse(
-        items=items,  # type: ignore[arg-type]  # FastAPI serializes via from_attributes
-        total=total,
-        page=page,
-        page_size=page_size,
-    )
+    # Return a plain dict so FastAPI can wrap the ORM rows into
+    # ``NotificationListResponse`` via ``from_attributes``; constructing the
+    # Pydantic envelope directly would need an explicit ``model_validate``
+    # and fight with our mypy config.
+    return {
+        "items": items,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }
 
 
 @router.get("/unread-count", response_model=UnreadCountResponse)


### PR DESCRIPTION
## Summary

Endpoint signatures like `def create_new_course(...) -> CourseResponse` were lying: the function actually returns a SQLAlchemy `Course` ORM instance and relies on FastAPI's `response_model=CourseResponse` (with `from_attributes=True`) for serialization. The impedance mismatch forced a trail of `# type: ignore[return-value]` suppressions across the router layer — 24 of them in total, each with the same empty boilerplate comment.

That directly violates our backend rule ("never suppress type errors without a reason") and makes the function signatures actively misleading to future readers.

This PR removes the lies:

- Path operation functions now annotate their real return type (the ORM model / dict).
- `response_model` on the route decorator remains the single source of truth for the public API shape.
- For the two list-envelope endpoints (`/notifications`, `/audit`) that were constructing a wrapper Pydantic model from ORM rows, the handler now returns a plain dict so FastAPI hydrates the envelope itself — cleaner than an explicit `model_validate`.

No behaviour changes, no OpenAPI/schema changes — just honest types and zero suppressions.

Files touched:
- `announcements.py`, `audit.py`, `calendar.py`, `grades.py`, `notifications.py`
- `courses/{catalog,chapters,crud,enrollment,modules}.py`

## Test plan

- [x] `ruff check app` — clean
- [x] `ruff format --check app` — clean
- [x] `mypy --config-file mypy.ini` — 0 issues across 89 files
- [x] `pytest -q` — 396 passed
