### PR TITLE
fix(PageHeader): let description and meta span full width

### DIFF
--- a/frontend/src/components/patterns/PageHeader.tsx
+++ b/frontend/src/components/patterns/PageHeader.tsx
@@ -37,21 +37,19 @@ export function PageHeader({
       )}
       {cover && <div className="max-w-4xl">{cover}</div>}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0 flex-1 space-y-2">
-          <div className="min-w-0 text-wrap-safe">{title}</div>
-          {description && (
-            <div className="max-w-3xl text-sm text-muted-foreground text-wrap-safe">
-              {description}
-            </div>
-          )}
-          {meta && (
-            <div className="flex flex-wrap items-center gap-2 pt-1">{meta}</div>
-          )}
-        </div>
+        <div className="min-w-0 flex-1 text-wrap-safe">{title}</div>
         {actions && (
           <div className="flex shrink-0 items-center gap-2">{actions}</div>
         )}
       </div>
+      {description && (
+        <div className="max-w-3xl text-sm text-muted-foreground text-wrap-safe">
+          {description}
+        </div>
+      )}
+      {meta && (
+        <div className="flex flex-wrap items-center gap-2 pt-1">{meta}</div>
+      )}
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- Fixes the `PageHeader` pattern so the description is no longer artificially constrained by the actions on the right.
- Before: title + description + meta were all packed into the `flex-1` left column. When the right side had buttons (`CourseEditor`, `ModuleEditor`), the description got the same narrow width as the title, even though there was plenty of horizontal room below.
- After: only the **title** stays in the row with actions (title needs to be constrained — it sits next to buttons). Description and meta drop to their own rows below, spanning the full width up to `max-w-3xl` for readability.
- Pure layout change; no API change for the two call sites.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke as a teacher: open `/teacher/courses/:id` → description below title spans the full width. Same for `/teacher/courses/:id/modules/:id`.
- [ ] On narrow viewport (`<sm`) the actions stack below the title naturally — description still spans full width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
