### PR TITLE
chore(frontend): prune dead re-exports and internal-only exports

### DIFF
--- a/frontend/src/components/assignment/editor/index.ts
+++ b/frontend/src/components/assignment/editor/index.ts
@@ -1,8 +1,6 @@
 export { AssignmentForm } from "./AssignmentForm"
 export { AssignmentItem } from "./AssignmentItem"
-export { SubmissionGrader } from "./SubmissionGrader"
 export {
-  assignmentToFormState,
   EMPTY_ASSIGNMENT_FORM,
   formStateToPayload,
   type AssignmentFormState,

--- a/frontend/src/components/editor/blocks/index.ts
+++ b/frontend/src/components/editor/blocks/index.ts
@@ -1,5 +1,3 @@
 export { AddBlockMenu } from "./AddBlockMenu"
 export { BlockRow } from "./BlockRow"
-export { FileBlockEditor } from "./FileBlockEditor"
-export { TextBlockEditor } from "./TextBlockEditor"
-export { BLOCK_TYPES, blockIcon, blockLabel, type BlockType } from "./types"
+export { type BlockType } from "./types"

--- a/frontend/src/components/quiz/editor/index.ts
+++ b/frontend/src/components/quiz/editor/index.ts
@@ -1,4 +1,3 @@
 export { ModeToggle, type QuizEditorMode } from "./ModeToggle"
 export { QuizEditView } from "./QuizEditView"
 export { useQuizDraft } from "./useQuizDraft"
-export type { DraftOption, DraftQuestion } from "./types"

--- a/frontend/src/components/quiz/editor/types.ts
+++ b/frontend/src/components/quiz/editor/types.ts
@@ -18,7 +18,7 @@ export interface DraftQuestion {
 }
 
 let _uid = 0
-export function uid(): string {
+function uid(): string {
   return `draft-${++_uid}-${Date.now()}`
 }
 

--- a/frontend/src/components/quiz/taker/index.ts
+++ b/frontend/src/components/quiz/taker/index.ts
@@ -1,4 +1,3 @@
-export { EssayAnswer } from "./EssayAnswer"
 export { PreviousAttempts } from "./PreviousAttempts"
 export { QuestionPrompt } from "./QuestionPrompt"
 export { QuizHeader } from "./QuizHeader"

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -17,7 +17,7 @@ import {
  * list. Small tenants keep the familiar semantic table; large tenants
  * avoid paying ~500 avatar images + <select>s worth of DOM on mount.
  */
-export const USERS_VIRTUAL_THRESHOLD = 50
+const USERS_VIRTUAL_THRESHOLD = 50
 
 interface Props {
   users: ProfileRow[]

--- a/frontend/src/pages/Admin/dashboard/useAdminAudit.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminAudit.ts
@@ -11,7 +11,7 @@ import {
   RESOURCE_OPTIONS,
 } from "./constants"
 
-export const AUDIT_PAGE_SIZE = 25
+const AUDIT_PAGE_SIZE = 25
 
 interface UseAdminAuditArgs {
   /** When `false` the hook skips fetching — used to avoid loading the

--- a/frontend/src/pages/Calendar/constants.ts
+++ b/frontend/src/pages/Calendar/constants.ts
@@ -1,4 +1,4 @@
-export type EventColorPalette = {
+type EventColorPalette = {
   dot: string;
   bg: string;
   text: string;
@@ -32,7 +32,7 @@ export const EVENT_COLORS: Record<string, EventColorPalette> = {
   },
 };
 
-export const FALLBACK_EVENT_COLOR: EventColorPalette = {
+const FALLBACK_EVENT_COLOR: EventColorPalette = {
   dot: "bg-muted-foreground/50",
   bg: "bg-muted",
   text: "text-muted-foreground",

--- a/frontend/src/pages/Course/detail/types.ts
+++ b/frontend/src/pages/Course/detail/types.ts
@@ -7,7 +7,7 @@ export interface CourseMaterial {
   created: string | null
 }
 
-export type CohortEnrollmentStatus = "not_started" | "closed" | "open" | "no_window"
+type CohortEnrollmentStatus = "not_started" | "closed" | "open" | "no_window"
 
 export function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString(undefined, {
@@ -17,7 +17,7 @@ export function formatDate(dateStr: string): string {
   })
 }
 
-export function getCohortEnrollmentStatus(cohort: Cohort): CohortEnrollmentStatus {
+function getCohortEnrollmentStatus(cohort: Cohort): CohortEnrollmentStatus {
   const now = new Date()
   const start = cohort.enrollment_start ? new Date(cohort.enrollment_start) : null
   const end = cohort.enrollment_end ? new Date(cohort.enrollment_end) : null

--- a/frontend/src/pages/Teacher/editor/useAnnouncementsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useAnnouncementsSection.ts
@@ -6,7 +6,7 @@ import type { useConfirm } from "@/components/ui/alert-dialog"
 
 type Confirm = ReturnType<typeof useConfirm>
 
-export interface AnnouncementsSection {
+interface AnnouncementsSection {
   announcements: Announcement[]
   title: string
   setTitle: (v: string) => void

--- a/frontend/src/pages/Teacher/editor/useCohortsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useCohortsSection.ts
@@ -7,7 +7,7 @@ import { EMPTY_COHORT_FORM, type CohortFormState } from "./types"
 
 type Confirm = ReturnType<typeof useConfirm>
 
-export interface CohortsSection {
+interface CohortsSection {
   cohorts: Cohort[]
   form: CohortFormState
   setForm: (v: CohortFormState) => void

--- a/frontend/src/pages/Teacher/editor/useCourseData.ts
+++ b/frontend/src/pages/Teacher/editor/useCourseData.ts
@@ -10,7 +10,7 @@ type Confirm = ReturnType<typeof useConfirm>
 
 type CoursePatch = Parameters<typeof coursesService.updateCourse>[1]
 
-export interface CourseData {
+interface CourseData {
   course: Course | null
   loading: boolean
   sortedModules: NonNullable<Course["modules"]>

--- a/frontend/src/pages/Teacher/editor/useEventsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useEventsSection.ts
@@ -7,7 +7,7 @@ import { EMPTY_EVENT_FORM, type EventFormState } from "./types"
 
 type Confirm = ReturnType<typeof useConfirm>
 
-export interface EventsSection {
+interface EventsSection {
   events: CourseEvent[]
   form: EventFormState
   setForm: (v: EventFormState) => void

--- a/frontend/src/pages/Teacher/editor/useMaterialsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useMaterialsSection.ts
@@ -6,7 +6,7 @@ import type { MaterialFile } from "./types"
 
 type Confirm = ReturnType<typeof useConfirm>
 
-export interface MaterialsSection {
+interface MaterialsSection {
   materials: MaterialFile[]
   uploading: boolean
   inputRef: React.RefObject<HTMLInputElement>

--- a/frontend/src/pages/Teacher/progress/index.ts
+++ b/frontend/src/pages/Teacher/progress/index.ts
@@ -6,5 +6,4 @@ export {
   completionRate,
   type SortColumn,
   type SortDirection,
-  type StudentData,
 } from "./helpers"

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -1,7 +1,7 @@
 import api from "./api"
 import { cacheGet, cacheSet } from "@/lib/cache"
 
-export interface CourseAnalyticsEnrollment {
+interface CourseAnalyticsEnrollment {
   enrollment_id: string
   user_id: string
   full_name: string | null
@@ -10,7 +10,7 @@ export interface CourseAnalyticsEnrollment {
   enrolled_at: string | null
 }
 
-export interface CourseAnalytics {
+interface CourseAnalytics {
   course_id: string
   course_title: string
   total_students: number

--- a/frontend/src/services/assignments.ts
+++ b/frontend/src/services/assignments.ts
@@ -2,7 +2,7 @@ import api from "./api"
 import { cacheInvalidatePrefix } from "@/lib/cache"
 import type { Assignment, AssignmentSubmission } from "@/types"
 
-export type AssignmentCreateData = {
+type AssignmentCreateData = {
   chapter_id: string
   title: string
   description?: string | null

--- a/frontend/src/services/blocks.ts
+++ b/frontend/src/services/blocks.ts
@@ -2,7 +2,7 @@ import api from "./api"
 import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
 import type { ChapterBlock, BlockType } from "@/types"
 
-export type ChapterBlockCreateData = {
+type ChapterBlockCreateData = {
   block_type: BlockType
   order_index?: number
   content?: string | null
@@ -13,7 +13,7 @@ export type ChapterBlockCreateData = {
   file_name?: string | null
 }
 
-export type ChapterBlockUpdateData = Partial<Omit<ChapterBlockCreateData, "block_type">> & {
+type ChapterBlockUpdateData = Partial<Omit<ChapterBlockCreateData, "block_type">> & {
   block_type?: BlockType
 }
 

--- a/frontend/src/services/cohorts.ts
+++ b/frontend/src/services/cohorts.ts
@@ -2,7 +2,7 @@ import api from "./api"
 import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
 import type { Cohort } from "@/types"
 
-export type CohortMutation = {
+type CohortMutation = {
   name: string
   start_date: string
   end_date: string

--- a/frontend/src/services/courses.ts
+++ b/frontend/src/services/courses.ts
@@ -216,6 +216,10 @@ const courseCrud = {
  * Backwards-compatible aggregate. Prefer the per-domain services for new code
  * — this facade exists solely so the long-lived `coursesService.*` call sites
  * across the app keep working while we migrate them file-by-file.
+ *
+ * The individual domain services are re-exported from their own modules
+ * (e.g. `import { quizzesService } from "@/services/quizzes"`); routing
+ * every one through this file would just add an import hop.
  */
 export const coursesService = {
   ...courseCrud,
@@ -234,22 +238,4 @@ export const coursesService = {
   ...quizzesService,
   ...reviewsService,
   ...analyticsService,
-}
-
-export {
-  adminUsersService,
-  announcementsService,
-  assignmentsService,
-  auditService,
-  blocksService,
-  calendarService,
-  certificatesService,
-  cohortsService,
-  enrollmentsService,
-  gradesService,
-  notificationsService,
-  progressService,
-  quizzesService,
-  reviewsService,
-  analyticsService,
 }

--- a/frontend/src/services/quizzes.ts
+++ b/frontend/src/services/quizzes.ts
@@ -9,7 +9,7 @@ import type {
   PendingAnswer,
 } from "@/types"
 
-export type QuizCreateData = {
+type QuizCreateData = {
   chapter_id: string
   title: string
   description?: string | null
@@ -30,7 +30,7 @@ export type QuizCreateData = {
   }>
 }
 
-export type QuizSubmissionAnswer = {
+type QuizSubmissionAnswer = {
   question_id: string
   selected_option_id?: string
   text_answer?: string

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -37,11 +37,6 @@ export interface Module {
   chapters?: Chapter[]
 }
 
-// ``ChapterType`` is defined in ``@/lib/chapterTypes`` alongside the rest of
-// the chapter-type metadata (labels, icons, colours); re-exported here because
-// most domain consumers import from ``@/types``.
-export type { ChapterType }
-
 export interface Chapter {
   id: string
   module_id: string
@@ -79,7 +74,7 @@ export interface GradingConfig {
   participation_weight: number
 }
 
-export interface GradeBreakdown {
+interface GradeBreakdown {
   quiz_avg: number
   quiz_weighted: number
   assignment_avg: number
@@ -115,7 +110,7 @@ export interface Announcement {
   updated_at: string
 }
 
-export interface QuizOption {
+interface QuizOption {
   id: string
   question_id: string
   option_text: string
@@ -318,8 +313,8 @@ export interface Profile {
   updated_at: string | null
 }
 
-export type CalendarEventType = 'deadline' | 'live_session' | 'exam' | 'other'
-export type CalendarEventSource = 'module_deadline' | 'assignment_deadline' | 'course_event'
+type CalendarEventType = 'deadline' | 'live_session' | 'exam' | 'other'
+type CalendarEventSource = 'module_deadline' | 'assignment_deadline' | 'course_event'
 
 export interface CalendarEvent {
   id: string


### PR DESCRIPTION
## Summary

Tool-driven cleanup. Running `npx knip --reporter json` against
`frontend/` flagged 22 symbols that were marked `export` but never
imported by any external consumer. They were a mix of:

- dead barrel re-exports (`services/courses.ts` facade passthroughs,
  `quiz/taker`, `quiz/editor`, `assignment/editor`, `editor/blocks`,
  and `Teacher/progress` barrels),
- module-local types/constants/helpers mistakenly marked public
  (hook-return interfaces in `pages/Teacher/editor/use*Section.ts`,
  service-payload types in `services/{analytics,assignments,blocks,
  cohorts,quizzes}.ts`, `USERS_VIRTUAL_THRESHOLD`, `AUDIT_PAGE_SIZE`,
  `FALLBACK_EVENT_COLOR`, `EventColorPalette`, `uid`,
  `getCohortEnrollmentStatus`, `CohortEnrollmentStatus`),
- internal field-type aliases in `types/index.ts` (`GradeBreakdown`,
  `QuizOption`, `CalendarEventType`, `CalendarEventSource`) plus
  the redundant `ChapterType` re-export.

Either the `export` keyword is dropped or the dead re-export line is
removed, so the module boundaries now match the way the code is
actually consumed.

After this change `npx knip --reporter json` reports
`{"issues":[]}`.

Runtime behaviour is unchanged. No public API surface is broken
because none of these symbols were reachable outside their home
module in the first place.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint src --max-warnings=0`
- [x] `npx vitest run` — 85 passed
- [x] `python -m ruff check . && python -m ruff format --check .`
- [x] `python -m mypy app` — no issues in 89 source files
- [x] `python -m pytest -q` — 396 passed
- [x] `npx knip --reporter json` → `{"issues":[]}`
