### PR TITLE
fix(bible): localize ref tail when reference sits outside the blockquote

### DIFF
--- a/backend/app/services/bible/substitution.py
+++ b/backend/app/services/bible/substitution.py
@@ -208,6 +208,14 @@ def pre_substitute(
         ref = None
         verse_text_inner: str = inner
         ref_tail_inner: str = ""
+        # ``stored_ref_tail`` is the text we hand to ``post_substitute``
+        # for target-locale rewriting. Same as ``ref_tail_inner`` in
+        # the inner case (the marker re-emits it inside the
+        # blockquote), but in the outside case it points at the
+        # source-locale ref text that's still sitting in the
+        # surrounding HTML — so post can find and localize it without
+        # us re-emitting anything here.
+        stored_ref_tail: str = ""
         inner_refs = parse_references(inner)
         if inner_refs:
             # Take the *last* reference inside (it's almost always the
@@ -234,6 +242,15 @@ def pre_substitute(
                 ref = outside_refs[0].ref
                 verse_text_inner = inner
                 ref_tail_inner = ""
+                # The outside ref lives in the original HTML after the
+                # closing </blockquote>; we don't re-emit it here.
+                # ``post_substitute`` looks for ``stored_ref_tail`` in
+                # the translated HTML and rewrites the book name into
+                # the target locale (``Acts 1:8`` → ``Деян. 1:8``).
+                # Best-effort: if the LLM mutated the substring in
+                # transit, the literal replace becomes a no-op and the
+                # source-locale ref survives — never breaks rendering.
+                stored_ref_tail = outside_refs[0].raw_text
 
         if ref is None:
             continue
@@ -279,12 +296,17 @@ def pre_substitute(
         out_parts.append(emitted_tail)
         out_parts.append(closing_tag)
         cursor = bq_end
+        # ``ref_tail`` on Substitution is what post_substitute scans for
+        # to localize the book name. For inner-ref blockquotes it's the
+        # exact tail we just emitted; for outside-ref blockquotes it's
+        # the ref text we left untouched in the surrounding HTML so
+        # post can find and rewrite it (``stored_ref_tail`` set above).
         subs.append(
             Substitution(
                 marker=marker,
                 ref=ref,
                 original_inner=verse_text_inner,
-                ref_tail=emitted_tail,
+                ref_tail=emitted_tail or stored_ref_tail,
             )
         )
 

--- a/backend/tests/test_bible_substitution.py
+++ b/backend/tests/test_bible_substitution.py
@@ -450,6 +450,46 @@ def test_post_substitute_localizes_reference_book_name_in_inverse_direction():
     assert "(Матф. 28:19)" not in final
 
 
+def test_outside_blockquote_ref_localizes_into_target_locale():
+    """When the author put the citation AFTER ``</blockquote>``
+    (the older-content layout), substitution still replaces the verse
+    inside the blockquote. The outside reference text should also
+    surface in the target locale — a Russian student should read
+    ``(Деян. 1:8)`` next to a Synodal verse, not ``(Acts 1:8)``."""
+    canonical_en = lookup(BibleRef("acts", 1, 8), "en")
+    canonical_ru = lookup(BibleRef("acts", 1, 8), "ru")
+    assert canonical_en and canonical_ru
+    source_html = (
+        f"<p>Programme of the Book of Acts:</p>"
+        f"<blockquote>{canonical_en}</blockquote>"
+        f" (Acts 1:8). This is the central verse."
+    )
+    markered, subs = pre_substitute(source_html, "en")
+    assert len(subs) == 1
+    assert "Acts 1:8" in subs[0].ref_tail, "outside ref must be tracked on Substitution"
+    final = post_substitute(markered, subs, "ru")
+    assert canonical_ru in final
+    assert "(Деян. 1:8)" in final
+    assert "(Acts 1:8)" not in final
+
+
+def test_outside_blockquote_ref_inverse_direction():
+    """Inverse: RU author with outside ``(Деян. 1:8)`` → EN student
+    should see ``(Acts 1:8)`` next to the canonical KJV verse."""
+    canonical_ru = lookup(BibleRef("acts", 1, 8), "ru")
+    canonical_en = lookup(BibleRef("acts", 1, 8), "en")
+    assert canonical_ru and canonical_en
+    source_html = (
+        f"<p>Программа книги Деяний:</p><blockquote>{canonical_ru}</blockquote> (Деян. 1:8). Это центральный стих."
+    )
+    markered, subs = pre_substitute(source_html, "ru")
+    assert len(subs) == 1
+    final = post_substitute(markered, subs, "en")
+    assert canonical_en in final
+    assert "(Acts 1:8)" in final
+    assert "(Деян. 1:8)" not in final
+
+
 def test_post_substitute_handles_verse_range_in_reference_localization():
     """Range refs (``Matt. 28:18-20``) must localize to
     ``Матф. 28:18-20`` — the localizer respects ``verse_end``."""


### PR DESCRIPTION
## Summary

Closes the last unfinished case from the 2026-05-07 substitution series.

When a teacher writes the citation **inside** the blockquote (`<blockquote>...verse... (Acts 1:8).</blockquote>`) the localization already lands — PR #128 made that path swap `Acts.` → `Деян.` in the target locale.

The **outside** layout was different:

```
<blockquote>...verse...</blockquote> (Acts 1:8).
```

Substitution still replaced the verse and post-substitute restored the canonical KJV/Synodal text, but the ref tail itself stayed in the source locale because the code set `ref_tail_inner = ""` and never tracked the outside ref on the `Substitution` record. Result: a Russian student saw a Synodal verse next to a stray `(Acts 1:8)`.

## Fix

Capture `outside_refs[0].raw_text` when we detect an outside ref and store it on `Substitution.ref_tail` (via a new `stored_ref_tail` local so the inside path's `emitted_tail` semantics stay unchanged). `post_substitute` already knows how to localize a ref tail — best-effort literal-string replace lands cleanly when the LLM left the parenthesized ref untouched (the common case for identifier-shaped substrings) and degrades to a no-op (leaving the source-locale ref) when the LLM mutated it.

## Test plan

Two regression tests for both directions, plus the existing 37 substitution tests:
- [x] EN-author + outside `(Acts 1:8)` → RU student sees `(Деян. 1:8)`
- [x] RU-author + outside `(Деян. 1:8)` → EN student sees `(Acts 1:8)`
- [x] `ruff check .` — pass
- [x] `ruff format app/ tests/ --check` — pass
- [x] `mypy` — pass
- [x] `pytest` — **500 passed** (was 498 + 2 new tests)
- [ ] CI green