### PR TITLE
feat(design): page fade-in on AdminDashboard (Wave 3G)

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -42,7 +42,7 @@ export default function AdminDashboard() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-6xl">
+    <div className="animate-fade-in container mx-auto px-4 py-8 max-w-6xl">
       <div className="flex items-center gap-3 mb-6">
         <div className="p-2 rounded-lg bg-primary/10">
           <Shield className="h-6 w-6 text-primary" />


### PR DESCRIPTION
## Summary
- Wave 3G subtle entrance: `animate-fade-in` on the AdminDashboard root container.
- Tab switches use `useSearchParams` (URL state, no remount), so the fade fires once per visit — not on every tab change.
- Tables, filters, and bulk actions untouched per the wave plan ("less expressive, more functional").

Part of the design polish wave (#148).

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke as admin user: navigate to `/admin` → page fades in once. Switch between overview/audit tabs → no re-fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
