### PR TITLE
fix(test): use datetime.UTC alias to satisfy CI ruff (UP017)

### DIFF
--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -133,14 +133,14 @@ def test_reconcile_event_with_empty_description_skips_that_field(
 ):
     """An entity with one empty translatable field should still
     reconcile the non-empty fields, not skip the whole entity."""
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
     ev = CourseEvent(
         course_id=published_course.id,
         title="Final Exam",
         description="",
         event_type="exam",
-        event_date=datetime(2026, 12, 1, 10, 0, tzinfo=timezone.utc),
+        event_date=datetime(2026, 12, 1, 10, 0, tzinfo=UTC),
         created_by=teacher.id,
     )
     db.add(ev)


### PR DESCRIPTION
## Summary
Hotfix for the broken `lint-and-test` CI on main after PR #117 (translation registry). One line: `timezone.utc` → `datetime.UTC`.

## What broke
CI invokes `ruff check app/ tests/` (explicitly scoped). Local sandbox runs `ruff check .` without that narrowing — both use the same ruff (0.15.12 per requirements-ci.txt) but a different invocation surfaces UP017 differently.

## Test plan
- [x] `ruff check app/ tests/` matching CI invocation — clean
- [x] `pytest tests/test_translation_registry.py` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)