### PR TITLE
feat(translation): auto-detect source_locale from teacher profile

### DIFF
--- a/backend/app/api/v1/courses/crud.py
+++ b/backend/app/api/v1/courses/crud.py
@@ -37,7 +37,13 @@ def create_new_course(
 ) -> Course:
     if data.title:
         data.title = sanitize_string(data.title)
-    course = create_course(db, data, teacher.id)
+    # The teacher writes in their UI language by definition — derive the
+    # course's source_locale from their profile so they never have to pick
+    # it manually, and so RU↔EN translation is symmetric (a teacher who
+    # works in EN gets RU translations for their RU students; vice versa
+    # for an RU-authoring teacher). ``preferred_locale`` is itself
+    # CHECK-constrained to the supported locale set.
+    course = create_course(db, data, teacher.id, source_locale=teacher.preferred_locale)
     log_action(db, teacher.id, "create", "course", course.id, request=request)
     return course
 

--- a/backend/app/services/course_service/_courses.py
+++ b/backend/app/services/course_service/_courses.py
@@ -18,7 +18,22 @@ if TYPE_CHECKING:
     from app.schemas.course import CourseCreate, CourseUpdate
 
 
-def create_course(db: Session, data: CourseCreate, user_id: str | UUID) -> Course:
+def create_course(
+    db: Session,
+    data: CourseCreate,
+    user_id: str | UUID,
+    *,
+    source_locale: str | None = None,
+) -> Course:
+    """Create a new course owned by ``user_id``.
+
+    ``source_locale`` is the language the teacher is authoring in. The API
+    layer derives it from the teacher's ``preferred_locale`` profile
+    setting so the teacher never sees a "what language are you writing in?"
+    prompt — the system already knows from their UI choice. Passing
+    ``None`` (legacy callers, scripts) falls back to the column's DB
+    default (``'ru'``) to keep migrations / fixtures working unchanged.
+    """
     course = Course(
         id=str(uuid.uuid4()),
         title=data.title,
@@ -26,6 +41,8 @@ def create_course(db: Session, data: CourseCreate, user_id: str | UUID) -> Cours
         image_url=data.image_url,
         created_by=user_id,
     )
+    if source_locale is not None:
+        course.source_locale = source_locale
     db.add(course)
     db.commit()
     db.refresh(course)


### PR DESCRIPTION
## Why
Vadym's clarification: ⛔️ no UI dropdown for source language, ⛔️ no "main" language, no defaults presented to teachers. The system already knows the teacher's working language (from their profile `preferred_locale`) — use that. Translation pipeline auto-translates **to the other locale**.

## What
`create_new_course` now passes `teacher.preferred_locale` to `create_course`. The Course's `source_locale` is set explicitly at insert time instead of relying on the DB `DEFAULT 'ru'`. So:

- Teacher with `preferred_locale='ru'` creates a course → `source_locale='ru'` → pipeline auto-translates to `en`
- Teacher with `preferred_locale='en'` creates a course → `source_locale='en'` → pipeline auto-translates to `ru`

The pipeline (`other_locales(source)`) is already symmetric — this just stops forcing every new course to be RU-source by default.

## Backward compat
`create_course(...)` gains a `source_locale: str | None = None` kwarg. Legacy callers (scripts, fixtures, tests) that pass `None` keep the existing behaviour — DB `DEFAULT 'ru'` applies. Only the API layer is opinionated.

## Test plan
- [x] `ruff check app/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --config-file mypy.ini app` — 105 source files, no issues
- [x] Full `pytest tests/` — **461 passed** (no regressions)
- [ ] Backend CI green
- [ ] After merge: a teacher whose profile is on EN creates a course → `source_locale='en'` row in `courses`, pipeline produces `content_translations` rows for `locale='ru'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)