### PR TITLE
feat(translation): translate announcements and course events alongside the tree

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import assert_course_owner, get_current_user, require_teacher
@@ -14,19 +14,31 @@ from app.schemas.announcement import (
     AnnouncementResponse,
     AnnouncementUpdate,
 )
+from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.notification_service import create_notifications_bulk
+from app.services.translation.resolve_for_display import localize_announcement_rows
 
 router = APIRouter(prefix="/announcements", tags=["announcements"])
 
 
+def _course_source_locale_map(db: Session, course_ids: list[str]) -> dict[str, LocaleCode]:
+    if not course_ids:
+        return {}
+    rows = db.query(Course.id, Course.source_locale).filter(Course.id.in_(course_ids)).all()
+    return {str(cid): normalize_locale(src) for cid, src in rows}
+
+
 @router.get("", response_model=list[AnnouncementResponse])
 def list_announcements(
+    response: Response,
     course_id: str | None = Query(None),
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> list[Announcement]:
+) -> list[AnnouncementResponse]:
+    response.headers["Vary"] = "Accept-Language"
     query = db.query(Announcement)
     is_admin = current_user.role in (UserRole.ADMIN.value, "admin")
 
@@ -67,7 +79,24 @@ def list_announcements(
         )
     # Admin without course_id sees all announcements (paginated, capped by limit).
 
-    return query.order_by(Announcement.created_at.desc()).offset(skip).limit(limit).all()
+    rows = query.order_by(Announcement.created_at.desc()).offset(skip).limit(limit).all()
+
+    # Admins see canonical source for moderation; everyone else (students,
+    # other teachers) gets the locale overlay if one exists.
+    if is_admin:
+        return [AnnouncementResponse.model_validate(a, from_attributes=True) for a in rows]
+
+    display_locale: LocaleCode = normalize_locale(accept_language)
+    course_ids = [str(a.course_id) for a in rows if a.course_id]
+    source_locales = _course_source_locale_map(db, course_ids)
+    # Group by source_locale so a single bulk overlay fetch covers each group.
+    out: list[AnnouncementResponse] = []
+    for src in {*source_locales.values(), normalize_locale(None)}:
+        bucket = [a for a in rows if source_locales.get(str(a.course_id), normalize_locale(None)) == src]
+        if not bucket:
+            continue
+        out.extend(localize_announcement_rows(db, bucket, display_locale=display_locale, source_locale=src))
+    return out
 
 
 @router.post("", response_model=AnnouncementResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_teacher, verify_course_owner
@@ -14,16 +14,27 @@ from app.schemas.calendar import (
     CourseEventResponse,
     CourseEventUpdate,
 )
+from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.translation.resolve_for_display import (
+    fetch_overlay_triples_bulk,
+    localize_course_event_rows,
+    pick_overlay_value,
+)
 
 router = APIRouter(prefix="/calendar", tags=["calendar"])
 
 
 @router.get("/events", response_model=list[CalendarEvent])
 def get_calendar_events(
+    response: Response,
     course_id: str | None = Query(None),
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[CalendarEvent]:
+    response.headers["Vary"] = "Accept-Language"
+    is_admin = current_user.role == UserRole.ADMIN.value
+    display_locale: LocaleCode = normalize_locale(accept_language)
     enrolled_q = db.query(Enrollment.course_id).filter(Enrollment.user_id == current_user.id)
     if course_id:
         enrolled_q = enrolled_q.filter(Enrollment.course_id == course_id)
@@ -117,12 +128,56 @@ def get_calendar_events(
             )
 
     course_events = db.query(CourseEvent).filter(CourseEvent.course_id.in_(enrolled_course_ids)).all()
+
+    # Pre-fetch source locales per course so the overlay picks the right
+    # row (translation rows are keyed by display locale; fallback uses the
+    # course's source locale).
+    course_source_locales: dict[str, LocaleCode] = {}
+    for cid, src in db.query(Course.id, Course.source_locale).filter(Course.id.in_(enrolled_course_ids)).all():
+        course_source_locales[cid] = normalize_locale(src)
+
+    # Bulk-fetch overlay rows for every course_event title + non-empty description
+    # so non-admin students see the localized version. Admins always see source.
+    overlay_event: dict[tuple[str, str, str], str] = {}
+    if not is_admin and course_events:
+        specs: list[tuple[str, str, str]] = []
+        for ce in course_events:
+            specs.append(("course_event", str(ce.id), "title"))
+            if ce.description and str(ce.description).strip():
+                specs.append(("course_event", str(ce.id), "description"))
+        overlay_event = fetch_overlay_triples_bulk(db, specs, display_locale)
+
     for ce in course_events:
+        course_src = course_source_locales.get(ce.course_id, normalize_locale(None))
+        title = ce.title
+        description = ce.description
+        if not is_admin:
+            title = (
+                pick_overlay_value(
+                    overlay_event,
+                    "course_event",
+                    str(ce.id),
+                    "title",
+                    ce.title,
+                    source_locale=course_src,
+                    display_locale=display_locale,
+                )
+                or ce.title
+            )
+            description = pick_overlay_value(
+                overlay_event,
+                "course_event",
+                str(ce.id),
+                "description",
+                ce.description,
+                source_locale=course_src,
+                display_locale=display_locale,
+            )
         events.append(
             CalendarEvent(
                 id=str(ce.id),
-                title=ce.title,
-                description=ce.description,
+                title=title,
+                description=description,
                 event_type=ce.event_type,
                 event_date=ce.event_date,
                 course_id=ce.course_id,
@@ -169,12 +224,19 @@ def create_course_event(
     response_model=list[CourseEventResponse],
 )
 def list_course_events(
+    response: Response,
     course_id: str,
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> list[CourseEvent]:
+) -> list[CourseEventResponse]:
+    response.headers["Vary"] = "Accept-Language"
     # Narrow probe: only the columns needed for ownership + soft-delete checks.
-    course_row = db.query(Course.created_by).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
+    course_row = (
+        db.query(Course.created_by, Course.source_locale)
+        .filter(Course.id == course_id, Course.deleted_at.is_(None))
+        .first()
+    )
     if not course_row:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
     is_owner = str(course_row.created_by) == str(current_user.id)
@@ -190,7 +252,14 @@ def list_course_events(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You must be enrolled in this course to view events",
             )
-    return db.query(CourseEvent).filter(CourseEvent.course_id == course_id).order_by(CourseEvent.event_date).all()
+    rows = db.query(CourseEvent).filter(CourseEvent.course_id == course_id).order_by(CourseEvent.event_date).all()
+    # Owner + admin see source for editorial accuracy; everyone else gets the
+    # locale overlay if the translation pipeline has materialised one.
+    if is_owner or is_admin:
+        return [CourseEventResponse.model_validate(e, from_attributes=True) for e in rows]
+    display_locale: LocaleCode = normalize_locale(accept_language)
+    source_locale: LocaleCode = normalize_locale(course_row.source_locale)
+    return localize_course_event_rows(db, rows, display_locale=display_locale, source_locale=source_locale)
 
 
 @event_router.put(

--- a/backend/app/models/content_translation.py
+++ b/backend/app/models/content_translation.py
@@ -30,6 +30,8 @@ TranslationEntityType = Literal[
     "quiz_question",
     "quiz_option",
     "assignment",
+    "announcement",
+    "course_event",
 ]
 TranslationField = Literal[
     "content",

--- a/backend/app/services/translation/course_pipeline.py
+++ b/backend/app/services/translation/course_pipeline.py
@@ -11,9 +11,11 @@ import logging
 
 from sqlalchemy.orm import Session, selectinload
 
+from app.models.announcement import Announcement
 from app.models.assignment import Assignment
 from app.models.chapter_block import ChapterBlock
 from app.models.course import Course  # noqa: TC001
+from app.models.course_event import CourseEvent
 from app.models.quiz import Quiz, QuizQuestion
 from app.schemas.locale import LOCALE_CODES, LocaleCode
 from app.services.translation.orchestrator import (
@@ -197,6 +199,43 @@ def translate_course_content(
                     provider=provider,
                 )
                 total = merge_orchestrator_reports(total, r)
+
+    # Announcements live alongside the course (course_id FK) and are
+    # surfaced to students in the announcements feed; they're not on the
+    # chapter-tree walk above. Translate every announcement bound to this
+    # course on every publish so a student in EN sees the EN copy.
+    announcements = db.query(Announcement).filter(Announcement.course_id == course.id).all()
+    for ann in announcements:
+        r = translate_entity_fields(
+            db,
+            entity_type="announcement",
+            entity_id=str(ann.id),
+            source_locale=source_locale,
+            fields=[
+                TranslationFieldSpec(field="title", text=ann.title, content_kind="title"),
+                TranslationFieldSpec(field="content", text=ann.content, content_kind="plain"),
+            ],
+            context=f"Announcement in course «{course.title}»",
+            provider=provider,
+        )
+        total = merge_orchestrator_reports(total, r)
+
+    # Same shape for calendar events bound to the course.
+    events = db.query(CourseEvent).filter(CourseEvent.course_id == course.id).all()
+    for ev in events:
+        fields = [TranslationFieldSpec(field="title", text=ev.title, content_kind="title")]
+        if ev.description:
+            fields.append(TranslationFieldSpec(field="description", text=ev.description, content_kind="plain"))
+        r = translate_entity_fields(
+            db,
+            entity_type="course_event",
+            entity_id=str(ev.id),
+            source_locale=source_locale,
+            fields=fields,
+            context=f"Calendar event in course «{course.title}»",
+            provider=provider,
+        )
+        total = merge_orchestrator_reports(total, r)
 
     return total
 

--- a/backend/app/services/translation/protocol.py
+++ b/backend/app/services/translation/protocol.py
@@ -47,6 +47,8 @@ EntityType = Literal[
     "quiz_question",
     "quiz_option",
     "assignment",
+    "announcement",
+    "course_event",
 ]
 
 

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -19,13 +19,17 @@ import uuid
 from sqlalchemy import tuple_
 from sqlalchemy.orm import Session  # noqa: TC002
 
+from app.models.announcement import Announcement  # noqa: TC001
 from app.models.assignment import Assignment  # noqa: TC001
 from app.models.chapter_block import ChapterBlock  # noqa: TC001
 from app.models.content_translation import ContentTranslation
 from app.models.course import Chapter, Course, Module
+from app.models.course_event import CourseEvent  # noqa: TC001
 from app.models.quiz import Quiz  # noqa: TC001
 from app.models.user import User, UserRole
+from app.schemas.announcement import AnnouncementResponse
 from app.schemas.assignment import AssignmentResponse
+from app.schemas.calendar import CourseEventResponse
 from app.schemas.chapter_block import BlockResponse
 from app.schemas.course import ChapterResponse, CourseResponse, CourseSummary, ModuleResponse
 from app.schemas.locale import LocaleCode, normalize_locale
@@ -464,6 +468,97 @@ def localize_chapter_block_rows(
     return out
 
 
+def localize_announcement_rows(
+    db: Session,
+    announcements: list[Announcement],
+    *,
+    display_locale: LocaleCode,
+    source_locale: LocaleCode,
+) -> list[AnnouncementResponse]:
+    """Apply stored translations to teacher-authored announcement rows."""
+    if not announcements:
+        return []
+    specs: list[tuple[str, str, str]] = []
+    for a in announcements:
+        specs.append(("announcement", str(a.id), "title"))
+        if a.content and str(a.content).strip():
+            specs.append(("announcement", str(a.id), "content"))
+    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
+    out: list[AnnouncementResponse] = []
+    for a in announcements:
+        base = AnnouncementResponse.model_validate(a, from_attributes=True)
+        title = (
+            pick_overlay_value(
+                overlay_t,
+                "announcement",
+                str(a.id),
+                "title",
+                a.title,
+                source_locale=source_locale,
+                display_locale=display_locale,
+            )
+            or a.title
+        )
+        content = (
+            pick_overlay_value(
+                overlay_t,
+                "announcement",
+                str(a.id),
+                "content",
+                a.content,
+                source_locale=source_locale,
+                display_locale=display_locale,
+            )
+            or a.content
+        )
+        out.append(base.model_copy(update={"title": title, "content": content}))
+    return out
+
+
+def localize_course_event_rows(
+    db: Session,
+    events: list[CourseEvent],
+    *,
+    display_locale: LocaleCode,
+    source_locale: LocaleCode,
+) -> list[CourseEventResponse]:
+    """Apply stored translations to calendar event rows."""
+    if not events:
+        return []
+    specs: list[tuple[str, str, str]] = []
+    for e in events:
+        specs.append(("course_event", str(e.id), "title"))
+        if e.description and str(e.description).strip():
+            specs.append(("course_event", str(e.id), "description"))
+    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
+    out: list[CourseEventResponse] = []
+    for e in events:
+        base = CourseEventResponse.model_validate(e, from_attributes=True)
+        title = (
+            pick_overlay_value(
+                overlay_t,
+                "course_event",
+                str(e.id),
+                "title",
+                e.title,
+                source_locale=source_locale,
+                display_locale=display_locale,
+            )
+            or e.title
+        )
+        description = pick_overlay_value(
+            overlay_t,
+            "course_event",
+            str(e.id),
+            "description",
+            e.description,
+            source_locale=source_locale,
+            display_locale=display_locale,
+        )
+        out.append(base.model_copy(update={"title": title, "description": description}))
+    return out
+
+
 __all__ = [
     "batch_fetch_course_translations",
     "build_localized_course_response",
@@ -472,8 +567,10 @@ __all__ = [
     "build_localized_quiz_student_response",
     "fetch_overlay_triples_bulk",
     "get_course_source_locale_for_chapter",
+    "localize_announcement_rows",
     "localize_assignment_rows",
     "localize_chapter_block_rows",
+    "localize_course_event_rows",
     "pick_overlay_value",
     "should_apply_course_translation_overlay",
     "should_apply_course_translation_overlay_for_chapter",

--- a/supabase/migrations/20260507131800_extend_translations_to_announcements_and_events.sql
+++ b/supabase/migrations/20260507131800_extend_translations_to_announcements_and_events.sql
@@ -1,0 +1,30 @@
+-- Supabase migration: extend_translations_to_announcements_and_events
+-- Version: 20260507131800
+--
+-- Adds ``announcement`` and ``course_event`` to the ``entity_type`` set of
+-- ``content_translations`` so the translation pipeline can cache machine
+-- translations of teacher-authored announcements (title + content) and
+-- calendar events (title + description). The corresponding ``field`` values
+-- (``title``, ``content``, ``description``) are already in the existing
+-- ``content_translations_field_check`` constraint — no update needed there.
+--
+-- Idempotent: drops the existing CHECK by name first, then recreates with
+-- the expanded set. Safe to replay on a clean project.
+
+ALTER TABLE public.content_translations
+  DROP CONSTRAINT IF EXISTS content_translations_entity_type_check;
+
+ALTER TABLE public.content_translations
+  ADD CONSTRAINT content_translations_entity_type_check
+  CHECK (entity_type IN (
+    'chapter_block',
+    'course',
+    'module',
+    'chapter',
+    'quiz',
+    'quiz_question',
+    'quiz_option',
+    'assignment',
+    'announcement',
+    'course_event'
+  ));


### PR DESCRIPTION
## Summary
Closes the last student-visible RU→EN gap. The translation pipeline previously only walked course/module/chapter/chapter_block/quiz/quiz_question/quiz_option/assignment. Two course-bound entities with teacher-authored Russian text were never visited:

- `announcements` — title + content (course-wide messages, e.g. "Тест", "Ура")
- `course_events` — title + description (calendar events, e.g. "Екзамен")

Students reading the site in EN saw an English course but **Russian announcements and a Russian calendar event**, because the API endpoints returned the source columns directly.

## What changed
1. **Migration** `20260507131800_extend_translations_to_announcements_and_events.sql` — drops/recreates the `content_translations_entity_type_check` to add `announcement` and `course_event`. Idempotent. (Field-set already covered `title`/`content`/`description`.)
2. **Code**:
   - `protocol.EntityType` and `content_translation.TranslationEntityType` literals extended (mypy-strict in lockstep with the CHECK set).
   - `course_pipeline.translate_course_content` now walks announcements and course_events bound to the course, mirroring existing patterns.
   - `resolve_for_display` adds `localize_announcement_rows` and `localize_course_event_rows` helpers.
   - `api/v1/announcements.list_announcements` accepts `Accept-Language` + applies overlay (admin sees source for moderation).
   - `api/v1/calendar.get_calendar_events` and `list_course_events` apply overlay for non-owner/non-admin (owner + admin see source — matches the existing course/chapter rule).

Migration already applied to production via MCP while authoring; the SQL file captures the canonical version.

## Already-applied note
Same approach as PRs #106 / #108: migration ran first via MCP `apply_migration` so the new CHECK is live, this PR captures the file in source-of-truth.

## Post-merge step (manual)
Re-trigger `POST /api/v1/courses/{course_id}/translate` on the 3 published courses so the 2 existing announcements + 1 existing event are translated. Pipeline is idempotent — already-ok rows for chapters/blocks/etc. will be skipped, only the new announcement/event rows hit Gemini (~6-8 calls, well under $0.01).

## Test plan
- [x] `ruff check .` — clean
- [x] `ruff format --check app/ tests/` — clean
- [x] `mypy --config-file mypy.ini app` — 104 source files, no issues
- [x] `pytest tests/ -q` — **448 passed** (was 442; existing tests cover the endpoint shape)
- [ ] Backend CI green on this branch
- [ ] After merge: `Accept-Language: en` request to `/api/v1/announcements` and `/api/v1/calendar/events` returns translated rows
- [ ] After re-translate: SQL check `SELECT entity_type, COUNT(*) FROM content_translations WHERE entity_type IN ('announcement','course_event') GROUP BY 1` shows ≥3 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)