### PR TITLE
feat(design): page fade-in on CourseDetail EnrolledView (Wave 3D3)

### DIFF
--- a/frontend/src/pages/Course/detail/EnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/EnrolledView.tsx
@@ -65,7 +65,7 @@ export function EnrolledView({
   }, [])
 
   return (
-    <div className="container mx-auto px-4 py-6 max-w-4xl">
+    <div className="animate-fade-in container mx-auto px-4 py-6 max-w-4xl">
       <EnrolledHeader
         course={course}
         enrollment={enrollment}


### PR DESCRIPTION
## Summary
- Mirrors #155 on the enrolled side of the course-detail page: `animate-fade-in` on the root container so the entrance feels consistent whether the viewer is enrolled or not.
- One-class change.

Part of the design polish wave (#148). Pairs with #159 which staggers the ModuleList inside.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke: navigate from `/courses/:id` (not enrolled) → enroll → page should fade in gently after redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
