### PR TITLE
feat(design): CTA glow on quiz submit button (Wave 3E2)

### DIFF
--- a/frontend/src/components/quiz/QuizTaker.tsx
+++ b/frontend/src/components/quiz/QuizTaker.tsx
@@ -180,7 +180,11 @@ export default function QuizTaker({ chapterId, quizId, onSubmitted }: QuizTakerP
           <Button
             onClick={handleSubmit}
             disabled={!allAnswered || submitting || attemptsReached}
-            className="w-full"
+            className={
+              !allAnswered || submitting || attemptsReached
+                ? "w-full"
+                : "w-full bg-cta-glow"
+            }
           >
             {submitting ? (
               <>


### PR DESCRIPTION
## Summary
- Wave 3E2: `bg-cta-glow` on the QuizTaker submit Button, gated on enabled state. Matches the pattern on enroll / auth CTAs (#155, #156, #157).
- Disabled states (incomplete answers, in-flight submit, max attempts) stay flat — no glow on something that can't be clicked.

Part of the design polish wave (#148). Follows #163.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass — QuizTaker.test.tsx included)
- [ ] Visual smoke: open a quiz; submit glows once all questions answered. After submit, glow stops on disabled state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
