### PR TITLE
feat(design): stagger quiz question entrance (Wave 3E1)

### DIFF
--- a/frontend/src/components/quiz/QuizTaker.tsx
+++ b/frontend/src/components/quiz/QuizTaker.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import PageSpinner from "@/components/ui/PageSpinner"
+import { StaggerChildren } from "@/components/motion"
 import { coursesService } from "@/services/courses"
 import { getErrorDetail } from "@/lib/errorDetail"
 import { toast } from "@/lib/toast"
@@ -164,15 +165,17 @@ export default function QuizTaker({ chapterId, quizId, onSubmitted }: QuizTakerP
               {t("quiz.maxAttemptsReached", { type: t(assessmentTypeKey).toLowerCase() })}
             </div>
           )}
-          {sortedQuestions.map((question, idx) => (
-            <QuestionPrompt
-              key={question.id}
-              question={question}
-              index={idx}
-              answer={answers[question.id]}
-              onAnswer={(val) => setAnswer(question.id, val)}
-            />
-          ))}
+          <StaggerChildren className="space-y-6">
+            {sortedQuestions.map((question, idx) => (
+              <QuestionPrompt
+                key={question.id}
+                question={question}
+                index={idx}
+                answer={answers[question.id]}
+                onAnswer={(val) => setAnswer(question.id, val)}
+              />
+            ))}
+          </StaggerChildren>
 
           <Button
             onClick={handleSubmit}


### PR DESCRIPTION
## Summary
- Wave 3E1: wrap the question list in QuizTaker with `<StaggerChildren>` so quiz questions fade in sequentially on load (~45ms per item, editorial easing).
- Pure presentational; selection logic, submit gating, and attempt tracking untouched.
- Reduced-motion users get the existing no-animation branch from the primitive.

Smallest slice of the 3E quiz polish. Follow-ups (separate PRs): submit-CTA glow, results-card trophy/error icon pop, review-answer stagger.

Part of the design polish wave (#148).

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass — QuizTaker.test.tsx included)
- [ ] Visual smoke: open a chapter with a quiz; questions should appear one after another.
- [ ] Switch from results → "Try Again": new question render also staggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
