### PR TITLE
fix(translation): trigger pipeline on announcement/event create+update

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -16,6 +16,7 @@ from app.schemas.announcement import (
 )
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.notification_service import create_notifications_bulk
+from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
 from app.services.translation.resolve_for_display import localize_announcement_rows
 
 router = APIRouter(prefix="/announcements", tags=["announcements"])
@@ -146,6 +147,8 @@ def create_announcement(
 
     db.commit()
     db.refresh(announcement)
+    if data.course_id:
+        run_course_translation_pipeline_if_published(db, data.course_id)
     return announcement
 
 
@@ -175,6 +178,8 @@ def update_announcement(
 
     db.commit()
     db.refresh(announcement)
+    if announcement.course_id:
+        run_course_translation_pipeline_if_published(db, str(announcement.course_id))
     return announcement
 
 

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -15,6 +15,7 @@ from app.schemas.calendar import (
     CourseEventUpdate,
 )
 from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
 from app.services.translation.resolve_for_display import (
     fetch_overlay_triples_bulk,
     localize_course_event_rows,
@@ -216,6 +217,7 @@ def create_course_event(
     db.add(event)
     db.commit()
     db.refresh(event)
+    run_course_translation_pipeline_if_published(db, course_id)
     return event
 
 
@@ -288,6 +290,7 @@ def update_course_event(
         setattr(event, field, value)
     db.commit()
     db.refresh(event)
+    run_course_translation_pipeline_if_published(db, course_id)
     return event
 
 


### PR DESCRIPTION
## Closes Category C of the audit
> _Class C: write endpoint forgets to call the translation hook_

When a teacher creates a new announcement or calendar event on a published course, the entity is persisted but `translate_course_content` was never invoked — so a student opening the page in EN saw the source RU until the next course-level edit happened to fire the pipeline. **This caused yesterday's manual backfill** for the 2 announcements + 1 event already in the DB.

## Why
Every other write endpoint that mutates a translatable entity bound to a course (`chapters.py`, `blocks.py`, `modules.py`, `assignments.py`) already calls `run_course_translation_pipeline_if_published` after the commit. `announcements.py` and `calendar.py` were the two stragglers — when PR #114 added `announcement` + `course_event` as translatable entity types in the registry/CHECK, the matching write hooks weren't added.

## Fix
4 lines:
- `announcements.create_announcement` — hook after commit when `course_id` is set (course-bound announcements; orphan announcements stay as-is)
- `announcements.update_announcement` — hook after commit
- `calendar.create_course_event` — hook after commit
- `calendar.update_course_event` — hook after commit

Pipeline is idempotent via `source_hash`, so re-running after every announcement edit only translates changed text. Hook swallows exceptions internally so a Gemini outage never breaks the save.

## Follow-up architecture (separate PRs)
This is a hot-fix for the immediate gap. The proper architectural cleanup — translation registry + per-entity reconcile + CI guard against forgotten hooks/overlays + lazy-on-read fallback — is queued as PRs B/C/D.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — clean
- [x] `pytest -k 'announcement or calendar or translat or hook'` — 121 passed
- [ ] Backend CI green
- [ ] After merge: create a fresh announcement on a published course → student in EN sees the EN translation on next page load (no manual backfill needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)