### PR TITLE
fix(translation): default Gemini model to flash-lite (avoids thinking-budget truncation)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -59,7 +59,13 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173,https://biblie-school-f
 # Get one from https://aistudio.google.com/apikey
 GEMINI_API_KEY=your-gemini-api-key
 # Model id; override per-environment if needed.
-GEMINI_MODEL=gemini-flash-latest
+# NOTE: ``gemini-2.5-flash-lite`` is preferred over ``gemini-flash-latest`` /
+# ``gemini-2.5-flash`` for translation: those variants spend "thinking"
+# tokens on every call, which silently consumed our 8192-token output
+# budget and produced finishReason=MAX_TOKENS truncations on long course
+# blocks. Lite has no thinking, so the whole budget goes to the
+# translation, and it's cheaper at our volumes.
+GEMINI_MODEL=gemini-2.5-flash-lite
 # Per-call HTTP timeout in seconds. 30s gives the model headroom for ~5 KB
 # Russian-HTML blocks (which regularly take 18-25s on flash-latest); the
 # bounded retry budget in GeminiTranslationProvider keeps worst-case bounded

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -35,7 +35,15 @@ class Settings(BaseSettings):
     # ``SecretStr`` keeps the value out of any incidental ``Settings``
     # repr/log dump; callers must use ``.get_secret_value()`` to read it.
     GEMINI_API_KEY: SecretStr | None = Field(default=None, description="Google AI Studio API key (server-only)")
-    GEMINI_MODEL: str = Field(default="gemini-flash-latest", description="Gemini model id used for translations")
+    # gemini-2.5-flash-lite: no "thinking" tokens (translation doesn't need
+    # them) so the full GEMINI_MAX_OUTPUT_TOKENS budget goes to the actual
+    # translation. The previous default ``gemini-flash-latest`` resolves to
+    # the thinking-enabled 2.5-Flash, which consumed the budget on long
+    # course blocks and tripped finishReason=MAX_TOKENS. Lite is also
+    # cheaper for our volume. Switch to ``gemini-2.5-flash`` only if a
+    # specific course needs the higher quality and you've raised the
+    # output cap accordingly (or set thinkingConfig in the payload).
+    GEMINI_MODEL: str = Field(default="gemini-2.5-flash-lite", description="Gemini model id used for translations")
     # 30s headroom: a 5 KB Russian HTML block (lesson-overview callout in
     # the Acts course backfill) on ``gemini-flash-latest`` regularly takes
     # 18-25s to translate to English. The earlier 15s default produced


### PR DESCRIPTION
## Summary
After today's backfill of the Acts course (74 rows landed via PR #112's finishReason fix), 12 long blocks kept hitting `finishReason='MAX_TOKENS'` despite the 8192 token cap.

## Root cause
`gemini-flash-latest` resolves to **Gemini 2.5 Flash**, which spends *thinking tokens* on every call. The thinking tokens count against the same `maxOutputTokens` budget as the output, so on long Russian-HTML inputs the model exhausted the budget thinking and truncated mid-translation. Empirical confirmation: failed translations were 1100-1300 chars before MAX_TOKENS — far under 8192 tokens. The model wasn't running out of room for the *translation*; it was running out of room because it had spent most of the budget thinking first.

## Fix
Switch default `GEMINI_MODEL` from `gemini-flash-latest` → `gemini-2.5-flash-lite`. Lite doesn't think, so the full token budget is available for the actual translation. Lite is also cheaper.

## Verified end-to-end
With lite as the model, all 12 previously-failed chapter blocks translated successfully on first try with the same 8192 cap. Final DB state: 74 rows for the 3 published courses, **all status='ok', zero truncated**.

## Notes
- Env var `GEMINI_MODEL` still wins, so anyone who needs the higher-quality 2.5-Flash (with custom `thinkingConfig`) can opt in.
- Comment in `.env.example` documents the gotcha so the next person who sees `MAX_TOKENS` on long content knows where to look.

## Test plan
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check app/ tests/` — clean
- [x] `mypy --config-file mypy.ini app` — 104 source files, no issues
- [x] `pytest tests/test_translation_*.py -q` — 40 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)