### PR TITLE
feat(design): CTA glow on Login + Register submit buttons (Wave 3H)

### DIFF
--- a/frontend/src/pages/Auth/Login.tsx
+++ b/frontend/src/pages/Auth/Login.tsx
@@ -143,7 +143,7 @@ export default function Login() {
             {errors.password && <p id="password-error" role="alert" className="text-xs text-destructive mt-1">{errors.password}</p>}
           </div>
 
-          <Button type="submit" size="lg" className="w-full font-medium rounded-md" disabled={loading}>
+          <Button type="submit" size="lg" className="bg-cta-glow w-full font-medium rounded-md" disabled={loading}>
             {loading ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/frontend/src/pages/Auth/register/RegisterForm.tsx
+++ b/frontend/src/pages/Auth/register/RegisterForm.tsx
@@ -249,7 +249,7 @@ export function RegisterForm({
           <Button
             type="submit"
             size="lg"
-            className="w-full font-medium rounded-md"
+            className="bg-cta-glow w-full font-medium rounded-md"
             disabled={loading}
           >
             {loading ? (


### PR DESCRIPTION
## Summary

Adds `.bg-cta-glow` to the two auth submit buttons:
- Login → "Sign in"
- Register → "Create account"

Two-character class addition per file. Both are large, full-width, default-variant buttons — the textbook surface for the glow utility per Foundation's "expressive moment" guidance.

Google OAuth button, "Forgot password" link, and Login↔Register switch stay quiet. The primary action wins the eye.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 104/104
- [ ] Vercel preview: hover/focus Sign-in button → soft radial glow below button
- [ ] Same on Register → "Create account"
- [ ] Both themes
- [ ] `prefers-reduced-motion`: glow `transition` removed per CSS rule (utility-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
