### PR TITLE
fix(test): apply ruff format to test_bible_substitution.py

### DIFF
--- a/backend/tests/test_bible_substitution.py
+++ b/backend/tests/test_bible_substitution.py
@@ -279,10 +279,7 @@ def test_pre_substitute_reference_inside_blockquote():
     """
     canonical_ru = lookup(BibleRef("acts", 20, 28), "ru")
     assert canonical_ru is not None
-    html = (
-        f"<blockquote>«{canonical_ru}» (Деян. 20:28).</blockquote>\n"
-        f"<p>Это пастырское наставление.</p>"
-    )
+    html = f"<blockquote>«{canonical_ru}» (Деян. 20:28).</blockquote>\n<p>Это пастырское наставление.</p>"
     out, subs = pre_substitute(html, "ru")
     assert len(subs) == 1
     assert subs[0].ref == BibleRef("acts", 20, 28)


### PR DESCRIPTION
Hotfix for failing Backend CI on main after PR #123/#124. CI's `ruff format app/ tests/ --check` flagged the new test file (5-line whitespace diff). Local `ruff check` passes; format --check is a separate gate that I missed locally.

After this lands, main is green again.