### PR TITLE
i18n(teacherDashboard): subcomponents → t()

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -447,6 +447,50 @@
       "actionEditCourse": "Edit course",
       "actionDelete": "Delete",
       "actionMore": "More actions"
+    },
+    "createForm": {
+      "title": "Create New Course",
+      "titleLabel": "Title",
+      "titlePlaceholder": "Introduction to Theology",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "A brief description of the course...",
+      "imageUrlLabel": "Cover Image URL (optional — or upload after creating)",
+      "imageUrlPlaceholder": "https://... (you can upload in the editor)",
+      "creating": "Creating...",
+      "submit": "Create Course",
+      "cancel": "Cancel"
+    },
+    "empty": {
+      "title": "No courses yet",
+      "description": "Create your first course to start teaching",
+      "action": "Create Course"
+    },
+    "trash": {
+      "show": "Show Trash",
+      "hide": "Hide Trash",
+      "empty": "Trash is empty.",
+      "loadFailed": "Failed to load trash",
+      "restored": "Course restored",
+      "restoreFailed": "Failed to restore course",
+      "confirmDelete": {
+        "title": "Permanently delete this course?",
+        "description": "This will permanently delete the course and all its data (modules, chapters, enrollments, grades). This action cannot be undone.",
+        "confirm": "Delete permanently"
+      },
+      "deleted": "Course permanently deleted",
+      "deleteFailed": "Failed to delete course",
+      "deletedAt": "Deleted {{date}}",
+      "restore": "Restore",
+      "deleteForever": "Delete Forever"
+    },
+    "pendingCerts": {
+      "title": "Pending Certificates",
+      "studentFallback": "Student",
+      "courseFallback": "Course",
+      "requestedPrefix": "Requested {{date}}",
+      "requestedUnknown": "Requested (unknown date)",
+      "approve": "Approve",
+      "reject": "Reject"
     }
   },
   "teacherEditor": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -459,6 +459,50 @@
       "actionEditCourse": "Редактировать курс",
       "actionDelete": "Удалить",
       "actionMore": "Ещё действия"
+    },
+    "createForm": {
+      "title": "Создать новый курс",
+      "titleLabel": "Название",
+      "titlePlaceholder": "Введение в богословие",
+      "descriptionLabel": "Описание",
+      "descriptionPlaceholder": "Краткое описание курса...",
+      "imageUrlLabel": "URL обложки (необязательно — можно загрузить после создания)",
+      "imageUrlPlaceholder": "https://... (можно загрузить в редакторе)",
+      "creating": "Создание...",
+      "submit": "Создать курс",
+      "cancel": "Отмена"
+    },
+    "empty": {
+      "title": "Пока нет курсов",
+      "description": "Создайте первый курс, чтобы начать преподавать",
+      "action": "Создать курс"
+    },
+    "trash": {
+      "show": "Показать корзину",
+      "hide": "Скрыть корзину",
+      "empty": "Корзина пуста.",
+      "loadFailed": "Не удалось загрузить корзину",
+      "restored": "Курс восстановлен",
+      "restoreFailed": "Не удалось восстановить курс",
+      "confirmDelete": {
+        "title": "Удалить курс навсегда?",
+        "description": "Курс и все его данные (модули, главы, записи, оценки) будут удалены безвозвратно. Это действие нельзя отменить.",
+        "confirm": "Удалить навсегда"
+      },
+      "deleted": "Курс удалён навсегда",
+      "deleteFailed": "Не удалось удалить курс",
+      "deletedAt": "Удалён {{date}}",
+      "restore": "Восстановить",
+      "deleteForever": "Удалить навсегда"
+    },
+    "pendingCerts": {
+      "title": "Сертификаты на одобрение",
+      "studentFallback": "Студент",
+      "courseFallback": "Курс",
+      "requestedPrefix": "Запрошен {{date}}",
+      "requestedUnknown": "Запрошен (дата неизвестна)",
+      "approve": "Одобрить",
+      "reject": "Отклонить"
     }
   },
   "teacherEditor": {

--- a/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -23,15 +24,20 @@ export function CreateCourseForm({
   onSubmit,
   onCancel,
 }: Props) {
+  const { t } = useTranslation()
   return (
     <Card className="mb-8 border-dashed">
       <CardHeader>
-        <CardTitle className="text-lg">Create New Course</CardTitle>
+        <CardTitle className="text-lg">
+          {t("teacherDashboard.createForm.title")}
+        </CardTitle>
       </CardHeader>
       <form onSubmit={onSubmit}>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="title">Title</Label>
+            <Label htmlFor="title">
+              {t("teacherDashboard.createForm.titleLabel")}
+            </Label>
             <Input
               id="title"
               value={form.title}
@@ -39,29 +45,31 @@ export function CreateCourseForm({
                 setForm((p) => ({ ...p, title: e.target.value }))
                 setErrors((p) => ({ ...p, title: undefined }))
               }}
-              placeholder="Introduction to Theology"
+              placeholder={t("teacherDashboard.createForm.titlePlaceholder")}
             />
             {errors.title && <p className="text-sm text-destructive">{errors.title}</p>}
           </div>
           <div className="space-y-2">
-            <Label htmlFor="desc">Description</Label>
+            <Label htmlFor="desc">
+              {t("teacherDashboard.createForm.descriptionLabel")}
+            </Label>
             <textarea
               id="desc"
               className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               value={form.description}
               onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
-              placeholder="A brief description of the course..."
+              placeholder={t("teacherDashboard.createForm.descriptionPlaceholder")}
             />
           </div>
           <div className="space-y-2">
             <Label htmlFor="img">
-              Cover Image URL (optional — or upload after creating)
+              {t("teacherDashboard.createForm.imageUrlLabel")}
             </Label>
             <Input
               id="img"
               value={form.image_url}
               onChange={(e) => setForm((p) => ({ ...p, image_url: e.target.value }))}
-              placeholder="https://... (you can upload in the editor)"
+              placeholder={t("teacherDashboard.createForm.imageUrlPlaceholder")}
             />
             {errors.image_url && (
               <p className="text-sm text-destructive">{errors.image_url}</p>
@@ -69,10 +77,12 @@ export function CreateCourseForm({
           </div>
           <div className="flex gap-2 pt-2">
             <Button type="submit" disabled={saving}>
-              {saving ? "Creating..." : "Create Course"}
+              {saving
+                ? t("teacherDashboard.createForm.creating")
+                : t("teacherDashboard.createForm.submit")}
             </Button>
             <Button type="button" variant="ghost" onClick={onCancel}>
-              Cancel
+              {t("teacherDashboard.createForm.cancel")}
             </Button>
           </div>
         </CardContent>

--- a/frontend/src/pages/Teacher/dashboard/EmptyCoursesCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/EmptyCoursesCard.tsx
@@ -1,4 +1,5 @@
 import { BookOpen, Plus } from "lucide-react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -7,17 +8,20 @@ interface Props {
 }
 
 export function EmptyCoursesCard({ onCreate }: Props) {
+  const { t } = useTranslation()
   return (
     <Card className="border-dashed">
       <CardContent className="flex flex-col items-center justify-center py-16 text-center">
         <BookOpen className="h-12 w-12 text-muted-foreground/50 mb-4" />
-        <h3 className="text-lg font-medium mb-1">No courses yet</h3>
+        <h3 className="text-lg font-medium mb-1">
+          {t("teacherDashboard.empty.title")}
+        </h3>
         <p className="text-sm text-muted-foreground mb-4">
-          Create your first course to start teaching
+          {t("teacherDashboard.empty.description")}
         </p>
         <Button onClick={onCreate} size="sm">
           <Plus className="h-4 w-4 mr-1.5" />
-          Create Course
+          {t("teacherDashboard.empty.action")}
         </Button>
       </CardContent>
     </Card>

--- a/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
@@ -1,4 +1,5 @@
 import { Award, CheckCircle, Clock, XCircle } from "lucide-react"
+import { useTranslation } from "react-i18next"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -13,13 +14,14 @@ interface Props {
 }
 
 export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props) {
+  const { t } = useTranslation()
   if (certs.length === 0) return null
   return (
     <Card className="mb-8 border-l-[3px] border-l-warning">
       <CardHeader>
         <CardTitle className="text-xl flex items-center gap-2">
           <Award className="h-5 w-5 text-warning" />
-          Pending Certificates
+          {t("teacherDashboard.pendingCerts.title")}
           <Badge variant="warning" className="font-normal">
             {certs.length}
           </Badge>
@@ -33,16 +35,19 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
               className="flex items-center justify-between rounded-md border border-l-[3px] border-l-warning/60 bg-warning/5 p-4"
             >
               <div className="min-w-0">
-                <p className="font-medium truncate">{cert.student_name || "Student"}</p>
+                <p className="font-medium truncate">
+                  {cert.student_name || t("teacherDashboard.pendingCerts.studentFallback")}
+                </p>
                 <p className="text-sm text-muted-foreground truncate">
-                  {cert.course_title || "Course"}
+                  {cert.course_title || t("teacherDashboard.pendingCerts.courseFallback")}
                 </p>
                 <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
                   <Clock className="h-3 w-3" />
-                  Requested{" "}
                   {cert.requested_at
-                    ? formatDate(cert.requested_at)
-                    : "Unknown"}
+                    ? t("teacherDashboard.pendingCerts.requestedPrefix", {
+                        date: formatDate(cert.requested_at),
+                      })
+                    : t("teacherDashboard.pendingCerts.requestedUnknown")}
                 </p>
               </div>
               <div className="flex items-center gap-2 shrink-0 ml-4">
@@ -52,7 +57,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
                   disabled={actionId === cert.id}
                 >
                   <CheckCircle className="h-4 w-4 mr-1.5" />
-                  Approve
+                  {t("teacherDashboard.pendingCerts.approve")}
                 </Button>
                 <Button
                   size="sm"
@@ -62,7 +67,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
                   className="text-destructive hover:text-destructive"
                 >
                   <XCircle className="h-4 w-4 mr-1.5" />
-                  Reject
+                  {t("teacherDashboard.pendingCerts.reject")}
                 </Button>
               </div>
             </div>

--- a/frontend/src/pages/Teacher/dashboard/TrashSection.tsx
+++ b/frontend/src/pages/Teacher/dashboard/TrashSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Archive, RotateCcw, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
@@ -18,6 +19,7 @@ interface Props {
 
 export function TrashSection({ visible, onToggle, onRestore }: Props) {
   const confirm = useConfirm()
+  const { t } = useTranslation()
   const [trashedCourses, setTrashedCourses] = useState<Course[]>([])
   const [loading, setLoading] = useState(false)
   const [restoringId, setRestoringId] = useState<string | null>(null)
@@ -33,7 +35,7 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
       })
       .catch(() => {
         if (!signal.cancelled)
-          toast({ title: "Failed to load trash", variant: "destructive" })
+          toast({ title: t("teacherDashboard.trash.loadFailed"), variant: "destructive" })
       })
       .finally(() => {
         if (!signal.cancelled) setLoading(false)
@@ -41,7 +43,7 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
     return () => {
       signal.cancelled = true
     }
-  }, [visible])
+  }, [visible, t])
 
   const handleRestore = async (id: string) => {
     setRestoringId(id)
@@ -49,10 +51,10 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
       const restored = await coursesService.restoreCourse(id)
       setTrashedCourses((prev) => prev.filter((c) => c.id !== id))
       onRestore(restored)
-      toast({ title: "Course restored", variant: "success" })
+      toast({ title: t("teacherDashboard.trash.restored"), variant: "success" })
     } catch (err) {
       toast({
-        title: getErrorDetail(err, "Failed to restore course"),
+        title: getErrorDetail(err, t("teacherDashboard.trash.restoreFailed")),
         variant: "destructive",
       })
     } finally {
@@ -62,20 +64,19 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
 
   const handlePermanentDelete = async (id: string) => {
     const ok = await confirm({
-      title: "Permanently delete this course?",
-      description:
-        "This will permanently delete the course and all its data (modules, chapters, enrollments, grades). This action cannot be undone.",
-      confirmLabel: "Delete permanently",
+      title: t("teacherDashboard.trash.confirmDelete.title"),
+      description: t("teacherDashboard.trash.confirmDelete.description"),
+      confirmLabel: t("teacherDashboard.trash.confirmDelete.confirm"),
       tone: "destructive",
     })
     if (!ok) return
     try {
       await coursesService.permanentlyDeleteCourse(id)
       setTrashedCourses((prev) => prev.filter((c) => c.id !== id))
-      toast({ title: "Course permanently deleted" })
+      toast({ title: t("teacherDashboard.trash.deleted") })
     } catch (err) {
       toast({
-        title: getErrorDetail(err, "Failed to delete course"),
+        title: getErrorDetail(err, t("teacherDashboard.trash.deleteFailed")),
         variant: "destructive",
       })
     }
@@ -88,7 +89,9 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
         className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
         <Archive className="h-4 w-4" />
-        {visible ? "Hide Trash" : "Show Trash"}
+        {visible
+          ? t("teacherDashboard.trash.hide")
+          : t("teacherDashboard.trash.show")}
       </button>
 
       {visible && (
@@ -96,7 +99,9 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
           {loading ? (
             <PageSpinner variant="section" />
           ) : trashedCourses.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4">Trash is empty.</p>
+            <p className="text-sm text-muted-foreground py-4">
+              {t("teacherDashboard.trash.empty")}
+            </p>
           ) : (
             <div className="space-y-3">
               {trashedCourses.map((course) => (
@@ -106,7 +111,9 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
                       <h4 className="text-sm font-medium truncate">{course.title}</h4>
                       {course.deleted_at && (
                         <p className="text-xs text-muted-foreground">
-                          Deleted {formatDate(course.deleted_at)}
+                          {t("teacherDashboard.trash.deletedAt", {
+                            date: formatDate(course.deleted_at),
+                          })}
                         </p>
                       )}
                     </div>
@@ -118,7 +125,7 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
                         disabled={restoringId === course.id}
                       >
                         <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
-                        Restore
+                        {t("teacherDashboard.trash.restore")}
                       </Button>
                       <Button
                         size="sm"
@@ -126,7 +133,7 @@ export function TrashSection({ visible, onToggle, onRestore }: Props) {
                         onClick={() => handlePermanentDelete(course.id)}
                       >
                         <Trash2 className="h-3.5 w-3.5 mr-1.5" />
-                        Delete Forever
+                        {t("teacherDashboard.trash.deleteForever")}
                       </Button>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
Third Phase-2 batch — translates the four subcomponents rendered from `TeacherDashboard.tsx`:

- **EmptyCoursesCard** (3 strings) — empty-state.
- **CreateCourseForm** (10 strings) — title heading, field labels, placeholders, Create/Creating, Cancel.
- **PendingCertsCard** (7 strings) — section title, student/course fallbacks, `Requested {{date}}` (with unknown-date fallback), Approve / Reject.
- **TrashSection** (14 strings) — Show/Hide toggle, empty state, all toast messages, permanent-delete confirm dialog, `Deleted {{date}}`, Restore + Delete Forever buttons.

New i18n nesting under `teacherDashboard.{createForm,empty,trash,pendingCerts}.*`. Parity now **586 EN / 604 RU**.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU as teacher with 0 courses: empty card in Russian.
- [ ] Click `+ New course` → create-course form in Russian (labels, placeholders, buttons).
- [ ] If pending certs exist: section card in Russian.
- [ ] Show Trash → all controls + delete-forever confirm in Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
