### PR TITLE
feat(design): scale-pop on quiz result icon (Wave 3E3)

### DIFF
--- a/frontend/src/components/quiz/taker/ResultsView.tsx
+++ b/frontend/src/components/quiz/taker/ResultsView.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, BookOpen, CheckCircle, Trophy, XCircle } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { motion, useReducedMotion } from "motion/react"
 import { Card, CardContent } from "@/components/ui/card"
 import type { Quiz, QuizAttempt, QuizQuestion } from "@/types"
 import type { AnswerMap } from "./types"
@@ -13,6 +14,7 @@ interface Props {
 
 export function ResultsView({ result, quiz, questions, answers }: Props) {
   const { t } = useTranslation()
+  const prefersReducedMotion = useReducedMotion()
   const scorePercent = result.max_score
     ? Math.round(((result.score ?? 0) / result.max_score) * 100)
     : 0
@@ -21,6 +23,9 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
   const hasOpenEnded = questions.some(
     (q) => q.question_type === "short_answer" || q.question_type === "essay",
   )
+
+  const ResultIcon = result.passed ? Trophy : AlertCircle
+  const iconColor = result.passed ? "text-success" : "text-destructive"
 
   return (
     <div className="p-5 space-y-6">
@@ -32,10 +37,17 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
         }
       >
         <CardContent className="py-6 text-center">
-          {result.passed ? (
-            <Trophy className="mx-auto mb-3 h-10 w-10 text-success" />
+          {prefersReducedMotion ? (
+            <ResultIcon className={`mx-auto mb-3 h-10 w-10 ${iconColor}`} />
           ) : (
-            <AlertCircle className="mx-auto mb-3 h-10 w-10 text-destructive" />
+            <motion.div
+              className="mx-auto mb-3 w-fit"
+              initial={{ scale: 0, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: "spring", stiffness: 320, damping: 18, delay: 0.05 }}
+            >
+              <ResultIcon className={`h-10 w-10 ${iconColor}`} />
+            </motion.div>
           )}
           <h3 className="text-lg font-bold mb-1">
             {result.passed ? t("quiz.passedTitle") : t("quiz.notPassedTitle")}


### PR DESCRIPTION
## Summary
- Wave 3E3: Trophy / AlertCircle in `ResultsView` spring-pops into place when the results card renders after submit. Gives the pass/fail moment a small reward beat.
- Uses motion's spring (stiffness 320, damping 18) for an overshoot/settle feel — editorial cubic-bezier doesn't pop the same way.
- Hand-rolled `motion.div` rather than a new primitive. If a second scale-pop site shows up (e.g. review-answer check icons), the inline pattern gets extracted into a `<Pop>` primitive.
- Reduced-motion users render the icon statically.

Part of the design polish wave (#148). Pairs with #163 (questions stagger) and #164 (submit glow).

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke: pass and fail a quiz; trophy and alert-circle should pop in on results render.
- [ ] Reduced-motion: enable OS reduced-motion → icon appears statically, no scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
