### PR TITLE
feat(design): stagger ModuleList entries on CourseDetail (Wave 3D2)

### DIFF
--- a/frontend/src/pages/Course/detail/ModuleList.tsx
+++ b/frontend/src/pages/Course/detail/ModuleList.tsx
@@ -16,6 +16,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { StaggerChildren } from "@/components/motion"
 import { isGradableChapterType } from "@/lib/chapterTypes"
 import type { Module } from "@/types"
 import { formatDate } from "./types"
@@ -37,7 +38,7 @@ export function ModuleList({ courseId, modules, completedChapterIds }: Props) {
       </h2>
 
       {modules.length > 0 ? (
-        <div className="space-y-2">
+        <StaggerChildren className="space-y-2">
           {modules.map((module, idx) => (
             <ModuleRow
               key={module.id}
@@ -48,7 +49,7 @@ export function ModuleList({ courseId, modules, completedChapterIds }: Props) {
               completedChapterIds={completedChapterIds}
             />
           ))}
-        </div>
+        </StaggerChildren>
       ) : (
         <Card className="border-dashed">
           <CardContent className="py-8 text-center text-muted-foreground text-sm">


### PR DESCRIPTION
## Summary
- Wave 3D continued: wrap the module list on the enrolled course-detail page in `<StaggerChildren>` so module cards fade in sequentially on load.
- Reduced-motion users get the existing no-animation path via the primitive's `useReducedMotion` branch.
- Pure presentational change; no logic, ordering, or geometry touched.

Part of the design polish wave (#148). Follows #155 (NotEnrolledView entrance + CTA glow).

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke: open an enrolled course detail page; modules should stagger-fade in.
- [ ] Reduced-motion: enable OS reduced-motion → no animation, modules render statically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
