### PR TITLE
feat(translation): trigger Gemini pipeline on draft->published

### DIFF
--- a/backend/app/api/v1/courses/__init__.py
+++ b/backend/app/api/v1/courses/__init__.py
@@ -14,6 +14,7 @@ from . import chapters as _chapters  # noqa: F401
 from . import crud as _crud  # noqa: F401
 from . import enrollment as _enrollment  # noqa: F401
 from . import modules as _modules  # noqa: F401
+from . import translate as _translate  # noqa: F401
 from ._router import router
 
 __all__ = ["router"]

--- a/backend/app/api/v1/courses/crud.py
+++ b/backend/app/api/v1/courses/crud.py
@@ -1,5 +1,7 @@
 """Course-level write endpoints: create / update / delete / clone / restore."""
 
+import logging
+
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
@@ -19,8 +21,11 @@ from app.services.course_service import (
     restore_course,
     update_course,
 )
+from app.services.translation.orchestrator import translate_course_metadata
 
 from ._router import router
+
+logger = logging.getLogger(__name__)
 
 
 @router.post("", response_model=CourseResponse, status_code=status.HTTP_201_CREATED)
@@ -61,8 +66,21 @@ def update_existing_course(
         details = {"old_status": old_status, "new_status": data.status}
     # Special-case draft→published so the audit log distinguishes a
     # publication event from a generic update.
-    action = "publish" if data.status == "published" and old_status != "published" else "update"
+    is_publish_event = data.status == "published" and old_status != "published"
+    action = "publish" if is_publish_event else "update"
     log_action(db, teacher.id, action, "course", course_id, details=details or None, request=request)
+
+    # Kick off the translation pipeline on first publish. We run it
+    # synchronously inside the request so the catalog has translated metadata
+    # by the time the teacher's "Publish" toast settles. Errors must NOT
+    # block the publish itself — the orchestrator already persists
+    # ``status='failed'`` rows for retries, so we just log and move on.
+    if is_publish_event:
+        try:
+            translate_course_metadata(db, result)
+        except Exception:
+            logger.exception("Translation hook failed for course %s", course_id)
+
     return result
 
 

--- a/backend/app/api/v1/courses/translate.py
+++ b/backend/app/api/v1/courses/translate.py
@@ -1,0 +1,70 @@
+"""Manual translation backfill for already-published courses.
+
+The ``draft → published`` hook in ``crud.py`` covers every new publish, but
+courses that were already live before the translation pipeline shipped need
+a way to get their ``content_translations`` rows seeded after the fact. This
+endpoint exposes a teacher-only "Translate now" action for exactly that
+case.
+
+Designed to be safe to call repeatedly: the orchestrator's
+``source_hash`` short-circuit means re-translating an unchanged course costs
+zero Gemini calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import Depends, HTTPException, status
+
+from app.api.dependencies import assert_course_owner, require_teacher
+from app.core.database import get_db
+from app.schemas.course import CourseTranslationResponse
+from app.services.course_service import get_course
+from app.services.translation.orchestrator import translate_course_metadata
+from app.services.translation.service import is_translation_enabled
+
+from ._router import router
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+@router.post("/{course_id}/translate", response_model=CourseTranslationResponse)
+def trigger_course_translation(
+    course_id: str,
+    teacher: User = Depends(require_teacher),
+    db: Session = Depends(get_db),
+) -> CourseTranslationResponse:
+    """Run the translation pipeline against an existing course.
+
+    Authorization mirrors the rest of the course write surface — the owner
+    or an admin can trigger it; everyone else gets a 404. The body returns
+    a counter so the UI can render a "translated 2 fields" toast.
+    """
+    course = get_course(db, course_id)
+    if not course:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Course '{course_id}' not found",
+        )
+    assert_course_owner(course, teacher, allow_admin=True)
+
+    if not is_translation_enabled():
+        # Surface the disabled state explicitly so the UI can render a
+        # "translation provider not configured" hint instead of a
+        # silent no-op.
+        return CourseTranslationResponse(enabled=False)
+
+    report = translate_course_metadata(db, course)
+    return CourseTranslationResponse(
+        translated=report.translated,
+        skipped=report.skipped,
+        failed=report.failed,
+        enabled=True,
+    )

--- a/backend/app/schemas/course.py
+++ b/backend/app/schemas/course.py
@@ -167,3 +167,17 @@ class EnrollmentSummaryResponse(BaseModel):
     enrolled_at: datetime
     progress: int
     course: CourseSummary | None = None
+
+
+class CourseTranslationResponse(BaseModel):
+    """Summary returned by the manual ``POST /courses/{id}/translate`` hook.
+
+    Mirrors ``OrchestratorReport`` from the translation service so the
+    teacher UI can show "X translated, Y skipped, Z failed" without having
+    to re-shape the payload on the client.
+    """
+
+    translated: int = 0
+    skipped: int = 0
+    failed: int = 0
+    enabled: bool = True

--- a/backend/app/services/translation/orchestrator.py
+++ b/backend/app/services/translation/orchestrator.py
@@ -1,0 +1,344 @@
+"""Domain-level translation orchestrator.
+
+The provider in ``app.services.translation.gemini`` only knows how to turn a
+single chunk of text into another chunk of text. This module wraps that
+primitive with the persistence + idempotency rules the rest of the app needs:
+
+* Look up the existing ``content_translations`` row (if any) for the
+  ``(entity_type, entity_id, field, locale)`` tuple.
+* Skip the call when the source text is unchanged (``source_hash`` match)
+  and the row is already ``status='ok'``.
+* Never overwrite a ``origin='human'`` row — those are manual overrides.
+* Persist a ``status='failed'`` row when a provider call raises, so the
+  failed-rows queue UI (Wave 2 follow-up) can find them.
+
+Caller responsibilities:
+* Pass canonical, sanitized source text. The orchestrator does **not**
+  re-sanitize HTML — that already happened at the model edge.
+* Decide which target locales to translate into. The default helper
+  ``other_locales`` covers the common case (everything except the source).
+
+Public surface kept intentionally small (one function per concern) so the
+``draft → published`` hook reads as plain English at the call site.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.models.content_translation import (
+    ContentTranslation,
+    TranslationEntityType,
+    TranslationField,
+)
+from app.schemas.locale import LOCALE_CODES, LocaleCode
+from app.services.translation.hash import compute_source_hash
+from app.services.translation.protocol import (
+    TranslationError,
+    TranslationProvider,
+    TranslationRequest,
+)
+from app.services.translation.service import (
+    get_translation_provider,
+    is_translation_enabled,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from app.models.course import Course
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class TranslationFieldSpec:
+    """One ``(field, text, content_kind)`` tuple to translate.
+
+    ``text`` is allowed to be empty / ``None``; the orchestrator skips those
+    rows so the caller can build the spec list naively without filtering.
+    """
+
+    field: TranslationField
+    text: str | None
+    # See ``TranslationRequest.content_kind`` — chooses prompt nuances.
+    content_kind: str = "plain"
+
+
+@dataclass(frozen=True, slots=True)
+class OrchestratorReport:
+    """Lightweight summary returned to the caller.
+
+    Useful both in tests and in admin endpoints that surface a quick "X
+    fields translated, Y skipped" toast in the UI.
+    """
+
+    translated: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+def other_locales(source_locale: LocaleCode) -> tuple[LocaleCode, ...]:
+    """Return every supported locale other than ``source_locale``.
+
+    Wrapped in a function (not a constant) because adding a new locale to
+    ``LOCALE_CODES`` should automatically extend this tuple — see
+    ``app/schemas/locale.py`` for the three-step language-rollout checklist.
+    """
+    return tuple(code for code in LOCALE_CODES if code != source_locale)
+
+
+def translate_entity_fields(
+    db: Session,
+    *,
+    entity_type: TranslationEntityType,
+    entity_id: str,
+    source_locale: LocaleCode,
+    fields: list[TranslationFieldSpec],
+    target_locales: tuple[LocaleCode, ...] | None = None,
+    context: str | None = None,
+    provider: TranslationProvider | None = None,
+) -> OrchestratorReport:
+    """Translate ``fields`` of ``(entity_type, entity_id)`` into each target.
+
+    Returns a per-call summary. Never raises for ordinary translation
+    failures — those become ``status='failed'`` rows. Re-raises only on
+    SQLAlchemy errors, which surface bugs that the caller does want to see.
+    """
+    if not is_translation_enabled():
+        # Don't burn DB writes when there's no real provider configured;
+        # the noop fallback would just echo the source text back.
+        logger.info("Translation disabled; skipping %s:%s", entity_type, entity_id)
+        return OrchestratorReport()
+
+    targets = target_locales if target_locales is not None else other_locales(source_locale)
+    if not targets:
+        return OrchestratorReport()
+
+    active_provider = provider or get_translation_provider()
+    translated = 0
+    skipped = 0
+    failed = 0
+
+    for spec in fields:
+        text = (spec.text or "").strip()
+        if not text:
+            # Empty source has nothing to translate; we also actively avoid
+            # creating empty translation rows that would later round-trip
+            # back into the UI as blanks.
+            skipped += len(targets)
+            continue
+
+        source_hash = compute_source_hash(text, locale=source_locale)
+        for target in targets:
+            outcome = _translate_one_field(
+                db,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                field=spec.field,
+                source_locale=source_locale,
+                target_locale=target,
+                text=text,
+                content_kind=spec.content_kind,
+                source_hash=source_hash,
+                context=context,
+                provider=active_provider,
+            )
+            if outcome == "translated":
+                translated += 1
+            elif outcome == "skipped":
+                skipped += 1
+            else:
+                failed += 1
+
+    try:
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise
+
+    logger.info(
+        "Translation orchestrator finished entity=%s:%s translated=%d skipped=%d failed=%d",
+        entity_type,
+        entity_id,
+        translated,
+        skipped,
+        failed,
+    )
+    return OrchestratorReport(translated=translated, skipped=skipped, failed=failed)
+
+
+def translate_course_metadata(
+    db: Session,
+    course: Course,
+    *,
+    provider: TranslationProvider | None = None,
+) -> OrchestratorReport:
+    """Translate ``title`` + ``description`` for a course into every other locale.
+
+    Wave 2 will extend this to module/chapter titles and chapter blocks; the
+    course-level metadata is what the catalog and SEO snippets read, so it's
+    the highest-leverage subset to ship first.
+    """
+    fields: list[TranslationFieldSpec] = [
+        TranslationFieldSpec(field="title", text=course.title, content_kind="title"),
+        TranslationFieldSpec(field="description", text=course.description, content_kind="plain"),
+    ]
+    source_locale: LocaleCode = _coerce_locale(course.source_locale)
+    return translate_entity_fields(
+        db,
+        entity_type="course",
+        entity_id=str(course.id),
+        source_locale=source_locale,
+        fields=fields,
+        context=f"Course title: {course.title}" if course.title else None,
+        provider=provider,
+    )
+
+
+def _translate_one_field(
+    db: Session,
+    *,
+    entity_type: TranslationEntityType,
+    entity_id: str,
+    field: TranslationField,
+    source_locale: LocaleCode,
+    target_locale: LocaleCode,
+    text: str,
+    content_kind: str,
+    source_hash: str,
+    context: str | None,
+    provider: TranslationProvider,
+) -> str:
+    """Translate (or up-to-date short-circuit) one ``(field, target)`` row.
+
+    Returns ``"translated" | "skipped" | "failed"`` so the orchestrator can
+    aggregate counters without inspecting the DB row again.
+    """
+    existing = (
+        db.query(ContentTranslation)
+        .filter(
+            ContentTranslation.entity_type == entity_type,
+            ContentTranslation.entity_id == entity_id,
+            ContentTranslation.field == field,
+            ContentTranslation.locale == target_locale,
+        )
+        .one_or_none()
+    )
+
+    # ``origin='human'`` means a teacher manually wrote a localized copy;
+    # the auto-pipeline must never clobber that, even if the source mutated.
+    if existing is not None and existing.origin == "human":
+        return "skipped"
+
+    if existing is not None and existing.status == "ok" and existing.source_hash == source_hash:
+        return "skipped"
+
+    request = TranslationRequest(
+        text=text,
+        source_locale=source_locale,
+        target_locale=target_locale,
+        content_kind=content_kind,
+        context=context,
+    )
+    try:
+        result = provider.translate(request)
+    except TranslationError as exc:
+        logger.warning(
+            "Translation failed entity=%s:%s field=%s locale=%s err=%s",
+            entity_type,
+            entity_id,
+            field,
+            target_locale,
+            exc,
+        )
+        _persist_translation(
+            db,
+            existing=existing,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            target_locale=target_locale,
+            text=existing.text if existing is not None else text,
+            source_hash=source_hash,
+            status="failed",
+        )
+        return "failed"
+
+    _persist_translation(
+        db,
+        existing=existing,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        target_locale=target_locale,
+        text=result.text,
+        source_hash=source_hash,
+        status="ok",
+    )
+    return "translated"
+
+
+def _persist_translation(
+    db: Session,
+    *,
+    existing: ContentTranslation | None,
+    entity_type: TranslationEntityType,
+    entity_id: str,
+    field: TranslationField,
+    target_locale: LocaleCode,
+    text: str,
+    source_hash: str,
+    status: str,
+) -> None:
+    """Insert or update one translation row.
+
+    Caller is responsible for committing — letting the orchestrator batch
+    the commit means a partially-failed batch still leaves a coherent set of
+    rows on disk (or none at all on rollback).
+    """
+    if existing is None:
+        row = ContentTranslation(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            locale=target_locale,
+            text=text,
+            source_hash=source_hash,
+            status=status,
+            origin="mt",
+        )
+        db.add(row)
+        return
+
+    existing.text = text
+    existing.source_hash = source_hash
+    existing.status = status
+
+
+def _coerce_locale(value: str | None) -> LocaleCode:
+    """Narrow a runtime ``str`` to ``LocaleCode``.
+
+    ``Course.source_locale`` is a plain Postgres TEXT column (CHECK-constrained
+    to ``ru | en``), so SQLAlchemy hands us back ``str``. mypy needs help to
+    treat it as the literal type the rest of the pipeline expects.
+    """
+    for code in LOCALE_CODES:
+        if value == code:
+            return code
+    # Unknown locales fall back to Russian — matches ``DEFAULT_LOCALE`` and
+    # the server-default on ``courses.source_locale``.
+    return "ru"
+
+
+__all__ = [
+    "OrchestratorReport",
+    "TranslationFieldSpec",
+    "other_locales",
+    "translate_course_metadata",
+    "translate_entity_fields",
+]

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -1,0 +1,401 @@
+"""Tests for the domain-level translation orchestrator + publish hook.
+
+These tests exercise the orchestrator without going through Gemini: a fake
+``TranslationProvider`` is injected so we can assert exactly which calls
+are made and how the resulting ``content_translations`` rows look.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from app.models.content_translation import ContentTranslation
+from app.models.course import Course
+from app.models.user import User
+from app.services.translation.orchestrator import (
+    TranslationFieldSpec,
+    other_locales,
+    translate_course_metadata,
+    translate_entity_fields,
+)
+from app.services.translation.protocol import (
+    TranslationError,
+    TranslationRequest,
+    TranslationResult,
+)
+from app.services.translation.service import reset_translation_provider_cache
+from tests.conftest import TEACHER_ID
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+# ---------------------------------------------------------------------------
+# Fake provider — captures every call so tests can assert on them.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingProvider:
+    name = "recording"
+
+    def __init__(self, *, failures: set[str] | None = None) -> None:
+        self.calls: list[TranslationRequest] = []
+        self._failures = failures or set()
+
+    def translate(self, request: TranslationRequest) -> TranslationResult:
+        self.calls.append(request)
+        if request.text in self._failures:
+            raise TranslationError(f"forced failure for {request.text!r}")
+        # Return a deterministic, distinguishable string per target locale so
+        # assertions can pinpoint which row a translation produced.
+        return TranslationResult(text=f"[{request.target_locale}]{request.text}", model="test")
+
+    def translate_batch(self, requests: list[TranslationRequest]) -> list[TranslationResult]:
+        return [self.translate(r) for r in requests]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_teacher(db: Session) -> None:
+    """Seed the teacher row required by the ``courses.created_by`` FK.
+
+    The orchestrator unit tests don't use the ``teacher`` fixture (they
+    operate on ``db`` directly), so we insert the row on demand. A duplicate
+    insert is harmless because we check first.
+    """
+    if db.get(User, TEACHER_ID) is not None:
+        return
+    db.add(
+        User(
+            id=TEACHER_ID,
+            email="teacher@example.com",
+            full_name="Test Teacher",
+            role="teacher",
+        )
+    )
+    db.commit()
+
+
+def _make_course(db: Session, **overrides: Any) -> Course:
+    _ensure_teacher(db)
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "title": "Acts of the Apostles",
+        "description": "An overview of the early Church.",
+        "status": "draft",
+        "source_locale": "ru",
+        "created_by": TEACHER_ID,
+    }
+    defaults.update(overrides)
+    course = Course(**defaults)
+    db.add(course)
+    db.commit()
+    db.refresh(course)
+    return course
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_other_locales_excludes_source():
+    assert other_locales("ru") == ("en",)
+    assert other_locales("en") == ("ru",)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _enable_translation(monkeypatch):
+    """Make the orchestrator believe a provider is configured.
+
+    The default ``GEMINI_API_KEY`` is unset in tests, which would short-circuit
+    ``is_translation_enabled`` to ``False`` and skip every call. We patch the
+    settings field directly so the orchestrator runs end-to-end.
+    """
+    monkeypatch.setattr(
+        "app.services.translation.service.settings.GEMINI_API_KEY",
+        "fake-test-key",
+        raising=False,
+    )
+    reset_translation_provider_cache()
+    yield
+    reset_translation_provider_cache()
+
+
+def test_translate_course_metadata_writes_rows_for_each_target(db: Session):
+    course = _make_course(db)
+    provider = _RecordingProvider()
+
+    report = translate_course_metadata(db, course, provider=provider)
+
+    # ru source -> en target x 2 fields (title + description)
+    assert report.translated == 2
+    assert report.failed == 0
+
+    rows = db.query(ContentTranslation).filter_by(entity_type="course", entity_id=course.id).all()
+    assert {(r.field, r.locale) for r in rows} == {("title", "en"), ("description", "en")}
+    assert all(r.status == "ok" for r in rows)
+    assert all(r.origin == "mt" for r in rows)
+    assert all(r.text.startswith("[en]") for r in rows)
+
+
+def test_translate_course_metadata_skips_unchanged_source(db: Session):
+    course = _make_course(db)
+    provider = _RecordingProvider()
+
+    translate_course_metadata(db, course, provider=provider)
+    first_call_count = len(provider.calls)
+    assert first_call_count == 2
+
+    # Re-running with the same source text must short-circuit on source_hash.
+    report = translate_course_metadata(db, course, provider=provider)
+    assert len(provider.calls) == first_call_count, "provider should not be re-invoked"
+    assert report.skipped == 2
+    assert report.translated == 0
+
+
+def test_translate_course_metadata_retranslates_when_source_changes(db: Session):
+    course = _make_course(db)
+    provider = _RecordingProvider()
+
+    translate_course_metadata(db, course, provider=provider)
+
+    course.title = "Acts of the Apostles — Revised"
+    db.commit()
+
+    report = translate_course_metadata(db, course, provider=provider)
+    assert report.translated == 1  # only title changed
+    assert report.skipped == 1  # description unchanged
+
+    title_row = (
+        db.query(ContentTranslation)
+        .filter_by(entity_type="course", entity_id=course.id, field="title", locale="en")
+        .one()
+    )
+    assert title_row.text == "[en]Acts of the Apostles — Revised"
+
+
+def test_translate_course_metadata_preserves_human_translations(db: Session):
+    course = _make_course(db)
+    provider = _RecordingProvider()
+
+    db.add(
+        ContentTranslation(
+            entity_type="course",
+            entity_id=course.id,
+            field="title",
+            locale="en",
+            text="Hand-crafted English title",
+            source_hash="0" * 32,  # intentionally stale
+            status="ok",
+            origin="human",
+        )
+    )
+    db.commit()
+
+    report = translate_course_metadata(db, course, provider=provider)
+
+    # Title was human-edited so the orchestrator must not touch it; the
+    # description still lacks a row, so that one gets created.
+    title_row = (
+        db.query(ContentTranslation)
+        .filter_by(entity_type="course", entity_id=course.id, field="title", locale="en")
+        .one()
+    )
+    assert title_row.origin == "human"
+    assert title_row.text == "Hand-crafted English title"
+    assert report.skipped >= 1
+    assert report.translated == 1  # description
+
+
+def test_translate_entity_fields_records_failed_rows(db: Session):
+    course = _make_course(db)
+    provider = _RecordingProvider(failures={course.title or ""})
+
+    report = translate_entity_fields(
+        db,
+        entity_type="course",
+        entity_id=str(course.id),
+        source_locale="ru",
+        fields=[
+            TranslationFieldSpec(field="title", text=course.title, content_kind="title"),
+            TranslationFieldSpec(field="description", text=course.description),
+        ],
+        provider=provider,
+    )
+
+    assert report.failed == 1
+    assert report.translated == 1
+
+    title_row = (
+        db.query(ContentTranslation)
+        .filter_by(entity_type="course", entity_id=course.id, field="title", locale="en")
+        .one()
+    )
+    assert title_row.status == "failed"
+
+
+def test_translate_entity_fields_skips_empty_text(db: Session):
+    course = _make_course(db, description=None)
+    provider = _RecordingProvider()
+
+    report = translate_entity_fields(
+        db,
+        entity_type="course",
+        entity_id=str(course.id),
+        source_locale="ru",
+        fields=[
+            TranslationFieldSpec(field="title", text=course.title),
+            TranslationFieldSpec(field="description", text=None),
+        ],
+        provider=provider,
+    )
+
+    assert report.translated == 1
+    # Empty description must NOT have called the provider.
+    assert all(req.text != "" for req in provider.calls)
+    rows = db.query(ContentTranslation).filter_by(entity_type="course", entity_id=course.id).all()
+    assert {r.field for r in rows} == {"title"}
+
+
+def test_translate_entity_fields_no_op_when_provider_disabled(monkeypatch, db: Session):
+    monkeypatch.setattr(
+        "app.services.translation.service.settings.GEMINI_API_KEY",
+        None,
+        raising=False,
+    )
+    reset_translation_provider_cache()
+
+    course = _make_course(db)
+    report = translate_course_metadata(db, course)
+
+    assert (report.translated, report.skipped, report.failed) == (0, 0, 0)
+    assert db.query(ContentTranslation).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level integration: publish hook + manual trigger endpoint
+# ---------------------------------------------------------------------------
+
+
+def _patch_provider(monkeypatch, provider: _RecordingProvider) -> None:
+    monkeypatch.setattr(
+        "app.api.v1.courses.crud.translate_course_metadata",
+        lambda db, course: translate_course_metadata(db, course, provider=provider),
+    )
+    monkeypatch.setattr(
+        "app.api.v1.courses.translate.translate_course_metadata",
+        lambda db, course: translate_course_metadata(db, course, provider=provider),
+    )
+
+
+def test_publishing_a_course_triggers_translation(monkeypatch, client: TestClient):
+    provider = _RecordingProvider()
+    _patch_provider(monkeypatch, provider)
+
+    course = client.post(
+        "/api/v1/courses",
+        json={"title": "Genesis Overview", "description": "Intro to Genesis."},
+    ).json()
+
+    assert provider.calls == [], "draft create must not translate"
+
+    resp = client.put(f"/api/v1/courses/{course['id']}", json={"status": "published"})
+    assert resp.status_code == 200
+    assert len(provider.calls) == 2  # title + description
+
+
+def test_publishing_does_not_translate_again_on_idempotent_update(monkeypatch, client: TestClient):
+    provider = _RecordingProvider()
+    _patch_provider(monkeypatch, provider)
+
+    course = client.post(
+        "/api/v1/courses",
+        json={"title": "Acts", "description": "Course."},
+    ).json()
+
+    client.put(f"/api/v1/courses/{course['id']}", json={"status": "published"})
+    assert len(provider.calls) == 2
+
+    # Publishing-while-already-published must not re-trigger the hook.
+    client.put(f"/api/v1/courses/{course['id']}", json={"status": "published"})
+    assert len(provider.calls) == 2
+
+
+def test_publish_hook_swallows_translation_failures(monkeypatch, client: TestClient):
+    """A Gemini outage must not block ``draft → published``."""
+    provider = _RecordingProvider()
+
+    def _boom(_db, _course):
+        raise RuntimeError("simulated translation outage")
+
+    monkeypatch.setattr("app.api.v1.courses.crud.translate_course_metadata", _boom)
+    monkeypatch.setattr(
+        "app.api.v1.courses.translate.translate_course_metadata",
+        lambda db, course: translate_course_metadata(db, course, provider=provider),
+    )
+
+    course = client.post("/api/v1/courses", json={"title": "Genesis"}).json()
+    resp = client.put(f"/api/v1/courses/{course['id']}", json={"status": "published"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "published"
+
+
+def test_manual_translate_endpoint_backfills_existing_courses(monkeypatch, client: TestClient):
+    provider = _RecordingProvider()
+    _patch_provider(monkeypatch, provider)
+
+    course = client.post(
+        "/api/v1/courses",
+        json={"title": "Acts", "description": "Course on Acts."},
+    ).json()
+
+    # Publish *without* the hook running so we end up in the "already
+    # published, no translations yet" state that prod is in for legacy
+    # courses.
+    monkeypatch.setattr(
+        "app.api.v1.courses.crud.translate_course_metadata",
+        lambda db, course: None,
+    )
+    client.put(f"/api/v1/courses/{course['id']}", json={"status": "published"})
+    assert provider.calls == []
+
+    # Now restore the patched orchestrator and call the manual endpoint.
+    _patch_provider(monkeypatch, provider)
+    resp = client.post(f"/api/v1/courses/{course['id']}/translate")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["enabled"] is True
+    assert body["translated"] == 2
+    assert body["failed"] == 0
+
+
+def test_manual_translate_endpoint_returns_disabled_when_provider_off(monkeypatch, client: TestClient):
+    monkeypatch.setattr(
+        "app.services.translation.service.settings.GEMINI_API_KEY",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.api.v1.courses.translate.is_translation_enabled",
+        lambda: False,
+    )
+
+    course = client.post("/api/v1/courses", json={"title": "Acts"}).json()
+
+    resp = client.post(f"/api/v1/courses/{course['id']}/translate")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["translated"] == 0


### PR DESCRIPTION
## Summary

Wave 1 of the multilingual rollout (PR #89) wired up the translation provider, schema, and locale infrastructure but **intentionally did not invoke the pipeline anywhere**, so no Gemini calls were ever produced after a course was published. This PR closes that gap.

### What's new
- `app/services/translation/orchestrator.py` — domain-level wrapper that upserts `content_translations` rows with idempotency rules (`source_hash` short-circuit, `origin='human'` never overwritten, `status='failed'` rows persisted for retries).
- Hook inside `PUT /api/v1/courses/{id}` so a `draft -> published` transition translates `title` + `description` into every non-source locale before responding. Failures are logged but **never block the publish**.
- New `POST /api/v1/courses/{id}/translate` endpoint to backfill already-published courses (e.g. "Деяния Апостолов"). Safe to call repeatedly thanks to the orchestrator's hash-based skip.

### Test plan
- [x] `pytest` — 431 passing, including 13 new orchestrator/integration tests.
- [x] `mypy app` — clean.
- [x] `ruff check` + `ruff format --check` — clean.
- [ ] Vercel preview / production: publish a draft course and confirm new rows in `content_translations`.
- [ ] Hit `POST /api/v1/courses/{id}/translate` for an existing published course and confirm a `200` with non-zero `translated`.

### Out of scope (Wave 2)
- Module / chapter / chapter-block / quiz translations.
- Stale-rows admin UI.
- Async/background processing (current hook is synchronous, fine for course-level metadata).
