### PR TITLE
i18n(courseDetail): student-facing modals + EnrolledView labels → t()

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -692,7 +692,25 @@
     "moduleLocked": "Locked",
     "moduleLockHint": "Complete all assessments in the previous module to unlock.",
     "due": "Due",
-    "overdue": "Overdue"
+    "overdue": "Overdue",
+    "downloadFailed": "Failed to download file",
+    "materialsButton": "Materials ({{count}})",
+    "reviewsButton": "Reviews",
+    "reviewsModalTitle": "Course Reviews",
+    "materialsModal": {
+      "title": "Course Materials",
+      "empty": "No materials available."
+    },
+    "cohortSelect": {
+      "title": "Select a Cohort",
+      "intro": "Multiple cohorts are available. Choose one to enroll in:",
+      "spotsFilled": "{{enrolled}}/{{max}} spots filled",
+      "enrolling": "Enrolling...",
+      "enroll": "Enroll"
+    },
+    "upcoming": {
+      "heading": "Upcoming Deadlines & Events"
+    }
   },
   "gradebook": {
     "summaryTab": "Summary Grades",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -712,7 +712,25 @@
     "moduleLocked": "Заблокировано",
     "moduleLockHint": "Завершите все задания предыдущего модуля, чтобы разблокировать.",
     "due": "Сдать до",
-    "overdue": "Просрочено"
+    "overdue": "Просрочено",
+    "downloadFailed": "Не удалось скачать файл",
+    "materialsButton": "Материалы ({{count}})",
+    "reviewsButton": "Отзывы",
+    "reviewsModalTitle": "Отзывы о курсе",
+    "materialsModal": {
+      "title": "Материалы курса",
+      "empty": "Материалов пока нет."
+    },
+    "cohortSelect": {
+      "title": "Выберите когорту",
+      "intro": "Доступно несколько когорт. Выберите, в какую записаться:",
+      "spotsFilled": "{{enrolled}}/{{max}} мест занято",
+      "enrolling": "Запись...",
+      "enroll": "Записаться"
+    },
+    "upcoming": {
+      "heading": "Ближайшие дедлайны и события"
+    }
   },
   "gradebook": {
     "summaryTab": "Сводка оценок",

--- a/frontend/src/pages/Course/detail/CohortSelectModal.tsx
+++ b/frontend/src/pages/Course/detail/CohortSelectModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Modal } from "@/components/patterns"
 import { Button } from "@/components/ui/button"
 import type { Cohort } from "@/types"
@@ -22,11 +23,12 @@ export function CohortSelectModal({
   onConfirm,
   enrolling,
 }: Props) {
+  const { t } = useTranslation()
   return (
-    <Modal open={open} onClose={onClose} title="Select a Cohort">
+    <Modal open={open} onClose={onClose} title={t("courseDetail.cohortSelect.title")}>
       <div className="space-y-3">
         <p className="text-sm text-muted-foreground">
-          Multiple cohorts are available. Choose one to enroll in:
+          {t("courseDetail.cohortSelect.intro")}
         </p>
         {cohorts.map((cohort) => (
           <label
@@ -51,7 +53,10 @@ export function CohortSelectModal({
               </p>
               {cohort.max_students && (
                 <p className="text-xs text-muted-foreground">
-                  {cohort.student_count}/{cohort.max_students} spots filled
+                  {t("courseDetail.cohortSelect.spotsFilled", {
+                    enrolled: cohort.student_count,
+                    max: cohort.max_students,
+                  })}
                 </p>
               )}
             </div>
@@ -62,7 +67,9 @@ export function CohortSelectModal({
           disabled={!selectedCohortId || enrolling}
           className="w-full"
         >
-          {enrolling ? "Enrolling..." : "Enroll"}
+          {enrolling
+            ? t("courseDetail.cohortSelect.enrolling")
+            : t("courseDetail.cohortSelect.enroll")}
         </Button>
       </div>
     </Modal>

--- a/frontend/src/pages/Course/detail/EnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/EnrolledView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Paperclip, Star } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import CourseAnnouncements from "@/components/announcements/CourseAnnouncements"
@@ -46,6 +47,7 @@ export function EnrolledView({
   certificate,
   onCertificateUpdate,
 }: Props) {
+  const { t } = useTranslation()
   const [materialsModal, setMaterialsModal] = useState(false)
   const [reviewsModal, setReviewsModal] = useState(false)
   const [downloadingPath, setDownloadingPath] = useState<string | null>(null)
@@ -58,11 +60,11 @@ export function EnrolledView({
       const url = await storageService.getSignedMaterialUrl(path)
       window.open(url, "_blank", "noopener,noreferrer")
     } catch {
-      toast({ title: "Failed to download file", variant: "destructive" })
+      toast({ title: t("courseDetail.downloadFailed"), variant: "destructive" })
     } finally {
       setDownloadingPath(null)
     }
-  }, [])
+  }, [t])
 
   return (
     <div className="animate-fade-in container mx-auto px-4 py-6 max-w-4xl">
@@ -98,12 +100,12 @@ export function EnrolledView({
         {materials.length > 0 && (
           <Button variant="outline" size="sm" onClick={() => setMaterialsModal(true)}>
             <Paperclip className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
-            Materials ({materials.length})
+            {t("courseDetail.materialsButton", { count: materials.length })}
           </Button>
         )}
         <Button variant="outline" size="sm" onClick={() => setReviewsModal(true)}>
           <Star className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
-          Reviews
+          {t("courseDetail.reviewsButton")}
         </Button>
       </div>
 
@@ -115,7 +117,7 @@ export function EnrolledView({
         onDownload={handleDownload}
       />
 
-      <Modal open={reviewsModal} onClose={() => setReviewsModal(false)} title="Course Reviews">
+      <Modal open={reviewsModal} onClose={() => setReviewsModal(false)} title={t("courseDetail.reviewsModalTitle")}>
         <CourseReviews courseId={course.id} />
       </Modal>
     </div>

--- a/frontend/src/pages/Course/detail/MaterialsModal.tsx
+++ b/frontend/src/pages/Course/detail/MaterialsModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Modal } from "@/components/patterns"
 import { Button } from "@/components/ui/button"
 import { Download } from "lucide-react"
@@ -18,11 +19,12 @@ export function MaterialsModal({
   downloadingPath,
   onDownload,
 }: Props) {
+  const { t } = useTranslation()
   return (
-    <Modal open={open} onClose={onClose} title="Course Materials">
+    <Modal open={open} onClose={onClose} title={t("courseDetail.materialsModal.title")}>
       {materials.length === 0 ? (
         <p className="text-sm text-muted-foreground text-center py-6">
-          No materials available.
+          {t("courseDetail.materialsModal.empty")}
         </p>
       ) : (
         <div className="divide-y rounded-md border text-sm">

--- a/frontend/src/pages/Course/detail/UpcomingEvents.tsx
+++ b/frontend/src/pages/Course/detail/UpcomingEvents.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, CalendarDays } from "lucide-react"
+import { useTranslation } from "react-i18next"
 import type { CalendarEvent } from "@/types"
 import { formatDate } from "@/i18n/format"
 
@@ -7,14 +8,15 @@ interface Props {
 }
 
 export function UpcomingEvents({ events }: Props) {
+  const { t } = useTranslation()
   if (events.length === 0) return null
 
   const now = new Date()
   const upcoming = events
     .filter((e) => {
       if (!e.event_date) return false
-      const t = new Date(e.event_date).getTime()
-      return !Number.isNaN(t) && t > now.getTime() - 24 * 60 * 60 * 1000
+      const ts = new Date(e.event_date).getTime()
+      return !Number.isNaN(ts) && ts > now.getTime() - 24 * 60 * 60 * 1000
     })
     .slice(0, 5)
 
@@ -24,7 +26,7 @@ export function UpcomingEvents({ events }: Props) {
     <div className="mb-5">
       <h2 className="mb-2 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
         <CalendarDays className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
-        Upcoming Deadlines & Events
+        {t("courseDetail.upcoming.heading")}
       </h2>
       <div className="space-y-1.5">
         {upcoming.map((evt) => {


### PR DESCRIPTION
## Summary
Fifth Phase-2 batch. Student-facing surface on the course-detail page (the page enrolled students actually look at):

- **EnrolledView** — download-failure toast, `Materials ({n})` + `Reviews` buttons, Course Reviews modal title.
- **MaterialsModal** (`pages/Course/detail/MaterialsModal.tsx` — the student version, different from the teacher one already translated in #178) — title + empty state.
- **CohortSelectModal** — title, intro paragraph, per-row "spots filled" label with interpolation, Enroll / Enrolling… button.
- **UpcomingEvents** — section heading.

Keys land under `courseDetail.{downloadFailed,materialsButton,reviewsButton,reviewsModalTitle,materialsModal,cohortSelect,upcoming}`. Parity now **649 EN / 669 RU**.

Also: rename `t` (event timestamp) → `ts` in UpcomingEvents to avoid shadowing the i18n `t` function I just imported.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU: open enrolled course detail → buttons in Russian; click Materials → modal in Russian; click Reviews → modal title in Russian.
- [ ] Enroll into a course with >1 active cohort → cohort-select modal in Russian.
- [ ] UpcomingEvents section heading in Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
