### PR TITLE
feat(design): fade-in on EmptyState + ErrorState (Wave 4A)

### DIFF
--- a/frontend/src/components/patterns/EmptyState.tsx
+++ b/frontend/src/components/patterns/EmptyState.tsx
@@ -13,7 +13,7 @@ export function EmptyState({ icon, title, description, action, className }: Empt
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-background px-6 py-12 text-center",
+        "animate-fade-in flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-background px-6 py-12 text-center",
         className,
       )}
     >

--- a/frontend/src/components/patterns/ErrorState.tsx
+++ b/frontend/src/components/patterns/ErrorState.tsx
@@ -36,7 +36,7 @@ export function ErrorState({
     <div
       role="alert"
       className={cn(
-        "flex flex-col items-center justify-center gap-4 py-20 text-center",
+        "animate-fade-in flex flex-col items-center justify-center gap-4 py-20 text-center",
         className,
       )}
     >


### PR DESCRIPTION
Single class addition per file. Every page that shows an empty/error placeholder now has a soft entrance instead of snap. Reduced-motion covered by the existing CSS rule.

Blast radius: HomePage no-courses, MyCourses load error, certificates empty, teacher dashboard empty courses, profile load failures, and every other consumer of these patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)