### PR TITLE
feat(design): staggered entrance for chapter blocks in ChapterView (Wave 3C)

### DIFF
--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -153,14 +153,18 @@ function ChapterBodyBlocks({
     )
   }
   return (
-    <div className="space-y-6">
-      {blocks.map((block) => (
-        <BlockRenderer
+    <div className="stagger-fade-in space-y-6">
+      {blocks.map((block, idx) => (
+        <div
           key={block.id}
-          block={block}
-          onProgressChanged={onProgressChanged}
-          onAssignmentCountLoaded={onAssignmentCountLoaded}
-        />
+          style={{ "--stagger-index": Math.min(idx, 12) } as React.CSSProperties}
+        >
+          <BlockRenderer
+            block={block}
+            onProgressChanged={onProgressChanged}
+            onAssignmentCountLoaded={onAssignmentCountLoaded}
+          />
+        </div>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary

Lesson reader (ChapterView) blocks now stagger-fade-in sequentially when the chapter loads, instead of all snapping in at once. Pure CSS — uses the existing `.stagger-fade-in` system from `index.css`, no motion lib.

Stagger delay is capped at index 12 (~540 ms total) so very long chapters with 50+ blocks don't make later blocks wait seconds. Beyond 12, the remaining blocks share the same delay and slide in together.

## Why CSS, not motion

A long chapter can have 30+ blocks. Wrapping each in a `motion.div` would create 30+ IntersectionObservers (Reveal) or 30+ motion contexts (FadeIn). The CSS stagger system has near-zero overhead and already has `prefers-reduced-motion` baked in.

## What's NOT in this PR

- ChapterNav prev/next button motion — disabled-state edge cases (no prev, next locked, no next) make a clean motion treatment tricky; deferred.
- Per-block scroll reveal — overkill for the reading flow; users scroll continuously and don't want each block to "appear" as it enters view.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 104/104
- [ ] Vercel preview: load a chapter with several blocks. Blocks fade in sequentially, top to bottom.
- [ ] Load a chapter with 50+ blocks. Later blocks don't wait — they all enter near-simultaneously after index 12.
- [ ] Both themes
- [ ] `prefers-reduced-motion: reduce`: instant render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
