### PR TITLE
fix(translation): reject truncated Gemini responses via finishReason check

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,3 +60,13 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173,https://biblie-school-f
 GEMINI_API_KEY=your-gemini-api-key
 # Model id; override per-environment if needed.
 GEMINI_MODEL=gemini-flash-latest
+# Per-call HTTP timeout in seconds. 30s gives the model headroom for ~5 KB
+# Russian-HTML blocks (which regularly take 18-25s on flash-latest); the
+# bounded retry budget in GeminiTranslationProvider keeps worst-case bounded
+# even on bad batches. Lower if your content is shorter; raise if you see
+# transient timeouts on long lesson blocks.
+# GEMINI_TIMEOUT_SECONDS=30
+# Maximum output tokens per call. 8192 is the ceiling on flash-latest. Lower
+# values silently truncate long translations (returns finishReason=MAX_TOKENS
+# which the parser now rejects as failed; better to leave the cap high).
+# GEMINI_MAX_OUTPUT_TOKENS=8192

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -43,7 +43,13 @@ class Settings(BaseSettings):
     # bounded retry schedule in ``GeminiTranslationProvider`` (≤0.3s budget)
     # this still keeps a single bad batch from monopolising a worker.
     GEMINI_TIMEOUT_SECONDS: float = Field(default=30.0, description="Per-request timeout for Gemini calls")
-    GEMINI_MAX_OUTPUT_TOKENS: int = Field(default=4096, description="Cap on generation length")
+    # 8192 is the per-call ceiling on ``gemini-flash-latest``; the previous
+    # 4096 default truncated long course-block translations (e.g. an 11.8 KB
+    # Russian HTML appendix in the Acts course came back at 715 chars with
+    # ``finishReason='MAX_TOKENS'``). Bumping to the model's actual ceiling
+    # plus the new ``finishReason`` check in ``GeminiTranslationProvider``
+    # closes that hole. Cost-wise the cap only matters when actually emitted.
+    GEMINI_MAX_OUTPUT_TOKENS: int = Field(default=8192, description="Cap on generation length")
 
     @model_validator(mode="after")
     def load_alternative_env_vars(self):

--- a/backend/app/services/translation/gemini.py
+++ b/backend/app/services/translation/gemini.py
@@ -179,8 +179,22 @@ class GeminiTranslationProvider:
             content = candidates[0].get("content") or {}
             parts = content.get("parts") or []
             text = "".join(p.get("text", "") for p in parts).strip()
+            finish_reason = candidates[0].get("finishReason")
         except (AttributeError, KeyError, TypeError, IndexError) as exc:
             raise TranslationError(f"Gemini returned malformed candidate: {body!r}") from exc
+
+        # Only ``STOP`` represents a complete, voluntarily-terminated response.
+        # Anything else (``MAX_TOKENS``, ``SAFETY``, ``RECITATION``, ``OTHER``,
+        # …) means the model bailed mid-flight and we'd be persisting a
+        # truncated or refused output as if it were a real translation. Fail
+        # so the orchestrator records ``status='failed'`` and we can fix the
+        # cause (bump ``maxOutputTokens``, adjust the prompt, etc.).
+        # ``finish_reason`` is only allowed to be missing entirely; older
+        # Gemini API shapes occasionally omitted it for short responses.
+        if finish_reason is not None and finish_reason != "STOP":
+            raise TranslationError(
+                f"Gemini stopped with finishReason={finish_reason!r}; discarding partial output ({len(text)} chars)"
+            )
 
         if not text:
             raise TranslationError("Gemini returned an empty translation")

--- a/backend/tests/test_translation_service.py
+++ b/backend/tests/test_translation_service.py
@@ -278,6 +278,66 @@ def test_gemini_raises_typed_error_on_malformed_candidate():
         provider.translate(TranslationRequest(text="hi", source_locale="en", target_locale="ru"))
 
 
+@pytest.mark.parametrize("finish_reason", ["MAX_TOKENS", "SAFETY", "RECITATION", "OTHER"])
+def test_gemini_rejects_non_stop_finish_reason(finish_reason: str):
+    """Translations that didn't finish naturally (truncated, refused, blocked)
+    must surface as ``TranslationError`` so the orchestrator persists
+    ``status='failed'`` instead of silently caching a partial output."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "candidates": [
+                    {
+                        "content": {"parts": [{"text": "<p>Partial output cut off here"}]},
+                        "finishReason": finish_reason,
+                    }
+                ]
+            },
+        )
+
+    provider = _gemini_with(handler)
+    with pytest.raises(TranslationError, match=f"finishReason={finish_reason!r}"):
+        provider.translate(TranslationRequest(text="long text", source_locale="ru", target_locale="en"))
+
+
+def test_gemini_accepts_stop_finish_reason():
+    """``finishReason='STOP'`` is the only complete-response signal; output is kept."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "candidates": [
+                    {
+                        "content": {"parts": [{"text": "<p>Hello world</p>"}]},
+                        "finishReason": "STOP",
+                    }
+                ]
+            },
+        )
+
+    provider = _gemini_with(handler)
+    result = provider.translate(TranslationRequest(text="Привет мир", source_locale="ru", target_locale="en"))
+    assert result.text == "<p>Hello world</p>"
+
+
+def test_gemini_accepts_missing_finish_reason_for_back_compat():
+    """Older Gemini API shapes occasionally omit ``finishReason`` on short
+    successful responses; we keep the output rather than fail the batch."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"candidates": [{"content": {"parts": [{"text": "<p>OK</p>"}]}}]},
+        )
+
+    provider = _gemini_with(handler)
+    result = provider.translate(TranslationRequest(text="Хорошо", source_locale="ru", target_locale="en"))
+    assert result.text == "<p>OK</p>"
+
+
 def test_gemini_does_not_close_caller_owned_client():
     """If the caller injected an ``httpx.Client``, the provider must never
     close it — closing a client the caller still owns broke tests in the past."""


### PR DESCRIPTION
## Summary
Real bug discovered while answering the user's question about whitespace differences between source and translation: the translations in `content_translations` were not just whitespace-different, they were **silently truncated to 6-15% of source length** for 14 chapter-block rows in the Acts course. They were stored as `status='ok'` so students reading in EN saw an amputated course.

The "different newlines" symptom was downstream of the truncation — fewer newlines because most of the content was missing.

## Root cause
`GeminiTranslationProvider._parse_response` extracted text from `candidates[0].content.parts` and never inspected `candidates[0].finishReason`. When Gemini hit `maxOutputTokens=4096` and terminated with `finishReason='MAX_TOKENS'` (or `SAFETY`/`RECITATION`/`OTHER`), the partial text was persisted as a complete translation.

Concrete example — block `d26d485d-…`:
- Source: 11833 bytes (full HTML reference appendix: reading plan, key passages, names list, glossary, three missionary journeys, exam rules, bibliography)
- Translation: **715 bytes** — first 2 H2 sections, then cut off mid-heading at `<h3>Option A: Four Weeks Alongside`. Everything else missing.

## Fixes

1. **`gemini.py:_parse_response`** — `finishReason` is now checked. Anything other than `STOP` raises `TranslationError`, which the orchestrator persists as `status='failed'`. Older API shapes that omit `finishReason` still pass (back-compat for short responses).
2. **`config.py`** — `GEMINI_MAX_OUTPUT_TOKENS` default raised 4096 → 8192. 8192 is the per-call ceiling on `gemini-flash-latest`. Long Russian-HTML blocks need ~3-4k output tokens; the prior cap was the proximate reason for these failures. Cost is the same — only matters for actually-emitted tokens.
3. **`.env.example`** — added commented `GEMINI_TIMEOUT_SECONDS` and `GEMINI_MAX_OUTPUT_TOKENS` with rationale, since both were tuned in PR #108 / #111 / now and deployers couldn't see the knobs.

## Tests added (6)
- `test_gemini_rejects_non_stop_finish_reason` — parametrized over `MAX_TOKENS`, `SAFETY`, `RECITATION`, `OTHER`. Must raise `TranslationError`. (4 cases.)
- `test_gemini_accepts_stop_finish_reason` — must keep the output.
- `test_gemini_accepts_missing_finish_reason_for_back_compat` — older response shape, must not break.

## Post-merge data fix (manual one-time)
The 14 already-truncated rows in production must be marked `status='stale'` so the next `translate_course_content` retries them. The orchestrator short-circuits only on `status='ok' AND source_hash=match`; flipping the status forces a fresh translation:

```sql
UPDATE public.content_translations
SET status = 'stale', updated_at = now()
WHERE id IN (
  SELECT ct.id
  FROM public.content_translations ct
  JOIN public.chapter_blocks cb ON cb.id::text = ct.entity_id
  WHERE ct.entity_type = 'chapter_block'
    AND ct.field = 'content'
    AND ct.status = 'ok'
    AND LENGTH(cb.content) > 1500
    AND LENGTH(ct.text) < LENGTH(cb.content) * 0.5
);
```

Then re-trigger `POST /api/v1/courses/{id}/translate` (or run an inline backfill) on the Acts course (`1f3c4803-d229-464b-ad8e-848a0355e71f`). With the new 8192 cap and the finishReason check, the rows will refill correctly OR be persisted as `status='failed'` — never silently truncated again.

## Test plan
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check app/ tests/` — 120 files already formatted
- [x] `mypy --config-file mypy.ini app` — 104 source files, no issues
- [x] `pytest tests/test_translation_*.py -q` — 40 passed (was 34, +6 new)
- [ ] Backend CI green on this branch
- [ ] After merge: run the SQL above + re-translate Acts; verify no row ends with `status='ok' AND len(target) < 0.5*len(source)` for blocks > 1.5 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
