### PR TITLE
feat(design): CourseDetail NotEnrolledView page entrance + CTA glow (Wave 3D)

### DIFF
--- a/frontend/src/pages/Course/detail/NotEnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/NotEnrolledView.tsx
@@ -57,7 +57,7 @@ export function NotEnrolledView({
   }
 
   return (
-    <div className="container mx-auto px-4 py-6 max-w-3xl">
+    <div className="animate-fade-in container mx-auto px-4 py-6 max-w-3xl">
       <Link to="/">
         <Button variant="ghost" size="sm" className="mb-4 h-8 text-xs">
           <ArrowLeft className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
@@ -148,7 +148,9 @@ export function NotEnrolledView({
           // surfaced the prior conditional that hid Enroll from owners.
           <div className="flex flex-wrap items-center gap-3">
             <Link to={`/teacher/courses/${course.id}`}>
-              <Button size="lg">{t("courseDetail.manageCourse")}</Button>
+              <Button size="lg" className="bg-cta-glow">
+                {t("courseDetail.manageCourse")}
+              </Button>
             </Link>
             <Button
               onClick={handleEnrollClick}
@@ -166,7 +168,12 @@ export function NotEnrolledView({
           </div>
         ) : isSignedIn ? (
           <div>
-            <Button onClick={handleEnrollClick} disabled={enrolling || !canEnroll} size="lg">
+            <Button
+              onClick={handleEnrollClick}
+              disabled={enrolling || !canEnroll}
+              size="lg"
+              className={!canEnroll ? undefined : "bg-cta-glow"}
+            >
               <Users className="mr-2 h-4 w-4" strokeWidth={1.75} aria-hidden />
               {!canEnroll
                 ? t("courseDetail.enrollmentNotAvailable")
@@ -184,7 +191,9 @@ export function NotEnrolledView({
           </div>
         ) : (
           <Link to="/login">
-            <Button size="lg">{t("courseDetail.signInToEnroll")}</Button>
+            <Button size="lg" className="bg-cta-glow">
+              {t("courseDetail.signInToEnroll")}
+            </Button>
           </Link>
         )}
       </div>


### PR DESCRIPTION
## Summary

Polish on `/courses/:id` for the not-yet-enrolled view (most-seen state for prospects):

- Page container gets `animate-fade-in` — content settles in on first paint instead of snapping.
- Three primary enroll CTAs get `.bg-cta-glow`: "Manage Course" (owner path), "Enroll in Course" (signed-in & enrollable), "Sign in to enroll" (anonymous). Disabled / "enrollment not available" state stays plain — no glow on a button you can't press.

Both moves are opt-in utilities from Foundation. No new motion library usage on this view; existing CSS handles motion and reduced-motion fallback.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 104/104
- [ ] Vercel preview: navigate to a course while logged out → "Sign in to enroll" button has soft glow on hover/focus
- [ ] As a logged-in non-enrolled user: "Enroll in course" button glows on hover; disabled state shows no glow
- [ ] As course owner: "Manage Course" glows, "Enroll in Course" (outline variant) does not
- [ ] Both themes
- [ ] `prefers-reduced-motion`: container renders without fade, glow `transition` is dropped per the CSS rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
