### PR TITLE
feat(backend): ship WARNING+ logs to Datadog HTTP intake

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,5 +1,62 @@
+import json
 import logging
+import os
 import sys
+import urllib.error
+import urllib.request
+
+
+class DatadogHTTPHandler(logging.Handler):
+    """Ship WARNING+ records straight to Datadog's HTTP logs intake.
+
+    There is no Datadog Agent on Vercel serverless, so the handler does
+    its own HTTPS POST per record. WARNING+ traffic is low enough that
+    the small per-error latency is acceptable; INFO logs stay on stdout
+    where Vercel's own log viewer captures them.
+    """
+
+    _REENTRY_GUARD_ATTR = "_dd_inside_emit"
+
+    def __init__(self, api_key: str, site: str, service: str, env: str, version: str) -> None:
+        super().__init__()
+        self.api_key = api_key
+        self.service = service
+        self.env = env
+        self.version = version
+        self.endpoint = f"https://http-intake.logs.{site}/api/v2/logs"
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if getattr(record, self._REENTRY_GUARD_ATTR, False):
+            return
+        try:
+            payload = {
+                "ddsource": "python",
+                "ddtags": f"env:{self.env},service:{self.service},version:{self.version}",
+                "service": self.service,
+                "hostname": "vercel",
+                "message": self.format(record),
+                "status": record.levelname.lower(),
+                "logger.name": record.name,
+            }
+            if record.exc_info and self.formatter:
+                exc_type = record.exc_info[0]
+                if exc_type is not None:
+                    payload["error.kind"] = exc_type.__name__
+                payload["error.stack"] = self.formatter.formatException(record.exc_info)
+            body = json.dumps(payload).encode("utf-8")
+            req = urllib.request.Request(
+                self.endpoint,
+                data=body,
+                headers={"DD-API-KEY": self.api_key, "Content-Type": "application/json"},
+                method="POST",
+            )
+            setattr(record, self._REENTRY_GUARD_ATTR, True)
+            urllib.request.urlopen(req, timeout=2)
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+            # Best effort. Losing a log record is preferable to crashing the request.
+            pass
+        finally:
+            setattr(record, self._REENTRY_GUARD_ATTR, False)
 
 
 def setup_logging() -> None:
@@ -14,7 +71,22 @@ def setup_logging() -> None:
 
     root = logging.getLogger()
     root.setLevel(logging.INFO)
+    root.handlers.clear()
     root.addHandler(handler)
+
+    api_key = os.environ.get("DD_API_KEY")
+    if api_key:
+        version = (os.environ.get("VERCEL_GIT_COMMIT_SHA") or "dev")[:7]
+        dd_handler = DatadogHTTPHandler(
+            api_key=api_key,
+            site=os.environ.get("DD_SITE", "datadoghq.com"),
+            service=os.environ.get("DD_SERVICE", "biblie-school-backend"),
+            env=os.environ.get("DD_ENV", "production"),
+            version=version,
+        )
+        dd_handler.setLevel(logging.WARNING)
+        dd_handler.setFormatter(formatter)
+        root.addHandler(dd_handler)
 
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)

--- a/backend/tests/test_dd_logging.py
+++ b/backend/tests/test_dd_logging.py
@@ -1,0 +1,110 @@
+"""Tests for the Datadog HTTP logging handler in app.core.logging."""
+
+import json
+import logging
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.logging import DatadogHTTPHandler, setup_logging
+
+
+def _make_handler() -> DatadogHTTPHandler:
+    return DatadogHTTPHandler(
+        api_key="test-key",
+        site="us5.datadoghq.com",
+        service="biblie-school-backend",
+        env="production",
+        version="abc1234",
+    )
+
+
+def test_endpoint_uses_site_param() -> None:
+    h = _make_handler()
+    assert h.endpoint == "https://http-intake.logs.us5.datadoghq.com/api/v2/logs"
+
+
+def test_emit_posts_to_intake_with_api_key() -> None:
+    h = _make_handler()
+    h.setFormatter(logging.Formatter("%(message)s"))
+    record = logging.LogRecord(
+        name="api",
+        level=logging.WARNING,
+        pathname="x.py",
+        lineno=1,
+        msg="boom",
+        args=(),
+        exc_info=None,
+    )
+    with patch("urllib.request.urlopen") as urlopen:
+        urlopen.return_value = MagicMock()
+        h.emit(record)
+    assert urlopen.called, "expected urlopen to be called once"
+    req = urlopen.call_args.args[0]
+    assert req.headers["Dd-api-key"] == "test-key"
+    body = json.loads(req.data.decode("utf-8"))
+    assert body["service"] == "biblie-school-backend"
+    assert body["status"] == "warning"
+    assert "env:production" in body["ddtags"]
+    assert "version:abc1234" in body["ddtags"]
+    assert body["message"] == "boom"
+
+
+def test_emit_swallows_network_errors() -> None:
+    h = _make_handler()
+    h.setFormatter(logging.Formatter("%(message)s"))
+    record = logging.LogRecord(
+        name="api",
+        level=logging.ERROR,
+        pathname="x.py",
+        lineno=1,
+        msg="db down",
+        args=(),
+        exc_info=None,
+    )
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("no network")):
+        # Must not raise — losing a log record is preferable to crashing the request
+        h.emit(record)
+
+
+def test_emit_includes_exc_info_when_present() -> None:
+    h = _make_handler()
+    h.setFormatter(logging.Formatter("%(message)s"))
+    try:
+        raise ValueError("kaboom")
+    except ValueError:
+        import sys
+
+        record = logging.LogRecord(
+            name="api",
+            level=logging.ERROR,
+            pathname="x.py",
+            lineno=1,
+            msg="failed",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+    with patch("urllib.request.urlopen") as urlopen:
+        urlopen.return_value = MagicMock()
+        h.emit(record)
+    body = json.loads(urlopen.call_args.args[0].data.decode("utf-8"))
+    assert body["error.kind"] == "ValueError"
+    assert "ValueError: kaboom" in body["error.stack"]
+
+
+def test_setup_logging_skips_dd_handler_when_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DD_API_KEY", raising=False)
+    setup_logging()
+    root = logging.getLogger()
+    assert not any(isinstance(h, DatadogHTTPHandler) for h in root.handlers)
+
+
+def test_setup_logging_installs_dd_handler_when_key_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DD_API_KEY", "x")
+    monkeypatch.setenv("DD_SITE", "us5.datadoghq.com")
+    setup_logging()
+    root = logging.getLogger()
+    dd_handlers = [h for h in root.handlers if isinstance(h, DatadogHTTPHandler)]
+    assert len(dd_handlers) == 1
+    assert dd_handlers[0].level == logging.WARNING

--- a/frontend/src/lib/datadog.ts
+++ b/frontend/src/lib/datadog.ts
@@ -29,7 +29,7 @@ export function initDatadogRum() {
 
   const env = import.meta.env.VITE_DATADOG_ENV ?? import.meta.env.MODE
   const site = import.meta.env.VITE_DATADOG_SITE ?? "us5.datadoghq.com"
-  const service = import.meta.env.VITE_DATADOG_SERVICE ?? "bible-school-frontend"
+  const service = import.meta.env.VITE_DATADOG_SERVICE ?? "biblie-school-frontend"
   const version = import.meta.env.VITE_APP_VERSION ?? "0.0.0"
 
   datadogRum.init({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,9 +2,18 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+// VERCEL_GIT_COMMIT_SHA is injected by Vercel at build time. Falls back to
+// 'dev' for local builds so Datadog RUM can still tag events with a version.
+const appVersion =
+  process.env.VITE_APP_VERSION ||
+  (process.env.VERCEL_GIT_COMMIT_SHA ? process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7) : 'dev')
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- Add `DatadogHTTPHandler` in `app.core.logging` that POSTs WARNING+ records directly to Datadog's HTTP logs intake.
- Activates only when `DD_API_KEY` is set, so local dev and any deploy without the var are unaffected.
- Tags every record with `service`, `env`, `version` (git SHA from `VERCEL_GIT_COMMIT_SHA`).
- Vercel env vars `DD_API_KEY`, `DD_SITE`, `DD_SERVICE`, `DD_ENV` already set on `biblie-school-backend` production.

## Why
Until now the only Datadog signal we had was browser RUM from the frontend. Any server-side error or constraint violation was invisible unless someone tailed Vercel logs. With this in, backend warnings/errors land in Datadog and can be alerted on next to RUM data.

Vercel Pro is required for Log Drains and our team is on Hobby, so direct in-process shipping is the only path that does not require a manual UI install.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format` clean (handler + tests)
- [x] `mypy` clean on the whole backend (110 files)
- [x] `pytest tests/` — 506 passed
- [x] 6 dedicated unit tests covering endpoint construction, payload shape, exc_info handling, network failure swallowing, conditional install
- [ ] After deploy, trigger a backend warning (e.g. hit a route that raises an integrity error in test fashion) and verify the log shows up under `service:biblie-school-backend env:production` in Datadog Logs Explorer