### PR TITLE
feat(design): press feedback on ChapterNav prev/next (Wave 3C+)

### DIFF
--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react"
 import QuizTaker from "@/components/quiz/QuizTaker"
 import AssignmentPanel from "@/components/assignment/AssignmentPanel"
+import { PressFeedback } from "@/components/motion"
 import {
   isGradableChapterType,
   normalizeChapterType,
@@ -193,14 +194,16 @@ function ChapterNav({
   return (
     <div className="mt-8 pt-6 border-t flex items-center justify-between">
       {prevChapter ? (
-        <Button
-          variant="outline"
-          onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}/chapters/${prevChapter.id}`)}
-          className="gap-2"
-        >
-          <ArrowLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          {t("chapter.prevChapter")}
-        </Button>
+        <PressFeedback>
+          <Button
+            variant="outline"
+            onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}/chapters/${prevChapter.id}`)}
+            className="gap-2"
+          >
+            <ArrowLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+            {t("chapter.prevChapter")}
+          </Button>
+        </PressFeedback>
       ) : (
         <Button variant="outline" disabled className="gap-2">
           <ArrowLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
@@ -219,14 +222,16 @@ function ChapterNav({
             {t("chapter.nextChapter")}
           </Button>
         ) : (
-          <Button
-            variant="outline"
-            onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}/chapters/${nextChapter.id}`)}
-            className="gap-2"
-          >
-            {t("chapter.nextChapter")}
-            <ArrowRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          </Button>
+          <PressFeedback>
+            <Button
+              variant="outline"
+              onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}/chapters/${nextChapter.id}`)}
+              className="gap-2"
+            >
+              {t("chapter.nextChapter")}
+              <ArrowRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+            </Button>
+          </PressFeedback>
         )
       ) : (
         <Button variant="outline" disabled className="gap-2">


### PR DESCRIPTION
## Summary
- Picks up the ChapterNav add-on deferred from Wave 3C (#153): wraps the **enabled** prev/next buttons with `<PressFeedback>` for tactile scale-down on tap.
- Three disabled branches stay untouched (no prev, no next, or next locked) so they keep the static feel that matches their semantics.
- Reduced-motion users get the no-animation path via the primitive's `useReducedMotion` branch.

Part of the design polish wave (#148).

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke: open a chapter mid-module, tap prev/next — buttons should compress slightly on press.
- [ ] First/last chapter, or locked-next: disabled buttons should NOT compress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
