### PR TITLE
refactor(backend): extract certificate status transitions into a service

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -91,20 +91,24 @@ def _resolve_admin_flag(db: Session, teacher: User | str | UUID) -> bool:
     return bool(db.query(User.id).filter(User.id == teacher, User.role == UserRole.ADMIN.value).first())
 
 
-def assert_course_owner(course: Course, user: User, *, allow_admin: bool = True) -> None:
+def assert_course_owner(
+    course: Course,
+    user: User,
+    *,
+    allow_admin: bool = True,
+    detail: str = "You do not own this course",
+) -> None:
     """Raise 403 unless ``user`` owns ``course`` (or is admin and allowed).
 
-    Use when the caller already holds the ``Course`` row; otherwise prefer
-    :func:`verify_course_owner`.
+    Callers can override ``detail`` to return a more specific 403 message
+    (e.g. "You can only approve certificates for your own courses"), which
+    avoids wrapping this call in a ``try/except HTTPException`` block.
     """
     if str(course.created_by) == str(user.id):
         return
     if allow_admin and user.role == UserRole.ADMIN.value:
         return
-    raise HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
-        detail="You do not own this course",
-    )
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
 
 
 def verify_course_owner(

--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -83,13 +83,11 @@ def create_announcement(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Course '{data.course_id}' not found",
             )
-        try:
-            assert_course_owner(course, teacher)
-        except HTTPException:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="You can only create announcements for your own courses",
-            ) from None
+        assert_course_owner(
+            course,
+            teacher,
+            detail="You can only create announcements for your own courses",
+        )
     else:
         course = None
 

--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -1,29 +1,19 @@
-import hashlib
-import time
-import uuid
-from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import assert_course_owner, get_current_user, require_admin, require_teacher
+from app.api.dependencies import get_current_user, require_admin, require_teacher
 from app.core.database import get_db
 from app.models.certificate import Certificate
 from app.models.course import Course
 from app.models.enrollment import Enrollment
 from app.models.user import User
 from app.schemas.certificate import CertificateResponse, CertificateVerifyResponse
-from app.services.audit_service import log_action
-from app.services.notification_service import create_notification
+from app.services import certificate_service
 
 router = APIRouter(prefix="/certificates", tags=["certificates"])
-
-
-def _generate_certificate_number() -> str:
-    raw = f"{uuid.uuid4().hex}{time.time()}"
-    return "CERT-" + hashlib.sha256(raw.encode()).hexdigest()[:12].upper()
 
 
 @router.post("/course/{course_id}", response_model=CertificateResponse, status_code=status.HTTP_201_CREATED)
@@ -31,7 +21,7 @@ def request_certificate(
     course_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-):
+) -> Certificate:
     """Request a certificate (creates a pending request)."""
     # Soft-deleted courses must not accept new certificate requests.
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
@@ -55,12 +45,7 @@ def request_certificate(
     if existing:
         return existing
 
-    cert = Certificate(
-        user_id=current_user.id,
-        course_id=course_id,
-        status="pending",
-        requested_at=datetime.now(UTC),
-    )
+    cert = Certificate(user_id=current_user.id, course_id=course_id, status="pending")
     db.add(cert)
     try:
         db.commit()
@@ -83,7 +68,7 @@ def get_course_certificate(
     course_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-):
+) -> Certificate:
     """Get the current user's certificate for a specific course."""
     cert = (
         db.query(Certificate).filter(Certificate.user_id == current_user.id, Certificate.course_id == course_id).first()
@@ -99,7 +84,7 @@ def list_my_certificates(
     limit: int = Query(50, ge=1, le=200),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-):
+) -> list[Certificate]:
     return (
         db.query(Certificate)
         .filter(Certificate.user_id == current_user.id)
@@ -116,10 +101,8 @@ def list_pending_certificates(
     limit: int = Query(50, ge=1, le=200),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-):
+) -> list[Certificate]:
     """Teacher: list pending certificates for courses they teach."""
-    # One query: join through Course with the ownership + soft-delete filter,
-    # instead of materializing a Python list of course ids for IN (...).
     return (
         db.query(Certificate)
         .join(Course, Course.id == Certificate.course_id)
@@ -141,7 +124,7 @@ def list_admin_pending_certificates(
     limit: int = Query(50, ge=1, le=200),
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
-):
+) -> list[Certificate]:
     """Admin: list all teacher-approved certificates awaiting admin approval."""
     return (
         db.query(Certificate)
@@ -159,35 +142,8 @@ def teacher_approve_certificate(
     request: Request,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-):
-    cert = db.query(Certificate).filter(Certificate.id == cert_id).first()
-    if not cert:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Certificate not found")
-    if cert.status != "pending":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Certificate is not pending (current status: {cert.status})",
-        )
-    course = db.query(Course).filter(Course.id == cert.course_id, Course.deleted_at.is_(None)).first()
-    if not course:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You can only approve certificates for your own courses",
-        )
-    try:
-        assert_course_owner(course, teacher, allow_admin=False)
-    except HTTPException:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You can only approve certificates for your own courses",
-        ) from None
-    cert.status = "teacher_approved"
-    cert.teacher_approved_at = datetime.now(UTC)
-    cert.teacher_approved_by = teacher.id
-    db.commit()
-    db.refresh(cert)
-    log_action(db, teacher.id, "approve", "certificate", str(cert_id), details={"level": "teacher"}, request=request)
-    return cert
+) -> Certificate:
+    return certificate_service.teacher_approve(db, cert_id, teacher, request)
 
 
 @router.put("/{cert_id}/admin-approve", response_model=CertificateResponse)
@@ -196,37 +152,8 @@ def admin_approve_certificate(
     request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
-):
-    cert = db.query(Certificate).filter(Certificate.id == cert_id).first()
-    if not cert:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Certificate not found")
-    if cert.status != "teacher_approved":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Certificate must be teacher-approved first (current status: {cert.status})",
-        )
-    cert.status = "approved"
-    cert.certificate_number = _generate_certificate_number()
-    cert.admin_approved_at = datetime.now(UTC)
-    cert.admin_approved_by = admin.id
-    cert.issued_at = datetime.now(UTC)
-
-    course = db.query(Course).filter(Course.id == cert.course_id, Course.deleted_at.is_(None)).first()
-    course_title = course.title if course else "a course"
-    create_notification(
-        db,
-        user_id=cert.user_id,
-        type="certificate_approved",
-        title="Certificate Approved",
-        message=f'Your certificate for "{course_title}" has been approved!',
-        link="/certificates",
-        metadata={"course_id": cert.course_id, "certificate_id": str(cert.id)},
-    )
-
-    db.commit()
-    db.refresh(cert)
-    log_action(db, admin.id, "approve", "certificate", str(cert_id), details={"level": "admin"}, request=request)
-    return cert
+) -> Certificate:
+    return certificate_service.admin_approve(db, cert_id, admin, request)
 
 
 @router.put("/{cert_id}/reject", response_model=CertificateResponse)
@@ -235,53 +162,16 @@ def reject_certificate(
     request: Request,
     current_user: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-):
+) -> Certificate:
     """Teacher or admin can reject a certificate."""
-    cert = db.query(Certificate).filter(Certificate.id == cert_id).first()
-    if not cert:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Certificate not found")
-    if cert.status in ("approved", "rejected"):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Certificate cannot be rejected (current status: {cert.status})",
-        )
-    course = db.query(Course).filter(Course.id == cert.course_id).first()
-    if not course:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You can only reject certificates for your own courses",
-        )
-    try:
-        assert_course_owner(course, current_user)
-    except HTTPException:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You can only reject certificates for your own courses",
-        ) from None
-    cert.status = "rejected"
-
-    course_title = course.title if course else "a course"
-    create_notification(
-        db,
-        user_id=cert.user_id,
-        type="certificate_rejected",
-        title="Certificate Rejected",
-        message=f'Your certificate request for "{course_title}" was rejected.',
-        link="/certificates",
-        metadata={"course_id": cert.course_id, "certificate_id": str(cert.id)},
-    )
-
-    db.commit()
-    db.refresh(cert)
-    log_action(db, current_user.id, "reject", "certificate", str(cert_id), request=request)
-    return cert
+    return certificate_service.reject(db, cert_id, current_user, request)
 
 
 @router.get("/verify/{certificate_number}", response_model=CertificateVerifyResponse)
 def verify_certificate(
     certificate_number: str,
     db: Session = Depends(get_db),
-):
+) -> CertificateVerifyResponse:
     row = (
         db.query(Certificate, User, Course)
         .outerjoin(User, Certificate.user_id == User.id)

--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -1,0 +1,186 @@
+"""Business rules for certificate status transitions.
+
+Each of the approve/reject flows shares the same shape:
+  1. Load the certificate (404 if missing).
+  2. Assert the current status is a valid starting state for this transition.
+  3. Resolve the related course (soft-delete-aware for approvals; reject may
+     still run against a deleted course so a bad request is not silently
+     accepted).
+  4. Assert the acting user owns the course (or is an allowed admin).
+  5. Mutate the certificate, commit, refresh.
+  6. Audit log and, for user-facing transitions, fire a notification.
+
+Routers should stay as thin wrappers that map HTTP -> these functions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from fastapi import HTTPException, Request, status
+
+from app.api.dependencies import assert_course_owner
+from app.models.certificate import Certificate
+from app.models.course import Course
+from app.services.audit_service import log_action
+from app.services.notification_service import create_notification
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from app.models.user import User
+
+
+def generate_certificate_number() -> str:
+    """Opaque, human-presentable certificate id (stored verbatim)."""
+    raw = f"{uuid.uuid4().hex}{time.time()}"
+    return "CERT-" + hashlib.sha256(raw.encode()).hexdigest()[:12].upper()
+
+
+def _load_cert_or_404(db: Session, cert_id: UUID) -> Certificate:
+    cert = db.query(Certificate).filter(Certificate.id == cert_id).first()
+    if not cert:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Certificate not found",
+        )
+    return cert
+
+
+def _load_active_course_or_403(
+    db: Session,
+    course_id: str,
+    *,
+    ownership_detail: str,
+) -> Course:
+    """Load a non-deleted course. If it's gone, surface a 403 with the
+    provided ownership-denied message — a missing course for a cert is
+    indistinguishable to the caller from "you don't own it".
+    """
+    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ownership_detail)
+    return course
+
+
+def _assert_status(cert: Certificate, expected: str | tuple[str, ...]) -> None:
+    allowed = (expected,) if isinstance(expected, str) else expected
+    if cert.status not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_status_error_message(cert, allowed),
+        )
+
+
+def _status_error_message(cert: Certificate, allowed: tuple[str, ...]) -> str:
+    if allowed == ("pending",):
+        return f"Certificate is not pending (current status: {cert.status})"
+    if allowed == ("teacher_approved",):
+        return f"Certificate must be teacher-approved first (current status: {cert.status})"
+    return f"Certificate cannot transition from status: {cert.status}"
+
+
+def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request) -> Certificate:
+    cert = _load_cert_or_404(db, cert_id)
+    _assert_status(cert, "pending")
+
+    ownership_detail = "You can only approve certificates for your own courses"
+    course = _load_active_course_or_403(db, cert.course_id, ownership_detail=ownership_detail)
+    assert_course_owner(course, teacher, allow_admin=False, detail=ownership_detail)
+
+    cert.status = "teacher_approved"
+    cert.teacher_approved_at = datetime.now(UTC)
+    cert.teacher_approved_by = teacher.id
+    db.commit()
+    db.refresh(cert)
+
+    log_action(
+        db,
+        teacher.id,
+        "approve",
+        "certificate",
+        str(cert_id),
+        details={"level": "teacher"},
+        request=request,
+    )
+    return cert
+
+
+def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> Certificate:
+    cert = _load_cert_or_404(db, cert_id)
+    _assert_status(cert, "teacher_approved")
+
+    cert.status = "approved"
+    cert.certificate_number = generate_certificate_number()
+    now = datetime.now(UTC)
+    cert.admin_approved_at = now
+    cert.admin_approved_by = admin.id
+    cert.issued_at = now
+
+    # Soft-deleted course is OK here — we still notify the student and issue
+    # the cert since the course was live when approval started.
+    course = db.query(Course).filter(Course.id == cert.course_id, Course.deleted_at.is_(None)).first()
+    course_title = course.title if course else "a course"
+    create_notification(
+        db,
+        user_id=cert.user_id,
+        type="certificate_approved",
+        title="Certificate Approved",
+        message=f'Your certificate for "{course_title}" has been approved!',
+        link="/certificates",
+        metadata={"course_id": cert.course_id, "certificate_id": str(cert.id)},
+    )
+
+    db.commit()
+    db.refresh(cert)
+
+    log_action(
+        db,
+        admin.id,
+        "approve",
+        "certificate",
+        str(cert_id),
+        details={"level": "admin"},
+        request=request,
+    )
+    return cert
+
+
+def reject(db: Session, cert_id: UUID, user: User, request: Request) -> Certificate:
+    cert = _load_cert_or_404(db, cert_id)
+    if cert.status in ("approved", "rejected"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Certificate cannot be rejected (current status: {cert.status})",
+        )
+
+    ownership_detail = "You can only reject certificates for your own courses"
+    # Reject does not require the course to be live — teachers may still need
+    # to clear a request against a course they've since soft-deleted.
+    course = db.query(Course).filter(Course.id == cert.course_id).first()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ownership_detail)
+    assert_course_owner(course, user, detail=ownership_detail)
+
+    cert.status = "rejected"
+
+    create_notification(
+        db,
+        user_id=cert.user_id,
+        type="certificate_rejected",
+        title="Certificate Rejected",
+        message=f'Your certificate request for "{course.title}" was rejected.',
+        link="/certificates",
+        metadata={"course_id": cert.course_id, "certificate_id": str(cert.id)},
+    )
+
+    db.commit()
+    db.refresh(cert)
+
+    log_action(db, user.id, "reject", "certificate", str(cert_id), request=request)
+    return cert


### PR DESCRIPTION
## Summary

`backend/app/api/v1/certificates.py` had three approve/reject endpoints
that each inlined the same six-step flow — look up the certificate,
guard on status, look up the course, enforce course ownership, mutate,
commit + notify + audit log. Every time, the ownership check was
wrapped in a `try / except HTTPException: raise HTTPException(...) from None`
block just to rewrite the 403 message. That pattern buried the actual
business rule (what state a certificate is allowed to move to, and
who is allowed to move it) inside request handlers.

## Changes

- Added `backend/app/services/certificate_service.py` with
  `teacher_approve` / `admin_approve` / `reject` as the public entry
  points and shared `_load_cert_or_404` / `_assert_status` /
  `_load_active_course_or_403` helpers. The state transitions and
  authorization rules now live in one place.
- Added an optional `detail` kwarg to `assert_course_owner` so callers
  can pass a custom 403 message directly. This removes the `try / except
  HTTPException` re-raise boilerplate in both certificates.py and
  announcements.py.
- Slimmed the router down to HTTP plumbing only. `request_certificate`
  also drops the redundant `requested_at=datetime.now(UTC)` because the
  column has `server_default=func.now()`.
- Net: +217 / -139 lines, but most of the additions are the service
  docstring and typed helpers; the router itself dropped ~100 lines of
  duplication.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] `pytest backend/tests` — 396 passed
- [x] `mypy` on changed files — only pre-existing unrelated errors
  (`config.py` missing named arg, `psycopg2` stubs)
