### PR TITLE
fix(i18n): close locale switcher race + harden locale state machine

### DIFF
--- a/frontend/src/components/layout/LanguageSwitcher.tsx
+++ b/frontend/src/components/layout/LanguageSwitcher.tsx
@@ -5,11 +5,12 @@ import { Globe } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/context/useAuth"
 import {
-  LOCALE_STORAGE_KEY,
   SUPPORTED_LOCALES,
   isSupportedLocale,
   type SupportedLocale,
 } from "@/i18n/config"
+import { setDesiredLocale } from "@/i18n/useLocaleSync"
+import { toast } from "@/lib/toast"
 import { preferencesService } from "@/services/preferences"
 
 interface LanguageSwitcherProps {
@@ -35,24 +36,36 @@ export default function LanguageSwitcher({ variant = "full" }: LanguageSwitcherP
 
   const switchTo = async (locale: SupportedLocale) => {
     if (locale === active || pending) return
+    const previous = active
     setPending(locale)
+    // Mark the desired locale BEFORE flipping i18n so the sync hook never
+    // races with the auth profile while the PATCH is in flight.
+    setDesiredLocale(locale)
     try {
-      // Flip i18n + storage immediately so the UI never lags behind a click.
-      // The API call below catches up in the background; if it fails the
-      // local choice still stands until the next login.
+      // Flip i18n immediately so the UI never lags behind a click. The
+      // language-detector's `caches: ["localStorage"]` setting persists
+      // the new value to localStorage on the `languageChanged` event,
+      // so we don't write to localStorage manually.
       await i18n.changeLanguage(locale)
-      try {
-        window.localStorage.setItem(LOCALE_STORAGE_KEY, locale)
-      } catch {
-        // Storage may be unavailable; UI already reflects the change.
-      }
       if (user) {
-        await preferencesService.setPreferredLocale(locale).catch(() => {
-          // Network failure should not roll back the local switch — the user
-          // already sees the new language. The next successful save will
-          // sync server-side.
-        })
-        await refreshUser()
+        try {
+          await preferencesService.setPreferredLocale(locale)
+          // Once the profile reflects the new locale, the desired-guard
+          // clears itself the next time `useLocaleSync` runs.
+          await refreshUser()
+        } catch {
+          // PATCH failed: roll back UI + guard, and let the user know
+          // their choice did not persist server-side.
+          setDesiredLocale(null)
+          await i18n.changeLanguage(previous)
+          // Reuse the profile-update failure copy — saving a preference is
+          // semantically a profile mutation, and this avoids touching the
+          // locale JSON files (owned by other PRs running in parallel).
+          toast({ title: t("profile.updateFailed"), variant: "destructive" })
+        }
+      } else {
+        // Guests have no profile to reconcile against; clear the guard.
+        setDesiredLocale(null)
       }
     } finally {
       setPending(null)

--- a/frontend/src/components/layout/__tests__/LanguageSwitcher.test.tsx
+++ b/frontend/src/components/layout/__tests__/LanguageSwitcher.test.tsx
@@ -1,0 +1,161 @@
+import type { ReactNode } from "react"
+import { render, screen, waitFor, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { I18nextProvider } from "react-i18next"
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest"
+import i18n from "@/i18n/config"
+import type { User } from "@/types"
+
+// Mocks must be declared before importing the SUT.
+const setPreferredLocale = vi.fn()
+vi.mock("@/services/preferences", () => ({
+  preferencesService: {
+    setPreferredLocale: (...a: unknown[]) => setPreferredLocale(...a),
+  },
+}))
+
+const toast = vi.fn()
+vi.mock("@/lib/toast", () => ({
+  toast: (...a: unknown[]) => toast(...a),
+}))
+
+// Stand-in auth context. The real provider depends on Supabase + Datadog; the
+// switcher only reads `user` and `refreshUser`, so a fake provider keeps this
+// test small and deterministic.
+type AuthState = { user: User | null; refreshUser: () => Promise<void> }
+let authState: AuthState = { user: null, refreshUser: vi.fn().mockResolvedValue(undefined) }
+vi.mock("@/context/useAuth", () => ({
+  useAuth: () => authState,
+}))
+
+import LanguageSwitcher from "../LanguageSwitcher"
+import { setDesiredLocale, getDesiredLocale } from "@/i18n/useLocaleSync"
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "user-1",
+    email: "a@b.com",
+    full_name: "A",
+    avatar_url: null,
+    role: "student",
+    preferred_locale: "ru",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function I18nWrapper({ children }: { children: ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+describe("LanguageSwitcher", () => {
+  beforeEach(async () => {
+    setPreferredLocale.mockReset()
+    toast.mockReset()
+    authState = {
+      user: makeUser(),
+      refreshUser: vi.fn().mockResolvedValue(undefined),
+    }
+    setDesiredLocale(null)
+    await act(async () => {
+      await i18n.changeLanguage("ru")
+    })
+  })
+
+  afterEach(() => {
+    setDesiredLocale(null)
+  })
+
+  it("flips the UI optimistically and persists via the preferences API on success", async () => {
+    setPreferredLocale.mockResolvedValue(makeUser({ preferred_locale: "en" }))
+    const user = userEvent.setup()
+
+    render(<LanguageSwitcher variant="compact" />, { wrapper: I18nWrapper })
+
+    const button = screen.getByRole("button")
+    await user.click(button)
+
+    await waitFor(() => {
+      expect(setPreferredLocale).toHaveBeenCalledWith("en")
+    })
+    expect(i18n.language).toBe("en")
+    expect(toast).not.toHaveBeenCalled()
+    expect(authState.refreshUser).toHaveBeenCalledTimes(1)
+  })
+
+  it("rolls the UI back and toasts when the PATCH fails (race fix)", async () => {
+    setPreferredLocale.mockRejectedValue(new Error("network down"))
+    const user = userEvent.setup()
+
+    render(<LanguageSwitcher variant="compact" />, { wrapper: I18nWrapper })
+
+    const button = screen.getByRole("button")
+    await user.click(button)
+
+    await waitFor(() => {
+      expect(setPreferredLocale).toHaveBeenCalledWith("en")
+    })
+    // i18n was rolled back to the previous locale.
+    expect(i18n.language).toBe("ru")
+    // The desired-locale guard was cleared so the sync hook can run normally.
+    expect(getDesiredLocale()).toBeNull()
+    // refreshUser must NOT be called on failure — that would re-trigger the
+    // sync hook with the stale profile.
+    expect(authState.refreshUser).not.toHaveBeenCalled()
+    // The user gets a destructive toast about the failed save.
+    expect(toast).toHaveBeenCalledTimes(1)
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive" }),
+    )
+  })
+
+  it("sets the desired-locale guard before flipping i18n so useLocaleSync can no-op", async () => {
+    // Slow-resolve PATCH so we can observe the in-flight state.
+    let resolvePatch: ((v: unknown) => void) | null = null
+    setPreferredLocale.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePatch = resolve as (v: unknown) => void
+      }),
+    )
+    const user = userEvent.setup()
+
+    render(<LanguageSwitcher variant="compact" />, { wrapper: I18nWrapper })
+
+    const button = screen.getByRole("button")
+    // userEvent's promise won't resolve until the PATCH does, so fire and
+    // assert without awaiting the click.
+    void user.click(button)
+
+    await waitFor(() => {
+      expect(getDesiredLocale()).toBe("en")
+    })
+    expect(i18n.language).toBe("en")
+
+    // Resolve the PATCH; refreshUser is invoked, and the guard clears once
+    // the profile is in sync (handled inside useLocaleSync's effect — here
+    // we just confirm the switcher's contract: it left the guard set).
+    await act(async () => {
+      resolvePatch!(makeUser({ preferred_locale: "en" }))
+    })
+    await waitFor(() => {
+      expect(authState.refreshUser).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("does not call the preferences API for guests", async () => {
+    authState = {
+      user: null,
+      refreshUser: vi.fn().mockResolvedValue(undefined),
+    }
+    const user = userEvent.setup()
+
+    render(<LanguageSwitcher variant="compact" />, { wrapper: I18nWrapper })
+
+    await user.click(screen.getByRole("button"))
+
+    expect(setPreferredLocale).not.toHaveBeenCalled()
+    expect(i18n.language).toBe("en")
+    expect(getDesiredLocale()).toBeNull()
+  })
+})

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react"
 import { supabase } from "@/lib/supabase"
 import { authService } from "@/services/auth"
+import { DEFAULT_LOCALE, isSupportedLocale } from "@/i18n/config"
 import type { User } from "@/types"
 import { AuthContext } from "./auth-context"
 import { setDatadogUser, clearDatadogUser } from "@/lib/datadog"
@@ -35,7 +36,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             full_name: data.full_name,
             avatar_url: data.avatar_url ?? null,
             role: data.role,
-            preferred_locale: data.preferred_locale === "en" ? "en" : "ru",
+            // Profile rows are CHECK-constrained to the supported locale
+            // set, but defend against drift / older rows by validating with
+            // `isSupportedLocale`. Fall back to `DEFAULT_LOCALE` ("ru") since
+            // that's the project's source language and every existing course
+            // is authored in it — this keeps unknown values from silently
+            // pinning users to a locale that isn't actually theirs.
+            preferred_locale: isSupportedLocale(data.preferred_locale)
+              ? data.preferred_locale
+              : DEFAULT_LOCALE,
             created_at: data.created_at,
             updated_at: data.updated_at,
           } as const

--- a/frontend/src/i18n/__tests__/useLocaleSync.test.tsx
+++ b/frontend/src/i18n/__tests__/useLocaleSync.test.tsx
@@ -1,0 +1,119 @@
+import { act, render } from "@testing-library/react"
+import { I18nextProvider } from "react-i18next"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import i18n from "@/i18n/config"
+import type { User } from "@/types"
+
+let authState: { user: User | null } = { user: null }
+vi.mock("@/context/useAuth", () => ({
+  useAuth: () => authState,
+}))
+
+import { useLocaleSync, setDesiredLocale, getDesiredLocale } from "../useLocaleSync"
+
+function Probe() {
+  useLocaleSync()
+  return null
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "u1",
+    email: "a@b.com",
+    full_name: "A",
+    avatar_url: null,
+    role: "student",
+    preferred_locale: "ru",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("useLocaleSync", () => {
+  beforeEach(async () => {
+    setDesiredLocale(null)
+    await act(async () => {
+      await i18n.changeLanguage("ru")
+    })
+    authState = { user: null }
+  })
+
+  afterEach(() => {
+    setDesiredLocale(null)
+  })
+
+  it("syncs i18n to the profile's preferred_locale on login", async () => {
+    authState = { user: makeUser({ preferred_locale: "en" }) }
+
+    await act(async () => {
+      render(
+        <I18nextProvider i18n={i18n}>
+          <Probe />
+        </I18nextProvider>,
+      )
+    })
+
+    expect(i18n.language).toBe("en")
+  })
+
+  it("ignores a stale profile while a switch is in flight (race fix)", async () => {
+    // Simulate the LanguageSwitcher having just flipped to "en" and called
+    // setDesiredLocale("en") — but the auth profile still says "ru" because
+    // the PATCH hasn't landed yet.
+    await act(async () => {
+      await i18n.changeLanguage("en")
+    })
+    setDesiredLocale("en")
+    authState = { user: makeUser({ preferred_locale: "ru" }) }
+
+    await act(async () => {
+      render(
+        <I18nextProvider i18n={i18n}>
+          <Probe />
+        </I18nextProvider>,
+      )
+    })
+
+    // Without the guard, the hook would have flipped i18n back to "ru" and
+    // silently undone the user's choice. The guard prevents that.
+    expect(i18n.language).toBe("en")
+    expect(getDesiredLocale()).toBe("en")
+  })
+
+  it("clears the desired-locale guard once the profile catches up", async () => {
+    await act(async () => {
+      await i18n.changeLanguage("en")
+    })
+    setDesiredLocale("en")
+    // Profile now matches the desired locale (PATCH succeeded + refresh ran).
+    authState = { user: makeUser({ preferred_locale: "en" }) }
+
+    await act(async () => {
+      render(
+        <I18nextProvider i18n={i18n}>
+          <Probe />
+        </I18nextProvider>,
+      )
+    })
+
+    expect(i18n.language).toBe("en")
+    expect(getDesiredLocale()).toBeNull()
+  })
+
+  it("ignores unsupported preferred_locale values", async () => {
+    authState = {
+      user: makeUser({ preferred_locale: "fr" as unknown as User["preferred_locale"] }),
+    }
+
+    await act(async () => {
+      render(
+        <I18nextProvider i18n={i18n}>
+          <Probe />
+        </I18nextProvider>,
+      )
+    })
+
+    expect(i18n.language).toBe("ru")
+  })
+})

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -60,6 +60,19 @@ const updateHtmlLang = (lng: string) => {
   }
 }
 updateHtmlLang(i18n.language)
-i18n.on("languageChanged", updateHtmlLang)
+
+// HMR re-evaluates this module on every save, so guard the listener
+// registration to avoid stacking duplicate handlers across hot reloads.
+declare global {
+  interface Window {
+    __bibleSchoolLocaleListener?: boolean
+  }
+}
+const globalScope: { __bibleSchoolLocaleListener?: boolean } =
+  typeof window !== "undefined" ? window : (globalThis as { __bibleSchoolLocaleListener?: boolean })
+if (!globalScope.__bibleSchoolLocaleListener) {
+  i18n.on("languageChanged", updateHtmlLang)
+  globalScope.__bibleSchoolLocaleListener = true
+}
 
 export default i18n

--- a/frontend/src/i18n/useLocaleSync.ts
+++ b/frontend/src/i18n/useLocaleSync.ts
@@ -3,16 +3,43 @@ import { useTranslation } from "react-i18next"
 
 import { useAuth } from "@/context/useAuth"
 
-import { LOCALE_STORAGE_KEY, isSupportedLocale } from "./config"
+import { isSupportedLocale, type SupportedLocale } from "./config"
 
 /**
- * Keep i18next, localStorage, and the authenticated profile in lockstep.
+ * Module-level "pending desired locale" guard.
  *
- * - On login: profile.preferred_locale wins. We update i18n and persist
- *   the choice to localStorage so a refresh picks the same value before
- *   the auth context has a chance to load.
+ * `LanguageSwitcher` updates this *before* it flips i18n optimistically and
+ * fires the `PATCH /users/me/preferences` request. While it's set, the sync
+ * hook below treats it as the source of truth and refuses to "correct" the
+ * UI back to the (still-stale) profile value. Once the profile catches up
+ * (or the switcher rolls back on failure), the guard is cleared.
+ *
+ * This is module-level on purpose: the switcher and the sync hook live in
+ * different parts of the tree but share a single i18n instance, so a single
+ * shared mutable cell is the simplest correct coordination.
+ */
+let desiredLocale: SupportedLocale | null = null
+
+export function setDesiredLocale(locale: SupportedLocale | null): void {
+  desiredLocale = locale
+}
+
+export function getDesiredLocale(): SupportedLocale | null {
+  return desiredLocale
+}
+
+/**
+ * Keep i18next and the authenticated profile in lockstep.
+ *
+ * - On login: profile.preferred_locale wins. We update i18n; the
+ *   `i18next-browser-languagedetector` cache (configured with
+ *   `caches: ["localStorage"]` in `config.ts`) writes the value to
+ *   localStorage automatically on `languageChanged`, so a refresh picks
+ *   the same value before the auth context has a chance to load.
  * - For guests: we leave i18next's detector alone (browser → localStorage
  *   fallback already runs at init time).
+ * - During an in-flight `LanguageSwitcher` PATCH: the `desiredLocale` guard
+ *   makes us a no-op so we don't fight the optimistic update.
  *
  * Mounted once in `App` near the auth provider.
  */
@@ -22,15 +49,18 @@ export function useLocaleSync(): void {
 
   useEffect(() => {
     if (!user) return
-    const desired = user.preferred_locale
-    if (!isSupportedLocale(desired)) return
-    if (i18n.language === desired) return
-    void i18n.changeLanguage(desired)
-    try {
-      window.localStorage.setItem(LOCALE_STORAGE_KEY, desired)
-    } catch {
-      // Storage can throw in privacy mode or quota-exceeded scenarios.
-      // The change still takes effect for the current session.
+    const profileLocale = user.preferred_locale
+    if (!isSupportedLocale(profileLocale)) return
+
+    // A switch is in progress and the profile hasn't caught up yet — defer.
+    if (desiredLocale !== null && desiredLocale !== profileLocale) return
+    // Profile now matches the user's pending desire (PATCH succeeded and the
+    // refresh landed). Drop the guard so future profile changes win normally.
+    if (desiredLocale === profileLocale) {
+      desiredLocale = null
     }
+
+    if (i18n.language === profileLocale) return
+    void i18n.changeLanguage(profileLocale)
   }, [user, i18n])
 }


### PR DESCRIPTION
## Summary
Closes a subtle race in the locale state machine where a logged-in user's language switch could be silently undone by a profile-refresh.

## Root cause
1. User clicks RU→EN in `LanguageSwitcher`.
2. Switcher flips i18n optimistically + writes localStorage + fires `PATCH /users/me/preferences`.
3. PATCH fails — switcher swallows the error.
4. Next `refreshUser()` re-fetches the profile with stale `preferred_locale: "ru"`.
5. `useLocaleSync` sees stale "ru", calls `i18n.changeLanguage("ru")` — **silently undoes the user's choice with no warning**.

## Fix
**Optimistic + rollback + sonner toast on failure**, coordinated through a module-level "desired locale" guard exported from `useLocaleSync.ts`:

- `LanguageSwitcher` calls `setDesiredLocale(target)` *before* flipping i18n, then awaits the PATCH. On success it `refreshUser()`s; the sync hook clears the guard once the profile catches up. On failure it rolls i18n back, clears the guard, and surfaces a destructive sonner toast (`profile.updateFailed`).
- `useLocaleSync` checks the guard before reconciling i18n against the profile and no-ops while a switch is in flight, so it can't fight the optimistic update or stomp on a rollback.

## Other fixes bundled (same locale state machine)
- **`AuthContext` profile mapping** — uses `isSupportedLocale` + `DEFAULT_LOCALE` instead of the hand-rolled `=== "en" ? "en" : "ru"` ternary, defending against profile-row drift / older locales.
- **Redundant localStorage writes removed** — `i18next-browser-languagedetector` already caches via the `caches: ["localStorage"]` config; `LanguageSwitcher` and `useLocaleSync` no longer duplicate the write.
- **HMR listener-stacking guard** — `i18n.on("languageChanged", …)` now wrapped in a `globalThis` flag so dev HMR doesn't stack listeners.

## Tradeoffs
- Toast reuses the existing `profile.updateFailed` translation key (semantically correct — locale lives on the user's profile row). A new translation key would have collided with PR-A which is wiring up locale JSONs in parallel.

## Test plan
New tests added (8 total):
- `frontend/src/components/layout/__tests__/LanguageSwitcher.test.tsx` — success path, PATCH-failure rollback + toast, in-flight guard, guest path.
- `frontend/src/i18n/__tests__/useLocaleSync.test.tsx` — login sync, race no-op, guard auto-clear, unsupported-locale ignored.

Local gates (final commit `f1129a7`):
- `npm run lint` — pass (zero warnings)
- `npx tsc --noEmit` — pass
- `npm run build` — pass
- `npm run test:run` — **93/93** (8 new + 85 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
