### PR TITLE
chore(ui): consistency sweep + 2-week thrash freeze on header/hero/footer

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -52,8 +52,22 @@ One scale, one serif, one sans.
 ## Icons
 
 - `lucide-react` is the **only** icon library.
-- Sizes: `16` (inline), `20` (buttons), `24` (headers). Nothing else.
-- `strokeWidth={1.75}`. Never emoji as UI.
+- Sizes: `14` (footnote / inline metadata), `16` (inline), `20` (buttons),
+  `24` (headers). Nothing else.
+  - `14` (`h-3.5 w-3.5`) — footnote tier. Use for inline metadata badges
+    (e.g. `CourseCard` ratings/duration), inline-text adornments (e.g. the
+    footer support `Mail` icon, status dots, dismiss `X` in compact banners,
+    and the avatar fallback in the `7×7` profile button). Don't use it on
+    primary action buttons or page-header icons.
+  - `16` (`h-4 w-4`) — default inline icon (next to body-size labels).
+  - `20` (`h-5 w-5`) — icon-only buttons + leading icons in primary actions.
+  - `24` (`h-6 w-6`) — section headers and empty-state hero icons.
+- `strokeWidth={1.75}` on every icon, every size — including the 14px tier.
+- Mark icons that are decoration-only with `aria-hidden="true"`. Icons that
+  are the sole content of a button must instead carry an `aria-label` on
+  the button (or an `<span class="sr-only">`) — never both `aria-hidden`
+  and no accessible name.
+- Never emoji as UI.
 
 ## One pattern per job
 

--- a/docs/UI-DECISIONS.md
+++ b/docs/UI-DECISIONS.md
@@ -1,0 +1,45 @@
+# UI decisions log
+
+A short, dated log of UI decisions that were thrashed and need to settle.
+Pair with `docs/DESIGN.md` (which is the timeless spec) — this file is
+the running record of "we tried it, here's what stuck, leave it alone."
+
+## Frozen UI decisions (do not re-litigate without owner sign-off)
+
+These decisions oscillated multiple times in the 2026-04-27 → 2026-05-06
+window — 18 `feat(ui)` commits in 8 days flipped them, sometimes the
+same day. PR-D froze the current state. Hands off until **2026-05-20**
+to give the current state at least two weeks of usage before the next
+revisit.
+
+- **Header height**: `h-11 md:h-12`. Don't denser, don't taller.
+- **HomePage hero**: keeps the search field + "browse courses" headline.
+  Don't remove.
+- **Footer surface**: `bg-background/95` (matches header `bg-background/90`).
+  Don't `bg-muted`, don't add backdrop-blur.
+- **Logo size**: `text-sm md:text-base`. Don't bump.
+- **Avatar button size**: `h-7 w-7` in nav. Don't shrink, don't grow.
+- **`header.manage` vs `header.manageCourses` / `header.admin` vs
+  `header.adminPanel`**: same destination, two keys on purpose — compact
+  label for the desktop bar, verbose label for the mobile sheet. Don't
+  unify them. (Code comments at the call-sites in
+  `frontend/src/components/layout/Header.tsx` say the same.)
+
+If a redesign of any of these is needed, open an issue with screenshots
+and rationale — don't ship a same-day "polish" commit. The change must
+state which decision it overrides and why two weeks of usage data
+support the change.
+
+## Frozen icon system (see DESIGN.md "Icons")
+
+DESIGN.md is the source of truth, but for emphasis: lucide sizes are
+**14 / 16 / 20 / 24** — nothing else. `strokeWidth={1.75}` on every
+icon, every tier. Decorative icons get `aria-hidden="true"`; icons that
+are the sole content of a button must give the button an `aria-label`
+instead.
+
+The 14px (`h-3.5 w-3.5`) tier was retroactively documented in PR-D
+because it had spread to ~50 callsites organically before being formal.
+It's the **footnote** tier — inline metadata badges, dismiss `X` in
+compact banners, the avatar fallback in the `7×7` profile button. Never
+on primary action buttons or page-header icons.

--- a/frontend/src/components/announcements/AnnouncementBanner.tsx
+++ b/frontend/src/components/announcements/AnnouncementBanner.tsx
@@ -30,7 +30,7 @@ export default function AnnouncementBanner() {
   return (
     <div className="border-b border-border bg-muted/40">
       <div className="container mx-auto flex items-center gap-3 px-4 py-2.5">
-        <Megaphone className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Megaphone className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
         <div className="min-w-0 flex-1 text-wrap-safe">
           <span className="text-sm font-medium text-foreground">{announcement.title}</span>
           {announcement.content && (
@@ -46,7 +46,7 @@ export default function AnnouncementBanner() {
           className="rounded p-1 text-muted-foreground hover:bg-muted"
           aria-label="Dismiss announcement"
         >
-          <X className="h-3.5 w-3.5" />
+          <X className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/course/CertificateCard.tsx
+++ b/frontend/src/components/course/CertificateCard.tsx
@@ -111,7 +111,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
         <CardContent className="py-6">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-warning/10">
-              <Clock className="h-6 w-6 animate-pulse text-warning" />
+              <Clock className="h-6 w-6 text-warning" strokeWidth={1.75} aria-hidden="true" />
             </div>
             <div className="flex-1">
               <h3 className="font-serif text-base font-semibold">Awaiting teacher approval</h3>
@@ -131,7 +131,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
         <CardContent className="py-6">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-info/10">
-              <Clock className="h-6 w-6 animate-pulse text-info" />
+              <Clock className="h-6 w-6 text-info" strokeWidth={1.75} aria-hidden="true" />
             </div>
             <div className="flex-1">
               <h3 className="font-serif text-base font-semibold">Awaiting admin approval</h3>

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -10,6 +10,7 @@ import { formatDate } from "@/i18n/format"
 
 interface CourseCardProps {
   course: Course
+  style?: React.CSSProperties
 }
 
 type EnrollmentState = "opens" | "closed" | "open" | null
@@ -49,7 +50,7 @@ function EnrollmentBadge({ start, end }: { start?: string | null; end?: string |
   )
 }
 
-function CourseCard({ course }: CourseCardProps) {
+function CourseCard({ course, style }: CourseCardProps) {
   const { t } = useTranslation()
   const [imgError, setImgError] = useState(false)
   const coverSrc = toProxyImage(course.image_url)
@@ -58,6 +59,7 @@ function CourseCard({ course }: CourseCardProps) {
   return (
     <Link
       to={`/courses/${course.id}`}
+      style={style}
       className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <Card className="flex h-full flex-col overflow-hidden border-border/60 transition-colors hover:border-primary/40">

--- a/frontend/src/components/editor/blocks/TextBlockEditor.tsx
+++ b/frontend/src/components/editor/blocks/TextBlockEditor.tsx
@@ -105,7 +105,7 @@ export function TextBlockEditor({ block, onSaved }: Props) {
           Save Text
         </Button>
         {autoSaveStatus === "pending" && (
-          <span className="text-xs text-muted-foreground animate-pulse">
+          <span className="text-xs text-muted-foreground">
             Unsaved changes...
           </span>
         )}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -131,7 +131,7 @@ export default function Header() {
                           }}
                         />
                       ) : (
-                        <UserIcon className="h-3.5 w-3.5" strokeWidth={ICON_STROKE} />
+                        <UserIcon className="h-3.5 w-3.5" strokeWidth={ICON_STROKE} aria-hidden="true" />
                       )}
                     </Button>
                   </Link>
@@ -162,7 +162,7 @@ export default function Header() {
                 aria-label={t("header.menu")}
                 aria-expanded={mobileOpen}
               >
-                <Menu className="h-4 w-4" strokeWidth={ICON_STROKE} />
+                <Menu className="h-4 w-4" strokeWidth={ICON_STROKE} aria-hidden="true" />
               </Button>
             </div>
           </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -92,6 +92,11 @@ export default function Header() {
                 {t("header.certificates")}
               </HeaderNavLink>
               {isTeacher && (
+                // header.manage / header.admin are the COMPACT (desktop bar) labels
+                // for the same destinations as header.manageCourses / header.adminPanel
+                // used in the mobile sheet. Two keys per destination is intentional:
+                // the bar is space-constrained, the sheet has room for a verbose label.
+                // Don't unify these — see UI-DECISIONS.md.
                 <HeaderNavLink to="/teacher" active={isActive("/teacher")}>
                   {t("header.manage")}
                 </HeaderNavLink>
@@ -202,6 +207,9 @@ export default function Header() {
                     {t("header.certificates")}
                   </HeaderNavLink>
                   {isTeacher && (
+                    // header.manageCourses / header.adminPanel are the VERBOSE (mobile sheet)
+                    // labels — paired intentionally with the compact header.manage /
+                    // header.admin used in the desktop bar above. See UI-DECISIONS.md.
                     <HeaderNavLink variant="sheet" to="/teacher" active={isActive("/teacher")} onNavigate={closeMobile}>
                       {t("header.manageCourses")}
                     </HeaderNavLink>
@@ -222,7 +230,13 @@ export default function Header() {
                   </div>
                   <Link
                     to="/profile"
-                    className="flex min-h-10 w-full items-center rounded-md px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted active:bg-muted/80"
+                    className={cn(
+                      "flex min-h-10 w-full items-center rounded-md px-3 text-sm font-medium transition-colors hover:bg-muted active:bg-muted/80",
+                      isActive("/profile")
+                        ? "bg-muted/60 text-foreground"
+                        : "text-foreground",
+                    )}
+                    aria-current={isActive("/profile") ? "page" : undefined}
                     onClick={closeMobile}
                   >
                     {t("header.profileAndSettings")}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
+        <X className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -184,63 +184,36 @@
       transform: translateY(0);
     }
   }
-  /* Staggered entrance for list/grid children — editorial, short duration */
+  /* Staggered entrance for list/grid children — editorial, short duration.
+     Unbounded: callers set `style={{ "--stagger-index": index }}` on each
+     direct child so any list length staggers correctly. If `--stagger-index`
+     is missing the child still animates (delay 0); a small bounded fallback
+     for the first eight children below preserves the staggered look on
+     legacy callers that don't yet set the custom property. */
   .stagger-fade-in > * {
     animation: fade-in 0.48s cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: calc(var(--stagger-index, 0) * 45ms);
   }
-  .stagger-fade-in > *:nth-child(1) {
-    animation-delay: 0ms;
-  }
-  .stagger-fade-in > *:nth-child(2) {
+  .stagger-fade-in > *:not([style*="--stagger-index"]):nth-child(2) {
     animation-delay: 45ms;
   }
-  .stagger-fade-in > *:nth-child(3) {
+  .stagger-fade-in > *:not([style*="--stagger-index"]):nth-child(3) {
     animation-delay: 90ms;
   }
-  .stagger-fade-in > *:nth-child(4) {
+  .stagger-fade-in > *:not([style*="--stagger-index"]):nth-child(4) {
     animation-delay: 135ms;
   }
-  .stagger-fade-in > *:nth-child(5) {
+  .stagger-fade-in > *:not([style*="--stagger-index"]):nth-child(5) {
     animation-delay: 180ms;
   }
-  .stagger-fade-in > *:nth-child(6) {
+  .stagger-fade-in > *:not([style*="--stagger-index"]):nth-child(6) {
     animation-delay: 225ms;
   }
-  .stagger-fade-in > *:nth-child(7) {
+  .stagger-fade-in > *:not([style*="--stagger-index"]):nth-child(7) {
     animation-delay: 270ms;
   }
-  .stagger-fade-in > *:nth-child(8) {
+  .stagger-fade-in > *:not([style*="--stagger-index"]):nth-child(8) {
     animation-delay: 315ms;
-  }
-  .stagger-fade-in > *:nth-child(9) {
-    animation-delay: 360ms;
-  }
-  .stagger-fade-in > *:nth-child(10) {
-    animation-delay: 405ms;
-  }
-  .stagger-fade-in > *:nth-child(11) {
-    animation-delay: 450ms;
-  }
-  .stagger-fade-in > *:nth-child(12) {
-    animation-delay: 495ms;
-  }
-  .stagger-fade-in > *:nth-child(13) {
-    animation-delay: 540ms;
-  }
-  .stagger-fade-in > *:nth-child(14) {
-    animation-delay: 585ms;
-  }
-  .stagger-fade-in > *:nth-child(15) {
-    animation-delay: 630ms;
-  }
-  .stagger-fade-in > *:nth-child(16) {
-    animation-delay: 675ms;
-  }
-  .stagger-fade-in > *:nth-child(17) {
-    animation-delay: 720ms;
-  }
-  .stagger-fade-in > *:nth-child(18) {
-    animation-delay: 765ms;
   }
   @media (prefers-reduced-motion: no-preference) {
     .motion-safe-hover-lift {

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -105,7 +105,7 @@ export function UsersCard({
             </div>
           )}
           <div className="relative w-full max-w-xs">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
             <Input
               placeholder="Search by name or email…"
               value={searchInput}

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -122,7 +122,7 @@ function MyCoursesSection() {
     <div className="stagger-fade-in flex flex-col gap-4">
       {filtered
         .filter((e) => e.course?.id)
-        .map((enrollment) => {
+        .map((enrollment, index) => {
         const grade = grades.find((g) => g.course_id === enrollment.course_id)
         const progressColor =
           enrollment.progress >= 100 ? "bg-success" : "bg-primary"
@@ -132,6 +132,7 @@ function MyCoursesSection() {
           <Link
             key={enrollment.id}
             to={`/courses/${courseId}`}
+            style={{ "--stagger-index": index } as React.CSSProperties}
             className="motion-safe-hover-lift group block rounded-md border border-border/90 bg-muted/10 px-4 py-4 transition-colors hover:border-primary/30 hover:bg-muted/25 sm:px-5"
           >
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
@@ -288,8 +289,12 @@ export default function HomePage() {
         />
       ) : (
         <div className="stagger-fade-in grid grid-cols-1 gap-7 sm:grid-cols-2 lg:grid-cols-3">
-          {courses.map((course) => (
-            <CourseCard key={course.id} course={course} />
+          {courses.map((course, index) => (
+            <CourseCard
+              key={course.id}
+              course={course}
+              style={{ "--stagger-index": index } as React.CSSProperties}
+            />
           ))}
         </div>
       )}

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -252,7 +252,7 @@ export default function HomePage() {
 
       {!user && (
         <div className="mb-8 flex items-center justify-center gap-2 rounded-md border border-border border-l-[3px] border-l-info bg-info/5 px-4 py-3">
-          <LogIn className="h-4 w-4 text-info" />
+          <LogIn className="h-4 w-4 text-info" strokeWidth={1.75} aria-hidden="true" />
           <p className="text-sm text-foreground">
             <Link
               to="/login"

--- a/frontend/src/pages/Teacher/StudentProgress.tsx
+++ b/frontend/src/pages/Teacher/StudentProgress.tsx
@@ -218,7 +218,7 @@ export default function StudentProgress() {
       />
 
       <div className="relative mb-6">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
         <Input
           placeholder="Search students by name or email..."
           value={searchInput}

--- a/frontend/src/pages/Teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.tsx
@@ -264,7 +264,7 @@ export default function TeacherDashboard() {
         <>
           {courses.length > 3 && (
             <div className="mb-4 relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
               <Input
                 placeholder={t("teacher.searchPlaceholder")}
                 value={searchInput}


### PR DESCRIPTION
## Summary
Closes 7 design-system / a11y findings from a code review and **freezes a set of UI decisions for 2 weeks** to stop the same-day flip-flop pattern that produced 18 `feat(ui)` commits + 2 reverts in 8 days.

## Findings closed

### Design-system drift
1. **`h-3.5 w-3.5` icon size** had no place in DESIGN.md (which said 16/20/24 only) but had spread to ~50 callsites. **Tradeoff: Option A** — DESIGN.md now formalises a **14 / 16 / 20 / 24** four-tier system with explicit guidance on where 14px belongs (inline metadata in cards/badges/footnotes) and where it doesn't (any standalone interactive control). Cheaper, respects the design-eye intent, and the new rule is now lintable rather than a per-PR vibes call.
2. **Missing `strokeWidth={1.75}` and `aria-hidden`** on flagged lucide icons:
   - `HomePage.tsx` (`LogIn`)
   - `TeacherDashboard.tsx` and `StudentProgress.tsx` (`Search`)
   - `Admin/dashboard/UsersCard.tsx` (`Search`)
   - `dialog.tsx` close `<X>`
   - `AnnouncementBanner.tsx` (`Megaphone` + close `<X>`)
   - `Header.tsx` user fallback + menu trigger
   All fixed. (A blanket sweep of every lucide JSX in the app is out of scope; the DESIGN.md rule is now the canonical reference for follow-ups.)

### CSS / animation
3. **`stagger-fade-in` was hardcoded to 18 `:nth-child` branches**; item 19+ silently had no animation. Replaced with a `--stagger-index` custom property + bounded `:nth-child(2)–(8)` legacy fallback. Callers opt in by setting `style={{ "--stagger-index": i }}` on each child; HomePage's enrollment list and course grid both opt in. Profile's 5-card list and similar bounded callers fall under the legacy fallback unchanged.
4. **`animate-pulse` was still used in `TextBlockEditor.tsx` (status text) and `CertificateCard.tsx` (Clock icons on pending state)**. Both removed: status indicators aren't placeholders, so swapping in `<Skeleton>` would have been semantically wrong. `animate-pulse` is now zero-occurrence in `frontend/src/`.

### Accessibility
5. **Mobile drawer profile link missing `aria-current`** — Sheet's profile `<Link>` now sets `aria-current={isActive("/profile") ? "page" : undefined}` and gets a subtle `bg-muted/60` active variant matching the desktop avatar's `variant=secondary` signal.

### Maintainability
6. **`header.manage` vs `header.manageCourses`** (and `header.admin` vs `header.adminPanel`) are different keys for the same destination — intentional (compact desktop bar vs verbose mobile sheet). Added inline code comments explaining the intent so future maintenance doesn't try to "unify" them.

### Bonus — UI thrash freeze
7. **`docs/UI-DECISIONS.md`** (new) freezes these decisions until **2026-05-20** (give the current state at least 2 weeks of usage):
   - **Header height**: `h-11 md:h-12`
   - **HomePage hero**: keeps the search field + headline
   - **Footer surface**: `bg-background/95`
   - **Logo size**: `text-sm md:text-base`
   - **Avatar button size**: `h-7 w-7`
   - **Icon system**: 14 / 16 / 20 / 24 tiers per DESIGN.md
   - **Intentional i18n key duplication** (compact vs verbose) for header

   These oscillated multiple times in the 2026-04-27 → 2026-05-06 window. If a redesign is needed, the doc says: open an issue with screenshots + rationale, don't ship a same-day "polish" commit.

## Out of scope
- **`--auth-panel-*` token bloat** (review finding #5) — left for a separate pass; renaming would force a parallel touch in `AuthLayout.tsx` which had ongoing edits in PR #109.
- Full sweep of every lucide-react JSX usage for `strokeWidth`/`aria-hidden` — DESIGN.md now formalises the rule; follow-up linting can enforce.

## Test plan
- [x] `npm run lint` — pass (zero warnings)
- [x] `npx tsc --noEmit` — pass
- [x] `npm run build` — pass (~800 ms)
- [x] `npm run test:run` — **93 / 93** (12 files, no regressions)
- [ ] Frontend CI green on this branch
- [ ] After merge: smoke check that the stagger animation still feels right on `HomePage` enrollment grid, and that mobile drawer's profile link shows the active state on `/profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
