### PR TITLE
i18n(quizEditor): full editor tree → t() (5 files)

### DIFF
--- a/frontend/src/components/quiz/QuizEditor.tsx
+++ b/frontend/src/components/quiz/QuizEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { ClipboardList, Loader2 } from "lucide-react"
 import { useConfirm } from "@/components/ui/alert-dialog"
 import { coursesService } from "@/services/courses"
@@ -23,6 +24,7 @@ export default function QuizEditor({
   onQuizSaved,
 }: QuizEditorProps) {
   const confirm = useConfirm()
+  const { t } = useTranslation()
   const draft = useQuizDraft({ chapterId, chapterType })
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -30,11 +32,11 @@ export default function QuizEditor({
 
   const handleSave = async () => {
     if (!draft.title.trim()) {
-      toast({ title: "Quiz title is required", variant: "destructive" })
+      toast({ title: t("quizEditor.validation.titleRequired"), variant: "destructive" })
       return
     }
     if (draft.questions.length === 0) {
-      toast({ title: "Add at least one question", variant: "destructive" })
+      toast({ title: t("quizEditor.validation.addAtLeastOneQuestion"), variant: "destructive" })
       return
     }
 
@@ -69,9 +71,9 @@ export default function QuizEditor({
           // Old quiz cleanup is best-effort; the new quiz was already saved
         })
       }
-      toast({ title: "Quiz saved", variant: "success" })
+      toast({ title: t("quizEditor.toast.quizSaved"), variant: "success" })
     } catch {
-      toast({ title: "Failed to save quiz", variant: "destructive" })
+      toast({ title: t("quizEditor.toast.quizSaveFailed"), variant: "destructive" })
     } finally {
       setSaving(false)
     }
@@ -80,9 +82,9 @@ export default function QuizEditor({
   const handleDelete = async () => {
     if (!draft.existingQuiz) return
     const ok = await confirm({
-      title: "Delete this quiz?",
-      description: "Students will lose access to the quiz and its attempts.",
-      confirmLabel: "Delete quiz",
+      title: t("quizEditor.confirmDelete.title"),
+      description: t("quizEditor.confirmDelete.description"),
+      confirmLabel: t("quizEditor.confirmDelete.confirm"),
       tone: "destructive",
     })
     if (!ok) return
@@ -90,9 +92,9 @@ export default function QuizEditor({
     try {
       await coursesService.deleteQuiz(draft.existingQuiz.id, chapterId)
       draft.resetAll()
-      toast({ title: "Quiz deleted", variant: "success" })
+      toast({ title: t("quizEditor.toast.quizDeleted"), variant: "success" })
     } catch {
-      toast({ title: "Failed to delete quiz", variant: "destructive" })
+      toast({ title: t("quizEditor.toast.quizDeleteFailed"), variant: "destructive" })
     } finally {
       setDeleting(false)
     }
@@ -118,8 +120,12 @@ export default function QuizEditor({
           <ClipboardList className="h-4 w-4 text-muted-foreground" />
           <span className="text-sm font-medium">
             {draft.existingQuiz
-              ? `Edit ${chapterType === "exam" ? "Exam" : "Quiz"}`
-              : `Create ${chapterType === "exam" ? "Exam" : "Quiz"}`}
+              ? chapterType === "exam"
+                ? t("quizEditor.heading.editExam")
+                : t("quizEditor.heading.editQuiz")
+              : chapterType === "exam"
+                ? t("quizEditor.heading.createExam")
+                : t("quizEditor.heading.createQuiz")}
           </span>
         </div>
         {draft.existingQuiz && hasManualQuestions && (

--- a/frontend/src/components/quiz/QuizSubmissionsReview.tsx
+++ b/frontend/src/components/quiz/QuizSubmissionsReview.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
 import { getErrorDetail } from "@/lib/errorDetail"
@@ -33,6 +34,7 @@ interface Props {
 }
 
 export default function QuizSubmissionsReview({ quizId }: Props) {
+  const { t } = useTranslation()
   const [items, setItems] = useState<EditableAnswer[]>([])
   const [loading, setLoading] = useState(true)
   const [showGraded, setShowGraded] = useState(false)
@@ -62,12 +64,12 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
   const handleSave = async (item: EditableAnswer) => {
     const pointsNum = Number(item.draftPoints)
     if (Number.isNaN(pointsNum) || pointsNum < 0) {
-      toast({ title: "Enter a valid score (0 or higher)", variant: "destructive" })
+      toast({ title: t("quizEditor.validation.validScoreRequired"), variant: "destructive" })
       return
     }
     if (pointsNum > item.max_points) {
       toast({
-        title: `Score can't exceed ${item.max_points} for this question`,
+        title: t("quizEditor.validation.scoreCantExceed", { max: item.max_points }),
         variant: "destructive",
       })
       return
@@ -80,7 +82,7 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
         item.draftComment.trim() || null,
       )
       updateDraft(item.answer_id, { savingState: "saved" })
-      toast({ title: "Grade saved", variant: "success" })
+      toast({ title: t("quizEditor.toast.gradeSaved"), variant: "success" })
       // Ungraded mode: drop the row from the list after a beat so the
       // teacher sees the success state before it disappears.
       if (!showGraded) {
@@ -90,7 +92,10 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
       }
     } catch (err: unknown) {
       const detail = getErrorDetail(err)
-      toast({ title: detail || "Failed to save grade", variant: "destructive" })
+      toast({
+        title: detail || t("quizEditor.toast.gradeSaveFailed"),
+        variant: "destructive",
+      })
       updateDraft(item.answer_id, { savingState: "idle" })
     }
   }
@@ -106,7 +111,7 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
   if (error) {
     return (
       <p className="text-sm text-destructive py-4 text-center">
-        Failed to load submissions. Please try again.
+        {t("quizEditor.review.loadFailed")}
       </p>
     )
   }
@@ -118,9 +123,9 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
           <Users className="h-4 w-4" />
           {items.length === 0
             ? showGraded
-              ? "No open-ended answers yet."
-              : "Nothing to grade — you're all caught up."
-            : `${items.length} open-ended answer${items.length === 1 ? "" : "s"}`}
+              ? t("quizEditor.review.emptyAlready")
+              : t("quizEditor.review.emptyAllGraded")
+            : t("quizEditor.review.openEndedCount", { count: items.length })}
         </div>
         <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer select-none">
           <input
@@ -129,7 +134,7 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
             onChange={(e) => setShowGraded(e.target.checked)}
             className="accent-primary"
           />
-          Show already graded
+          {t("quizEditor.review.showAlreadyGraded")}
         </label>
       </div>
 
@@ -148,17 +153,19 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
                 <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
                   <span className="inline-flex items-center gap-1">
                     <GraduationCap className="h-3.5 w-3.5" />
-                    {item.question_type === "essay" ? "Essay" : "Short answer"} · up to{" "}
-                    {item.max_points} pt{item.max_points !== 1 ? "s" : ""}
+                    {item.question_type === "essay"
+                      ? t("quizEditor.review.essay")
+                      : t("quizEditor.review.shortAnswer")}{" "}
+                    · {t("quizEditor.review.upToPoints", { count: item.max_points })}
                   </span>
                   {item.min_words ? (
                     <span
                       className={wordCount < item.min_words ? "text-warning" : undefined}
                     >
-                      {wordCount} / {item.min_words} words
+                      {t("quizEditor.review.wordsWithMin", { count: wordCount, min: item.min_words })}
                     </span>
                   ) : (
-                    <span>{wordCount} words</span>
+                    <span>{t("quizEditor.review.wordsCount", { count: wordCount })}</span>
                   )}
                 </div>
               </div>
@@ -173,12 +180,18 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
             </div>
 
             <div className="rounded-md border border-dashed bg-muted/30 p-3 text-sm whitespace-pre-wrap text-wrap-safe">
-              {item.text_answer || <span className="text-muted-foreground italic">(empty)</span>}
+              {item.text_answer || (
+                <span className="text-muted-foreground italic">
+                  {t("quizEditor.review.emptyAnswer")}
+                </span>
+              )}
             </div>
 
             <div className="flex flex-wrap items-end gap-3">
               <div className="space-y-1">
-                <label className="text-xs text-muted-foreground">Points (0–{item.max_points})</label>
+                <label className="text-xs text-muted-foreground">
+                  {t("quizEditor.review.pointsLabel", { max: item.max_points })}
+                </label>
                 <Input
                   type="number"
                   min={0}
@@ -189,11 +202,13 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
                 />
               </div>
               <div className="flex-1 min-w-[220px] space-y-1">
-                <label className="text-xs text-muted-foreground">Comment (optional)</label>
+                <label className="text-xs text-muted-foreground">
+                  {t("quizEditor.review.commentLabel")}
+                </label>
                 <Input
                   value={item.draftComment}
                   onChange={(e) => updateDraft(item.answer_id, { draftComment: e.target.value })}
-                  placeholder="Feedback shown to the student…"
+                  placeholder={t("quizEditor.review.commentPlaceholder")}
                   className="h-8 text-sm"
                 />
               </div>
@@ -209,7 +224,9 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
                 ) : (
                   <Save className="h-3.5 w-3.5 mr-1.5" />
                 )}
-                {item.savingState === "saved" ? "Saved" : "Save grade"}
+                {item.savingState === "saved"
+                  ? t("quizEditor.review.saved")
+                  : t("quizEditor.review.saveGrade")}
               </Button>
             </div>
           </div>

--- a/frontend/src/components/quiz/editor/QuestionCard.tsx
+++ b/frontend/src/components/quiz/editor/QuestionCard.tsx
@@ -1,4 +1,5 @@
 import { ArrowDown, ArrowUp, Plus, Trash2 } from "lucide-react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -28,6 +29,7 @@ export function QuestionCard({
   onRemoveOption,
   onUpdateOption,
 }: Props) {
+  const { t } = useTranslation()
   return (
     <Card className="bg-muted/30">
       <CardContent className="p-4 space-y-3">
@@ -53,12 +55,12 @@ export function QuestionCard({
           <div className="flex-1 space-y-3">
             <div className="flex items-center gap-2">
               <span className="text-xs font-semibold text-muted-foreground">
-                Q{qIdx + 1}
+                {t("quizEditor.questions.questionPrefix", { n: qIdx + 1 })}
               </span>
               <Input
                 value={q.question_text}
                 onChange={(e) => onUpdate({ question_text: e.target.value })}
-                placeholder="Question text..."
+                placeholder={t("quizEditor.questions.questionPlaceholder")}
                 className="h-8 text-sm flex-1"
               />
               <Button
@@ -81,14 +83,16 @@ export function QuestionCard({
                 }
                 className="h-7 rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                <option value="multiple_choice">Multiple Choice</option>
-                <option value="true_false">True / False</option>
-                <option value="short_answer">Short Answer</option>
-                <option value="essay">Essay</option>
+                <option value="multiple_choice">{t("quizEditor.questions.types.multiple_choice")}</option>
+                <option value="true_false">{t("quizEditor.questions.types.true_false")}</option>
+                <option value="short_answer">{t("quizEditor.questions.types.short_answer")}</option>
+                <option value="essay">{t("quizEditor.questions.types.essay")}</option>
               </select>
               {q.question_type === "essay" && (
                 <div className="flex items-center gap-1">
-                  <Label className="text-xs text-muted-foreground">Min words:</Label>
+                  <Label className="text-xs text-muted-foreground">
+                    {t("quizEditor.questions.minWords")}
+                  </Label>
                   <Input
                     type="number"
                     min={1}
@@ -107,7 +111,9 @@ export function QuestionCard({
                 </div>
               )}
               <div className="flex items-center gap-1">
-                <Label className="text-xs text-muted-foreground">Points:</Label>
+                <Label className="text-xs text-muted-foreground">
+                  {t("quizEditor.questions.points")}
+                </Label>
                 <Input
                   type="number"
                   min={1}
@@ -128,14 +134,14 @@ export function QuestionCard({
                       checked={opt.is_correct}
                       onChange={() => onUpdateOption(oIdx, { is_correct: true })}
                       className="accent-primary shrink-0"
-                      title="Mark as correct"
+                      title={t("quizEditor.questions.markCorrect")}
                     />
                     <Input
                       value={opt.option_text}
                       onChange={(e) =>
                         onUpdateOption(oIdx, { option_text: e.target.value })
                       }
-                      placeholder={`Option ${oIdx + 1}`}
+                      placeholder={t("quizEditor.questions.optionPlaceholder", { n: oIdx + 1 })}
                       className="h-7 text-xs flex-1"
                     />
                     {q.options.length > 2 && (
@@ -152,7 +158,7 @@ export function QuestionCard({
                 ))}
                 <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onAddOption}>
                   <Plus className="h-3 w-3 mr-1" />
-                  Add Option
+                  {t("quizEditor.questions.addOption")}
                 </Button>
               </div>
             )}
@@ -183,13 +189,13 @@ export function QuestionCard({
 
             {q.question_type === "short_answer" && (
               <p className="text-xs text-muted-foreground italic">
-                Students will type a free-text answer. Graded manually.
+                {t("quizEditor.questions.shortAnswerHint")}
               </p>
             )}
 
             {q.question_type === "essay" && (
               <p className="text-xs text-muted-foreground italic">
-                Long-form written response. Graded manually from the Submissions tab.
+                {t("quizEditor.questions.essayHint")}
               </p>
             )}
           </div>

--- a/frontend/src/components/quiz/editor/QuizEditView.tsx
+++ b/frontend/src/components/quiz/editor/QuizEditView.tsx
@@ -1,4 +1,5 @@
 import { Loader2, Plus, Save, Trash2 } from "lucide-react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import type { Quiz } from "@/types"
 import { QuestionCard } from "./QuestionCard"
@@ -54,6 +55,7 @@ export function QuizEditView({
   deleting,
   onDelete,
 }: Props) {
+  const { t } = useTranslation()
   return (
     <>
       <QuizHeaderFields
@@ -70,10 +72,12 @@ export function QuizEditView({
 
       <div className="space-y-3">
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium">Questions ({questions.length})</span>
+          <span className="text-sm font-medium">
+            {t("quizEditor.questions.heading", { count: questions.length })}
+          </span>
           <Button variant="outline" size="sm" onClick={onAddQuestion} className="h-7 text-xs">
             <Plus className="h-3 w-3 mr-1" />
-            Add Question
+            {t("quizEditor.questions.addQuestion")}
           </Button>
         </div>
 
@@ -94,7 +98,7 @@ export function QuizEditView({
 
         {questions.length === 0 && (
           <div className="text-center py-6 border border-dashed rounded-md text-sm text-muted-foreground">
-            No questions yet. Click "Add Question" to start.
+            {t("quizEditor.questions.empty")}
           </div>
         )}
       </div>
@@ -106,7 +110,11 @@ export function QuizEditView({
           ) : (
             <Save className="h-3.5 w-3.5 mr-1.5" />
           )}
-          {saving ? "Saving..." : `Save ${chapterType === "exam" ? "Exam" : "Quiz"}`}
+          {saving
+            ? t("quizEditor.save.saving")
+            : chapterType === "exam"
+              ? t("quizEditor.save.saveExam")
+              : t("quizEditor.save.saveQuiz")}
         </Button>
         {existingQuiz && (
           <Button size="sm" variant="destructive" onClick={onDelete} disabled={deleting}>
@@ -115,7 +123,9 @@ export function QuizEditView({
             ) : (
               <Trash2 className="h-3.5 w-3.5 mr-1.5" />
             )}
-            {`Delete ${chapterType === "exam" ? "Exam" : "Quiz"}`}
+            {chapterType === "exam"
+              ? t("quizEditor.save.deleteExam")
+              : t("quizEditor.save.deleteQuiz")}
           </Button>
         )}
       </div>

--- a/frontend/src/components/quiz/editor/QuizHeaderFields.tsx
+++ b/frontend/src/components/quiz/editor/QuizHeaderFields.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
@@ -25,30 +26,31 @@ export function QuizHeaderFields({
   setMaxAttempts,
   chapterType,
 }: Props) {
+  const { t } = useTranslation()
   return (
     <div className="grid gap-3">
       <div className="space-y-1.5">
-        <Label className="text-xs">Quiz Title</Label>
+        <Label className="text-xs">{t("quizEditor.fields.quizTitle")}</Label>
         <Input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="e.g. Chapter Review Quiz"
+          placeholder={t("quizEditor.fields.titlePlaceholder")}
           fieldSize="sm"
           className="text-sm"
         />
       </div>
       <div className="space-y-1.5">
-        <Label className="text-xs">Description (optional)</Label>
+        <Label className="text-xs">{t("quizEditor.fields.description")}</Label>
         <Textarea
           fieldSize="sm"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          placeholder="Brief description of the quiz..."
+          placeholder={t("quizEditor.fields.descriptionPlaceholder")}
           className="text-sm"
         />
       </div>
       <div className="space-y-1.5">
-        <Label className="text-xs">Passing Score (%)</Label>
+        <Label className="text-xs">{t("quizEditor.fields.passingScore")}</Label>
         <Input
           type="number"
           min={0}
@@ -61,7 +63,7 @@ export function QuizHeaderFields({
       </div>
       {chapterType === "exam" && (
         <div className="space-y-1.5">
-          <Label className="text-xs">Maximum Attempts</Label>
+          <Label className="text-xs">{t("quizEditor.fields.maxAttempts")}</Label>
           <Input
             type="number"
             min={1}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -369,6 +369,88 @@
     "inProgress": "In progress",
     "attemptPoints": "{{score}}/{{max}} points"
   },
+  "quizEditor": {
+    "validation": {
+      "titleRequired": "Quiz title is required",
+      "addAtLeastOneQuestion": "Add at least one question",
+      "validScoreRequired": "Enter a valid score (0 or higher)",
+      "scoreCantExceed": "Score can't exceed {{max}} for this question"
+    },
+    "toast": {
+      "quizSaved": "Quiz saved",
+      "quizSaveFailed": "Failed to save quiz",
+      "quizDeleted": "Quiz deleted",
+      "quizDeleteFailed": "Failed to delete quiz",
+      "gradeSaved": "Grade saved",
+      "gradeSaveFailed": "Failed to save grade"
+    },
+    "confirmDelete": {
+      "title": "Delete this quiz?",
+      "description": "Students will lose access to the quiz and its attempts.",
+      "confirm": "Delete quiz"
+    },
+    "heading": {
+      "editQuiz": "Edit Quiz",
+      "editExam": "Edit Exam",
+      "createQuiz": "Create Quiz",
+      "createExam": "Create Exam"
+    },
+    "fields": {
+      "quizTitle": "Quiz Title",
+      "titlePlaceholder": "e.g. Chapter Review Quiz",
+      "description": "Description (optional)",
+      "descriptionPlaceholder": "Brief description of the quiz...",
+      "passingScore": "Passing Score (%)",
+      "maxAttempts": "Maximum Attempts"
+    },
+    "questions": {
+      "heading": "Questions ({{count}})",
+      "addQuestion": "Add Question",
+      "empty": "No questions yet. Click \"Add Question\" to start.",
+      "questionPrefix": "Q{{n}}",
+      "questionPlaceholder": "Question text...",
+      "types": {
+        "multiple_choice": "Multiple Choice",
+        "true_false": "True / False",
+        "short_answer": "Short Answer",
+        "essay": "Essay"
+      },
+      "minWords": "Min words:",
+      "points": "Points:",
+      "markCorrect": "Mark as correct",
+      "optionPlaceholder": "Option {{n}}",
+      "addOption": "Add Option",
+      "shortAnswerHint": "Students will type a free-text answer. Graded manually.",
+      "essayHint": "Long-form written response. Graded manually from the Submissions tab."
+    },
+    "save": {
+      "saving": "Saving...",
+      "saveQuiz": "Save Quiz",
+      "saveExam": "Save Exam",
+      "deleteQuiz": "Delete Quiz",
+      "deleteExam": "Delete Exam"
+    },
+    "review": {
+      "loadFailed": "Failed to load submissions. Please try again.",
+      "emptyAlready": "No open-ended answers yet.",
+      "emptyAllGraded": "Nothing to grade — you're all caught up.",
+      "openEndedCount_one": "{{count}} open-ended answer",
+      "openEndedCount_other": "{{count}} open-ended answers",
+      "showAlreadyGraded": "Show already graded",
+      "essay": "Essay",
+      "shortAnswer": "Short answer",
+      "upToPoints_one": "up to {{count}} pt",
+      "upToPoints_other": "up to {{count}} pts",
+      "wordsWithMin": "{{count}} / {{min}} words",
+      "wordsCount": "{{count}} words",
+      "emptyAnswer": "(empty)",
+      "pointsLabel": "Points (0–{{max}})",
+      "commentLabel": "Comment (optional)",
+      "commentPlaceholder": "Feedback shown to the student…",
+      "saved": "Saved",
+      "saveGrade": "Save grade"
+    }
+  },
   "assignment": {
     "loadFailed": "Failed to load assignments. Please try refreshing.",
     "statusSubmitted": "Submitted — Awaiting Review",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -379,6 +379,92 @@
     "inProgress": "В процессе",
     "attemptPoints": "{{score}}/{{max}} баллов"
   },
+  "quizEditor": {
+    "validation": {
+      "titleRequired": "Укажите название теста",
+      "addAtLeastOneQuestion": "Добавьте хотя бы один вопрос",
+      "validScoreRequired": "Введите корректный балл (0 или больше)",
+      "scoreCantExceed": "Балл не может превышать {{max}} за этот вопрос"
+    },
+    "toast": {
+      "quizSaved": "Тест сохранён",
+      "quizSaveFailed": "Не удалось сохранить тест",
+      "quizDeleted": "Тест удалён",
+      "quizDeleteFailed": "Не удалось удалить тест",
+      "gradeSaved": "Оценка сохранена",
+      "gradeSaveFailed": "Не удалось сохранить оценку"
+    },
+    "confirmDelete": {
+      "title": "Удалить этот тест?",
+      "description": "Студенты потеряют доступ к тесту и попыткам.",
+      "confirm": "Удалить тест"
+    },
+    "heading": {
+      "editQuiz": "Изменить тест",
+      "editExam": "Изменить экзамен",
+      "createQuiz": "Создать тест",
+      "createExam": "Создать экзамен"
+    },
+    "fields": {
+      "quizTitle": "Название теста",
+      "titlePlaceholder": "напр. Тест по главе",
+      "description": "Описание (необязательно)",
+      "descriptionPlaceholder": "Краткое описание теста...",
+      "passingScore": "Проходной балл (%)",
+      "maxAttempts": "Максимум попыток"
+    },
+    "questions": {
+      "heading": "Вопросы ({{count}})",
+      "addQuestion": "Добавить вопрос",
+      "empty": "Пока нет вопросов. Нажмите «Добавить вопрос», чтобы начать.",
+      "questionPrefix": "В{{n}}",
+      "questionPlaceholder": "Текст вопроса...",
+      "types": {
+        "multiple_choice": "Один из вариантов",
+        "true_false": "Верно / Неверно",
+        "short_answer": "Короткий ответ",
+        "essay": "Эссе"
+      },
+      "minWords": "Мин. слов:",
+      "points": "Баллы:",
+      "markCorrect": "Отметить как правильный",
+      "optionPlaceholder": "Вариант {{n}}",
+      "addOption": "Добавить вариант",
+      "shortAnswerHint": "Студенты введут свободный текст. Оценивается вручную.",
+      "essayHint": "Развёрнутый письменный ответ. Оценивается вручную во вкладке проверки."
+    },
+    "save": {
+      "saving": "Сохранение...",
+      "saveQuiz": "Сохранить тест",
+      "saveExam": "Сохранить экзамен",
+      "deleteQuiz": "Удалить тест",
+      "deleteExam": "Удалить экзамен"
+    },
+    "review": {
+      "loadFailed": "Не удалось загрузить ответы. Попробуйте снова.",
+      "emptyAlready": "Пока нет открытых ответов.",
+      "emptyAllGraded": "Нет ответов на проверку — всё проверено.",
+      "openEndedCount_one": "{{count}} открытый ответ",
+      "openEndedCount_few": "{{count}} открытых ответа",
+      "openEndedCount_many": "{{count}} открытых ответов",
+      "openEndedCount_other": "{{count}} открытых ответа",
+      "showAlreadyGraded": "Показывать уже проверенные",
+      "essay": "Эссе",
+      "shortAnswer": "Короткий ответ",
+      "upToPoints_one": "до {{count}} балла",
+      "upToPoints_few": "до {{count}} баллов",
+      "upToPoints_many": "до {{count}} баллов",
+      "upToPoints_other": "до {{count}} баллов",
+      "wordsWithMin": "{{count}} / {{min}} слов",
+      "wordsCount": "{{count}} слов",
+      "emptyAnswer": "(пусто)",
+      "pointsLabel": "Баллы (0–{{max}})",
+      "commentLabel": "Комментарий (необязательно)",
+      "commentPlaceholder": "Отзыв, который увидит студент…",
+      "saved": "Сохранено",
+      "saveGrade": "Сохранить оценку"
+    }
+  },
   "assignment": {
     "loadFailed": "Не удалось загрузить задания. Обновите страницу.",
     "statusSubmitted": "Отправлено — на проверке",


### PR DESCRIPTION
## Summary
Sixth Phase-2 batch — the whole teacher-side quiz/exam editor surface. ~60 hardcoded English strings across 5 files now resolve from a new `quizEditor.*` namespace.

Files:
- **QuizEditor.tsx** — validation + save/delete toasts, "Delete this quiz?" confirm dialog, Edit/Create Quiz|Exam heading.
- **QuizHeaderFields.tsx** — Title / Description / Passing Score (%) / Maximum Attempts labels and placeholders.
- **QuestionCard.tsx** — `Q{n}` prefix, question-text placeholder, all four question-type options (multiple_choice / true_false / short_answer / essay), Min words / Points labels, Mark-as-correct title, option placeholders, Add Option, short-answer + essay hint lines.
- **QuizEditView.tsx** — `Questions ({n})` heading, Add Question, empty state, Save Quiz/Exam + Delete Quiz/Exam buttons.
- **QuizSubmissionsReview.tsx** — loadFailed, empty-state lines, "Show already graded" checkbox, per-row Essay/Short-answer label + "up to N pts", word counts, `(empty)` placeholder, Points + Comment labels, Saved / Save grade button.

Plural-aware: `openEndedCount` and `upToPoints` use i18next plural rules, so Russian gets `_one` / `_few` / `_many` variants.

Parity now **711 EN / 735 RU**.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU: open a chapter of type=quiz → entire editor in Russian incl. question-type options.
- [ ] Same for type=exam → buttons read "Сохранить экзамен" / "Удалить экзамен".
- [ ] Open Submissions tab on a quiz with short_answer/essay questions → review UI in Russian; plural "5 открытых ответов" works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
