### PR TITLE
fix(rum): correct Datadog service name and wire build SHA as version

### DIFF
--- a/frontend/src/lib/datadog.ts
+++ b/frontend/src/lib/datadog.ts
@@ -29,7 +29,7 @@ export function initDatadogRum() {
 
   const env = import.meta.env.VITE_DATADOG_ENV ?? import.meta.env.MODE
   const site = import.meta.env.VITE_DATADOG_SITE ?? "us5.datadoghq.com"
-  const service = import.meta.env.VITE_DATADOG_SERVICE ?? "bible-school-frontend"
+  const service = import.meta.env.VITE_DATADOG_SERVICE ?? "biblie-school-frontend"
   const version = import.meta.env.VITE_APP_VERSION ?? "0.0.0"
 
   datadogRum.init({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,9 +2,18 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+// VERCEL_GIT_COMMIT_SHA is injected by Vercel at build time. Falls back to
+// 'dev' for local builds so Datadog RUM can still tag events with a version.
+const appVersion =
+  process.env.VITE_APP_VERSION ||
+  (process.env.VERCEL_GIT_COMMIT_SHA ? process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7) : 'dev')
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- Fix the RUM service tag from `bible-school-frontend` (typo, missing `i`) to `biblie-school-frontend` so it matches the repo / Vercel project name. Both the source default in `datadog.ts` and the Vercel env var have been updated.
- Wire `VITE_APP_VERSION` to `VERCEL_GIT_COMMIT_SHA` (first 7 chars) so each RUM session is tagged with the exact deploy that produced it. Local builds fall back to `dev`.

## Why
The Datadog RUM app was renamed to `biblie-school-frontend` so the service tag, the RUM app, and the repo all line up. Tagging sessions with a SHA unlocks the "filter by version" feature in RUM and makes regression bisection trivial.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [ ] After Vercel prod deploys, verify in Datadog RUM that new sessions carry `service:biblie-school-frontend` and a 7-char `version`