### PR TITLE
feat(design): CTA glow on ForgotPassword + ResetPassword submit (Wave 3H+)

### DIFF
--- a/frontend/src/pages/Auth/ForgotPassword.tsx
+++ b/frontend/src/pages/Auth/ForgotPassword.tsx
@@ -99,7 +99,7 @@ export default function ForgotPassword() {
             />
           </div>
 
-          <Button type="submit" size="lg" className="w-full font-medium" disabled={loading}>
+          <Button type="submit" size="lg" className="bg-cta-glow w-full font-medium" disabled={loading}>
             {loading ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/frontend/src/pages/Auth/ResetPassword.tsx
+++ b/frontend/src/pages/Auth/ResetPassword.tsx
@@ -154,7 +154,7 @@ export default function ResetPassword() {
             )}
           </div>
 
-          <Button type="submit" size="lg" className="w-full font-medium" disabled={loading}>
+          <Button type="submit" size="lg" className="bg-cta-glow w-full font-medium" disabled={loading}>
             {loading ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" />


### PR DESCRIPTION
Same one-class addition as PR #156, applied to the two secondary auth flows. Keeps every primary submit button across /login, /register, /forgot-password, /auth/reset-password visually consistent.

Test plan: same as #156 — visual check on Vercel preview, both themes, reduced-motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)