### PR TITLE
refactor(layout): split NotificationBell into hook + panel modules

### DIFF
--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -1,156 +1,40 @@
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { AlertCircle, Bell, CheckCheck, Award, XCircle, ClipboardCheck, Megaphone, BookOpen, UserCheck, Trash2 } from "lucide-react"
+import { Bell } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { coursesService } from "@/services/courses"
-import type { Notification, NotificationType } from "@/types"
-import { cn } from "@/lib/utils"
-import PageSpinner from "@/components/ui/PageSpinner"
+import type { Notification } from "@/types"
+import { useNotifications } from "./notifications/useNotifications"
+import { NotificationPanel } from "./notifications/NotificationPanel"
 
-const NOTIFICATION_ICONS: Record<NotificationType, typeof Bell> = {
-  certificate_approved: Award,
-  certificate_rejected: XCircle,
-  assignment_graded: ClipboardCheck,
-  new_announcement: Megaphone,
-  course_update: BookOpen,
-  enrollment_confirmed: UserCheck,
-}
-
-const NOTIFICATION_COLORS: Record<NotificationType, string> = {
-  certificate_approved: "text-success",
-  certificate_rejected: "text-destructive",
-  assignment_graded: "text-info",
-  new_announcement: "text-warning",
-  course_update: "text-muted-foreground",
-  enrollment_confirmed: "text-success",
-}
-
-function timeAgo(dateStr: string): string {
-  const parsed = new Date(dateStr).getTime()
-  if (Number.isNaN(parsed)) return "—"
-  const now = Date.now()
-  const diff = now - parsed
-  const seconds = Math.floor(diff / 1000)
-  if (seconds < 60) return "just now"
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}d ago`
-  return new Date(dateStr).toLocaleDateString()
-}
-
+/**
+ * Header bell: unread badge + on-click dropdown.
+ *
+ * This component only owns the open/close state and the click-outside
+ * behaviour. Everything else (polling, pagination, mutations) lives in
+ * `useNotifications`, and the dropdown itself is a pure `NotificationPanel`.
+ */
 export default function NotificationBell() {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
-  const [notifications, setNotifications] = useState<Notification[]>([])
-  const [unreadCount, setUnreadCount] = useState(0)
-  const [loading, setLoading] = useState(false)
-  const [loadingMore, setLoadingMore] = useState(false)
-  const [loadError, setLoadError] = useState(false)
-  const [page, setPage] = useState(1)
-  const [hasMore, setHasMore] = useState(false)
   const panelRef = useRef<HTMLDivElement>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
 
-  const fetchUnreadCount = useCallback(async (signal?: { cancelled: boolean }) => {
-    try {
-      const count = await coursesService.getUnreadCount()
-      if (!signal?.cancelled) setUnreadCount(count)
-    } catch {
-      // Polling failure is non-critical; will retry on next interval
-    }
-  }, [])
-
-  const fetchNotifications = useCallback(async (pageNum: number, signal?: { cancelled: boolean }) => {
-    if (pageNum === 1) {
-      setLoading(true)
-      setLoadError(false)
-    } else {
-      setLoadingMore(true)
-    }
-    try {
-      const res = await coursesService.getNotifications(pageNum)
-      if (!signal?.cancelled) {
-        if (pageNum === 1) {
-          setNotifications(res.items)
-        } else {
-          setNotifications(prev => [...prev, ...res.items])
-        }
-        setPage(pageNum)
-        setHasMore(pageNum * res.page_size < res.total)
-      }
-    } catch {
-      // On the first page treat this as an error state so the user isn't
-      // silently shown the empty "No notifications yet" placeholder; on
-      // subsequent pages leave the already-rendered list alone.
-      if (!signal?.cancelled && pageNum === 1) setLoadError(true)
-    } finally {
-      if (!signal?.cancelled) {
-        if (pageNum === 1) setLoading(false)
-        else setLoadingMore(false)
-      }
-    }
-  }, [])
+  const {
+    notifications,
+    unreadCount,
+    loading,
+    loadingMore,
+    loadError,
+    hasMore,
+    loadMore,
+    retry,
+    markRead,
+    markAllRead,
+    remove,
+  } = useNotifications(open)
 
   useEffect(() => {
-    const signal = { cancelled: false }
-    fetchUnreadCount(signal)
-    let interval: ReturnType<typeof setInterval> | null = null
-    const start = () => {
-      if (interval == null) interval = setInterval(() => fetchUnreadCount(signal), 30_000)
-    }
-    const stop = () => {
-      if (interval != null) { clearInterval(interval); interval = null }
-    }
-    const onVisibility = () => {
-      if (document.visibilityState === "visible") { fetchUnreadCount(signal); start() } else stop()
-    }
-    if (document.visibilityState === "visible") start()
-    document.addEventListener("visibilitychange", onVisibility)
-    return () => {
-      signal.cancelled = true
-      stop()
-      document.removeEventListener("visibilitychange", onVisibility)
-    }
-  }, [fetchUnreadCount])
-
-  const loadMoreSignalRef = useRef<{ cancelled: boolean } | null>(null)
-  const lastFetchedAtRef = useRef<number>(0)
-
-  useEffect(() => {
-    if (!open) {
-      // Keep the already-loaded first page so reopening feels instant;
-      // only cancel in-flight "load more" so we don't append to stale state.
-      setLoadingMore(false)
-      if (loadMoreSignalRef.current) loadMoreSignalRef.current.cancelled = true
-      return
-    }
-    const signal = { cancelled: false }
-    const isStale = Date.now() - lastFetchedAtRef.current > 30_000
-    if (notifications.length === 0 || isStale) {
-      fetchNotifications(1, signal).then(() => {
-        if (!signal.cancelled) lastFetchedAtRef.current = Date.now()
-      })
-    }
-    return () => {
-      signal.cancelled = true
-      if (loadMoreSignalRef.current) loadMoreSignalRef.current.cancelled = true
-    }
-    // Intentionally do not depend on `notifications.length` — we only want
-    // to re-fetch on open/close transitions, not on every list mutation.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, fetchNotifications])
-
-  const handleLoadMore = useCallback(() => {
-    if (loadMoreSignalRef.current) loadMoreSignalRef.current.cancelled = true
-    const signal = { cancelled: false }
-    loadMoreSignalRef.current = signal
-    void fetchNotifications(page + 1, signal)
-  }, [fetchNotifications, page])
-
-  useEffect(() => {
+    if (!open) return
     function handleClickOutside(e: MouseEvent) {
       if (
         panelRef.current && !panelRef.current.contains(e.target as Node) &&
@@ -159,45 +43,18 @@ export default function NotificationBell() {
         setOpen(false)
       }
     }
-    if (open) document.addEventListener("mousedown", handleClickOutside)
+    document.addEventListener("mousedown", handleClickOutside)
     return () => document.removeEventListener("mousedown", handleClickOutside)
   }, [open])
 
-  const handleNotificationClick = async (n: Notification) => {
-    if (!n.is_read) {
-      try {
-        await coursesService.markAsRead(n.id)
-        setNotifications(prev => prev.map(x => x.id === n.id ? { ...x, is_read: true } : x))
-        setUnreadCount(prev => Math.max(0, prev - 1))
-      } catch {
-        // Optimistic UI: still navigate even if mark-read fails
-      }
-    }
-    setOpen(false)
-    if (n.link && n.link.startsWith("/")) navigate(n.link)
-  }
-
-  const handleMarkAllRead = async () => {
-    try {
-      await coursesService.markAllAsRead()
-      setNotifications(prev => prev.map(n => ({ ...n, is_read: true })))
-      setUnreadCount(0)
-    } catch {
-      // Mark-all best effort; badge will correct on next poll
-    }
-  }
-
-  const handleDelete = async (e: React.MouseEvent, id: string) => {
-    e.stopPropagation()
-    try {
-      await coursesService.deleteNotification(id)
-      const removed = notifications.find(n => n.id === id)
-      setNotifications(prev => prev.filter(n => n.id !== id))
-      if (removed && !removed.is_read) setUnreadCount(prev => Math.max(0, prev - 1))
-    } catch {
-      // Delete failed; notification remains in the list
-    }
-  }
+  const handleActivate = useCallback(
+    (n: Notification) => {
+      if (!n.is_read) void markRead(n.id)
+      setOpen(false)
+      if (n.link && n.link.startsWith("/")) navigate(n.link)
+    },
+    [markRead, navigate],
+  )
 
   return (
     <div className="relative">
@@ -206,7 +63,7 @@ export default function NotificationBell() {
         variant="ghost"
         size="sm"
         className="h-8 w-8 p-0 relative"
-        onClick={() => setOpen(prev => !prev)}
+        onClick={() => setOpen((prev) => !prev)}
         aria-label="Notifications"
         aria-expanded={open}
         aria-haspopup="true"
@@ -220,106 +77,20 @@ export default function NotificationBell() {
       </Button>
 
       {open && (
-        <div
+        <NotificationPanel
           ref={panelRef}
-          role="region"
-          aria-label="Notifications"
-          className="absolute right-0 top-full mt-2 w-80 sm:w-96 rounded-lg border border-border bg-background shadow-lg z-50 overflow-hidden"
-        >
-          <div className="flex items-center justify-between border-b border-border px-4 py-3">
-            <h3 className="text-sm font-semibold text-foreground">Notifications</h3>
-            {unreadCount > 0 && (
-              <button
-                onClick={handleMarkAllRead}
-                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <CheckCheck className="h-3.5 w-3.5" />
-                Mark all read
-              </button>
-            )}
-          </div>
-
-          <div className="max-h-[400px] overflow-y-auto">
-            {loading ? (
-              <PageSpinner variant="section" />
-            ) : loadError ? (
-              <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
-                <AlertCircle className="h-8 w-8 text-destructive/70" />
-                <p className="text-sm text-destructive">Failed to load notifications.</p>
-                <button
-                  onClick={() => fetchNotifications(1)}
-                  className="text-xs text-primary hover:underline"
-                >
-                  Try again
-                </button>
-              </div>
-            ) : notifications.length === 0 ? (
-              <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
-                <Bell className="h-8 w-8 opacity-30" />
-                <p className="text-sm">No notifications yet</p>
-              </div>
-            ) : (
-              <>
-                {notifications.map(n => {
-                  const Icon = NOTIFICATION_ICONS[n.type] ?? Bell
-                  const color = NOTIFICATION_COLORS[n.type] ?? "text-muted-foreground"
-                  return (
-                    <div
-                      key={n.id}
-                      className={cn(
-                        "flex gap-3 px-4 py-3 transition-colors hover:bg-muted/50 group border-b border-border/50 last:border-0",
-                        !n.is_read && "bg-primary/[0.03]",
-                      )}
-                    >
-                      <button
-                        onClick={() => handleNotificationClick(n)}
-                        className="flex gap-3 flex-1 min-w-0 text-left cursor-pointer bg-transparent border-0 p-0"
-                        aria-label={n.title}
-                      >
-                        <div className={cn("mt-0.5 shrink-0", color)}>
-                          <Icon className="h-4 w-4" />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-start justify-between gap-2">
-                            <p className={cn("text-sm leading-snug", !n.is_read ? "font-medium text-foreground" : "text-muted-foreground")}>
-                              {n.title}
-                            </p>
-                            {!n.is_read && (
-                              <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />
-                            )}
-                          </div>
-                          <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">{n.message}</p>
-                          <p className="mt-1 text-[11px] text-muted-foreground/70">{timeAgo(n.created_at)}</p>
-                        </div>
-                      </button>
-                      <button
-                        onClick={(e) => handleDelete(e, n.id)}
-                        className="mt-0.5 shrink-0 opacity-60 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
-                        aria-label="Delete notification"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                  )
-                })}
-                {hasMore && (
-                  <div className="border-t border-border/50 p-2">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="w-full text-xs"
-                      disabled={loadingMore}
-                      onClick={handleLoadMore}
-                    >
-                      {loadingMore ? "Loading..." : "Load more"}
-                    </Button>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
+          notifications={notifications}
+          unreadCount={unreadCount}
+          loading={loading}
+          loadingMore={loadingMore}
+          loadError={loadError}
+          hasMore={hasMore}
+          onActivate={handleActivate}
+          onDelete={(id) => void remove(id)}
+          onMarkAllRead={() => void markAllRead()}
+          onLoadMore={loadMore}
+          onRetry={retry}
+        />
       )}
     </div>
   )

--- a/frontend/src/components/layout/notifications/NotificationItem.tsx
+++ b/frontend/src/components/layout/notifications/NotificationItem.tsx
@@ -1,0 +1,75 @@
+import { Bell, Trash2 } from "lucide-react"
+import type { Notification } from "@/types"
+import { cn } from "@/lib/utils"
+import {
+  NOTIFICATION_COLORS,
+  NOTIFICATION_ICONS,
+  timeAgo,
+} from "./notificationMeta"
+
+interface Props {
+  notification: Notification
+  onActivate: (n: Notification) => void
+  onDelete: (id: string) => void
+}
+
+/**
+ * A single row in the bell dropdown. Pure presentation — all side effects
+ * live in `useNotifications`.
+ */
+export function NotificationItem({ notification, onActivate, onDelete }: Props) {
+  const Icon = NOTIFICATION_ICONS[notification.type] ?? Bell
+  const color = NOTIFICATION_COLORS[notification.type] ?? "text-muted-foreground"
+
+  return (
+    <div
+      className={cn(
+        "flex gap-3 px-4 py-3 transition-colors hover:bg-muted/50 group border-b border-border/50 last:border-0",
+        !notification.is_read && "bg-primary/[0.03]",
+      )}
+    >
+      <button
+        onClick={() => onActivate(notification)}
+        className="flex gap-3 flex-1 min-w-0 text-left cursor-pointer bg-transparent border-0 p-0"
+        aria-label={notification.title}
+      >
+        <div className={cn("mt-0.5 shrink-0", color)}>
+          <Icon className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <p
+              className={cn(
+                "text-sm leading-snug",
+                !notification.is_read
+                  ? "font-medium text-foreground"
+                  : "text-muted-foreground",
+              )}
+            >
+              {notification.title}
+            </p>
+            {!notification.is_read && (
+              <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />
+            )}
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
+            {notification.message}
+          </p>
+          <p className="mt-1 text-[11px] text-muted-foreground/70">
+            {timeAgo(notification.created_at)}
+          </p>
+        </div>
+      </button>
+      <button
+        onClick={(e) => {
+          e.stopPropagation()
+          onDelete(notification.id)
+        }}
+        className="mt-0.5 shrink-0 opacity-60 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
+        aria-label="Delete notification"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/notifications/NotificationPanel.tsx
+++ b/frontend/src/components/layout/notifications/NotificationPanel.tsx
@@ -1,0 +1,112 @@
+import { forwardRef } from "react"
+import { AlertCircle, Bell, CheckCheck } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import PageSpinner from "@/components/ui/PageSpinner"
+import type { Notification } from "@/types"
+import { NotificationItem } from "./NotificationItem"
+
+interface Props {
+  notifications: Notification[]
+  unreadCount: number
+  loading: boolean
+  loadingMore: boolean
+  loadError: boolean
+  hasMore: boolean
+  onActivate: (n: Notification) => void
+  onDelete: (id: string) => void
+  onMarkAllRead: () => void
+  onLoadMore: () => void
+  onRetry: () => void
+}
+
+/**
+ * Drop-down panel anchored below the bell. Purely presentational — all
+ * state lives in `useNotifications` and is handed in via props.
+ */
+export const NotificationPanel = forwardRef<HTMLDivElement, Props>(
+  function NotificationPanel(
+    {
+      notifications,
+      unreadCount,
+      loading,
+      loadingMore,
+      loadError,
+      hasMore,
+      onActivate,
+      onDelete,
+      onMarkAllRead,
+      onLoadMore,
+      onRetry,
+    },
+    ref,
+  ) {
+    return (
+      <div
+        ref={ref}
+        role="region"
+        aria-label="Notifications"
+        className="absolute right-0 top-full mt-2 w-80 sm:w-96 rounded-lg border border-border bg-background shadow-lg z-50 overflow-hidden"
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <h3 className="text-sm font-semibold text-foreground">Notifications</h3>
+          {unreadCount > 0 && (
+            <button
+              onClick={onMarkAllRead}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <CheckCheck className="h-3.5 w-3.5" />
+              Mark all read
+            </button>
+          )}
+        </div>
+
+        <div className="max-h-[400px] overflow-y-auto">
+          {loading ? (
+            <PageSpinner variant="section" />
+          ) : loadError ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
+              <AlertCircle className="h-8 w-8 text-destructive/70" />
+              <p className="text-sm text-destructive">Failed to load notifications.</p>
+              <button
+                onClick={onRetry}
+                className="text-xs text-primary hover:underline"
+              >
+                Try again
+              </button>
+            </div>
+          ) : notifications.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
+              <Bell className="h-8 w-8 opacity-30" />
+              <p className="text-sm">No notifications yet</p>
+            </div>
+          ) : (
+            <>
+              {notifications.map((n) => (
+                <NotificationItem
+                  key={n.id}
+                  notification={n}
+                  onActivate={onActivate}
+                  onDelete={onDelete}
+                />
+              ))}
+              {hasMore && (
+                <div className="border-t border-border/50 p-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="w-full text-xs"
+                    disabled={loadingMore}
+                    onClick={onLoadMore}
+                  >
+                    {loadingMore ? "Loading..." : "Load more"}
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    )
+  },
+)

--- a/frontend/src/components/layout/notifications/notificationMeta.ts
+++ b/frontend/src/components/layout/notifications/notificationMeta.ts
@@ -1,0 +1,53 @@
+import {
+  Award,
+  Bell,
+  BookOpen,
+  ClipboardCheck,
+  Megaphone,
+  UserCheck,
+  XCircle,
+} from "lucide-react"
+import type { NotificationType } from "@/types"
+
+/**
+ * Icon + colour lookup tables keyed by notification type.
+ *
+ * Kept here — not in `@/types` — because the icon component set and the
+ * Tailwind class palette are presentation concerns specific to the bell
+ * dropdown. Consumers that want other mappings (e.g. push notifications)
+ * should build their own table rather than import from here.
+ */
+export const NOTIFICATION_ICONS: Record<NotificationType, typeof Bell> = {
+  certificate_approved: Award,
+  certificate_rejected: XCircle,
+  assignment_graded: ClipboardCheck,
+  new_announcement: Megaphone,
+  course_update: BookOpen,
+  enrollment_confirmed: UserCheck,
+}
+
+export const NOTIFICATION_COLORS: Record<NotificationType, string> = {
+  certificate_approved: "text-success",
+  certificate_rejected: "text-destructive",
+  assignment_graded: "text-info",
+  new_announcement: "text-warning",
+  course_update: "text-muted-foreground",
+  enrollment_confirmed: "text-success",
+}
+
+/** Compact "x minutes ago" formatter used by the dropdown list. */
+export function timeAgo(dateStr: string): string {
+  const parsed = new Date(dateStr).getTime()
+  if (Number.isNaN(parsed)) return "—"
+  const now = Date.now()
+  const diff = now - parsed
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return "just now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(dateStr).toLocaleDateString()
+}

--- a/frontend/src/components/layout/notifications/useNotifications.ts
+++ b/frontend/src/components/layout/notifications/useNotifications.ts
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { Notification } from "@/types"
+import { coursesService } from "@/services/courses"
+
+/**
+ * Polling interval for the unread-count badge. Short enough that a newly
+ * arrived notification surfaces in roughly a minute, long enough that the
+ * endpoint doesn't burn through a serverless function's budget.
+ */
+const UNREAD_POLL_MS = 30_000
+
+/**
+ * How long we trust a cached first page of notifications before re-fetching
+ * on the next `open`. Keeping this equal to the unread-poll keeps the list
+ * and badge from drifting too far out of sync.
+ */
+const LIST_STALE_MS = 30_000
+
+type CancelSignal = { cancelled: boolean }
+
+/**
+ * Encapsulates every piece of runtime state the notification bell needs:
+ *
+ * - unread-count polling (with visibility-aware interval),
+ * - lazy first-page load on open,
+ * - paginated "load more",
+ * - optimistic mark-read / mark-all / delete.
+ *
+ * The dropdown panel stays a pure view over this hook's return value.
+ */
+export function useNotifications(open: boolean) {
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [loadError, setLoadError] = useState(false)
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(false)
+
+  const loadMoreSignalRef = useRef<CancelSignal | null>(null)
+  const lastFetchedAtRef = useRef<number>(0)
+
+  const fetchUnreadCount = useCallback(async (signal?: CancelSignal) => {
+    try {
+      const count = await coursesService.getUnreadCount()
+      if (!signal?.cancelled) setUnreadCount(count)
+    } catch {
+      // Polling failure is non-critical; will retry on next interval.
+    }
+  }, [])
+
+  const fetchNotifications = useCallback(
+    async (pageNum: number, signal?: CancelSignal) => {
+      if (pageNum === 1) {
+        setLoading(true)
+        setLoadError(false)
+      } else {
+        setLoadingMore(true)
+      }
+      try {
+        const res = await coursesService.getNotifications(pageNum)
+        if (!signal?.cancelled) {
+          setNotifications((prev) =>
+            pageNum === 1 ? res.items : [...prev, ...res.items],
+          )
+          setPage(pageNum)
+          setHasMore(pageNum * res.page_size < res.total)
+        }
+      } catch {
+        // First-page failure = error state. Later-page failures leave the
+        // existing list alone so the user still sees what we already have.
+        if (!signal?.cancelled && pageNum === 1) setLoadError(true)
+      } finally {
+        if (!signal?.cancelled) {
+          if (pageNum === 1) setLoading(false)
+          else setLoadingMore(false)
+        }
+      }
+    },
+    [],
+  )
+
+  // Background unread-count poll, paused while the tab is hidden.
+  useEffect(() => {
+    const signal: CancelSignal = { cancelled: false }
+    fetchUnreadCount(signal)
+
+    let interval: ReturnType<typeof setInterval> | null = null
+    const start = () => {
+      if (interval == null) {
+        interval = setInterval(() => fetchUnreadCount(signal), UNREAD_POLL_MS)
+      }
+    }
+    const stop = () => {
+      if (interval != null) {
+        clearInterval(interval)
+        interval = null
+      }
+    }
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        fetchUnreadCount(signal)
+        start()
+      } else {
+        stop()
+      }
+    }
+
+    if (document.visibilityState === "visible") start()
+    document.addEventListener("visibilitychange", onVisibility)
+
+    return () => {
+      signal.cancelled = true
+      stop()
+      document.removeEventListener("visibilitychange", onVisibility)
+    }
+  }, [fetchUnreadCount])
+
+  // Load the first page when the panel opens (or refresh if it's stale);
+  // cancel an in-flight "load more" when it closes so we don't append to
+  // stale state after re-opening.
+  useEffect(() => {
+    if (!open) {
+      setLoadingMore(false)
+      if (loadMoreSignalRef.current) loadMoreSignalRef.current.cancelled = true
+      return
+    }
+    const signal: CancelSignal = { cancelled: false }
+    const isStale = Date.now() - lastFetchedAtRef.current > LIST_STALE_MS
+    if (notifications.length === 0 || isStale) {
+      void fetchNotifications(1, signal).then(() => {
+        if (!signal.cancelled) lastFetchedAtRef.current = Date.now()
+      })
+    }
+    return () => {
+      signal.cancelled = true
+      if (loadMoreSignalRef.current) loadMoreSignalRef.current.cancelled = true
+    }
+    // Intentionally omitting `notifications.length` — we only refresh on
+    // open/close transitions, not on every mutation of the list itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, fetchNotifications])
+
+  const loadMore = useCallback(() => {
+    if (loadMoreSignalRef.current) loadMoreSignalRef.current.cancelled = true
+    const signal: CancelSignal = { cancelled: false }
+    loadMoreSignalRef.current = signal
+    void fetchNotifications(page + 1, signal)
+  }, [fetchNotifications, page])
+
+  const retry = useCallback(() => {
+    void fetchNotifications(1)
+  }, [fetchNotifications])
+
+  const markRead = useCallback(async (id: string) => {
+    try {
+      await coursesService.markAsRead(id)
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, is_read: true } : n)),
+      )
+      setUnreadCount((prev) => Math.max(0, prev - 1))
+    } catch {
+      // Optimistic UI — navigation still happens even if the mark fails.
+    }
+  }, [])
+
+  const markAllRead = useCallback(async () => {
+    try {
+      await coursesService.markAllAsRead()
+      setNotifications((prev) => prev.map((n) => ({ ...n, is_read: true })))
+      setUnreadCount(0)
+    } catch {
+      // Best effort — badge will correct on the next poll tick.
+    }
+  }, [])
+
+  const remove = useCallback(async (id: string) => {
+    try {
+      await coursesService.deleteNotification(id)
+      setNotifications((prev) => {
+        const removed = prev.find((n) => n.id === id)
+        if (removed && !removed.is_read) {
+          setUnreadCount((c) => Math.max(0, c - 1))
+        }
+        return prev.filter((n) => n.id !== id)
+      })
+    } catch {
+      // Delete failed — notification stays visible.
+    }
+  }, [])
+
+  return {
+    notifications,
+    unreadCount,
+    loading,
+    loadingMore,
+    loadError,
+    hasMore,
+    loadMore,
+    retry,
+    markRead,
+    markAllRead,
+    remove,
+  }
+}


### PR DESCRIPTION
## Summary

`NotificationBell.tsx` was a 326-line component tangling five
unrelated concerns: static icon/colour lookup tables, a `timeAgo`
helper, a visibility-aware unread-count poll, paginated list fetching
with optimistic mark-read / delete, and the dropdown JSX. Split them
so each file has a single job:

- `notifications/notificationMeta.ts` — `NOTIFICATION_ICONS`,
  `NOTIFICATION_COLORS`, and `timeAgo`.
- `notifications/useNotifications.ts` — hook owning every piece of
  runtime state: the visibility-aware unread-count poll, lazy
  first-page load on open (with a 30 s stale threshold), paginated
  load-more, and optimistic mark-read / mark-all-read / delete.
- `notifications/NotificationItem.tsx` — pure row.
- `notifications/NotificationPanel.tsx` — pure dropdown panel that
  renders loading / error / empty / list / load-more states from
  props only; `forwardRef` so the parent can keep owning
  click-outside.
- `NotificationBell.tsx` — 91-line thin orchestrator: open/close
  toggle, click-outside, bell button with unread badge.

No behaviour change. Poll interval (30 s), list stale threshold
(30 s), pagination semantics, and optimistic-mutation flows are all
preserved.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint src --max-warnings=0`
- [x] `npx knip --reporter json` → `{"issues":[]}`
- [x] `npx vitest run` — 85 passed
