### PR TITLE
fix(translation): apply locale overlay to module-detail endpoint

### DIFF
--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_optional_user, require_teacher
 from app.core.database import get_db
-from app.models.course import Course, Module
+from app.models.course import Course
 from app.models.user import User, UserRole
 from app.schemas.course import CourseResponse, CourseSummary, ModuleResponse
 from app.schemas.locale import LocaleCode, normalize_locale
@@ -19,6 +19,7 @@ from app.services.translation.resolve_for_display import (
     batch_fetch_course_translations,
     build_localized_course_response_with_tree,
     build_localized_course_summary,
+    build_localized_module_response,
     should_apply_course_translation_overlay,
 )
 
@@ -108,20 +109,25 @@ def get_course_detail(
 def get_module_detail(
     course_id: str,
     module_id: str,
+    response: Response,
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User | None = Depends(get_optional_user),
     db: Session = Depends(get_db),
-) -> Module:
+) -> ModuleResponse:
     # Lightweight access probe — avoids loading the whole course→modules→chapters
-    # tree just to check publication state.
+    # tree just to check publication state. Pull source_locale here too so we
+    # don't need a second course fetch to apply the translation overlay below.
     course_row = (
-        db.query(Course.status, Course.created_by).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
+        db.query(Course.status, Course.created_by, Course.source_locale)
+        .filter(Course.id == course_id, Course.deleted_at.is_(None))
+        .first()
     )
     if not course_row:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Course '{course_id}' not found",
         )
-    course_status, course_owner_id = course_row
+    course_status, course_owner_id, course_source_locale = course_row
     if course_status != "published":
         if not current_user or (
             str(course_owner_id) != str(current_user.id) and current_user.role != UserRole.ADMIN.value
@@ -136,4 +142,23 @@ def get_module_detail(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Module '{module_id}' not found in course '{course_id}'",
         )
-    return module
+
+    response.headers["Vary"] = "Accept-Language"
+
+    # Owner + admin always see source for editorial accuracy (matches the
+    # rule in ``should_apply_course_translation_overlay`` for the parent
+    # course-detail endpoint). Everyone else (students, anonymous catalog
+    # browsers, other teachers) gets the locale overlay.
+    is_owner = current_user is not None and str(course_owner_id) == str(current_user.id)
+    is_admin = current_user is not None and current_user.role == UserRole.ADMIN.value
+    if is_owner or is_admin:
+        return ModuleResponse.model_validate(module, from_attributes=True)
+
+    display_locale: LocaleCode = normalize_locale(accept_language)
+    source_locale: LocaleCode = normalize_locale(course_source_locale)
+    return build_localized_module_response(
+        db,
+        module,
+        display_locale=display_locale,
+        source_locale=source_locale,
+    )

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -468,6 +468,70 @@ def localize_chapter_block_rows(
     return out
 
 
+def build_localized_module_response(
+    db: Session,
+    module: Module,
+    *,
+    display_locale: LocaleCode,
+    source_locale: LocaleCode,
+) -> ModuleResponse:
+    """Localized module title/description plus chapter titles.
+
+    Mirror of ``build_localized_course_response_with_tree`` but scoped to a
+    single module — the dedicated module-detail endpoint hits this so a
+    student opening a module sees module + chapter titles in the active
+    locale (was returning raw RU even though chapter titles were already in
+    ``content_translations``).
+    """
+    specs: list[tuple[str, str, str]] = [
+        ("module", str(module.id), "title"),
+        ("module", str(module.id), "description"),
+    ]
+    for ch in module.chapters:
+        specs.append(("chapter", str(ch.id), "title"))
+    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
+
+    mt = (
+        pick_overlay_value(
+            overlay_t,
+            "module",
+            str(module.id),
+            "title",
+            module.title,
+            source_locale=source_locale,
+            display_locale=display_locale,
+        )
+        or module.title
+    )
+    md = pick_overlay_value(
+        overlay_t,
+        "module",
+        str(module.id),
+        "description",
+        module.description,
+        source_locale=source_locale,
+        display_locale=display_locale,
+    )
+    new_chapters: list[ChapterResponse] = []
+    for ch in module.chapters:
+        cht = (
+            pick_overlay_value(
+                overlay_t,
+                "chapter",
+                str(ch.id),
+                "title",
+                ch.title,
+                source_locale=source_locale,
+                display_locale=display_locale,
+            )
+            or ch.title
+        )
+        ch_base = ChapterResponse.model_validate(ch, from_attributes=True)
+        new_chapters.append(ch_base.model_copy(update={"title": cht}))
+    base = ModuleResponse.model_validate(module, from_attributes=True)
+    return base.model_copy(update={"title": mt, "description": md, "chapters": new_chapters})
+
+
 def localize_announcement_rows(
     db: Session,
     announcements: list[Announcement],
@@ -564,6 +628,7 @@ __all__ = [
     "build_localized_course_response",
     "build_localized_course_response_with_tree",
     "build_localized_course_summary",
+    "build_localized_module_response",
     "build_localized_quiz_student_response",
     "fetch_overlay_triples_bulk",
     "get_course_source_locale_for_chapter",


### PR DESCRIPTION
## Bug
Student opens `/courses/{cid}/modules/{mid}` (Acts course in EN UI) and sees:
- Module title in EN ✅ (came from the parent course-tree response)
- **Chapter titles inside the module in RU ❌**
- Click on a chapter → content in EN ✅ (blocks endpoint overlays correctly)

So the mismatch is exactly at the module-detail level.

## Root cause
`get_module_detail` in `backend/app/api/v1/courses/catalog.py` returned the raw SQLAlchemy `Module` object directly. No `Accept-Language` header, no overlay step, even though the chapter-title rows for that module already existed in `content_translations` with `status='ok'`. The frontend rendered `module.chapters[].title` as the source RU.

## Fix
Mirror the pattern from `get_course_detail` (which already overlays correctly):
- Read `Accept-Language` header
- Owner + admin still see source for editorial accuracy (matches the rule for course detail)
- Everyone else gets the localized response via a new `build_localized_module_response` helper in `resolve_for_display.py`, scoped to one module + its chapter titles

The helper is a smaller cousin of `build_localized_course_response_with_tree` — single module, no course metadata.

## Test plan
- [x] `ruff check .` — clean
- [x] `ruff format --check app/ tests/` — clean
- [x] `mypy --config-file mypy.ini app` — 104 source files, no issues
- [x] `pytest tests/` — **448 passed** (no regressions)
- [ ] Backend CI green
- [ ] After merge: open the Acts course in EN UI as a student, navigate to a module, all chapter titles visible there must be in EN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)