### PR TITLE
fix(teacherDashboard): icon-only Edit + group Clone/Delete into ⋯ menu

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -444,7 +444,8 @@
       "actionCloneShort": "Clone",
       "actionEdit": "Edit",
       "actionEditCourse": "Edit course",
-      "actionDelete": "Delete"
+      "actionDelete": "Delete",
+      "actionMore": "More actions"
     }
   },
   "teacherEditor": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -456,7 +456,8 @@
       "actionCloneShort": "Копия",
       "actionEdit": "Редактировать",
       "actionEditCourse": "Редактировать курс",
-      "actionDelete": "Удалить"
+      "actionDelete": "Удалить",
+      "actionMore": "Ещё действия"
     }
   },
   "teacherEditor": {

--- a/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
@@ -8,6 +8,7 @@ import {
   Eye,
   EyeOff,
   Layers,
+  MoreHorizontal,
   Pencil,
   Trash2,
   Users,
@@ -15,6 +16,13 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { toProxyImage } from "@/lib/images"
 import { formatDate } from "@/i18n/format"
 import type { Course } from "@/types"
@@ -135,38 +143,49 @@ export function CourseCard({
             )}
             <span className="sr-only">{togglePublishLabel}</span>
           </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            title={t("teacherDashboard.courseCard.actionClone")}
-            disabled={cloningId === course.id}
-            onClick={() => onClone(course.id)}
-          >
-            {cloningId === course.id ? (
-              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-            ) : (
-              <Copy className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-            )}
-            <span className="sr-only">
-              {t("teacherDashboard.courseCard.actionCloneShort")}
-            </span>
-          </Button>
           <Link to={`/teacher/courses/${course.id}`}>
             <Button
               variant="ghost"
               size="sm"
               aria-label={t("teacherDashboard.courseCard.actionEditCourse")}
+              title={t("teacherDashboard.courseCard.actionEditCourse")}
             >
               <Pencil className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-              <span className="hidden sm:inline">
-                {t("teacherDashboard.courseCard.actionEdit")}
-              </span>
             </Button>
           </Link>
-          <Button variant="destructive" size="sm" onClick={() => onDelete(course.id)}>
-            <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-            {t("teacherDashboard.courseCard.actionDelete")}
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={t("teacherDashboard.courseCard.actionMore")}
+                title={t("teacherDashboard.courseCard.actionMore")}
+              >
+                <MoreHorizontal className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onSelect={() => onClone(course.id)}
+                disabled={cloningId === course.id}
+              >
+                {cloningId === course.id ? (
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                ) : (
+                  <Copy className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+                )}
+                {t("teacherDashboard.courseCard.actionClone")}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => onDelete(course.id)}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+                {t("teacherDashboard.courseCard.actionDelete")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
     </Card>


### PR DESCRIPTION
## Summary
Cleans up the `TeacherDashboard` CourseCard row of seven buttons:

1. **Edit button**: drops the "Edit" text label. The pencil icon alone says "edit"; the redundant word is gone. `aria-label` + `title` keep it accessible.
2. **Clone + Delete**: moved into a single `⋯` DropdownMenu (same pattern as CourseEditor's existing more-menu). Delete is styled destructive inside the menu so the most dangerous action is the most ceremony-gated. Cuts inline button count from 7 → 5.
3. New i18n key `teacherDashboard.courseCard.actionMore` ("More actions" / "Ещё действия") for the trigger.

Frequent inline buttons still surfaced: Analytics, Gradebook, Students, Publish/Unpublish, Edit.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke as teacher: open `/teacher`. Pencil button has no text. ⋯ menu opens with Clone + Delete; Delete is red.
- [ ] Click Clone → loading spinner stays inside the menu item; closes after.
- [ ] Click Delete → existing confirm flow fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
