### PR TITLE
feat(design): stagger review-answer cards (Wave 3E4)

### DIFF
--- a/frontend/src/components/quiz/taker/ResultsView.tsx
+++ b/frontend/src/components/quiz/taker/ResultsView.tsx
@@ -2,6 +2,7 @@ import { AlertCircle, BookOpen, CheckCircle, Trophy, XCircle } from "lucide-reac
 import { useTranslation } from "react-i18next"
 import { motion, useReducedMotion } from "motion/react"
 import { Card, CardContent } from "@/components/ui/card"
+import { StaggerChildren } from "@/components/motion"
 import type { Quiz, QuizAttempt, QuizQuestion } from "@/types"
 import type { AnswerMap } from "./types"
 
@@ -68,7 +69,8 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
 
       <div className="space-y-4">
         <h4 className="text-sm font-semibold">{t("quiz.reviewAnswers")}</h4>
-        {questions.map((q, idx) => {
+        <StaggerChildren className="space-y-4">
+          {questions.map((q, idx) => {
           const userAnswer = answers[q.id]
           const answerResult = answerMap.get(q.id)
           const isManual =
@@ -174,6 +176,7 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
             </div>
           )
         })}
+        </StaggerChildren>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Wave 3E4: wrap the per-question review cards in `ResultsView` with `<StaggerChildren>` so they cascade in after the icon pops.
- The "Review your answers" heading stays flat so it anchors the eye first.
- Pure presentational; no changes to grading display or pass/fail logic.
- Reduced-motion path preserved.

Closes the student-facing quiz polish:
- #163 — questions stagger on load
- #164 — submit CTA glow
- #165 — result icon spring-pop
- #166 (this) — review-answer cascade

Part of the design polish wave (#148).

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke: submit a quiz; review cards should cascade in below the result icon.
- [ ] Try Again → submit again: cards still cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
