### PR TITLE
fix(bible): detect references nested inside the blockquote

### DIFF
--- a/backend/app/services/bible/substitution.py
+++ b/backend/app/services/bible/substitution.py
@@ -150,17 +150,55 @@ def pre_substitute(
     for bm in _BLOCKQUOTE_PATTERN.finditer(html):
         bq_start, bq_end = bm.span()
         inner = bm.group("inner")
-        # Lookahead window for the reference: text right after </blockquote>.
-        tail = html[bq_end : bq_end + _REFERENCE_LOOKAHEAD]
-        refs = parse_references(tail)
-        if not refs:
+
+        # Two real-world layouts for the reference:
+        #
+        #   A) Inside, at the end of the blockquote text:
+        #        <blockquote>«…verse…» (Acts 1:8).</blockquote>
+        #   B) Outside, immediately after the closing tag:
+        #        <blockquote>…verse…</blockquote> (Acts 1:8)
+        #
+        # Try inside first — that's where Synodal-style citations sit in
+        # most academic prose. Fall back to the lookahead window after
+        # the closing tag so older content keeps working.
+        ref = None
+        verse_text_inner: str = inner
+        ref_tail_inner: str = ""
+        inner_refs = parse_references(inner)
+        if inner_refs:
+            # Take the *last* reference inside (it's almost always the
+            # citation appended after the verse, even when the prose
+            # happens to mention an earlier verse number conversationally).
+            last = inner_refs[-1]
+            # Extend the citation tail leftwards to include a leading
+            # ``(`` if present, plus a closing ``"`` / ``»`` / ``)`` /
+            # punctuation that closes the verse quote. The regex starts
+            # at "Acts" / "Деян." so we'd otherwise leave a stray ``(``
+            # inside the marker-replaced verse text.
+            tail_start = last.span[0]
+            stripped_left = inner[:tail_start].rstrip()
+            if stripped_left.endswith(("(", " (")):
+                # Walk back over the trailing whitespace + ``(``.
+                tail_start = inner.rfind("(", 0, tail_start)
+            verse_text_inner = inner[:tail_start]
+            ref_tail_inner = inner[tail_start:]
+            ref = last.ref
+        else:
+            tail = html[bq_end : bq_end + _REFERENCE_LOOKAHEAD]
+            outside_refs = parse_references(tail)
+            if outside_refs:
+                ref = outside_refs[0].ref
+                verse_text_inner = inner
+                ref_tail_inner = ""
+
+        if ref is None:
             continue
-        ref = refs[0].ref  # take the first reference closest to the blockquote
+
         canonical_source = lookup(ref, source_locale)
         if canonical_source is None:
             continue
 
-        author_text = _strip_html(inner)
+        author_text = _strip_html(verse_text_inner)
         if not author_text:
             continue
         ratio = SequenceMatcher(
@@ -177,22 +215,24 @@ def pre_substitute(
             continue
 
         marker = _marker_token()
-        # Append everything up to the blockquote opening tag, the opening
-        # tag itself (preserved verbatim), the marker, and the closing tag.
-        # Re-derive the opening/closing tags from the match groups so we
-        # don't lose attributes like ``class="quote"``.
+        # Re-derive the opening/closing tags from the match so we don't
+        # lose attributes like ``class="quote"``.
         opening_tag = html[bq_start : bq_start + html[bq_start:bq_end].index(">") + 1]
         closing_tag = "</blockquote>"
         out_parts.append(html[cursor:bq_start])
         out_parts.append(opening_tag)
         out_parts.append(marker)
+        # Preserve the citation tail (e.g. ``(Деян. 1:8).``) so the
+        # reference notation survives translation. Gemini will localize
+        # the book name (``Деян.`` → ``Acts``) just like any other prose.
+        out_parts.append(ref_tail_inner)
         out_parts.append(closing_tag)
         cursor = bq_end
         subs.append(
             Substitution(
                 marker=marker,
                 ref=ref,
-                original_inner=inner,
+                original_inner=verse_text_inner,
             )
         )
 

--- a/backend/tests/test_bible_substitution.py
+++ b/backend/tests/test_bible_substitution.py
@@ -254,6 +254,45 @@ def test_full_roundtrip_synodal_to_kjv():
     assert "\x00" not in final
 
 
+def test_pre_substitute_reference_inside_blockquote():
+    """Real-world Synodal-style citation: the parenthesized reference
+    sits at the end of the blockquote text (not after the closing tag).
+    Substitution must still detect, replace the verse text with a
+    marker, and preserve the citation tail so the reader still sees
+    ``(Acts 20:28)`` next to the canonical English verse.
+    """
+    canonical_ru = lookup(BibleRef("acts", 20, 28), "ru")
+    assert canonical_ru is not None
+    html = (
+        f"<blockquote>«{canonical_ru}» (Деян. 20:28).</blockquote>\n"
+        f"<p>Это пастырское наставление.</p>"
+    )
+    out, subs = pre_substitute(html, "ru")
+    assert len(subs) == 1
+    assert subs[0].ref == BibleRef("acts", 20, 28)
+    # Russian verse text is gone, but the reference notation stays.
+    assert "пасти Церковь" not in out
+    assert "(Деян. 20:28)" in out
+
+
+def test_full_roundtrip_synodal_with_reference_inside():
+    """End-to-end: author wrote Synodal with citation inside the
+    blockquote → student in EN sees KJV with the (Acts ...) marker
+    surviving Gemini's locale transformation of the book name."""
+    canonical_ru = lookup(BibleRef("acts", 20, 28), "ru")
+    canonical_en = lookup(BibleRef("acts", 20, 28), "en")
+    assert canonical_ru and canonical_en
+    source_html = f"<blockquote>«{canonical_ru}» (Деян. 20:28).</blockquote>"
+    markered, subs = pre_substitute(source_html, "ru")
+    assert len(subs) == 1
+    # Mock Gemini: localize the citation prefix the way it really does.
+    translated = markered.replace("Деян.", "Acts")
+    final = post_substitute(translated, subs, "en")
+    assert canonical_en in final
+    assert canonical_ru not in final
+    assert "(Acts 20:28)" in final
+
+
 def test_full_roundtrip_kjv_to_synodal():
     """Inverse direction — author wrote KJV, student reads RU."""
     canonical_en = lookup(BibleRef("acts", 1, 8), "en")


### PR DESCRIPTION
## Bug
Real-world Synodal-style citations put the reference at the end of the blockquote text, **not** after the closing tag:
```html
<blockquote>«…verse…» (Деян. 20:28).</blockquote>
```
PR #122's first cut of `pre_substitute` only scanned the lookahead *after* `</blockquote>`, so these citations slipped through and the verse came out as the source RU text untranslated to KJV. Found running Acts course backfill — 11 of 12 stale chapter blocks have this inside-blockquote pattern.

## Fix
- Try `parse_references` on the blockquote inner FIRST. If found, take the *last* reference (Synodal-style citations always sit after the verse).
- Split inner into `(verse_text, citation_tail)`. Marker replaces verse_text only; citation_tail is preserved verbatim so the reader still sees `(Acts 20:28)` next to the canonical English verse after Gemini localizes the book name.
- Walk leftward from the regex span to include a leading `(` (the regex starts at the book name, so the leading paren would otherwise be stranded inside the marker-replaced region).
- Fall back to the existing lookahead path when no inner reference is detected — older content (citation outside) continues to work.

## Test plan
- [x] 2 new tests covering inside-blockquote citation + full RU↔EN round-trip with this pattern
- [x] `ruff check app/ tests/` — clean
- [x] `pytest tests/` — **488 passed** (was 486; +2 new)
- [ ] Backend CI green
- [ ] After merge: re-run Acts backfill → blockquotes with Synodal+`(Деян…)` come out as KJV verbatim with `(Acts …)` notation preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)