### PR TITLE
i18n(teacherEditor): course-editor modals → t()

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -505,7 +505,72 @@
     "noModulesYet": "No modules yet",
     "noModulesYetDescription": "Add your first module to start building the course.",
     "chapterCount_one": "{{count}} chapter",
-    "chapterCount_other": "{{count}} chapters"
+    "chapterCount_other": "{{count}} chapters",
+    "modals": {
+      "enrollment": {
+        "title": "Enrollment Period",
+        "status": "Status",
+        "start": "Start",
+        "end": "End",
+        "save": "Save",
+        "saving": "Saving…"
+      },
+      "announcements": {
+        "title": "Announcements",
+        "titlePlaceholder": "Title",
+        "contentPlaceholder": "Content (optional)",
+        "post": "Post",
+        "posting": "Posting…",
+        "empty": "No announcements yet."
+      },
+      "materials": {
+        "title": "Course Materials",
+        "upload": "Upload File",
+        "empty": "No materials uploaded yet.",
+        "sizeKb": "{{kb}} KB"
+      },
+      "events": {
+        "title": "Course Events",
+        "editEvent": "Edit Event",
+        "createEvent": "Create Event",
+        "titlePlaceholder": "Event title",
+        "descriptionPlaceholder": "Description (optional)",
+        "type": "Type",
+        "dateTime": "Date & Time",
+        "saving": "Saving…",
+        "update": "Update Event",
+        "create": "Create Event",
+        "cancel": "Cancel",
+        "empty": "No events yet.",
+        "types": {
+          "deadline": "Deadline",
+          "live_session": "Live Session",
+          "exam": "Exam",
+          "other": "Other"
+        }
+      },
+      "cohorts": {
+        "title": "Manage Cohorts",
+        "editCohort": "Edit Cohort",
+        "createCohort": "Create Cohort",
+        "namePlaceholder": "Cohort name (e.g. Spring 2026)",
+        "startDate": "Start Date",
+        "endDate": "End Date",
+        "enrollmentStart": "Enrollment Start",
+        "enrollmentEnd": "Enrollment End",
+        "maxStudents": "Max Students (optional)",
+        "maxStudentsPlaceholder": "Unlimited",
+        "saving": "Saving…",
+        "update": "Update Cohort",
+        "create": "Create Cohort",
+        "cancel": "Cancel",
+        "empty": "No cohorts yet.",
+        "studentCount_one": "{{count}} student",
+        "studentCount_other": "{{count}} students",
+        "studentMaxSuffix": " / {{max}} max",
+        "enrollmentWindow": "Enrollment: {{start}} — {{end}}"
+      }
+    }
   },
   "moduleEditor": {
     "toast": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -519,7 +519,74 @@
     "chapterCount_one": "{{count}} глава",
     "chapterCount_few": "{{count}} главы",
     "chapterCount_many": "{{count}} глав",
-    "chapterCount_other": "{{count}} глав"
+    "chapterCount_other": "{{count}} глав",
+    "modals": {
+      "enrollment": {
+        "title": "Период записи",
+        "status": "Статус",
+        "start": "Начало",
+        "end": "Окончание",
+        "save": "Сохранить",
+        "saving": "Сохранение…"
+      },
+      "announcements": {
+        "title": "Объявления",
+        "titlePlaceholder": "Заголовок",
+        "contentPlaceholder": "Текст (необязательно)",
+        "post": "Опубликовать",
+        "posting": "Публикация…",
+        "empty": "Пока нет объявлений."
+      },
+      "materials": {
+        "title": "Материалы курса",
+        "upload": "Загрузить файл",
+        "empty": "Пока нет загруженных материалов.",
+        "sizeKb": "{{kb}} КБ"
+      },
+      "events": {
+        "title": "События курса",
+        "editEvent": "Редактировать событие",
+        "createEvent": "Создать событие",
+        "titlePlaceholder": "Название события",
+        "descriptionPlaceholder": "Описание (необязательно)",
+        "type": "Тип",
+        "dateTime": "Дата и время",
+        "saving": "Сохранение…",
+        "update": "Обновить событие",
+        "create": "Создать событие",
+        "cancel": "Отмена",
+        "empty": "Пока нет событий.",
+        "types": {
+          "deadline": "Дедлайн",
+          "live_session": "Прямая сессия",
+          "exam": "Экзамен",
+          "other": "Другое"
+        }
+      },
+      "cohorts": {
+        "title": "Управление когортами",
+        "editCohort": "Редактировать когорту",
+        "createCohort": "Создать когорту",
+        "namePlaceholder": "Название когорты (например, Весна 2026)",
+        "startDate": "Дата начала",
+        "endDate": "Дата окончания",
+        "enrollmentStart": "Начало записи",
+        "enrollmentEnd": "Окончание записи",
+        "maxStudents": "Максимум студентов (необязательно)",
+        "maxStudentsPlaceholder": "Без ограничения",
+        "saving": "Сохранение…",
+        "update": "Обновить когорту",
+        "create": "Создать когорту",
+        "cancel": "Отмена",
+        "empty": "Пока нет когорт.",
+        "studentCount_one": "{{count}} студент",
+        "studentCount_few": "{{count}} студента",
+        "studentCount_many": "{{count}} студентов",
+        "studentCount_other": "{{count}} студента",
+        "studentMaxSuffix": " / {{max}} макс.",
+        "enrollmentWindow": "Запись: {{start}} — {{end}}"
+      }
+    }
   },
   "moduleEditor": {
     "toast": {

--- a/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -31,29 +32,32 @@ export function AnnouncementsModal({
   onPost,
   onDelete,
 }: Props) {
+  const { t } = useTranslation()
   return (
-    <Modal open={open} onClose={onClose} title="Announcements">
+    <Modal open={open} onClose={onClose} title={t("teacherEditor.modals.announcements.title")}>
       <div className="space-y-4">
         <div className="space-y-3 border rounded-lg p-3 bg-muted/30">
           <Input
             value={title}
             onChange={(e) => onTitleChange(e.target.value)}
-            placeholder="Title"
+            placeholder={t("teacherEditor.modals.announcements.titlePlaceholder")}
           />
           <Textarea
             fieldSize="sm"
             value={content}
             onChange={(e) => onContentChange(e.target.value)}
-            placeholder="Content (optional)"
+            placeholder={t("teacherEditor.modals.announcements.contentPlaceholder")}
           />
           <Button size="sm" onClick={onPost} disabled={posting || !title.trim()}>
             <Megaphone className="h-3.5 w-3.5 mr-1.5" />
-            {posting ? "Posting…" : "Post"}
+            {posting
+              ? t("teacherEditor.modals.announcements.posting")
+              : t("teacherEditor.modals.announcements.post")}
           </Button>
         </div>
         {announcements.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-4">
-            No announcements yet.
+            {t("teacherEditor.modals.announcements.empty")}
           </p>
         ) : (
           <div className="space-y-2 max-h-60 overflow-y-auto">

--- a/frontend/src/pages/Teacher/editor/CohortsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/CohortsModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -37,24 +38,27 @@ export function CohortsModal({
   onDelete,
   onComplete,
 }: Props) {
+  const { t } = useTranslation()
   const patch = (p: Partial<CohortFormState>) => onFormChange({ ...form, ...p })
   const canSubmit = form.name.trim() && form.start_date && form.end_date && !saving
 
   return (
-    <Modal open={open} onClose={onClose} title="Manage Cohorts">
+    <Modal open={open} onClose={onClose} title={t("teacherEditor.modals.cohorts.title")}>
       <div className="space-y-4">
         <div className="space-y-3 border rounded-lg p-3 bg-muted/30">
           <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-            {editingId ? "Edit Cohort" : "Create Cohort"}
+            {editingId
+              ? t("teacherEditor.modals.cohorts.editCohort")
+              : t("teacherEditor.modals.cohorts.createCohort")}
           </p>
           <Input
             value={form.name}
             onChange={(e) => patch({ name: e.target.value })}
-            placeholder="Cohort name (e.g. Spring 2026)"
+            placeholder={t("teacherEditor.modals.cohorts.namePlaceholder")}
           />
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1">
-              <Label className="text-xs">Start Date</Label>
+              <Label className="text-xs">{t("teacherEditor.modals.cohorts.startDate")}</Label>
               <Input
                 type="date"
                 value={form.start_date}
@@ -63,7 +67,7 @@ export function CohortsModal({
               />
             </div>
             <div className="space-y-1">
-              <Label className="text-xs">End Date</Label>
+              <Label className="text-xs">{t("teacherEditor.modals.cohorts.endDate")}</Label>
               <Input
                 type="date"
                 value={form.end_date}
@@ -74,7 +78,7 @@ export function CohortsModal({
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1">
-              <Label className="text-xs">Enrollment Start</Label>
+              <Label className="text-xs">{t("teacherEditor.modals.cohorts.enrollmentStart")}</Label>
               <Input
                 type="datetime-local"
                 value={form.enrollment_start}
@@ -83,7 +87,7 @@ export function CohortsModal({
               />
             </div>
             <div className="space-y-1">
-              <Label className="text-xs">Enrollment End</Label>
+              <Label className="text-xs">{t("teacherEditor.modals.cohorts.enrollmentEnd")}</Label>
               <Input
                 type="datetime-local"
                 value={form.enrollment_end}
@@ -93,30 +97,36 @@ export function CohortsModal({
             </div>
           </div>
           <div className="space-y-1">
-            <Label className="text-xs">Max Students (optional)</Label>
+            <Label className="text-xs">{t("teacherEditor.modals.cohorts.maxStudents")}</Label>
             <Input
               type="number"
               value={form.max_students}
               onChange={(e) => patch({ max_students: e.target.value })}
-              placeholder="Unlimited"
+              placeholder={t("teacherEditor.modals.cohorts.maxStudentsPlaceholder")}
               className="text-sm"
             />
           </div>
           <div className="flex gap-2">
             <Button size="sm" onClick={onSave} disabled={!canSubmit}>
               <Save className="h-3.5 w-3.5 mr-1.5" />
-              {saving ? "Saving…" : editingId ? "Update Cohort" : "Create Cohort"}
+              {saving
+                ? t("teacherEditor.modals.cohorts.saving")
+                : editingId
+                  ? t("teacherEditor.modals.cohorts.update")
+                  : t("teacherEditor.modals.cohorts.create")}
             </Button>
             {editingId && (
               <Button size="sm" variant="ghost" onClick={onCancelEdit}>
-                Cancel
+                {t("teacherEditor.modals.cohorts.cancel")}
               </Button>
             )}
           </div>
         </div>
 
         {cohorts.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-4">No cohorts yet.</p>
+          <p className="text-sm text-muted-foreground text-center py-4">
+            {t("teacherEditor.modals.cohorts.empty")}
+          </p>
         ) : (
           <div className="space-y-2 max-h-72 overflow-y-auto">
             {cohorts.map((c) => (
@@ -143,6 +153,7 @@ interface RowProps {
 }
 
 function CohortRow({ cohort, onEdit, onDelete, onComplete }: RowProps) {
+  const { t } = useTranslation()
   return (
     <div className="flex items-start gap-3 p-3 border rounded-lg">
       <div className="flex-1 min-w-0">
@@ -155,13 +166,16 @@ function CohortRow({ cohort, onEdit, onDelete, onComplete }: RowProps) {
           {formatDate(cohort.end_date)}
         </p>
         <p className="text-xs text-muted-foreground mt-0.5">
-          {cohort.student_count} student{cohort.student_count !== 1 ? "s" : ""}
-          {cohort.max_students && ` / ${cohort.max_students} max`}
+          {t("teacherEditor.modals.cohorts.studentCount", { count: cohort.student_count })}
+          {cohort.max_students &&
+            t("teacherEditor.modals.cohorts.studentMaxSuffix", { max: cohort.max_students })}
         </p>
         {cohort.enrollment_start && cohort.enrollment_end && (
           <p className="text-[10px] text-muted-foreground/70 mt-0.5">
-            Enrollment: {formatDate(cohort.enrollment_start)} —{" "}
-            {formatDate(cohort.enrollment_end)}
+            {t("teacherEditor.modals.cohorts.enrollmentWindow", {
+              start: formatDate(cohort.enrollment_start),
+              end: formatDate(cohort.enrollment_end),
+            })}
           </p>
         )}
       </div>

--- a/frontend/src/pages/Teacher/editor/EnrollmentModal.tsx
+++ b/frontend/src/pages/Teacher/editor/EnrollmentModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -28,6 +29,7 @@ export function EnrollmentModal({
   saving,
   onSave,
 }: Props) {
+  const { t } = useTranslation()
   useEffect(() => {
     if (!open) return
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -41,15 +43,15 @@ export function EnrollmentModal({
   }, [open, onSave])
 
   return (
-    <Modal open={open} onClose={onClose} title="Enrollment Period">
+    <Modal open={open} onClose={onClose} title={t("teacherEditor.modals.enrollment.title")}>
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Label className="font-medium">Status</Label>
+          <Label className="font-medium">{t("teacherEditor.modals.enrollment.status")}</Label>
           <EnrollmentStatusBadge start={start} end={end} />
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-1.5">
-            <Label className="text-xs">Start</Label>
+            <Label className="text-xs">{t("teacherEditor.modals.enrollment.start")}</Label>
             <Input
               type="datetime-local"
               value={start}
@@ -58,7 +60,7 @@ export function EnrollmentModal({
             />
           </div>
           <div className="space-y-1.5">
-            <Label className="text-xs">End</Label>
+            <Label className="text-xs">{t("teacherEditor.modals.enrollment.end")}</Label>
             <Input
               type="datetime-local"
               value={end}
@@ -69,7 +71,9 @@ export function EnrollmentModal({
         </div>
         <Button onClick={onSave} disabled={saving} className="w-full">
           <Save className="h-4 w-4 mr-1.5" />
-          {saving ? "Saving…" : "Save"}
+          {saving
+            ? t("teacherEditor.modals.enrollment.saving")
+            : t("teacherEditor.modals.enrollment.save")}
         </Button>
       </div>
     </Modal>

--- a/frontend/src/pages/Teacher/editor/EventsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/EventsModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -23,12 +24,7 @@ interface Props {
   onDelete: (id: string) => void
 }
 
-const EVENT_TYPES: readonly { value: string; label: string }[] = [
-  { value: "deadline", label: "Deadline" },
-  { value: "live_session", label: "Live Session" },
-  { value: "exam", label: "Exam" },
-  { value: "other", label: "Other" },
-]
+const EVENT_TYPE_VALUES = ["deadline", "live_session", "exam", "other"] as const
 
 export function EventsModal({
   open,
@@ -43,44 +39,47 @@ export function EventsModal({
   onEdit,
   onDelete,
 }: Props) {
+  const { t } = useTranslation()
   const patch = (p: Partial<EventFormState>) => onFormChange({ ...form, ...p })
   const canSubmit = form.title.trim() && form.event_date && !saving
 
   return (
-    <Modal open={open} onClose={onClose} title="Course Events">
+    <Modal open={open} onClose={onClose} title={t("teacherEditor.modals.events.title")}>
       <div className="space-y-4">
         <div className="space-y-3 border rounded-lg p-3 bg-muted/30">
           <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-            {editingId ? "Edit Event" : "Create Event"}
+            {editingId
+              ? t("teacherEditor.modals.events.editEvent")
+              : t("teacherEditor.modals.events.createEvent")}
           </p>
           <Input
             value={form.title}
             onChange={(e) => patch({ title: e.target.value })}
-            placeholder="Event title"
+            placeholder={t("teacherEditor.modals.events.titlePlaceholder")}
           />
           <Textarea
             fieldSize="sm"
             value={form.description}
             onChange={(e) => patch({ description: e.target.value })}
-            placeholder="Description (optional)"
+            placeholder={t("teacherEditor.modals.events.descriptionPlaceholder")}
           />
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1">
-              <Label className="text-xs">Type</Label>
+              <Label className="text-xs">{t("teacherEditor.modals.events.type")}</Label>
               <select
                 value={form.event_type}
                 onChange={(e) => patch({ event_type: e.target.value })}
                 className="w-full text-sm border rounded-md px-2 py-1.5 bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
               >
-                {EVENT_TYPES.map((t) => (
-                  <option key={t.value} value={t.value}>
-                    {t.label}
+                {EVENT_TYPE_VALUES.map((value) => (
+                  <option key={value} value={value}>
+                    {t(`teacherEditor.modals.events.types.${value}`)}
                   </option>
                 ))}
               </select>
             </div>
             <div className="space-y-1">
-              <Label className="text-xs">Date & Time</Label>
+              <Label className="text-xs">{t("teacherEditor.modals.events.dateTime")}</Label>
               <Input
                 type="datetime-local"
                 value={form.event_date}
@@ -92,18 +91,24 @@ export function EventsModal({
           <div className="flex gap-2">
             <Button size="sm" onClick={onSave} disabled={!canSubmit}>
               <Save className="h-3.5 w-3.5 mr-1.5" />
-              {saving ? "Saving…" : editingId ? "Update Event" : "Create Event"}
+              {saving
+                ? t("teacherEditor.modals.events.saving")
+                : editingId
+                  ? t("teacherEditor.modals.events.update")
+                  : t("teacherEditor.modals.events.create")}
             </Button>
             {editingId && (
               <Button size="sm" variant="ghost" onClick={onCancelEdit}>
-                Cancel
+                {t("teacherEditor.modals.events.cancel")}
               </Button>
             )}
           </div>
         </div>
 
         {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-4">No events yet.</p>
+          <p className="text-sm text-muted-foreground text-center py-4">
+            {t("teacherEditor.modals.events.empty")}
+          </p>
         ) : (
           <div className="space-y-2 max-h-72 overflow-y-auto">
             {events.map((event) => (

--- a/frontend/src/pages/Teacher/editor/MaterialsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/MaterialsModal.tsx
@@ -1,4 +1,5 @@
 import type { Ref } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Download, Loader2, Paperclip, X } from "lucide-react"
 import { Modal } from "@/components/patterns"
@@ -29,8 +30,9 @@ export function MaterialsModal({
   onDelete,
   fileInputRef,
 }: Props) {
+  const { t } = useTranslation()
   return (
-    <Modal open={open} onClose={onClose} title="Course Materials">
+    <Modal open={open} onClose={onClose} title={t("teacherEditor.modals.materials.title")}>
       <div className="space-y-4">
         <Button
           variant="outline"
@@ -44,7 +46,7 @@ export function MaterialsModal({
           ) : (
             <Paperclip className="h-4 w-4 mr-1.5" />
           )}
-          Upload File
+          {t("teacherEditor.modals.materials.upload")}
         </Button>
         <input
           ref={fileInputRef}
@@ -55,7 +57,7 @@ export function MaterialsModal({
         />
         {materials.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
-            No materials uploaded yet.
+            {t("teacherEditor.modals.materials.empty")}
           </p>
         ) : (
           <div className="space-y-2 max-h-60 overflow-y-auto">
@@ -68,7 +70,7 @@ export function MaterialsModal({
                 <span className="text-sm flex-1 truncate">{m.name}</span>
                 {m.size && (
                   <span className="text-xs text-muted-foreground shrink-0">
-                    {(m.size / 1024).toFixed(0)} KB
+                    {t("teacherEditor.modals.materials.sizeKb", { kb: (m.size / 1024).toFixed(0) })}
                   </span>
                 )}
                 <Button


### PR DESCRIPTION
## Summary
Fourth Phase-2 batch. Translates all five modals reachable from CourseEditor's ⋯ menu (`pages/Teacher/editor/*Modal.tsx`):

- **EnrollmentModal** — title, Status/Start/End labels, Save / Saving…
- **AnnouncementsModal** — title, Title + Content placeholders, Post / Posting…, empty state
- **MaterialsModal** — title, Upload File, empty state, `sizeKb` formatter (file-size suffix)
- **EventsModal** — title, Edit/Create headings, placeholders, Type/Date&Time labels, **all four event-type options** (deadline / live_session / exam / other) translated, Save/Update/Create buttons, Cancel, empty state
- **CohortsModal** — title, Edit/Create headings, placeholders, four date labels, action buttons, empty. **Per-row CohortRow**: student-count uses i18next plurals (so RU gets `_one`/`_few`/`_many`), max-students suffix interpolated, "Enrollment: {start} — {end}" line.

All under `teacherEditor.modals.*`. Parity now **637 EN / 657 RU**.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU: open course editor → ⋯ → each modal — all UI in Russian incl. event-type options + cohort student-count plurals (1 студент, 2 студента, 5 студентов).
- [ ] Switch to EN: same UI translates back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
