### PR TITLE
fix(courses): hide soft-deleted modules/chapters from course tree

### DIFF
--- a/backend/app/services/course_service/_courses.py
+++ b/backend/app/services/course_service/_courses.py
@@ -6,7 +6,9 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from app.models.course import Course
+from sqlalchemy import select
+
+from app.models.course import Chapter, Course, Module
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -41,24 +43,38 @@ def update_course(db: Session, course: Course, data: CourseUpdate) -> Course:
 def delete_course(db: Session, course: Course) -> None:
     """Soft-delete: tombstone the course and cascade to modules/chapters.
 
-    We don't touch enrollments / progress / quiz attempts so a restore is
-    lossless.
+    Uses bulk UPDATEs so a course with hundreds of chapters still completes in
+    three round trips (course + modules + chapters) instead of one per row.
+    Enrollments / progress / quiz attempts are intentionally left untouched
+    so a restore is lossless.
     """
     now = datetime.now(UTC)
     course.deleted_at = now
-    for module in course.modules:
-        module.deleted_at = now
-        for chapter in module.chapters:
-            chapter.deleted_at = now
+    db.query(Module).filter(
+        Module.course_id == course.id,
+        Module.deleted_at.is_(None),
+    ).update({Module.deleted_at: now}, synchronize_session=False)
+    module_ids = select(Module.id).where(Module.course_id == course.id).scalar_subquery()
+    db.query(Chapter).filter(
+        Chapter.module_id.in_(module_ids),
+        Chapter.deleted_at.is_(None),
+    ).update({Chapter.deleted_at: now}, synchronize_session=False)
     db.commit()
 
 
 def restore_course(db: Session, course: Course) -> Course:
+    """Undelete a soft-deleted course tree via bulk UPDATEs.
+
+    We rely on direct UPDATE statements rather than walking ``course.modules``
+    because the eager loader in ``_COURSE_TREE`` filters out the very rows we
+    need to flip back to live (their ``deleted_at`` is set).
+    """
     course.deleted_at = None
-    for module in course.modules:
-        module.deleted_at = None
-        for chapter in module.chapters:
-            chapter.deleted_at = None
+    db.query(Module).filter(Module.course_id == course.id).update({Module.deleted_at: None}, synchronize_session=False)
+    module_ids = select(Module.id).where(Module.course_id == course.id).scalar_subquery()
+    db.query(Chapter).filter(Chapter.module_id.in_(module_ids)).update(
+        {Chapter.deleted_at: None}, synchronize_session=False
+    )
     db.commit()
     db.refresh(course)
     return course

--- a/backend/app/services/course_service/_modules.py
+++ b/backend/app/services/course_service/_modules.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import func
 
-from app.models.course import Module
+from app.models.course import Chapter, Module
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -57,6 +57,11 @@ def update_module(db: Session, module: Module, data: ModuleUpdate) -> Module:
 def delete_module(db: Session, module: Module) -> None:
     now = datetime.now(UTC)
     module.deleted_at = now
-    for chapter in module.chapters:
-        chapter.deleted_at = now
+    # Bulk UPDATE so the cascade is one round trip regardless of chapter count
+    # and works whether ``module.chapters`` was eager-loaded with a deleted_at
+    # filter or not.
+    db.query(Chapter).filter(
+        Chapter.module_id == module.id,
+        Chapter.deleted_at.is_(None),
+    ).update({Chapter.deleted_at: now}, synchronize_session=False)
     db.commit()

--- a/backend/app/services/course_service/_queries.py
+++ b/backend/app/services/course_service/_queries.py
@@ -23,7 +23,16 @@ if TYPE_CHECKING:
 # chained ``joinedload`` would produce: one IN query per level means the
 # catalog page fetches ~3 rows of wire instead of ``courses * modules *
 # chapters`` when a course has many chapters.
-_COURSE_TREE: tuple = (selectinload(Course.modules).selectinload(Module.chapters),)
+#
+# The ``.and_()`` filters strip soft-deleted children at load time so the
+# course tree mirrors what students actually see. Trash and restore flows
+# operate via bulk UPDATEs (see ``_courses.delete_course`` / ``restore_course``)
+# so they don't depend on this filtered relationship.
+_COURSE_TREE: tuple = (
+    selectinload(Course.modules.and_(Module.deleted_at.is_(None))).selectinload(
+        Module.chapters.and_(Chapter.deleted_at.is_(None))
+    ),
+)
 
 
 def get_courses(
@@ -78,7 +87,7 @@ def get_teacher_courses(
 def get_module(db: Session, course_id: str, module_id: str) -> Module | None:
     return (
         db.query(Module)
-        .options(joinedload(Module.chapters))
+        .options(joinedload(Module.chapters.and_(Chapter.deleted_at.is_(None))))
         .filter(
             Module.id == module_id,
             Module.course_id == course_id,


### PR DESCRIPTION
## Summary

Final pre-release pass — practical perf + security audit (per the "no 1000 lines for 1ms" / "no 10 files for an unlikely vuln" mandate). One real user-facing bug fell out of the audit; everything else was already in good shape.

### The bug

When a teacher deletes a single chapter or module via the editor, the row is soft-deleted (`deleted_at` is set). But the catalog and course-detail endpoints kept returning those rows because the eager loaders on `_COURSE_TREE` and `get_module` walked the `Course.modules` / `Module.chapters` relationships without a `deleted_at IS NULL` filter. Result: students browsing a published course would see the trashed entry in the sidebar — and a 404 when they clicked it.

### The fix

- `_queries.py`: loaders now filter at the relationship level via `Course.modules.and_(Module.deleted_at.is_(None))` / `Module.chapters.and_(Chapter.deleted_at.is_(None))`. Soft-deleted children no longer leak into list/detail responses.
- `_courses.delete_course` / `_modules.delete_module`: switched from per-row attribute writes to bulk `UPDATE` statements. Soft-deleting a course with hundreds of chapters is now ~3 round trips total instead of one per row — incidental perf win on top of the correctness fix.
- `_courses.restore_course`: also moved to bulk `UPDATE`. It can't rely on `course.modules` anymore (which is now empty for trashed courses thanks to the loader filter), so the direct `UPDATE` on `Module` and `Chapter` is the source of truth.

### Audit notes (what was already fine)

- **JWT**: PyJWT decode with explicit `algorithms=` and `audience="authenticated"` — no algorithm-confusion or audience-skip surface.
- **Raw SQL**: only `SELECT 1` in `/health/db`. Search query parameters go through `func.plainto_tsquery` and escaped `ilike` patterns — no injection surface.
- **XSS**: a single `dangerouslySetInnerHTML` site (`ChapterView.tsx`) and it consumes pre-sanitised HTML; the API also re-runs DOMPurify on every block write (defence in depth).
- **IDOR**: chapter blocks gated by `verify_chapter_access` (admin / owner / enrolled-and-published); course mutations gated by `assert_course_owner`. Spot-checked the catalog — the public path is intentional and only exposes published courses + module skeletons (no block content).
- **Rate limiting**: in-memory limiter on `/api/v1/auth/*` (10/60s) plus the documented Vercel WAF as the hard backstop.
- **DB indexes**: covered for hot access patterns (FK + composite for `(course_id, order_index)` etc.); the partial `WHERE deleted_at IS NULL` indexes already align with the new filtered loaders.
- **N+1**: catalog and course tree use `selectinload` so the wire count is constant per level. Progress aggregation runs in a single `COUNT FILTER` query.

### Test plan

- [x] `ruff check . && ruff format --check .` clean
- [x] `mypy app` — 0 errors across 90 source files
- [x] `pytest -x` — 396/396 pass (incl. the full trash + restore suite, course-clone test)
- [x] No frontend changes; student/teacher views auto-pick-up the fix via the same endpoints
