### PR TITLE
feat(design): tactile hover-lift + press feedback on CourseCard (Wave 3B)

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -1,12 +1,15 @@
 import { useState, memo } from "react"
 import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
+import { motion, useReducedMotion } from "motion/react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import type { Course } from "@/types"
 import { BookOpen, ArrowRight } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import { formatDate } from "@/i18n/format"
+
+const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
 
 interface CourseCardProps {
   course: Course
@@ -52,9 +55,55 @@ function EnrollmentBadge({ start, end }: { start?: string | null; end?: string |
 
 function CourseCard({ course, style }: CourseCardProps) {
   const { t } = useTranslation()
+  const prefersReducedMotion = useReducedMotion()
   const [imgError, setImgError] = useState(false)
   const coverSrc = toProxyImage(course.image_url)
   const moduleCount = course.modules?.length ?? 0
+
+  const cardInner = (
+    <Card className="flex h-full flex-col overflow-hidden border-border/60 transition-colors hover:border-primary/40">
+      <div className="relative">
+        <EnrollmentBadge start={course.enrollment_start} end={course.enrollment_end} />
+        {coverSrc && !imgError ? (
+          <div className="aspect-[16/10] w-full overflow-hidden bg-muted">
+            <img
+              src={coverSrc}
+              alt={course.title}
+              loading="lazy"
+              decoding="async"
+              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.02]"
+              onError={() => setImgError(true)}
+            />
+          </div>
+        ) : (
+          <div className="flex aspect-[16/10] w-full items-center justify-center bg-muted">
+            <BookOpen className="h-10 w-10 text-muted-foreground/30" strokeWidth={1.75} aria-hidden />
+          </div>
+        )}
+      </div>
+      <CardHeader className="pb-2">
+        <CardTitle className="font-serif text-lg leading-snug line-clamp-2 text-wrap-safe">
+          {course.title}
+        </CardTitle>
+        {course.description && (
+          <CardDescription className="line-clamp-2 text-xs leading-relaxed text-wrap-safe">
+            {course.description}
+          </CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="mt-auto flex items-center justify-between pt-2 text-xs text-muted-foreground">
+        <span className="uppercase tracking-wide">{t("courseCard.modulesLabel", { count: moduleCount })}</span>
+        <span className="inline-flex items-center gap-1 text-foreground/80 transition-colors group-hover:text-primary">
+          {t("courseCard.openCourse")}
+          <ArrowRight
+            className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5"
+            strokeWidth={1.75}
+            aria-hidden
+          />
+        </span>
+      </CardContent>
+    </Card>
+  )
 
   return (
     <Link
@@ -62,48 +111,18 @@ function CourseCard({ course, style }: CourseCardProps) {
       style={style}
       className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
-      <Card className="flex h-full flex-col overflow-hidden border-border/60 transition-colors hover:border-primary/40">
-        <div className="relative">
-          <EnrollmentBadge start={course.enrollment_start} end={course.enrollment_end} />
-          {coverSrc && !imgError ? (
-            <div className="aspect-[16/10] w-full overflow-hidden bg-muted">
-              <img
-                src={coverSrc}
-                alt={course.title}
-                loading="lazy"
-                decoding="async"
-                className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.02]"
-                onError={() => setImgError(true)}
-              />
-            </div>
-          ) : (
-            <div className="flex aspect-[16/10] w-full items-center justify-center bg-muted">
-              <BookOpen className="h-10 w-10 text-muted-foreground/30" strokeWidth={1.75} aria-hidden />
-            </div>
-          )}
-        </div>
-        <CardHeader className="pb-2">
-          <CardTitle className="font-serif text-lg leading-snug line-clamp-2 text-wrap-safe">
-            {course.title}
-          </CardTitle>
-          {course.description && (
-            <CardDescription className="line-clamp-2 text-xs leading-relaxed text-wrap-safe">
-              {course.description}
-            </CardDescription>
-          )}
-        </CardHeader>
-        <CardContent className="mt-auto flex items-center justify-between pt-2 text-xs text-muted-foreground">
-          <span className="uppercase tracking-wide">{t("courseCard.modulesLabel", { count: moduleCount })}</span>
-          <span className="inline-flex items-center gap-1 text-foreground/80 transition-colors group-hover:text-primary">
-            {t("courseCard.openCourse")}
-            <ArrowRight
-              className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5"
-              strokeWidth={1.75}
-              aria-hidden
-            />
-          </span>
-        </CardContent>
-      </Card>
+      {prefersReducedMotion ? (
+        cardInner
+      ) : (
+        <motion.div
+          whileHover={{ y: -2 }}
+          whileTap={{ scale: 0.985 }}
+          transition={{ duration: 0.28, ease: EDITORIAL_EASE }}
+          className="h-full"
+        >
+          {cardInner}
+        </motion.div>
+      )}
     </Link>
   )
 }


### PR DESCRIPTION
## Summary

Adds a `motion.div` wrapper around the `<CourseCard>` body with `whileHover={{ y: -2 }}` and `whileTap={{ scale: 0.985 }}`, editorial easing 280 ms. The card now visibly lifts off the surface on hover and gently compresses on press, layering on top of the existing CSS group-hover ensemble (border tints to `primary/40`, cover image scales to 1.02, CTA shifts to primary, ArrowRight translates 0.5 px).

Reduced-motion users get the card without the motion wrapper — no transform, no animation.

## Blast radius

`<CourseCard>` is the catalog tile, used on:
- HomePage catalog grid
- TeacherDashboard
- CertificatesPage tiles
- Any other consumer

One component, every catalog surface in the app benefits.

## Implementation note

Extracted the card body into a `cardInner` variable so the reduced-motion fallback and the motion branch don't duplicate ~30 lines of JSX. `motion.div` carries `h-full` so the inner Card's flex chain still stretches inside grid cells.

## Test plan

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run test:run` — 104/104
- [ ] Vercel preview: hover a course tile on HomePage — visible lift, image scale-up, border tint compose smoothly
- [ ] Press/click a tile — gentle scale-down before navigation fires
- [ ] Both themes
- [ ] `prefers-reduced-motion: reduce`: no transform on hover/tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
