### PR TITLE
chore(supabase): revoke handle_new_user EXECUTE from anon/authenticated

### DIFF
--- a/supabase/migrations/20260506231600_revoke_handle_new_user_execute.sql
+++ b/supabase/migrations/20260506231600_revoke_handle_new_user_execute.sql
@@ -1,0 +1,16 @@
+-- Supabase migration: revoke_handle_new_user_execute
+-- Version: 20260506231600
+--
+-- Hardens the auto-profile-creation trigger function. Postgres functions
+-- inherit EXECUTE for PUBLIC by default, and Supabase auto-exposes any
+-- SECURITY DEFINER function in the public schema via PostgREST as
+-- /rest/v1/rpc/<name>. Revoking EXECUTE removes that RPC endpoint so
+-- handle_new_user can only fire as the AFTER INSERT trigger on
+-- auth.users (trigger invocation does not check EXECUTE on the function).
+--
+-- Addresses Supabase Advisor lints 0028 and 0029
+-- (anon_/authenticated_security_definer_function_executable).
+
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM authenticated;


### PR DESCRIPTION
## Summary
- Revoke `EXECUTE` on `public.handle_new_user()` from `PUBLIC`, `anon`, and `authenticated` so it can no longer be invoked via the auto-exposed PostgREST RPC at `/rest/v1/rpc/handle_new_user`.
- The `AFTER INSERT ON auth.users` trigger continues to fire (Postgres triggers don't check function `EXECUTE` grants).
- Closes Supabase Advisor lints **0028** (`anon_security_definer_function_executable`) and **0029** (`authenticated_security_definer_function_executable`) from the security advisor.

## Context
`handle_new_user` is the trigger that auto-creates a `public.profiles` row when a new auth user signs up (sets role from `raw_user_meta_data` → `pending_teacher` or `student`, never `teacher` directly, so the existing role-gating stays intact). Because it lives in `public` and is `SECURITY DEFINER`, PostgREST exposes it as RPC unless EXECUTE is revoked — that surface was unintended.

## Already-applied note
The same SQL has already been applied to production via Supabase MCP `apply_migration` (commit captures the file in the migration source-of-truth directory). Re-running `get_advisors` after the apply confirmed both 0028 and 0029 cleared.

## Test plan
- [x] `supabase/migrations/<ts>_revoke_handle_new_user_execute.sql` matches what was applied
- [x] Post-apply: `information_schema.role_routine_grants` shows EXECUTE only for `postgres` + `service_role`
- [x] Post-apply: `get_advisors` returns 2 fewer security WARNs
- [ ] Backend CI green on this branch
- [ ] After merge: signup flow on Vercel preview still creates a `profiles` row (trigger still fires)

## Out of scope
- `auth_leaked_password_protection` (the third advisor WARN) — Auth setting, not SQL; toggled via dashboard at https://supabase.com/dashboard/project/rrisqutxlkamwfhcashl/auth/providers.
- 32 INFO-level "Unused Index" advisors — defer until production traffic patterns are observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
