### PR TITLE
feat(design): HomePage hero gradient + animated progress bars (Wave 3A)

### DIFF
--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
+import { motion, useReducedMotion } from "motion/react"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
@@ -13,6 +14,8 @@ import { Search, BookOpen, LogIn, ArrowRight, CheckCircle } from "lucide-react"
 import { EmptyState, ErrorState } from "@/components/patterns"
 import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
+
+const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
 
 function MyCoursesSectionHeader() {
   const { t } = useTranslation()
@@ -40,6 +43,7 @@ function MyCoursesSectionBody({ children }: { children: React.ReactNode }) {
 function MyCoursesSection() {
   const { t } = useTranslation()
   const { user } = useAuth()
+  const prefersReducedMotion = useReducedMotion()
   const [enrollments, setEnrollments] = useState<Enrollment[]>([])
   const [grades, setGrades] = useState<StudentGrade[]>([])
   const [loading, setLoading] = useState(true)
@@ -147,14 +151,24 @@ function MyCoursesSection() {
                 </div>
                 <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
                   <div className="flex min-w-0 flex-1 items-center gap-3 sm:max-w-md">
-                    <div className="h-2 min-w-28 flex-1 rounded-full bg-muted">
-                      <div
-                        className={cn(
-                          "h-full rounded-full transition-[width] duration-700 ease-out",
-                          progressColor,
-                        )}
-                        style={{ width: `${Math.min(enrollment.progress, 100)}%` }}
-                      />
+                    <div className="h-2 min-w-28 flex-1 overflow-hidden rounded-full bg-muted">
+                      {prefersReducedMotion ? (
+                        <div
+                          className={cn("h-full rounded-full", progressColor)}
+                          style={{ width: `${Math.min(enrollment.progress, 100)}%` }}
+                        />
+                      ) : (
+                        <motion.div
+                          className={cn("h-full rounded-full", progressColor)}
+                          initial={{ width: 0 }}
+                          animate={{ width: `${Math.min(enrollment.progress, 100)}%` }}
+                          transition={{
+                            duration: 0.9,
+                            delay: 0.15 + index * 0.045,
+                            ease: EDITORIAL_EASE,
+                          }}
+                        />
+                      )}
                     </div>
                     <span className="shrink-0 text-xs font-medium tabular-nums text-muted-foreground">
                       {enrollment.progress}%
@@ -226,7 +240,7 @@ export default function HomePage() {
           </p>
           <h1
             id="home-catalog-heading"
-            className="animate-fade-in animate-delay-100 text-balance font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            className="animate-fade-in animate-delay-100 text-balance font-serif text-3xl font-bold tracking-tight text-gradient-primary sm:text-4xl"
           >
             {user ? t("home.browseCourses") : t("home.courseCatalog")}
           </h1>


### PR DESCRIPTION
## Summary

Two focused polish moves on HomePage, the most-seen page in the app:

1. **Hero H1 gets the brand gradient.** Applied `.text-gradient-primary` (the violet → sage → violet tri-stop utility from Foundation) to the page headline. Hero areas are sanctioned in `DESIGN.md` as an "expressive moment" — this is exactly the surface to use it on. The 8s gradient shift is gated behind `prefers-reduced-motion: no-preference` and stays slow enough to read as ambient, not flashy.

2. **MyCourses progress bars fill from 0 on mount.** Previously the bars rendered at full value immediately — users never saw "progress" as a thing that arrived. Now each bar animates 0 → actual value (~920ms, editorial easing) with a 45 ms stagger per row matching the parent `stagger-fade-in`. Reduced-motion users keep the existing instant render.

## What's NOT in this PR

- Catalog `<CourseCard>` grid — already uses `stagger-fade-in` CSS, no upgrade needed.
- Search input focus — already has `focus-visible:ring-2` from shadcn.
- Hero glow (`bg-home-hero-glow`) — already breathes via CSS.

Keeping the scope tight so the diff is reviewable and any regressions roll back cleanly.

## Test plan

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run test:run` — 104/104
- [ ] Vercel preview: hero gradient is readable in both themes (violet→sage→violet on warm paper / dark zinc)
- [ ] On preview, navigate to `/` while logged in: progress bars fill on first paint
- [ ] `prefers-reduced-motion: reduce`: gradient is static, bars render instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
