### PR TITLE
feat(backend): serve a real dark-variant favicon

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,12 @@
 import logging
 import os
 import time
+from pathlib import Path
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import FileResponse, JSONResponse, Response
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app.api.v1 import api_router
@@ -130,9 +131,25 @@ async def health() -> dict:
     return {"status": "ok"}
 
 
+_STATIC_DIR = Path(__file__).parent / "static"
+_FAVICON_SVG = _STATIC_DIR / "favicon.svg"
+
+
 @app.get("/favicon.ico", include_in_schema=False)
-@app.get("/favicon.png", include_in_schema=False)
 @app.get("/favicon.svg", include_in_schema=False)
+async def favicon() -> FileResponse:
+    """Serve the same book-mark glyph as the frontend, but in the
+    project's slate-900 dark variant so the two Vercel deployments
+    are visually paired (frontend = brand blue, backend = dark
+    sibling). Browsers accept SVG behind any of the favicon paths;
+    Vercel's project-card scraper picks up `/favicon.ico` first."""
+    return FileResponse(_FAVICON_SVG, media_type="image/svg+xml")
+
+
+# /favicon.png and /vite.svg are noise endpoints that some clients
+# probe but which we don't actually want to serve. 204 keeps the
+# logs clean without raising 404 alerts.
+@app.get("/favicon.png", include_in_schema=False)
 @app.get("/vite.svg", include_in_schema=False)
-async def static_icons() -> Response:
+async def _noise_icons() -> Response:
     return Response(status_code=204)

--- a/backend/app/static/favicon.svg
+++ b/backend/app/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#0f172a"/>
+  <path d="M8 7h7c1.1 0 2 .9 2 2v14c0-.55-.45-1-1-1H8V7z" fill="white" opacity="0.9"/>
+  <path d="M24 7h-7c-1.1 0-2 .9-2 2v14c0-.55.45-1 1-1h8V7z" fill="white" opacity="0.7"/>
+  <path d="M16 9v13" stroke="white" stroke-width="0.5" opacity="0.5"/>
+</svg>


### PR DESCRIPTION
## Summary

Vercel's project-card scraper looks at the production deployment's `/favicon.ico`. Backend was answering 204 No Content on every favicon path (leftover 'swallow browser noise' pattern), so the project tile rendered with a generic icon while the frontend showed the brand glyph.

Now the same book-mark SVG as the frontend, but with the rounded square in **slate-900 (`#0f172a`)** instead of brand blue (`#2563eb`). The two deployments read as a paired set — frontend = primary brand color, backend = its dark sibling.

## Changes
- `backend/app/static/favicon.svg` — the dark glyph (382 B). Lives under `app/` so the `@vercel/python` builder bundles it.
- `backend/app/main.py` — `/favicon.ico` and `/favicon.svg` now return the real file via `FileResponse` with `media_type=image/svg+xml`. `/favicon.png` and `/vite.svg` still return 204 (rare probes, no benefit to serving art).

Verified locally: `GET /favicon.svg` → 200, `image/svg+xml`, 382 B.

## Test plan

- [x] `ruff check .` — pass
- [x] `ruff format app/ tests/ --check` — pass
- [x] `mypy` — pass (110 files)
- [x] `pytest` — **498 passed**
- [ ] CI green
- [ ] After deploy: confirm `https://biblie-school-backend.vercel.app/favicon.svg` serves the dark book glyph and the Vercel project tile picks it up.