### PR TITLE
fix(layout): drop redundant page-lead subtitles (4 pages)

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -47,12 +47,7 @@ export default function AdminDashboard() {
         <div className="p-2 rounded-lg bg-primary/10">
           <Shield className="h-6 w-6 text-primary" />
         </div>
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">{t("admin.title")}</h1>
-          <p className="text-muted-foreground mt-0.5">
-            {t("admin.subtitle")}
-          </p>
-        </div>
+        <h1 className="text-3xl font-bold tracking-tight">{t("admin.title")}</h1>
       </div>
 
       <AdminTabs active={tab} onChange={setTab} />

--- a/frontend/src/pages/Calendar/CalendarPage.tsx
+++ b/frontend/src/pages/Calendar/CalendarPage.tsx
@@ -61,15 +61,10 @@ export default function CalendarPage() {
   return (
     <div className="container mx-auto px-4 py-6 max-w-6xl">
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-6">
-        <div>
-          <h1 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight flex items-center gap-2">
-            <CalendarDays className="h-6 w-6 text-primary" />
-            {t("calendar.title")}
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            {t("calendar.subtitle")}
-          </p>
-        </div>
+        <h1 className="font-serif text-2xl sm:text-3xl font-bold tracking-tight flex items-center gap-2">
+          <CalendarDays className="h-6 w-6 text-primary" />
+          {t("calendar.title")}
+        </h1>
 
         {enrollments.length > 0 && (
           <div className="flex items-center gap-2">

--- a/frontend/src/pages/Certificates/CertificatesPage.tsx
+++ b/frontend/src/pages/Certificates/CertificatesPage.tsx
@@ -60,15 +60,12 @@ export default function CertificatesPage() {
         </Button>
       </Link>
 
-      <div className="mb-8">
-        <h1 className="flex items-center gap-3 font-serif text-3xl font-bold tracking-tight">
-          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
-            <Award className="h-5 w-5 text-muted-foreground" />
-          </div>
-          {t("certificates.title")}
-        </h1>
-        <p className="mt-2 text-muted-foreground">{t("certificates.subtitle")}</p>
-      </div>
+      <h1 className="mb-8 flex items-center gap-3 font-serif text-3xl font-bold tracking-tight">
+        <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+          <Award className="h-5 w-5 text-muted-foreground" />
+        </div>
+        {t("certificates.title")}
+      </h1>
 
       {certificates.length === 0 ? (
         <Card className="border-dashed">

--- a/frontend/src/pages/Teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.tsx
@@ -214,12 +214,7 @@ export default function TeacherDashboard() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-5xl">
       <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">{t("teacher.dashboardTitle")}</h1>
-          <p className="text-muted-foreground mt-1">
-            {t("teacher.dashboardSubtitle")}
-          </p>
-        </div>
+        <h1 className="text-3xl font-bold tracking-tight">{t("teacher.dashboardTitle")}</h1>
         <Button onClick={() => setShowCreate(!showCreate)} size="sm">
           <Plus className="h-4 w-4 mr-1.5" />
           {t("teacher.newCourse")}


### PR DESCRIPTION
## Summary
Same problem #167 fixed on `/profile`, repeated across four more pages:

- `/teacher` — h1 "My Courses" + subtitle "Create and manage your course content"
- `/certificates` — h1 "My Certificates" + subtitle "Certificates you've earned for completing courses"
- `/calendar` — h1 "Calendar" + subtitle "Your deadlines, events, and schedule in one place"
- `/admin` — h1 "Admin Dashboard" + subtitle "Manage users, roles, and monitor platform activity"

Each subtitle restates the title without adding information. Removed. Primary actions and layout otherwise unchanged.

i18n keys (`teacher.dashboardSubtitle`, `certificates.subtitle`, `calendar.subtitle`, `admin.subtitle`) left in the bundles — pruning will be a separate janitor pass.

Continues owner feedback: «куууча подобных проблем».

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass)
- [ ] Visual smoke on `/teacher`, `/certificates`, `/calendar`, `/admin` — page title alone, no fluff line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
