### PR TITLE
chore(i18n): missingKeyHandler — throws in test, errors in dev

### DIFF
--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -30,6 +30,13 @@ export function isSupportedLocale(value: unknown): value is SupportedLocale {
   return typeof value === "string" && (SUPPORTED_LOCALES as readonly string[]).includes(value)
 }
 
+// Vite injects `import.meta.env.MODE` as "development" / "production" / "test"
+// (vitest sets MODE="test"). Guard for non-Vite environments just in case.
+const mode =
+  typeof import.meta !== "undefined" && import.meta.env ? import.meta.env.MODE : "production"
+const isProd = mode === "production"
+const isTest = mode === "test"
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
@@ -50,6 +57,23 @@ i18n
       caches: ["localStorage"],
     },
     returnNull: false,
+    // Surface missing keys loudly in non-prod so bilingual drift can't sneak
+    // in. In test mode we throw — a test rendering a component that calls
+    // `t("missing.key")` will fail immediately, catching the bug in CI. In
+    // dev we `console.error` so the page still renders but the developer sees
+    // it. In prod we stay silent (the key string is the fallback, which is
+    // ugly but not catastrophic).
+    saveMissing: !isProd,
+    missingKeyHandler: isProd
+      ? undefined
+      : (lngs, ns, key) => {
+          const locales = Array.isArray(lngs) ? lngs.join(", ") : String(lngs)
+          const msg = `[i18n] missing key "${ns}:${key}" for locale(s) ${locales}`
+          if (isTest) {
+            throw new Error(msg)
+          }
+          console.error(msg)
+        },
   })
 
 // Keep <html lang> in sync with the active locale so screen readers, browser


### PR DESCRIPTION
## Summary
Second piece of the bilingual-by-default foundation (after #172).

When `t("foo.bar")` resolves to a missing key:
- **test mode** (vitest sets `MODE="test"`): handler **throws** → the test fails. This is the layer that catches drift in PRs.
- **dev mode** (vite dev server): handler **console.error**s. Page still renders (key string as fallback), but developer sees it in DevTools.
- **prod**: handler is `undefined`. End user sees the ugly key string but app doesn't crash. The CI parity check (#172) and the upcoming render-test prevent missing keys from reaching prod anyway.

Gated on `import.meta.env.MODE`. Vite injects this; vitest plugin sets it to `"test"`.

Existing 104 tests still pass — confirms no missing keys in tested code paths.

Next PR: dual-locale render test that mounts a sample of pages under each locale, so missing keys in *untested* components also start failing CI.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (104 tests pass, no new failures)
- [ ] Sanity: temporarily add `t("not.a.real.key")` in a test, re-run → test fails with the new error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
