### PR TITLE
chore(deps): bump @datadog/browser-rum* to 6.33.0 together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,13 @@ updates:
       supabase:
         patterns:
           - "@supabase/*"
+      # @datadog/browser-rum and @datadog/browser-rum-react share an internal
+      # @datadog/browser-rum-core peer; bumping them out of sync produces a
+      # type-mismatch (two copies of the RumPlugin type), so they have to move
+      # together.
+      datadog:
+        patterns:
+          - "@datadog/*"
       dev-types:
         dependency-type: "development"
         patterns:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "biblie-school-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@datadog/browser-rum": "^6.32.0",
-        "@datadog/browser-rum-react": "^6.32.0",
+        "@datadog/browser-rum": "^6.33.0",
+        "@datadog/browser-rum-react": "^6.33.0",
         "@fontsource-variable/fraunces": "^5.2.9",
         "@fontsource-variable/inter": "^5.2.8",
         "@hello-pangea/dnd": "^18.0.1",
@@ -613,29 +613,6 @@
         "react-router-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -615,6 +615,31 @@
         }
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3368,9 +3393,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.10.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
+      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3485,9 +3510,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {
@@ -3825,9 +3850,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,8 +16,8 @@
     "test:run": "vitest run"
   },
   "dependencies": {
-    "@datadog/browser-rum": "^6.32.0",
-    "@datadog/browser-rum-react": "^6.32.0",
+    "@datadog/browser-rum": "^6.33.0",
+    "@datadog/browser-rum-react": "^6.33.0",
     "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",
     "@hello-pangea/dnd": "^18.0.1",


### PR DESCRIPTION
## Summary

Replaces and closes #95. Dependabot bumped only `@datadog/browser-rum`
to 6.33.0, leaving `@datadog/browser-rum-react` on 6.32.x. Both packages
share an internal `@datadog/browser-rum-core` peer dependency, so the
React plugin ended up typed against a different `RumPlugin` than the one
`datadogRum.init()` accepted, producing a TS2322 in `src/lib/datadog.ts`
and breaking Frontend CI.

This bumps both packages together to 6.33.0 and adds a `datadog` group
to `.github/dependabot.yml` so any future RUM bump stays bundled.

## Changes

- `frontend/package.json`: `@datadog/browser-rum` and
  `@datadog/browser-rum-react` → `^6.33.0`.
- `frontend/package-lock.json`: corresponding lockfile entries.
- `.github/dependabot.yml`: new `datadog` group covering `@datadog/*`.

## Test plan

- [x] `npx tsc --noEmit` — clean (was failing on PR #95)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test:run` — 85 passed
- [x] No runtime behaviour change (RUM init signature unchanged; this is
      purely a type/peer alignment).

## Out of scope

Triggering RUM in environments where it's currently disabled — this
preserves the existing opt-in behaviour controlled by
`VITE_DATADOG_APPLICATION_ID` / `VITE_DATADOG_CLIENT_TOKEN`.
