### PR TITLE
i18n(teacherEditor): CourseEditor + ChapterEditor → t()

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -505,6 +505,62 @@
     },
     "addChapter": "Add chapter"
   },
+  "courseEditor": {
+    "notFound": {
+      "title": "Course not found",
+      "description": "The course may have been deleted or you may not have access.",
+      "backToCourses": "Back to courses"
+    },
+    "myCourses": "My courses",
+    "untitledCourse": "Untitled course",
+    "addDescription": "Add a course description",
+    "editTitle": "Edit course title",
+    "editDescription": "Edit course description",
+    "published": "Published",
+    "draft": "Draft",
+    "publish": "Publish",
+    "unpublish": "Unpublish",
+    "moreActions": "More actions",
+    "menu": {
+      "enrollment": "Enrollment",
+      "announcements": "Announcements",
+      "materials": "Materials",
+      "events": "Events",
+      "cohorts": "Cohorts"
+    }
+  },
+  "chapterEditor": {
+    "notFound": {
+      "title": "Chapter not found",
+      "description": "The chapter may have been deleted or you may not have access.",
+      "backToModule": "Back to module"
+    },
+    "moduleFallback": "Module",
+    "chapterFallback": "Chapter",
+    "breadcrumb": {
+      "myCourses": "My Courses",
+      "course": "Course"
+    },
+    "toast": {
+      "chapterNotFound": "Chapter not found",
+      "loadFailed": "Failed to load chapter",
+      "invalidData": "Invalid chapter data",
+      "saved": "Chapter saved",
+      "saveFailed": "Failed to save: {{detail}}"
+    },
+    "unknownError": "Unknown error",
+    "leaveConfirm": {
+      "title": "Leave without saving?",
+      "description": "You have unsaved changes. They will be lost if you leave now.",
+      "confirm": "Leave"
+    },
+    "back": "Back",
+    "titlePlaceholder": "Chapter title",
+    "chapterType": "Chapter Type",
+    "save": "Save Chapter",
+    "saving": "Saving...",
+    "saveHint": "Ctrl+S to save"
+  },
   "courseDetail": {
     "allCourses": "All Courses",
     "manageCourse": "Manage Course",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -519,6 +519,62 @@
     },
     "addChapter": "Добавить главу"
   },
+  "courseEditor": {
+    "notFound": {
+      "title": "Курс не найден",
+      "description": "Курс мог быть удалён, или у вас нет доступа.",
+      "backToCourses": "К моим курсам"
+    },
+    "myCourses": "Мои курсы",
+    "untitledCourse": "Без названия",
+    "addDescription": "Добавьте описание курса",
+    "editTitle": "Изменить название курса",
+    "editDescription": "Изменить описание курса",
+    "published": "Опубликован",
+    "draft": "Черновик",
+    "publish": "Опубликовать",
+    "unpublish": "Снять с публикации",
+    "moreActions": "Ещё действия",
+    "menu": {
+      "enrollment": "Запись",
+      "announcements": "Объявления",
+      "materials": "Материалы",
+      "events": "События",
+      "cohorts": "Когорты"
+    }
+  },
+  "chapterEditor": {
+    "notFound": {
+      "title": "Глава не найдена",
+      "description": "Глава могла быть удалена, или у вас нет доступа.",
+      "backToModule": "К модулю"
+    },
+    "moduleFallback": "Модуль",
+    "chapterFallback": "Глава",
+    "breadcrumb": {
+      "myCourses": "Мои курсы",
+      "course": "Курс"
+    },
+    "toast": {
+      "chapterNotFound": "Глава не найдена",
+      "loadFailed": "Не удалось загрузить главу",
+      "invalidData": "Некорректные данные главы",
+      "saved": "Глава сохранена",
+      "saveFailed": "Не удалось сохранить: {{detail}}"
+    },
+    "unknownError": "Неизвестная ошибка",
+    "leaveConfirm": {
+      "title": "Выйти без сохранения?",
+      "description": "Есть несохранённые изменения. Они будут потеряны при выходе.",
+      "confirm": "Выйти"
+    },
+    "back": "Назад",
+    "titlePlaceholder": "Название главы",
+    "chapterType": "Тип главы",
+    "save": "Сохранить главу",
+    "saving": "Сохранение...",
+    "saveHint": "Ctrl+S для сохранения"
+  },
   "courseDetail": {
     "allCourses": "Все курсы",
     "manageCourse": "Управлять курсом",

--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react"
 import { useParams, Link, useNavigate } from "react-router-dom"
+import { useTranslation } from "react-i18next"
 import { getErrorDetail } from "@/lib/errorDetail"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -45,6 +46,7 @@ export default function ChapterEditor() {
   }>()
   const navigate = useNavigate()
   const confirm = useConfirm()
+  const { t } = useTranslation()
 
   const [chapter, setChapter] = useState<Chapter | null>(null)
   const [loading, setLoading] = useState(true)
@@ -52,7 +54,7 @@ export default function ChapterEditor() {
 
   const [title, setTitle] = useState("")
   const [chapterType, setChapterType] = useState<ChapterType>("reading")
-  const [moduleName, setModuleName] = useState("Module")
+  const [moduleName, setModuleName] = useState(() => t("chapterEditor.moduleFallback"))
   const [isDirty, setIsDirty] = useState(false)
 
   const load = useCallback(async (signal?: { cancelled: boolean }) => {
@@ -64,7 +66,7 @@ export default function ChapterEditor() {
       setModuleName(mod.title)
       const ch = mod.chapters?.find((c) => c.id === chapterId)
       if (!ch) {
-        toast({ title: "Chapter not found", variant: "destructive" })
+        toast({ title: t("chapterEditor.toast.chapterNotFound"), variant: "destructive" })
         navigate(`/teacher/courses/${courseId}/modules/${moduleId}/edit`)
         return
       }
@@ -79,12 +81,12 @@ export default function ChapterEditor() {
       setIsDirty(false)
     } catch {
       if (signal?.cancelled) return
-      toast({ title: "Failed to load chapter", variant: "destructive" })
+      toast({ title: t("chapterEditor.toast.loadFailed"), variant: "destructive" })
       navigate(`/teacher/courses/${courseId}/modules/${moduleId}/edit`)
     } finally {
       if (!signal?.cancelled) setLoading(false)
     }
-  }, [courseId, moduleId, chapterId, navigate])
+  }, [courseId, moduleId, chapterId, navigate, t])
 
   useEffect(() => {
     const signal = { cancelled: false }
@@ -125,7 +127,7 @@ export default function ChapterEditor() {
     if (!validation.success) {
       const first = validation.error.issues[0]
       toast({
-        title: first?.message ?? "Invalid chapter data",
+        title: first?.message ?? t("chapterEditor.toast.invalidData"),
         variant: "destructive",
       })
       return
@@ -141,14 +143,17 @@ export default function ChapterEditor() {
       const snapshot = JSON.stringify({ title: title.trim(), chapterType })
       setInitialSnapshot(snapshot)
       setIsDirty(false)
-      toast({ title: "Chapter saved" })
+      toast({ title: t("chapterEditor.toast.saved") })
     } catch (error: unknown) {
-      const detail = getErrorDetail(error) || "Unknown error"
-      toast({ title: `Failed to save: ${detail}`, variant: "destructive" })
+      const detail = getErrorDetail(error) || t("chapterEditor.unknownError")
+      toast({
+        title: t("chapterEditor.toast.saveFailed", { detail }),
+        variant: "destructive",
+      })
     } finally {
       setSaving(false)
     }
-  }, [courseId, moduleId, chapterId, title, chapterType])
+  }, [courseId, moduleId, chapterId, title, chapterType, t])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -179,15 +184,15 @@ export default function ChapterEditor() {
   if (!chapter) return (
     <div className="container mx-auto px-4">
       <ErrorState
-        title="Chapter not found"
-        description="The chapter may have been deleted or you may not have access."
+        title={t("chapterEditor.notFound.title")}
+        description={t("chapterEditor.notFound.description")}
         action={
           <Button
             variant="outline"
             size="sm"
             onClick={() => navigate(`/teacher/courses/${courseId}/modules/${moduleId}/edit`)}
           >
-            Back to module
+            {t("chapterEditor.notFound.backToModule")}
           </Button>
         }
       />
@@ -199,14 +204,14 @@ export default function ChapterEditor() {
       {/* Breadcrumb */}
       <div className="mb-6 flex items-center gap-2 text-sm text-muted-foreground">
         <Link to="/teacher" className="hover:text-foreground transition-colors">
-          My Courses
+          {t("chapterEditor.breadcrumb.myCourses")}
         </Link>
         <ChevronRight className="h-3.5 w-3.5" />
         <Link
           to={`/teacher/courses/${courseId}`}
           className="hover:text-foreground transition-colors"
         >
-          Course
+          {t("chapterEditor.breadcrumb.course")}
         </Link>
         <ChevronRight className="h-3.5 w-3.5" />
         <Link
@@ -217,7 +222,7 @@ export default function ChapterEditor() {
         </Link>
         <ChevronRight className="h-3.5 w-3.5" />
         <span className="text-foreground font-medium truncate max-w-[200px]">
-          {title || "Chapter"}
+          {title || t("chapterEditor.chapterFallback")}
         </span>
       </div>
 
@@ -230,9 +235,9 @@ export default function ChapterEditor() {
           onClick={async () => {
             if (isDirty) {
               const ok = await confirm({
-                title: "Leave without saving?",
-                description: "You have unsaved changes. They will be lost if you leave now.",
-                confirmLabel: "Leave",
+                title: t("chapterEditor.leaveConfirm.title"),
+                description: t("chapterEditor.leaveConfirm.description"),
+                confirmLabel: t("chapterEditor.leaveConfirm.confirm"),
                 tone: "destructive",
               })
               if (!ok) return
@@ -241,19 +246,21 @@ export default function ChapterEditor() {
           }}
         >
           <ArrowLeft className="h-4 w-4 mr-1" />
-          Back
+          {t("chapterEditor.back")}
         </Button>
         <Input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           className="font-serif text-2xl font-bold border-none shadow-none hover:border-border/50 hover:shadow-sm focus-visible:ring-1 h-auto py-1 px-2 flex-1"
-          placeholder="Chapter title"
+          placeholder={t("chapterEditor.titlePlaceholder")}
         />
       </div>
 
       {/* Chapter Type Selector */}
       <div className="mb-6">
-        <Label className="text-sm font-semibold mb-3 block">Chapter Type</Label>
+        <Label className="text-sm font-semibold mb-3 block">
+          {t("chapterEditor.chapterType")}
+        </Label>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {EDITOR_OPTIONS.map((ct) => {
             const Icon = ct.icon
@@ -316,9 +323,9 @@ export default function ChapterEditor() {
           ) : (
             <Save className="h-4 w-4 mr-2" />
           )}
-          {saving ? "Saving..." : "Save Chapter"}
+          {saving ? t("chapterEditor.saving") : t("chapterEditor.save")}
         </Button>
-        <span className="text-xs text-muted-foreground">Ctrl+S to save</span>
+        <span className="text-xs text-muted-foreground">{t("chapterEditor.saveHint")}</span>
       </div>
     </div>
   )

--- a/frontend/src/pages/Teacher/CourseEditor.tsx
+++ b/frontend/src/pages/Teacher/CourseEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -54,6 +55,7 @@ export default function CourseEditor() {
   const { courseId } = useParams<{ courseId: string }>()
   const navigate = useNavigate()
   const confirm = useConfirm()
+  const { t } = useTranslation()
 
   const [modal, setModal] = useState<CourseEditorModal>(null)
   const closeModal = useCallback(() => setModal(null), [])
@@ -70,11 +72,11 @@ export default function CourseEditor() {
     return (
       <div className="container mx-auto px-4">
         <ErrorState
-          title="Course not found"
-          description="The course may have been deleted or you may not have access."
+          title={t("courseEditor.notFound.title")}
+          description={t("courseEditor.notFound.description")}
           action={
             <Button variant="outline" size="sm" onClick={goBack}>
-              Back to courses
+              {t("courseEditor.notFound.backToCourses")}
             </Button>
           }
         />
@@ -87,7 +89,7 @@ export default function CourseEditor() {
     <div className="container mx-auto max-w-4xl px-4 py-8">
       <PageHeader
         backTo="/teacher"
-        backLabel="My courses"
+        backLabel={t("courseEditor.myCourses")}
         cover={
           <InlineEditCover
             value={course.image_url}
@@ -102,8 +104,8 @@ export default function CourseEditor() {
             value={course.title}
             onSave={(v) => data.savePatch({ title: v })}
             required
-            placeholder="Untitled course"
-            ariaLabel="Edit course title"
+            placeholder={t("courseEditor.untitledCourse")}
+            ariaLabel={t("courseEditor.editTitle")}
             maxLength={200}
           />
         }
@@ -113,14 +115,14 @@ export default function CourseEditor() {
             multiline
             value={course.description ?? ""}
             onSave={(v) => data.savePatch({ description: v || null })}
-            placeholder="Add a course description"
-            ariaLabel="Edit course description"
+            placeholder={t("courseEditor.addDescription")}
+            ariaLabel={t("courseEditor.editDescription")}
             maxLength={2000}
           />
         }
         meta={
           <Badge variant={pub ? "success" : "warning"} className="uppercase tracking-wide">
-            {pub ? "Published" : "Draft"}
+            {pub ? t("courseEditor.published") : t("courseEditor.draft")}
           </Badge>
         }
         actions={
@@ -131,23 +133,23 @@ export default function CourseEditor() {
               ) : (
                 <Eye className="h-3.5 w-3.5 mr-1.5" />
               )}
-              {pub ? "Unpublish" : "Publish"}
+              {pub ? t("courseEditor.unpublish") : t("courseEditor.publish")}
             </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="sm" aria-label="More actions">
+                <Button variant="outline" size="sm" aria-label={t("courseEditor.moreActions")}>
                   <MoreHorizontal className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onSelect={() => setModal("enroll")}>
-                  <Calendar /> Enrollment
+                  <Calendar /> {t("courseEditor.menu.enrollment")}
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setModal("announce")}>
-                  <Megaphone /> Announcements
+                  <Megaphone /> {t("courseEditor.menu.announcements")}
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setModal("materials")}>
-                  <Paperclip /> Materials
+                  <Paperclip /> {t("courseEditor.menu.materials")}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
@@ -156,7 +158,7 @@ export default function CourseEditor() {
                     setModal("events")
                   }}
                 >
-                  <CalendarDays /> Events
+                  <CalendarDays /> {t("courseEditor.menu.events")}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onSelect={() => {
@@ -164,7 +166,7 @@ export default function CourseEditor() {
                     setModal("cohorts")
                   }}
                 >
-                  <Users /> Cohorts
+                  <Users /> {t("courseEditor.menu.cohorts")}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>


### PR DESCRIPTION
## Summary
Second batch of Phase-2 hardcoded-string cleanup (after #175). Covers the two surfaces the teacher actually spends time editing in.

**CourseEditor.tsx** (~16 strings) → new `courseEditor.*` namespace:
- `notFound.{title,description,backToCourses}`
- `myCourses` (back-link label), `untitledCourse`, `addDescription`
- `editTitle`, `editDescription` (InlineEdit aria-labels)
- `published`, `draft` (Badge), `publish`, `unpublish` (button)
- `moreActions` (⋯ aria-label)
- `menu.{enrollment,announcements,materials,events,cohorts}`

**ChapterEditor.tsx** (~25 strings) → new `chapterEditor.*` namespace:
- `notFound.{title,description,backToModule}`
- `moduleFallback`, `chapterFallback`
- `breadcrumb.{myCourses,course}`
- `toast.{chapterNotFound,loadFailed,invalidData,saved,saveFailed}` (saveFailed uses `{{detail}}`)
- `unknownError`
- `leaveConfirm.{title,description,confirm}` (unsaved-changes guard)
- `back`, `titlePlaceholder`, `chapterType`, `save`, `saving`, `saveHint`

i18n parity now **552 EN / 570 RU**.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU: open `/teacher/courses/:id` — Russian everywhere; ⋯ menu items in Russian.
- [ ] Visual smoke RU: open chapter editor → breadcrumb / type-picker label / Save button in Russian.
- [ ] RU: make a change, try to leave → confirm dialog in Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
