### PR TITLE
feat(observability): unminified RUM stacks + Vercel request_id correlation

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,9 +1,16 @@
+import contextvars
 import json
 import logging
 import os
 import sys
 import urllib.error
 import urllib.request
+
+# Per-request correlation. Vercel populates ``x-vercel-id`` on every
+# inbound request; main.log_requests middleware copies it here so the
+# DatadogHTTPHandler can stitch a WARNING/ERROR log to the originating
+# RUM session that triggered the request.
+vercel_request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("vercel_request_id", default=None)
 
 
 class DatadogHTTPHandler(logging.Handler):
@@ -17,27 +24,45 @@ class DatadogHTTPHandler(logging.Handler):
 
     _REENTRY_GUARD_ATTR = "_dd_inside_emit"
 
-    def __init__(self, api_key: str, site: str, service: str, env: str, version: str) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        site: str,
+        service: str,
+        env: str,
+        version: str,
+        vercel_region: str,
+    ) -> None:
         super().__init__()
         self.api_key = api_key
         self.service = service
         self.env = env
         self.version = version
+        self.vercel_region = vercel_region
         self.endpoint = f"https://http-intake.logs.{site}/api/v2/logs"
 
     def emit(self, record: logging.LogRecord) -> None:
         if getattr(record, self._REENTRY_GUARD_ATTR, False):
             return
         try:
+            tags = [
+                f"env:{self.env}",
+                f"service:{self.service}",
+                f"version:{self.version}",
+                f"vercel_region:{self.vercel_region}",
+            ]
             payload = {
                 "ddsource": "python",
-                "ddtags": f"env:{self.env},service:{self.service},version:{self.version}",
+                "ddtags": ",".join(tags),
                 "service": self.service,
-                "hostname": "vercel",
+                "hostname": f"vercel-{self.vercel_region}",
                 "message": self.format(record),
                 "status": record.levelname.lower(),
                 "logger.name": record.name,
             }
+            req_id = vercel_request_id.get()
+            if req_id:
+                payload["vercel.request_id"] = req_id
             if record.exc_info and self.formatter:
                 exc_type = record.exc_info[0]
                 if exc_type is not None:
@@ -83,6 +108,7 @@ def setup_logging() -> None:
             service=os.environ.get("DD_SERVICE", "biblie-school-backend"),
             env=os.environ.get("DD_ENV", "production"),
             version=version,
+            vercel_region=os.environ.get("VERCEL_REGION", "unknown"),
         )
         dd_handler.setLevel(logging.WARNING)
         dd_handler.setFormatter(formatter)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app.api.v1 import api_router
 from app.core.config import settings
-from app.core.logging import setup_logging
+from app.core.logging import setup_logging, vercel_request_id
 from app.middleware.rate_limit import RateLimitMiddleware
 from app.middleware.security import SecurityHeadersMiddleware
 
@@ -108,17 +108,26 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
-    start = time.time()
-    response = await call_next(request)
-    duration = round((time.time() - start) * 1000, 1)
-    logger.info(
-        "%s %s %s %sms",
-        request.method,
-        request.url.path,
-        response.status_code,
-        duration,
-    )
-    return response
+    # Vercel attaches a unique id to every inbound request on the
+    # ``x-vercel-id`` header. Stashing it in a contextvar lets the
+    # DatadogHTTPHandler tag every WARNING+ log emitted during this
+    # request with the same id, so a RUM session error and the backend
+    # log line that produced it can be correlated by Vercel request id.
+    token = vercel_request_id.set(request.headers.get("x-vercel-id"))
+    try:
+        start = time.time()
+        response = await call_next(request)
+        duration = round((time.time() - start) * 1000, 1)
+        logger.info(
+            "%s %s %s %sms",
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration,
+        )
+        return response
+    finally:
+        vercel_request_id.reset(token)
 
 
 @app.get("/")

--- a/backend/tests/test_dd_logging.py
+++ b/backend/tests/test_dd_logging.py
@@ -17,6 +17,7 @@ def _make_handler() -> DatadogHTTPHandler:
         service="biblie-school-backend",
         env="production",
         version="abc1234",
+        vercel_region="iad1",
     )
 
 
@@ -48,7 +49,53 @@ def test_emit_posts_to_intake_with_api_key() -> None:
     assert body["status"] == "warning"
     assert "env:production" in body["ddtags"]
     assert "version:abc1234" in body["ddtags"]
+    assert "vercel_region:iad1" in body["ddtags"]
+    assert body["hostname"] == "vercel-iad1"
     assert body["message"] == "boom"
+
+
+def test_emit_includes_vercel_request_id_when_set() -> None:
+    from app.core.logging import vercel_request_id
+
+    h = _make_handler()
+    h.setFormatter(logging.Formatter("%(message)s"))
+    record = logging.LogRecord(
+        name="api",
+        level=logging.WARNING,
+        pathname="x.py",
+        lineno=1,
+        msg="boom",
+        args=(),
+        exc_info=None,
+    )
+    token = vercel_request_id.set("syd1::abc123")
+    try:
+        with patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = MagicMock()
+            h.emit(record)
+        body = json.loads(urlopen.call_args.args[0].data.decode("utf-8"))
+        assert body["vercel.request_id"] == "syd1::abc123"
+    finally:
+        vercel_request_id.reset(token)
+
+
+def test_emit_omits_vercel_request_id_when_unset() -> None:
+    h = _make_handler()
+    h.setFormatter(logging.Formatter("%(message)s"))
+    record = logging.LogRecord(
+        name="api",
+        level=logging.WARNING,
+        pathname="x.py",
+        lineno=1,
+        msg="boom",
+        args=(),
+        exc_info=None,
+    )
+    with patch("urllib.request.urlopen") as urlopen:
+        urlopen.return_value = MagicMock()
+        h.emit(record)
+    body = json.loads(urlopen.call_args.args[0].data.decode("utf-8"))
+    assert "vercel.request_id" not in body
 
 
 def test_emit_swallows_network_errors() -> None:

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,6 +8,14 @@ export default tseslint.config(
   {
     ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
   },
+  {
+    files: ['scripts/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+  },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   reactHooks.configs.flat.recommended,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,6 +44,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@datadog/datadog-ci": "^5.16.1",
         "@eslint/js": "^10.0.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -610,6 +611,19 @@
         "react-router-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@datadog/datadog-ci": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-ci/-/datadog-ci-5.16.1.tgz",
+      "integrity": "sha512-Uz6gS0hl4zG3I2JEBTsmpPZbURaA8kVs+09xFxcCsnWK6t7zvjWUksG5GKS2woWRYnaFb+54SFfQ3rMyaVagcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "datadog-ci": "dist/bundle.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/upload-sourcemaps.mjs",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest",
@@ -52,6 +52,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@datadog/datadog-ci": "^5.16.1",
     "@eslint/js": "^10.0.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/frontend/scripts/upload-sourcemaps.mjs
+++ b/frontend/scripts/upload-sourcemaps.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Upload Vite source maps to Datadog so RUM stack traces resolve to
+// real file names and line numbers. Runs after `vite build`. Silently
+// skips when DATADOG_API_KEY isn't set so local builds still work.
+
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+if (!process.env.DATADOG_API_KEY) {
+  console.log('[sourcemaps] DATADOG_API_KEY not set, skipping upload (local build)')
+  process.exit(0)
+}
+
+if (!existsSync('dist/assets')) {
+  console.log('[sourcemaps] dist/assets not found, skipping')
+  process.exit(0)
+}
+
+const version =
+  process.env.VITE_APP_VERSION ||
+  (process.env.VERCEL_GIT_COMMIT_SHA ? process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7) : 'dev')
+
+const args = [
+  'datadog-ci',
+  'sourcemaps',
+  'upload',
+  'dist/assets',
+  '--service',
+  'biblie-school-frontend',
+  '--release-version',
+  version,
+  '--minified-path-prefix',
+  'https://biblie-school-frontend.vercel.app/assets',
+]
+
+console.log(`[sourcemaps] uploading version=${version}`)
+const result = spawnSync('npx', args, { stdio: 'inherit', shell: true })
+process.exit(result.status ?? 1)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,7 +20,11 @@ export default defineConfig({
     },
   },
   build: {
-    sourcemap: false,
+    // 'hidden' generates .map files alongside bundles but omits the
+    // //# sourceMappingURL trailer, so browsers don't auto-fetch them.
+    // Datadog RUM still resolves them server-side after upload via
+    // datadog-ci in the postbuild step.
+    sourcemap: 'hidden',
     rollupOptions: {
       output: {
         // Keep only the two chunks that genuinely benefit from manual


### PR DESCRIPTION
## Summary
- **Frontend source maps in Datadog RUM.** Vite now builds with `sourcemap: 'hidden'`; a postbuild script uploads the .map files to Datadog via `datadog-ci` so prod RUM errors resolve to real file/line/column instead of minified gibberish.
- **Backend Vercel request_id correlation.** Middleware copies `x-vercel-id` into a contextvar; the Datadog log handler attaches it to every WARNING+ event. That gives you the join key to walk from a RUM session error in the browser back to the exact backend log line that produced it.
- **Better backend log tags.** `vercel_region` is now a real tag (was hard-coded `vercel`); hostname uses the region too.

## Why
Without source maps, the very first prod JS error gives you a stack trace pointing at `index-9ynSb-qg.js:1:24356`. Useless. Datadog's been waiting for the .map upload to be wired in — this does it.

Without request_id correlation, the two halves of an incident (RUM error from the browser + backend ERROR log) are linked only by approximate timestamp. With it, both sides carry the same `vercel.request_id` and a one-click join is possible.

## Test plan
- [x] Frontend: `npm run lint` clean, `npx tsc --noEmit` clean, `npm run build` produces .map files and silently skips upload when `DATADOG_API_KEY` isn't set
- [x] Backend: `ruff check` + `ruff format --check` + `mypy` clean, 8 dd-logging unit tests pass, full backend pytest suite 508 / 508
- [x] Vercel env vars `DATADOG_API_KEY` + `DATADOG_SITE` set on biblie-school-frontend production
- [ ] After deploy: trigger a JS error, confirm the RUM error in Datadog resolves to a real .tsx file and line number
- [ ] After deploy: induce a backend warning, confirm the log line carries `vercel.request_id` and `vercel_region:iad1` (or whichever region the function ran in)