### PR TITLE
refactor(auth): split Register into view + hook modules

### DIFF
--- a/frontend/src/pages/Auth/Register.tsx
+++ b/frontend/src/pages/Auth/Register.tsx
@@ -1,347 +1,45 @@
-import { useState } from "react"
-import { Link } from "react-router-dom"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { useAuth } from "@/context/useAuth"
-import { registerSchema } from "@/lib/validations/auth"
-import AuthLayout from "@/components/layout/AuthLayout"
-import { GraduationCap, BookOpenCheck, Loader2, MailCheck, ArrowLeft, Clock, Mail } from "lucide-react"
+import { DuplicateEmailView } from "./register/DuplicateEmailView"
+import { RegisterForm } from "./register/RegisterForm"
+import { SuccessView } from "./register/SuccessView"
+import { useRegister } from "./register/useRegister"
 
-function GoogleIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24">
-      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
-      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
-    </svg>
-  )
-}
-
-type FormState = {
-  full_name: string
-  email: string
-  password: string
-  confirmPassword: string
-  role: "teacher" | "student"
-}
-
-const roles = [
-  {
-    value: "student" as const,
-    label: "Student",
-    description: "Enroll in courses and learn",
-    icon: GraduationCap,
-  },
-  {
-    value: "teacher" as const,
-    label: "Teacher",
-    description: "Create and manage courses",
-    icon: BookOpenCheck,
-  },
-]
-
+/**
+ * Top-level /register route. Picks one of three views based on the
+ * current `useRegister` state; everything else (validation, mutations,
+ * error handling) lives inside the hook and the sibling view components.
+ */
 export default function Register() {
-  const [form, setForm] = useState<FormState>({
-    full_name: "",
-    email: "",
-    password: "",
-    confirmPassword: "",
-    role: "student",
-  })
-  const [errors, setErrors] = useState<Partial<Record<string, string>>>({})
-  const [serverError, setServerError] = useState("")
-  const [duplicateEmail, setDuplicateEmail] = useState(false)
-  const [success, setSuccess] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [googleLoading, setGoogleLoading] = useState(false)
-  const { register, signInWithGoogle } = useAuth()
-
-  const handleChange = (field: keyof FormState, value: string) => {
-    setForm((prev) => ({ ...prev, [field]: value }))
-    setErrors((prev) => ({ ...prev, [field]: undefined }))
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setServerError("")
-
-    const result = registerSchema.safeParse(form)
-    if (!result.success) {
-      const fieldErrors: typeof errors = {}
-      for (const issue of result.error.issues) {
-        const key = String(issue.path[0])
-        if (!fieldErrors[key]) fieldErrors[key] = issue.message
-      }
-      setErrors(fieldErrors)
-      return
-    }
-
-    setLoading(true)
-    try {
-      await register(result.data.email, result.data.password, result.data.full_name, result.data.role)
-      setSuccess(true)
-    } catch (err: unknown) {
-      const supaErr = err as { message?: string }
-      if (supaErr.message === "DUPLICATE_EMAIL") {
-        setDuplicateEmail(true)
-      } else {
-        setServerError(supaErr.message || "Registration failed. Please try again.")
-      }
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleGoogleSignUp = async () => {
-    setGoogleLoading(true)
-    try {
-      await signInWithGoogle()
-    } catch (err: unknown) {
-      const supaErr = err as { message?: string }
-      setServerError(supaErr.message || "Google sign-up failed.")
-    } finally {
-      setGoogleLoading(false)
-    }
-  }
+  const {
+    form,
+    errors,
+    serverError,
+    duplicateEmail,
+    success,
+    loading,
+    googleLoading,
+    handleChange,
+    handleSubmit,
+    handleGoogleSignUp,
+  } = useRegister()
 
   if (duplicateEmail) {
-    return (
-      <AuthLayout heading="Account may exist" subheading="This email might already be registered">
-        <div className="space-y-6 animate-fade-in">
-          <div className="flex flex-col items-center text-center gap-4 py-4">
-            <div className="flex h-16 w-16 items-center justify-center rounded-md bg-warning/10">
-              <Mail className="h-8 w-8 text-warning" />
-            </div>
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                An account with <strong className="text-foreground">{form.email}</strong> may already exist.
-              </p>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Please try signing in instead, or use the "Forgot password" option if you can't remember your credentials.
-              </p>
-            </div>
-          </div>
-          <div className="space-y-3">
-            <Link to="/login" className="block">
-              <Button className="w-full h-11">
-                Go to Sign In
-              </Button>
-            </Link>
-            <Link to="/forgot-password" className="block">
-              <Button variant="outline" className="w-full h-11">
-                Forgot Password?
-              </Button>
-            </Link>
-            <a href="mailto:support@bibleschool.com" className="block">
-              <Button variant="ghost" className="w-full h-11 text-muted-foreground">
-                Contact Support
-              </Button>
-            </a>
-          </div>
-        </div>
-      </AuthLayout>
-    )
+    return <DuplicateEmailView email={form.email} />
   }
 
   if (success) {
-    const isTeacher = form.role === "teacher"
-    return (
-      <AuthLayout
-        heading={isTeacher ? "Application submitted" : "Check your email"}
-        subheading={isTeacher ? "One more step before you can start teaching" : "Almost there — just one more step"}
-      >
-        <div className="space-y-6 animate-fade-in">
-          <div className="flex flex-col items-center text-center gap-4 py-4">
-            <div
-              className={`flex h-16 w-16 items-center justify-center rounded-md ${
-                isTeacher ? "bg-warning/10" : "bg-primary/10"
-              }`}
-            >
-              {isTeacher ? (
-                <Clock className="h-8 w-8 text-warning" />
-              ) : (
-                <MailCheck className="h-8 w-8 text-primary" />
-              )}
-            </div>
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                We sent a confirmation link to <strong className="text-foreground">{form.email}</strong>.
-                <br />Click the link in the email to activate your account.
-              </p>
-              {isTeacher && (
-                <div className="mt-4 rounded-md border border-border border-l-[3px] border-l-warning bg-warning/5 p-3">
-                  <p className="text-sm leading-relaxed text-foreground">
-                    After confirming your email, your teacher account will need to be approved by an administrator.
-                    You'll be able to log in, but course creation tools will be available once approved.
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-          <Link to="/login" className="block">
-            <Button variant="outline" className="w-full h-11">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Sign In
-            </Button>
-          </Link>
-        </div>
-      </AuthLayout>
-    )
+    return <SuccessView email={form.email} isTeacher={form.role === "teacher"} />
   }
 
   return (
-    <AuthLayout heading="Create an account" subheading="Choose your role and start learning today">
-      <div className="space-y-6 animate-fade-in">
-        {serverError && (
-          <div role="alert" className="text-sm text-destructive bg-destructive/10 border border-destructive/20 p-3 rounded-lg">
-            {serverError}
-          </div>
-        )}
-
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full h-11 font-medium rounded-md"
-          onClick={handleGoogleSignUp}
-          disabled={googleLoading || loading}
-        >
-          {googleLoading ? (
-            <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Connecting...</>
-          ) : (
-            <><GoogleIcon className="h-4 w-4 mr-2.5" />Continue with Google</>
-          )}
-        </Button>
-
-        <div className="relative">
-          <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t" />
-          </div>
-          <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-background px-3 text-muted-foreground">or register with email</span>
-          </div>
-        </div>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Role selector */}
-          <div className="space-y-2">
-            <Label>I am a</Label>
-            <div role="radiogroup" aria-label="Account type" className="grid grid-cols-2 gap-3">
-              {roles.map((r) => {
-                const Icon = r.icon
-                const selected = form.role === r.value
-                return (
-                  <button
-                    key={r.value}
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    onClick={() => handleChange("role", r.value)}
-                    className={`relative flex flex-col items-center gap-1.5 rounded-md border-2 p-4 transition-all duration-200 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
-                      selected
-                        ? "border-primary bg-primary/5 shadow-sm"
-                        : "border-border hover:border-muted-foreground/30 hover:bg-muted/50"
-                    }`}
-                  >
-                    <Icon className={`h-6 w-6 transition-colors ${selected ? "text-primary" : "text-muted-foreground"}`} />
-                    <span className={`text-sm font-medium transition-colors ${selected ? "text-primary" : ""}`}>
-                      {r.label}
-                    </span>
-                    <span className="text-[11px] text-muted-foreground text-center leading-tight">
-                      {r.description}
-                    </span>
-                  </button>
-                )
-              })}
-            </div>
-            {errors.role && <p className="text-xs text-destructive">{errors.role}</p>}
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="fullName">Full Name</Label>
-            <Input
-              id="fullName"
-              placeholder="John Doe"
-              autoComplete="name"
-              className="h-11"
-              value={form.full_name}
-              onChange={(e) => handleChange("full_name", e.target.value)}
-              aria-invalid={!!errors.full_name}
-              aria-describedby={errors.full_name ? "fullName-error" : undefined}
-              autoFocus
-            />
-            {errors.full_name && <p id="fullName-error" role="alert" className="text-xs text-destructive mt-1">{errors.full_name}</p>}
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
-            <Input
-              id="email"
-              type="email"
-              placeholder="you@example.com"
-              autoComplete="email"
-              className="h-11"
-              value={form.email}
-              onChange={(e) => handleChange("email", e.target.value)}
-              aria-invalid={!!errors.email}
-              aria-describedby={errors.email ? "reg-email-error" : undefined}
-            />
-            {errors.email && <p id="reg-email-error" role="alert" className="text-xs text-destructive mt-1">{errors.email}</p>}
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                autoComplete="new-password"
-                className="h-11"
-                value={form.password}
-                onChange={(e) => handleChange("password", e.target.value)}
-                aria-invalid={!!errors.password}
-                aria-describedby={errors.password ? "reg-password-error" : undefined}
-              />
-              {errors.password && <p id="reg-password-error" role="alert" className="text-xs text-destructive mt-1">{errors.password}</p>}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword">Confirm</Label>
-              <Input
-                id="confirmPassword"
-                type="password"
-                autoComplete="new-password"
-                className="h-11"
-                value={form.confirmPassword}
-                onChange={(e) => handleChange("confirmPassword", e.target.value)}
-                aria-invalid={!!errors.confirmPassword}
-                aria-describedby={errors.confirmPassword ? "confirmPassword-error" : undefined}
-              />
-              {errors.confirmPassword && (
-                <p id="confirmPassword-error" role="alert" className="text-xs text-destructive mt-1">{errors.confirmPassword}</p>
-              )}
-            </div>
-          </div>
-
-          <Button type="submit" className="w-full h-11 font-medium rounded-md" disabled={loading}>
-            {loading ? (
-              <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                Creating account...
-              </>
-            ) : (
-              "Create Account"
-            )}
-          </Button>
-        </form>
-
-        <p className="text-sm text-center text-muted-foreground">
-          Already have an account?{" "}
-          <Link to="/login" className="text-primary font-medium hover:text-primary/80 transition-colors">
-            Sign in
-          </Link>
-        </p>
-      </div>
-    </AuthLayout>
+    <RegisterForm
+      form={form}
+      errors={errors}
+      serverError={serverError}
+      loading={loading}
+      googleLoading={googleLoading}
+      onChange={handleChange}
+      onSubmit={handleSubmit}
+      onGoogleSignUp={handleGoogleSignUp}
+    />
   )
 }

--- a/frontend/src/pages/Auth/register/DuplicateEmailView.tsx
+++ b/frontend/src/pages/Auth/register/DuplicateEmailView.tsx
@@ -1,0 +1,51 @@
+import { Link } from "react-router-dom"
+import { Mail } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import AuthLayout from "@/components/layout/AuthLayout"
+
+/**
+ * Terminal state shown when the register endpoint reports a duplicate
+ * email. We can't tell whether it was a typo or a genuine prior
+ * registration, so surface all three recovery paths (login, reset, support)
+ * instead of forcing one.
+ */
+export function DuplicateEmailView({ email }: { email: string }) {
+  return (
+    <AuthLayout
+      heading="Account may exist"
+      subheading="This email might already be registered"
+    >
+      <div className="space-y-6 animate-fade-in">
+        <div className="flex flex-col items-center text-center gap-4 py-4">
+          <div className="flex h-16 w-16 items-center justify-center rounded-md bg-warning/10">
+            <Mail className="h-8 w-8 text-warning" />
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              An account with <strong className="text-foreground">{email}</strong> may already exist.
+            </p>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Please try signing in instead, or use the "Forgot password" option if you can't
+              remember your credentials.
+            </p>
+          </div>
+        </div>
+        <div className="space-y-3">
+          <Link to="/login" className="block">
+            <Button className="w-full h-11">Go to Sign In</Button>
+          </Link>
+          <Link to="/forgot-password" className="block">
+            <Button variant="outline" className="w-full h-11">
+              Forgot Password?
+            </Button>
+          </Link>
+          <a href="mailto:support@bibleschool.com" className="block">
+            <Button variant="ghost" className="w-full h-11 text-muted-foreground">
+              Contact Support
+            </Button>
+          </a>
+        </div>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/pages/Auth/register/GoogleIcon.tsx
+++ b/frontend/src/pages/Auth/register/GoogleIcon.tsx
@@ -1,0 +1,15 @@
+/**
+ * Inline Google "G" mark used on the Continue-with-Google button.
+ * Kept as a component (not an `<img>`) so it inherits Tailwind sizing
+ * classes and adapts to dark mode with the rest of the button chrome.
+ */
+export function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  )
+}

--- a/frontend/src/pages/Auth/register/RegisterForm.tsx
+++ b/frontend/src/pages/Auth/register/RegisterForm.tsx
@@ -1,0 +1,274 @@
+import { Link } from "react-router-dom"
+import { BookOpenCheck, GraduationCap, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import AuthLayout from "@/components/layout/AuthLayout"
+import { GoogleIcon } from "./GoogleIcon"
+import type { FormState } from "./useRegister"
+
+const ROLES = [
+  {
+    value: "student" as const,
+    label: "Student",
+    description: "Enroll in courses and learn",
+    icon: GraduationCap,
+  },
+  {
+    value: "teacher" as const,
+    label: "Teacher",
+    description: "Create and manage courses",
+    icon: BookOpenCheck,
+  },
+]
+
+interface Props {
+  form: FormState
+  errors: Partial<Record<string, string>>
+  serverError: string
+  loading: boolean
+  googleLoading: boolean
+  onChange: (field: keyof FormState, value: string) => void
+  onSubmit: () => void
+  onGoogleSignUp: () => void
+}
+
+/**
+ * The actual registration form — role toggle, four text inputs,
+ * Google OAuth shortcut, submit button. Receives state and handlers from
+ * `useRegister`; nothing in here owns mutable state.
+ */
+export function RegisterForm({
+  form,
+  errors,
+  serverError,
+  loading,
+  googleLoading,
+  onChange,
+  onSubmit,
+  onGoogleSignUp,
+}: Props) {
+  return (
+    <AuthLayout
+      heading="Create an account"
+      subheading="Choose your role and start learning today"
+    >
+      <div className="space-y-6 animate-fade-in">
+        {serverError && (
+          <div
+            role="alert"
+            className="text-sm text-destructive bg-destructive/10 border border-destructive/20 p-3 rounded-lg"
+          >
+            {serverError}
+          </div>
+        )}
+
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full h-11 font-medium rounded-md"
+          onClick={onGoogleSignUp}
+          disabled={googleLoading || loading}
+        >
+          {googleLoading ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              Connecting...
+            </>
+          ) : (
+            <>
+              <GoogleIcon className="h-4 w-4 mr-2.5" />
+              Continue with Google
+            </>
+          )}
+        </Button>
+
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t" />
+          </div>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-background px-3 text-muted-foreground">
+              or register with email
+            </span>
+          </div>
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            onSubmit()
+          }}
+          className="space-y-4"
+        >
+          <div className="space-y-2">
+            <Label>I am a</Label>
+            <div
+              role="radiogroup"
+              aria-label="Account type"
+              className="grid grid-cols-2 gap-3"
+            >
+              {ROLES.map((r) => {
+                const Icon = r.icon
+                const selected = form.role === r.value
+                return (
+                  <button
+                    key={r.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    onClick={() => onChange("role", r.value)}
+                    className={`relative flex flex-col items-center gap-1.5 rounded-md border-2 p-4 transition-all duration-200 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                      selected
+                        ? "border-primary bg-primary/5 shadow-sm"
+                        : "border-border hover:border-muted-foreground/30 hover:bg-muted/50"
+                    }`}
+                  >
+                    <Icon
+                      className={`h-6 w-6 transition-colors ${
+                        selected ? "text-primary" : "text-muted-foreground"
+                      }`}
+                    />
+                    <span
+                      className={`text-sm font-medium transition-colors ${
+                        selected ? "text-primary" : ""
+                      }`}
+                    >
+                      {r.label}
+                    </span>
+                    <span className="text-[11px] text-muted-foreground text-center leading-tight">
+                      {r.description}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+            {errors.role && <p className="text-xs text-destructive">{errors.role}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="fullName">Full Name</Label>
+            <Input
+              id="fullName"
+              placeholder="John Doe"
+              autoComplete="name"
+              className="h-11"
+              value={form.full_name}
+              onChange={(e) => onChange("full_name", e.target.value)}
+              aria-invalid={!!errors.full_name}
+              aria-describedby={errors.full_name ? "fullName-error" : undefined}
+              autoFocus
+            />
+            {errors.full_name && (
+              <p
+                id="fullName-error"
+                role="alert"
+                className="text-xs text-destructive mt-1"
+              >
+                {errors.full_name}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="you@example.com"
+              autoComplete="email"
+              className="h-11"
+              value={form.email}
+              onChange={(e) => onChange("email", e.target.value)}
+              aria-invalid={!!errors.email}
+              aria-describedby={errors.email ? "reg-email-error" : undefined}
+            />
+            {errors.email && (
+              <p
+                id="reg-email-error"
+                role="alert"
+                className="text-xs text-destructive mt-1"
+              >
+                {errors.email}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="new-password"
+                className="h-11"
+                value={form.password}
+                onChange={(e) => onChange("password", e.target.value)}
+                aria-invalid={!!errors.password}
+                aria-describedby={errors.password ? "reg-password-error" : undefined}
+              />
+              {errors.password && (
+                <p
+                  id="reg-password-error"
+                  role="alert"
+                  className="text-xs text-destructive mt-1"
+                >
+                  {errors.password}
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">Confirm</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                autoComplete="new-password"
+                className="h-11"
+                value={form.confirmPassword}
+                onChange={(e) => onChange("confirmPassword", e.target.value)}
+                aria-invalid={!!errors.confirmPassword}
+                aria-describedby={
+                  errors.confirmPassword ? "confirmPassword-error" : undefined
+                }
+              />
+              {errors.confirmPassword && (
+                <p
+                  id="confirmPassword-error"
+                  role="alert"
+                  className="text-xs text-destructive mt-1"
+                >
+                  {errors.confirmPassword}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full h-11 font-medium rounded-md"
+            disabled={loading}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Creating account...
+              </>
+            ) : (
+              "Create Account"
+            )}
+          </Button>
+        </form>
+
+        <p className="text-sm text-center text-muted-foreground">
+          Already have an account?{" "}
+          <Link
+            to="/login"
+            className="text-primary font-medium hover:text-primary/80 transition-colors"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/pages/Auth/register/SuccessView.tsx
+++ b/frontend/src/pages/Auth/register/SuccessView.tsx
@@ -1,0 +1,65 @@
+import { Link } from "react-router-dom"
+import { ArrowLeft, Clock, MailCheck } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import AuthLayout from "@/components/layout/AuthLayout"
+
+interface Props {
+  email: string
+  isTeacher: boolean
+}
+
+/**
+ * Post-register confirmation screen. Teachers get a second banner that
+ * explains the additional admin-approval step before the course-creation
+ * tools unlock.
+ */
+export function SuccessView({ email, isTeacher }: Props) {
+  return (
+    <AuthLayout
+      heading={isTeacher ? "Application submitted" : "Check your email"}
+      subheading={
+        isTeacher
+          ? "One more step before you can start teaching"
+          : "Almost there — just one more step"
+      }
+    >
+      <div className="space-y-6 animate-fade-in">
+        <div className="flex flex-col items-center text-center gap-4 py-4">
+          <div
+            className={`flex h-16 w-16 items-center justify-center rounded-md ${
+              isTeacher ? "bg-warning/10" : "bg-primary/10"
+            }`}
+          >
+            {isTeacher ? (
+              <Clock className="h-8 w-8 text-warning" />
+            ) : (
+              <MailCheck className="h-8 w-8 text-primary" />
+            )}
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              We sent a confirmation link to <strong className="text-foreground">{email}</strong>.
+              <br />
+              Click the link in the email to activate your account.
+            </p>
+            {isTeacher && (
+              <div className="mt-4 rounded-md border border-border border-l-[3px] border-l-warning bg-warning/5 p-3">
+                <p className="text-sm leading-relaxed text-foreground">
+                  After confirming your email, your teacher account will need to be approved by an
+                  administrator. You'll be able to log in, but course creation tools will be
+                  available once approved.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+        <Link to="/login" className="block">
+          <Button variant="outline" className="w-full h-11">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Sign In
+          </Button>
+        </Link>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/pages/Auth/register/useRegister.ts
+++ b/frontend/src/pages/Auth/register/useRegister.ts
@@ -1,0 +1,106 @@
+import { useCallback, useState } from "react"
+import { useAuth } from "@/context/useAuth"
+import { registerSchema } from "@/lib/validations/auth"
+
+export type FormState = {
+  full_name: string
+  email: string
+  password: string
+  confirmPassword: string
+  role: "teacher" | "student"
+}
+
+const EMPTY_FORM: FormState = {
+  full_name: "",
+  email: "",
+  password: "",
+  confirmPassword: "",
+  role: "student",
+}
+
+/**
+ * Registration form state machine.
+ *
+ * Exposes the mutable form + per-field validation errors, the three
+ * terminal states (server error, duplicate-email, success), and the two
+ * async handlers (email/password submit and Google OAuth). The view just
+ * renders whichever state is active; nothing else lives in the page.
+ */
+export function useRegister() {
+  const { register, signInWithGoogle } = useAuth()
+  const [form, setForm] = useState<FormState>(EMPTY_FORM)
+  const [errors, setErrors] = useState<Partial<Record<string, string>>>({})
+  const [serverError, setServerError] = useState("")
+  const [duplicateEmail, setDuplicateEmail] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [googleLoading, setGoogleLoading] = useState(false)
+
+  const handleChange = useCallback(
+    (field: keyof FormState, value: string) => {
+      setForm((prev) => ({ ...prev, [field]: value }))
+      setErrors((prev) => ({ ...prev, [field]: undefined }))
+    },
+    [],
+  )
+
+  const handleSubmit = useCallback(async () => {
+    setServerError("")
+
+    const result = registerSchema.safeParse(form)
+    if (!result.success) {
+      const fieldErrors: Partial<Record<string, string>> = {}
+      for (const issue of result.error.issues) {
+        const key = String(issue.path[0])
+        if (!fieldErrors[key]) fieldErrors[key] = issue.message
+      }
+      setErrors(fieldErrors)
+      return
+    }
+
+    setLoading(true)
+    try {
+      await register(
+        result.data.email,
+        result.data.password,
+        result.data.full_name,
+        result.data.role,
+      )
+      setSuccess(true)
+    } catch (err: unknown) {
+      const supaErr = err as { message?: string }
+      if (supaErr.message === "DUPLICATE_EMAIL") {
+        setDuplicateEmail(true)
+      } else {
+        setServerError(supaErr.message || "Registration failed. Please try again.")
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [form, register])
+
+  const handleGoogleSignUp = useCallback(async () => {
+    setGoogleLoading(true)
+    try {
+      await signInWithGoogle()
+    } catch (err: unknown) {
+      const supaErr = err as { message?: string }
+      setServerError(supaErr.message || "Google sign-up failed.")
+    } finally {
+      setGoogleLoading(false)
+    }
+  }, [signInWithGoogle])
+
+  return {
+    form,
+    errors,
+    serverError,
+    duplicateEmail,
+    success,
+    loading,
+    googleLoading,
+    handleChange,
+    handleSubmit,
+    handleGoogleSignUp,
+  }
+}


### PR DESCRIPTION
## Summary

`Register.tsx` was 347 lines that mixed form state, validation, and
async handlers with three different full-page views (duplicate-email,
success, and the form itself). Split them so the route picks a view
and everything stateful lives in one hook:

- `register/useRegister.ts` — form state, per-field validation,
  server/duplicate/success flags, loading flags, `handleChange`,
  `handleSubmit` (with `registerSchema` + `DUPLICATE_EMAIL` mapping),
  `handleGoogleSignUp`.
- `register/DuplicateEmailView.tsx` — terminal screen with the three
  recovery CTAs (login, password reset, support).
- `register/SuccessView.tsx` — post-register confirmation; teacher
  variant surfaces the admin-approval banner.
- `register/RegisterForm.tsx` — role selector + four inputs + Google
  OAuth shortcut. Purely controlled by props.
- `register/GoogleIcon.tsx` — the inline brand SVG.
- `Register.tsx` — 42-line thin orchestrator that reads `useRegister`
  and picks one of the three views.

No behaviour change. All error messages, validation rules, and
terminal-state flow are preserved 1:1.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint src --max-warnings=0`
- [x] `npx knip --reporter json` → `{"issues":[]}`
- [x] `npx vitest run` — 85 passed
