### PR TITLE
Add floating scroll to top button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import Header from "./components/layout/Header"
 import Footer from "./components/layout/Footer"
 import AnnouncementBanner from "./components/announcements/AnnouncementBanner"
 import PageSpinner from "./components/ui/PageSpinner"
+import ScrollToTop from "./components/layout/ScrollToTop";
 
 const NotFound = lazy(() => import("./pages/NotFound"))
 
@@ -143,6 +144,7 @@ function AppRoutes() {
         </ErrorBoundary>
       </main>
       <Footer />
+      <ScrollToTop />
       <Toaster />
     </div>
   )

--- a/frontend/src/components/layout/ScrollToTop.tsx
+++ b/frontend/src/components/layout/ScrollToTop.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+
+export default function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      style={{
+        position: "fixed",
+        bottom: "20px",
+
+        left: "50%",
+        transform: "translateX(-50%)",
+
+        width: "50px",
+        height: "50px",
+        borderRadius: "50%",
+
+        backgroundColor: "black",
+        color: "white",
+
+        border: "none",
+        cursor: "pointer",
+        zIndex: 9999,
+
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+
+        fontSize: "20px",
+
+        opacity: visible ? 1 : 0,
+        transition: "opacity 0.3s ease",
+        pointerEvents: visible ? "auto" : "none",
+      }}
+    >
+      ↑
+    </button>
+  );
+}

--- a/frontend/src/components/layout/ScrollToTop.tsx
+++ b/frontend/src/components/layout/ScrollToTop.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { ChevronUp } from "lucide-react";
 
 export default function ScrollToTop() {
   const [visible, setVisible] = useState(false);
@@ -26,36 +27,21 @@ export default function ScrollToTop() {
     <button
       onClick={scrollToTop}
       aria-label="Scroll to top"
-      style={{
-        position: "fixed",
-        bottom: "20px",
-
-        left: "50%",
-        transform: "translateX(-50%)",
-
-        width: "50px",
-        height: "50px",
-        borderRadius: "50%",
-
-        backgroundColor: "black",
-        color: "white",
-
-        border: "none",
-        cursor: "pointer",
-        zIndex: 9999,
-
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-
-        fontSize: "20px",
-
-        opacity: visible ? 1 : 0,
-        transition: "opacity 0.3s ease",
-        pointerEvents: visible ? "auto" : "none",
-      }}
+      className={`
+        fixed bottom-6 right-6 z-50
+        flex items-center justify-center
+        w-12 h-12 rounded-full
+        bg-primary text-primary-foreground
+        hover:bg-primary/90
+        transition-opacity duration-300
+        ${
+          visible
+            ? "opacity-100 pointer-events-auto"
+            : "opacity-0 pointer-events-none"
+        }
+      `}
     >
-      ↑
+      <ChevronUp className="h-5 w-5" strokeWidth={1.75} />
     </button>
   );
 }


### PR DESCRIPTION
Closes #62 
## Summary

Added a floating scroll-to-top button that appears after scrolling down and smoothly scrolls the user back to the top of the page.

The button is available globally across all pages through the root layout.

## Type of change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Refactor (code change that neither fixes a bug nor adds a feature)
* [ ] Documentation
* [ ] CI / tooling
* [ ] Breaking change (explain in the summary above)

## Checklist

* [x] Follows `docs/DESIGN.md`
* [ ] New async views have loading / empty / error states.
* [x] Verified in dark mode and at 360x640 (if UI changes).
* [ ] `npm run lint` and `npm run test:run` pass locally.
* [ ] `ruff check .` and `mypy app/` pass locally (if backend changes).
* [x] No new library without the four-check rule in DESIGN.md.
* [x] Commit messages follow Conventional Commits.

## Screenshots / recordings

Added a circular floating scroll-to-top button positioned at the bottom-center of the page with smooth scrolling behavior.
<img width="959" height="450" alt="Screenshot 2026-05-09 195543" src="https://github.com/user-attachments/assets/13de07d0-c582-4a2c-9967-d709252cd50d" />
