### PR TITLE
feat(design): morphing active-nav underline in header (Wave 2 shell polish)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,12 +1,15 @@
 import { lazy, Suspense, useEffect, useState } from "react"
 import { Link, useLocation } from "react-router-dom"
 import { useTranslation } from "react-i18next"
+import { LayoutGroup, motion, useReducedMotion } from "motion/react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { useAuth } from "@/context/useAuth"
 import { User as UserIcon, Menu } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import { cn } from "@/lib/utils"
+
+const UNDERLINE_LAYOUT_ID = "header-active-underline"
 
 const NotificationBell = lazy(() => import("./NotificationBell"))
 
@@ -25,6 +28,7 @@ function HeaderNavLink({
   onNavigate?: () => void
   variant?: "bar" | "sheet"
 }) {
+  const prefersReducedMotion = useReducedMotion()
   const isSheet = variant === "sheet"
   return (
     <Link
@@ -40,12 +44,25 @@ function HeaderNavLink({
             ? "border-primary bg-muted/25 font-medium text-foreground"
             : "text-foreground hover:border-border hover:bg-muted/40"),
         !isSheet &&
-          (active
-            ? "text-foreground after:pointer-events-none after:absolute after:inset-x-3 after:bottom-0 after:h-0.5 after:rounded-sm after:bg-primary"
-            : "text-muted-foreground hover:text-foreground"),
+          (active ? "text-foreground" : "text-muted-foreground hover:text-foreground"),
       )}
     >
       {children}
+      {!isSheet &&
+        active &&
+        (prefersReducedMotion ? (
+          <span
+            className="pointer-events-none absolute inset-x-3 bottom-0 h-0.5 rounded-sm bg-primary"
+            aria-hidden
+          />
+        ) : (
+          <motion.span
+            layoutId={UNDERLINE_LAYOUT_ID}
+            className="pointer-events-none absolute inset-x-3 bottom-0 h-0.5 rounded-sm bg-primary"
+            transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
+            aria-hidden
+          />
+        ))}
     </Link>
   )
 }
@@ -78,35 +95,37 @@ export default function Header() {
           </Link>
 
           {user ? (
-            <nav
-              className="hidden min-w-0 flex-1 flex-wrap items-stretch justify-center md:flex"
-              aria-label={t("header.navAriaLabel")}
-            >
-              <HeaderNavLink to="/" active={location.pathname === "/"}>
-                {t("header.courses")}
-              </HeaderNavLink>
-              <HeaderNavLink to="/calendar" active={isActive("/calendar")}>
-                {t("header.calendar")}
-              </HeaderNavLink>
-              <HeaderNavLink to="/certificates" active={isActive("/certificates")}>
-                {t("header.certificates")}
-              </HeaderNavLink>
-              {isTeacher && (
-                // header.manage / header.admin are the COMPACT (desktop bar) labels
-                // for the same destinations as header.manageCourses / header.adminPanel
-                // used in the mobile sheet. Two keys per destination is intentional:
-                // the bar is space-constrained, the sheet has room for a verbose label.
-                // Don't unify these — see UI-DECISIONS.md.
-                <HeaderNavLink to="/teacher" active={isActive("/teacher")}>
-                  {t("header.manage")}
+            <LayoutGroup id="header-nav">
+              <nav
+                className="hidden min-w-0 flex-1 flex-wrap items-stretch justify-center md:flex"
+                aria-label={t("header.navAriaLabel")}
+              >
+                <HeaderNavLink to="/" active={location.pathname === "/"}>
+                  {t("header.courses")}
                 </HeaderNavLink>
-              )}
-              {user.role === "admin" && (
-                <HeaderNavLink to="/admin" active={isActive("/admin")}>
-                  {t("header.admin")}
+                <HeaderNavLink to="/calendar" active={isActive("/calendar")}>
+                  {t("header.calendar")}
                 </HeaderNavLink>
-              )}
-            </nav>
+                <HeaderNavLink to="/certificates" active={isActive("/certificates")}>
+                  {t("header.certificates")}
+                </HeaderNavLink>
+                {isTeacher && (
+                  // header.manage / header.admin are the COMPACT (desktop bar) labels
+                  // for the same destinations as header.manageCourses / header.adminPanel
+                  // used in the mobile sheet. Two keys per destination is intentional:
+                  // the bar is space-constrained, the sheet has room for a verbose label.
+                  // Don't unify these — see UI-DECISIONS.md.
+                  <HeaderNavLink to="/teacher" active={isActive("/teacher")}>
+                    {t("header.manage")}
+                  </HeaderNavLink>
+                )}
+                {user.role === "admin" && (
+                  <HeaderNavLink to="/admin" active={isActive("/admin")}>
+                    {t("header.admin")}
+                  </HeaderNavLink>
+                )}
+              </nav>
+            </LayoutGroup>
           ) : (
             <div className="hidden flex-1 md:block" aria-hidden />
           )}


### PR DESCRIPTION
## Summary

First visual polish lands: the active-nav underline in the desktop header now smoothly morphs between nav items as the route changes, instead of jumping. Built on Foundation PR #148 primitives.

Geometry is unchanged — the underline position, size, and color are byte-identical to the old `::after` pseudo-element. Only the motion is added.

## What changed

- Wrapped desktop nav in `<LayoutGroup id="header-nav">` (scopes the layoutId so future motion elsewhere won't collide).
- Active nav link now renders `<motion.span layoutId="header-active-underline">` instead of an `::after` pseudo. Motion picks up the single rendered span and morphs its position between mounts (~320ms, editorial easing).
- `useReducedMotion` gates the branch: reduced-motion users get a static `<span>` in the same position, no animation.
- Mobile sheet nav untouched. The sheet auto-closes on navigation (existing `useEffect` on `location.pathname`), so an active-indicator animation there would never be seen.

## What's NOT in this PR

- Profile button press feedback — deferred to keep this PR focused.
- Footer micro-interactions — minimal value, deferred.
- Page-transition wiring (View Transitions API / AnimatePresence routes) — needs deliberate handling of lazy-route Suspense fallbacks; will be its own focused PR or part of Wave 3.
- Theme-switcher polish — switcher lives in Profile / AuthLayout, not in shell. Will land in Wave 3 (page-by-page).

## Bundle impact

First import of the `motion` library lands in the route-aware vendor chunk. Expect ~30 KB gzip added to whichever chunk pulls it in first (likely `vendor`). Same chunk is reused by every page that imports a motion primitive going forward, so the cost is paid once.

## Test plan

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run test:run` — 104/104 pass (no Header tests to break)
- [x] `npx vite build` succeeds locally
- [ ] On Vercel preview: navigate Courses → Calendar → Certificates → Profile and back. Underline glides smoothly, no jump.
- [ ] Dark mode: same behavior.
- [ ] `prefers-reduced-motion: reduce` via OS setting: underline is static, no animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
