### PR TITLE
chore(translation): close all KNOWN_VIOLATIONS — cohorts, certificates, prerequisites

### DIFF
--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -11,9 +11,59 @@ from app.models.course import Course
 from app.models.enrollment import Enrollment
 from app.models.user import User
 from app.schemas.certificate import CertificateResponse, CertificateVerifyResponse
+from app.schemas.locale import LocaleCode, normalize_locale
 from app.services import certificate_service
+from app.services.translation.resolve_for_display import (
+    fetch_overlay_triples_bulk,
+    pick_overlay_value,
+)
 
 router = APIRouter(prefix="/certificates", tags=["certificates"])
+
+
+def _localize_cert_responses(
+    db: Session,
+    certs: list[Certificate],
+    *,
+    display_locale: LocaleCode,
+) -> list[CertificateResponse]:
+    """Build ``CertificateResponse`` instances with the course title
+    overlaid into the requested display locale. Falls back to the
+    course's source title when no translation row exists.
+    """
+    if not certs:
+        return []
+    course_ids = sorted({str(c.course_id) for c in certs if c.course_id})
+    if not course_ids:
+        return [CertificateResponse.model_validate(c, from_attributes=True) for c in certs]
+    courses = db.query(Course.id, Course.title, Course.source_locale).filter(Course.id.in_(course_ids)).all()
+    course_meta: dict[str, tuple[str, LocaleCode]] = {
+        str(cid): (title, normalize_locale(src)) for cid, title, src in courses
+    }
+    specs = [("course", cid, "title") for cid in course_meta]
+    overlay = fetch_overlay_triples_bulk(db, specs, display_locale)
+    out: list[CertificateResponse] = []
+    for cert in certs:
+        base = CertificateResponse.model_validate(cert, from_attributes=True)
+        meta = course_meta.get(str(cert.course_id))
+        if meta is None:
+            out.append(base)
+            continue
+        source_title, source_locale = meta
+        title = (
+            pick_overlay_value(
+                overlay,
+                "course",
+                str(cert.course_id),
+                "title",
+                source_title,
+                source_locale=source_locale,
+                display_locale=display_locale,
+            )
+            or source_title
+        )
+        out.append(base.model_copy(update={"course_title": title}))
+    return out
 
 
 @router.post("/course/{course_id}", response_model=CertificateResponse, status_code=status.HTTP_201_CREATED)
@@ -65,27 +115,34 @@ def request_certificate(
 
 @router.get("/course/{course_id}", response_model=CertificateResponse)
 def get_course_certificate(
+    response: Response,
     course_id: str,
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Certificate:
+) -> CertificateResponse:
     """Get the current user's certificate for a specific course."""
+    response.headers["Vary"] = "Accept-Language"
     cert = (
         db.query(Certificate).filter(Certificate.user_id == current_user.id, Certificate.course_id == course_id).first()
     )
     if not cert:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No certificate found")
-    return cert
+    display_locale: LocaleCode = normalize_locale(accept_language)
+    return _localize_cert_responses(db, [cert], display_locale=display_locale)[0]
 
 
 @router.get("/my", response_model=list[CertificateResponse])
 def list_my_certificates(
+    response: Response,
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> list[Certificate]:
-    return (
+) -> list[CertificateResponse]:
+    response.headers["Vary"] = "Accept-Language"
+    rows = (
         db.query(Certificate)
         .filter(Certificate.user_id == current_user.id)
         .order_by(Certificate.requested_at.desc())
@@ -93,6 +150,8 @@ def list_my_certificates(
         .limit(limit)
         .all()
     )
+    display_locale: LocaleCode = normalize_locale(accept_language)
+    return _localize_cert_responses(db, rows, display_locale=display_locale)
 
 
 @router.get("/pending", response_model=list[CertificateResponse])

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -10,6 +10,12 @@ from app.models.enrollment import Enrollment
 from app.models.student_grade import StudentGrade
 from app.models.user import User, UserRole
 from app.schemas.cohort import CohortCreate, CohortResponse, CohortUpdate
+from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
+from app.services.translation.resolve_for_display import (
+    fetch_overlay_triples_bulk,
+    pick_overlay_value,
+)
 
 router = APIRouter(prefix="/cohorts", tags=["cohorts"])
 
@@ -39,10 +45,13 @@ def _get_cohort_or_404(db: Session, cohort_id: str) -> Cohort:
 
 @router.get("/course/{course_id}", response_model=list[CohortResponse])
 def list_cohorts(
+    response: Response,
     course_id: str,
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User | None = Depends(get_optional_user),
     db: Session = Depends(get_db),
 ) -> list[CohortResponse]:
+    response.headers["Vary"] = "Accept-Language"
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
@@ -63,7 +72,39 @@ def list_cohorts(
         .all()
     )
     count_map = {row[0]: row[1] for row in counts}
-    return [_cohort_to_response(c, count_map.get(c.id, 0)) for c in cohorts]
+
+    # Owner + admin see source for editorial accuracy; everyone else
+    # gets the locale overlay (cohort.name is teacher-authored, so when
+    # a student in EN reads a course list whose cohorts were created in
+    # RU we'd otherwise display the source name).
+    is_owner = current_user is not None and str(course.created_by) == str(current_user.id)
+    is_admin = current_user is not None and current_user.role == UserRole.ADMIN.value
+    if is_owner or is_admin:
+        return [_cohort_to_response(c, count_map.get(c.id, 0)) for c in cohorts]
+
+    display_locale: LocaleCode = normalize_locale(accept_language)
+    source_locale: LocaleCode = normalize_locale(course.source_locale)
+    overlay_specs = [("cohort", str(c.id), "title") for c in cohorts]
+    overlay = fetch_overlay_triples_bulk(db, overlay_specs, display_locale)
+    out: list[CohortResponse] = []
+    for c in cohorts:
+        localized_name = (
+            pick_overlay_value(
+                overlay,
+                "cohort",
+                str(c.id),
+                "title",
+                c.name,
+                source_locale=source_locale,
+                display_locale=display_locale,
+            )
+            or c.name
+        )
+        resp = CohortResponse.model_validate(c)
+        resp.name = localized_name
+        resp.student_count = count_map.get(c.id, 0)
+        out.append(resp)
+    return out
 
 
 @router.post(
@@ -91,6 +132,7 @@ def create_cohort(
     db.add(cohort)
     db.commit()
     db.refresh(cohort)
+    reconcile_entity_if_course_published(db, "cohort", cohort)
     return _cohort_to_response(cohort, 0)
 
 
@@ -109,6 +151,7 @@ def update_cohort(
 
     db.commit()
     db.refresh(cohort)
+    reconcile_entity_if_course_published(db, "cohort", cohort)
     return _cohort_to_response(cohort, _count_students_in_cohort(db, cohort.id))
 
 

--- a/backend/app/api/v1/prerequisites.py
+++ b/backend/app/api/v1/prerequisites.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -7,6 +7,11 @@ from app.core.database import get_db
 from app.models.course import Course
 from app.models.prerequisite import CoursePrerequisite
 from app.models.user import User, UserRole
+from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.translation.resolve_for_display import (
+    fetch_overlay_triples_bulk,
+    pick_overlay_value,
+)
 
 router = APIRouter(prefix="/prerequisites", tags=["prerequisites"])
 
@@ -21,12 +26,52 @@ class PrerequisiteResponse(BaseModel):
     prerequisite_course_title: str | None = None
 
 
+def _localized_title_map(
+    db: Session,
+    course_ids: list[str],
+    *,
+    display_locale: LocaleCode,
+) -> dict[str, str]:
+    """Return ``{course_id -> course title in display_locale}`` for live
+    courses, falling back to the source title when no translation row
+    exists. Uses the same overlay machinery as the catalog endpoint so
+    behaviour stays identical to ``GET /courses``.
+    """
+    if not course_ids:
+        return {}
+    rows = (
+        db.query(Course.id, Course.title, Course.source_locale)
+        .filter(Course.id.in_(course_ids), Course.deleted_at.is_(None))
+        .all()
+    )
+    specs = [("course", str(cid), "title") for cid, _, _ in rows]
+    overlay = fetch_overlay_triples_bulk(db, specs, display_locale)
+    out: dict[str, str] = {}
+    for cid, source_title, source_locale in rows:
+        out[str(cid)] = (
+            pick_overlay_value(
+                overlay,
+                "course",
+                str(cid),
+                "title",
+                source_title,
+                source_locale=normalize_locale(source_locale),
+                display_locale=display_locale,
+            )
+            or source_title
+        )
+    return out
+
+
 @router.get("/course/{course_id}", response_model=list[PrerequisiteResponse])
 def get_prerequisites(
+    response: Response,
     course_id: str,
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
+    response.headers["Vary"] = "Accept-Language"
     # Requires auth and that the course is visible to the caller. Previously
     # this endpoint was public and would happily leak draft-course
     # relationships to anonymous callers (audit P1.4). Trashed courses are
@@ -42,14 +87,9 @@ def get_prerequisites(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 
     prereqs = db.query(CoursePrerequisite).filter(CoursePrerequisite.course_id == course_id).all()
-
     prereq_ids = [p.prerequisite_course_id for p in prereqs]
-    # Hide trashed prerequisite targets — they should not appear as
-    # "required" courses when they've been removed from the catalog.
-    courses = (
-        db.query(Course).filter(Course.id.in_(prereq_ids), Course.deleted_at.is_(None)).all() if prereq_ids else []
-    )
-    title_map = {str(c.id): c.title for c in courses}
+    display_locale: LocaleCode = normalize_locale(accept_language)
+    title_map = _localized_title_map(db, prereq_ids, display_locale=display_locale)
 
     return [
         PrerequisiteResponse(

--- a/backend/app/models/content_translation.py
+++ b/backend/app/models/content_translation.py
@@ -32,6 +32,7 @@ TranslationEntityType = Literal[
     "assignment",
     "announcement",
     "course_event",
+    "cohort",
 ]
 TranslationField = Literal[
     "content",

--- a/backend/app/services/translation/course_pipeline.py
+++ b/backend/app/services/translation/course_pipeline.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import selectinload
 from app.models.announcement import Announcement
 from app.models.assignment import Assignment
 from app.models.chapter_block import ChapterBlock
+from app.models.cohort import Cohort
 from app.models.course_event import CourseEvent
 from app.models.quiz import Quiz, QuizQuestion
 from app.services.translation.orchestrator import OrchestratorReport
@@ -169,6 +170,11 @@ def _translate_course_side_entities(
         total = merge_orchestrator_reports(
             total,
             reconcile_entity(db, "course_event", ev, provider=provider),
+        )
+    for co in db.query(Cohort).filter(Cohort.course_id == course.id).all():
+        total = merge_orchestrator_reports(
+            total,
+            reconcile_entity(db, "cohort", co, provider=provider),
         )
     return total
 

--- a/backend/app/services/translation/protocol.py
+++ b/backend/app/services/translation/protocol.py
@@ -49,6 +49,7 @@ EntityType = Literal[
     "assignment",
     "announcement",
     "course_event",
+    "cohort",
 ]
 
 

--- a/backend/app/services/translation/registry.py
+++ b/backend/app/services/translation/registry.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 from app.models.announcement import Announcement
 from app.models.assignment import Assignment
 from app.models.chapter_block import ChapterBlock
+from app.models.cohort import Cohort
 from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent
 from app.models.quiz import Quiz, QuizOption, QuizQuestion
@@ -60,13 +61,22 @@ if TYPE_CHECKING:
 class FieldSpec:
     """A translatable field on an entity model.
 
-    ``name`` is keyed against the ``TranslationField`` literal that
-    ``translate_entity_fields`` accepts; mypy enforces that nothing
-    outside the literal sneaks in.
+    ``name`` is what gets stored in ``content_translations.field``; it
+    must be a member of the ``TranslationField`` literal (which maps to
+    the DB ``field`` CHECK constraint). ``model_attr`` is the Python
+    attribute on the entity to read source text from — defaults to
+    ``name`` when the model attribute matches the DB field. They differ
+    when an entity uses a non-canonical field name (e.g. ``Cohort.name``
+    is conceptually a title — store it under ``field='title'``).
     """
 
     name: TranslationField
     content_kind: ContentKind
+    model_attr: str | None = None
+
+    @property
+    def attr(self) -> str:
+        return self.model_attr or self.name
 
 
 @dataclass(frozen=True, slots=True)
@@ -231,6 +241,12 @@ REGISTRY: dict[EntityType, EntityRegistration] = {
         resolve_course=_resolve_course_via_attr("course_id"),
         build_context=lambda _e, c: f"Calendar event in course «{c.title}»",
     ),
+    "cohort": EntityRegistration(
+        entity_type="cohort",
+        fields=(FieldSpec("title", "title", model_attr="name"),),
+        resolve_course=_resolve_course_via_attr("course_id"),
+        build_context=lambda _co, c: f"Student cohort name in course «{c.title}»",
+    ),
 }
 
 
@@ -246,6 +262,7 @@ ENTITY_MODEL: dict[EntityType, type] = {
     "assignment": Assignment,
     "announcement": Announcement,
     "course_event": CourseEvent,
+    "cohort": Cohort,
 }
 
 
@@ -284,7 +301,7 @@ def reconcile_entity(
 
     fields: list[TranslationFieldSpec] = []
     for fs in reg.fields:
-        text = getattr(entity, fs.name, None)
+        text = getattr(entity, fs.attr, None)
         if text is None or not str(text).strip():
             continue
         fields.append(TranslationFieldSpec(field=fs.name, text=text, content_kind=fs.content_kind))

--- a/backend/tests/test_translation_coverage.py
+++ b/backend/tests/test_translation_coverage.py
@@ -146,24 +146,11 @@ WHITELIST_ENDPOINTS: dict[str, str] = {}
 
 KNOWN_VIOLATIONS_RULE1: frozenset[tuple[str, str]] = frozenset(
     {
-        # (endpoint_name, route_path). Each entry MUST cite a follow-up.
-        # The intent of this list is to *surface*, not to silence — every
-        # entry is a TODO ticket waiting for an owning PR.
-        # ----- existing gaps as of 2026-05-07 (PR-D introduces this test):
-        # certificates: course_title is teacher-authored RU but the read
-        # endpoints predate the locale overlay refactor.
-        # TODO follow-up PR: thread Accept-Language through certificates.
-        ("get_course_certificate", "/api/v1/certificates/course/{course_id}"),
-        ("list_my_certificates", "/api/v1/certificates/my"),
-        # cohorts: name is teacher-authored RU; cohorts.py still serves
-        # source for everyone. Translation pipeline does not yet cover
-        # cohort metadata.
-        # TODO follow-up PR: extend the entity registry + overlay to cohorts.
-        ("list_cohorts", "/api/v1/cohorts/course/{course_id}"),
-        # prerequisites: prerequisite_course_title is the upstream course
-        # title — same overlay should apply.
-        # TODO follow-up PR: localize prerequisite_course_title.
-        ("get_prerequisites", "/api/v1/prerequisites/course/{course_id}"),
+        # No known Rule 1 violations on main as of 2026-05-07 — PR #120
+        # closed certificates / cohorts / prerequisites by routing them
+        # through the same overlay machinery used by /courses. Adding a
+        # new entry here means a real gap we're choosing to leave open
+        # temporarily — cite the follow-up PR or issue.
     }
 )
 

--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -84,14 +84,14 @@ def test_registry_has_model_class_for_every_entry():
 
 
 def test_registry_field_names_exist_on_models():
-    """A typo in ``FieldSpec.name`` is silent at registration time —
+    """A typo in ``FieldSpec.attr`` is silent at registration time —
     catch it here by introspecting each registered model."""
     for entity_type, reg in REGISTRY.items():
         model = ENTITY_MODEL[entity_type]
         attrs = set(dir(model))
         for fs in reg.fields:
-            assert fs.name in attrs, (
-                f"Registry says {entity_type!r} has field {fs.name!r}, but {model.__name__} has no such attribute"
+            assert fs.attr in attrs, (
+                f"Registry says {entity_type!r} reads field {fs.attr!r}, but {model.__name__} has no such attribute"
             )
 
 

--- a/supabase/migrations/20260507155100_extend_translations_to_cohorts.sql
+++ b/supabase/migrations/20260507155100_extend_translations_to_cohorts.sql
@@ -1,0 +1,26 @@
+-- Supabase migration: extend_translations_to_cohorts
+-- Version: 20260507155100
+--
+-- Adds ``cohort`` to the ``entity_type`` set of ``content_translations``
+-- so the translation pipeline can cache machine translations of
+-- teacher-authored cohort names. Mirrors the shape used for
+-- announcements and course events. Idempotent.
+
+ALTER TABLE public.content_translations
+  DROP CONSTRAINT IF EXISTS content_translations_entity_type_check;
+
+ALTER TABLE public.content_translations
+  ADD CONSTRAINT content_translations_entity_type_check
+  CHECK (entity_type IN (
+    'chapter_block',
+    'course',
+    'module',
+    'chapter',
+    'quiz',
+    'quiz_question',
+    'quiz_option',
+    'assignment',
+    'announcement',
+    'course_event',
+    'cohort'
+  ));


### PR DESCRIPTION
## Summary
Closes the 4 surfaced gaps from PR #119's CI guard. Each was 0-data today but would silently regress as soon as data appeared.

## What

**Cohorts** — registered as a new translatable entity:
- Migration: `content_translations.entity_type` CHECK extends to include `'cohort'`
- `registry.REGISTRY['cohort']` declares `name` (mapped via new `FieldSpec.model_attr` indirection — DB stores under `field='title'` because cohort.name is conceptually a title)
- `course_pipeline` walks cohorts alongside announcements + events
- `create_cohort` and `update_cohort` fire `reconcile_entity_if_course_published`
- `list_cohorts` reads Accept-Language + applies overlay (owner + admin see source)

**Certificates** — `course_title` overlay:
- `get_course_certificate` and `list_my_certificates` accept Accept-Language
- New helper `_localize_cert_responses` looks up the course's translation for the requested locale, falling back to source

**Prerequisites** — `prerequisite_course_title` overlay:
- `get_prerequisites` accepts Accept-Language
- New helper `_localized_title_map` reuses the catalog overlay machinery

## CI guard
`tests/test_translation_coverage.py` KNOWN_VIOLATIONS_RULE1 is **empty** now. Future regressions of any of these endpoints will fail CI.

## Architecture: `FieldSpec.model_attr`
Cohort's translatable text lives on the model as `name` but the DB `field` column is constrained to `{content, title, description, question_text, option_text, instructions}`. Adding `name` to that constraint would require migrations on every locale-CHECK redefinition forever. Cleaner: `FieldSpec(name='title', ..., model_attr='name')` — registry reads source from `cohort.name`, persists under `field='title'` (semantically: "the title-like field of this cohort"). Backward-compatible with existing entities (`model_attr=None` falls back to `name`).

## Test plan
- [x] `ruff check app/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --config-file mypy.ini app` — 105 source files, no issues
- [x] Full `pytest tests/` — **461 passed** (was 457; +4 from cohort wiring)
- [ ] Backend CI green
- [ ] After merge: `POST /cohorts/course/<id>` on a published course immediately gets translated; `GET /cohorts/course/<id>` with Accept-Language: en returns the EN cohort name

🤖 Generated with [Claude Code](https://claude.com/claude-code)