### PR TITLE
i18n(assignmentEditor): full editor tree → t() (4 files)

### DIFF
--- a/frontend/src/components/assignment/AssignmentEditor.tsx
+++ b/frontend/src/components/assignment/AssignmentEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { FileText, Loader2, Plus } from "lucide-react"
 import { useConfirm } from "@/components/ui/alert-dialog"
@@ -28,6 +29,7 @@ export default function AssignmentEditor({
   onAssignmentCreated,
 }: AssignmentEditorProps) {
   const confirm = useConfirm()
+  const { t } = useTranslation()
   const [assignments, setAssignments] = useState<Assignment[]>([])
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState(false)
@@ -58,7 +60,7 @@ export default function AssignmentEditor({
 
   const handleCreate = async () => {
     if (!form.title.trim()) {
-      toast({ title: "Assignment title is required", variant: "destructive" })
+      toast({ title: t("assignmentEditor.validation.titleRequired"), variant: "destructive" })
       return
     }
     setCreating(true)
@@ -71,9 +73,9 @@ export default function AssignmentEditor({
       onAssignmentCreated?.(a.id)
       setForm(EMPTY_ASSIGNMENT_FORM)
       setShowCreate(false)
-      toast({ title: "Assignment created", variant: "success" })
+      toast({ title: t("assignmentEditor.toast.created"), variant: "success" })
     } catch {
-      toast({ title: "Failed to create assignment", variant: "destructive" })
+      toast({ title: t("assignmentEditor.toast.createFailed"), variant: "destructive" })
     } finally {
       setCreating(false)
     }
@@ -81,18 +83,18 @@ export default function AssignmentEditor({
 
   const handleDelete = async (id: string) => {
     const ok = await confirm({
-      title: "Delete this assignment?",
-      description: "All student submissions will also be deleted.",
-      confirmLabel: "Delete assignment",
+      title: t("assignmentEditor.confirmDelete.title"),
+      description: t("assignmentEditor.confirmDelete.description"),
+      confirmLabel: t("assignmentEditor.confirmDelete.confirm"),
       tone: "destructive",
     })
     if (!ok) return
     try {
       await coursesService.deleteAssignment(id)
       setAssignments((prev) => prev.filter((a) => a.id !== id))
-      toast({ title: "Assignment deleted", variant: "success" })
+      toast({ title: t("assignmentEditor.toast.deleted"), variant: "success" })
     } catch {
-      toast({ title: "Failed to delete assignment", variant: "destructive" })
+      toast({ title: t("assignmentEditor.toast.deleteFailed"), variant: "destructive" })
     }
   }
 
@@ -107,7 +109,7 @@ export default function AssignmentEditor({
   if (fetchError) {
     return (
       <p className="text-sm text-destructive py-4 text-center">
-        Failed to load assignments. Please try refreshing.
+        {t("assignmentEditor.loadFailed")}
       </p>
     )
   }
@@ -117,7 +119,9 @@ export default function AssignmentEditor({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <FileText className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm font-medium">Assignments ({assignments.length})</span>
+          <span className="text-sm font-medium">
+            {t("assignmentEditor.heading", { count: assignments.length })}
+          </span>
         </div>
         <Button
           variant="outline"
@@ -126,7 +130,7 @@ export default function AssignmentEditor({
           onClick={() => setShowCreate((v) => !v)}
         >
           <Plus className="h-3 w-3 mr-1" />
-          New Assignment
+          {t("assignmentEditor.newAssignment")}
         </Button>
       </div>
 
@@ -154,7 +158,7 @@ export default function AssignmentEditor({
 
       {assignments.length === 0 && !showCreate && (
         <div className="text-center py-6 border border-dashed rounded-md text-sm text-muted-foreground">
-          No assignments for this chapter.
+          {t("assignmentEditor.empty")}
         </div>
       )}
     </div>

--- a/frontend/src/components/assignment/editor/AssignmentForm.tsx
+++ b/frontend/src/components/assignment/editor/AssignmentForm.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
@@ -21,48 +22,49 @@ interface Props {
  * component collapses that into a single source of truth.
  */
 export function AssignmentForm({ value, onChange, onSubmit, onCancel, submitting, mode }: Props) {
+  const { t } = useTranslation()
   const patch = (p: Partial<AssignmentFormState>) => onChange({ ...value, ...p })
 
   const submitLabel =
     mode === "create"
       ? submitting
-        ? "Creating..."
-        : "Create Assignment"
+        ? t("assignmentEditor.form.creating")
+        : t("assignmentEditor.form.create")
       : submitting
-        ? "Updating..."
-        : "Update Assignment"
+        ? t("assignmentEditor.form.updating")
+        : t("assignmentEditor.form.update")
 
   return (
     <Card className="bg-muted/30">
       <CardContent className="p-4 space-y-3">
         <div className="space-y-1.5">
           <Label className="text-xs" htmlFor="assignment-title">
-            Title
+            {t("assignmentEditor.form.title")}
           </Label>
           <Input
             id="assignment-title"
             value={value.title}
             onChange={(e) => patch({ title: e.target.value })}
-            placeholder="e.g. Chapter Reflection Essay"
+            placeholder={t("assignmentEditor.form.titlePlaceholder")}
             fieldSize="sm"
           />
         </div>
         <div className="space-y-1.5">
           <Label className="text-xs" htmlFor="assignment-description">
-            Description (optional)
+            {t("assignmentEditor.form.description")}
           </Label>
           <Textarea
             id="assignment-description"
             value={value.description}
             onChange={(e) => patch({ description: e.target.value })}
-            placeholder="Assignment instructions..."
+            placeholder={t("assignmentEditor.form.descriptionPlaceholder")}
             fieldSize="sm"
           />
         </div>
         <div className="flex gap-3">
           <div className="space-y-1.5">
             <Label className="text-xs" htmlFor="assignment-max-score">
-              Max Score
+              {t("assignmentEditor.form.maxScore")}
             </Label>
             <Input
               id="assignment-max-score"
@@ -76,7 +78,7 @@ export function AssignmentForm({ value, onChange, onSubmit, onCancel, submitting
           </div>
           <div className="space-y-1.5">
             <Label className="text-xs" htmlFor="assignment-due">
-              Due Date (optional)
+              {t("assignmentEditor.form.dueDate")}
             </Label>
             <Input
               id="assignment-due"
@@ -98,7 +100,7 @@ export function AssignmentForm({ value, onChange, onSubmit, onCancel, submitting
           </Button>
           <Button size="sm" variant="ghost" onClick={onCancel}>
             {mode === "edit" && <X className="h-3.5 w-3.5 mr-1.5" />}
-            Cancel
+            {t("assignmentEditor.form.cancel")}
           </Button>
         </div>
       </CardContent>

--- a/frontend/src/components/assignment/editor/AssignmentItem.tsx
+++ b/frontend/src/components/assignment/editor/AssignmentItem.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { ChevronDown, ChevronRight, Loader2, Pencil, Trash2 } from "lucide-react"
@@ -25,6 +26,7 @@ interface Props {
  * list of student submissions (lazy-loaded on first expand).
  */
 export function AssignmentItem({ assignment, onDelete, onUpdate }: Props) {
+  const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const [submissions, setSubmissions] = useState<AssignmentSubmission[]>([])
   const [loadingSubs, setLoadingSubs] = useState(false)
@@ -55,7 +57,7 @@ export function AssignmentItem({ assignment, onDelete, onUpdate }: Props) {
 
   const handleUpdate = async () => {
     if (!form.title.trim()) {
-      toast({ title: "Assignment title is required", variant: "destructive" })
+      toast({ title: t("assignmentEditor.validation.titleRequired"), variant: "destructive" })
       return
     }
     setUpdating(true)
@@ -66,9 +68,9 @@ export function AssignmentItem({ assignment, onDelete, onUpdate }: Props) {
       )
       onUpdate(updated)
       setEditing(false)
-      toast({ title: "Assignment updated", variant: "success" })
+      toast({ title: t("assignmentEditor.toast.updated"), variant: "success" })
     } catch {
-      toast({ title: "Failed to update assignment", variant: "destructive" })
+      toast({ title: t("assignmentEditor.toast.updateFailed"), variant: "destructive" })
     } finally {
       setUpdating(false)
     }
@@ -96,9 +98,11 @@ export function AssignmentItem({ assignment, onDelete, onUpdate }: Props) {
         <div className="flex-1 min-w-0">
           <span className="text-sm font-medium">{assignment.title}</span>
           <div className="flex items-center gap-3 text-xs text-muted-foreground">
-            <span>Max: {assignment.max_score} pts</span>
+            <span>{t("assignmentEditor.item.maxPts", { max: assignment.max_score })}</span>
             {assignment.due_date && (
-              <span>Due: {formatDate(assignment.due_date)}</span>
+              <span>
+                {t("assignmentEditor.item.due", { date: formatDate(assignment.due_date) })}
+              </span>
             )}
           </div>
         </div>
@@ -151,12 +155,12 @@ export function AssignmentItem({ assignment, onDelete, onUpdate }: Props) {
             </div>
           ) : submissions.length === 0 ? (
             <p className="text-sm text-muted-foreground py-4 text-center">
-              No submissions yet.
+              {t("assignmentEditor.item.noSubmissions")}
             </p>
           ) : (
             <div className="space-y-3 mt-3">
               <h4 className="text-xs font-semibold text-muted-foreground">
-                Submissions ({submissions.length})
+                {t("assignmentEditor.item.submissionsCount", { count: submissions.length })}
               </h4>
               {submissions.map((sub) => (
                 <SubmissionGrader

--- a/frontend/src/components/assignment/editor/SubmissionGrader.tsx
+++ b/frontend/src/components/assignment/editor/SubmissionGrader.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -22,6 +23,7 @@ const STATUS_COLORS: Record<string, string> = {
 }
 
 export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
+  const { t } = useTranslation()
   const [grade, setGrade] = useState(submission.grade ?? 0)
   const [feedback, setFeedback] = useState(submission.feedback ?? "")
   const [status, setStatus] = useState(submission.status)
@@ -36,9 +38,9 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
         status,
       })
       onUpdate(updated)
-      toast({ title: "Submission graded", variant: "success" })
+      toast({ title: t("assignmentEditor.toast.graded"), variant: "success" })
     } catch {
-      toast({ title: "Failed to grade", variant: "destructive" })
+      toast({ title: t("assignmentEditor.toast.gradeFailed"), variant: "destructive" })
     } finally {
       setSaving(false)
     }
@@ -75,7 +77,7 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
             className="flex items-center gap-1 text-xs text-info hover:underline"
           >
             <FileText className="h-3 w-3" />
-            View attached file
+            {t("assignmentEditor.grader.viewFile")}
           </a>
         )}
 
@@ -98,21 +100,21 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
             onChange={(e) => setStatus(e.target.value as AssignmentSubmission["status"])}
             className="h-7 rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <option value="graded">Grade</option>
-            <option value="returned">Return for revision</option>
+            <option value="graded">{t("assignmentEditor.grader.statusGrade")}</option>
+            <option value="returned">{t("assignmentEditor.grader.statusReturn")}</option>
           </select>
         </div>
 
         <div className="space-y-1">
           <Label className="text-xs flex items-center gap-1">
             <MessageSquare className="h-3 w-3" />
-            Feedback
+            {t("assignmentEditor.grader.feedback")}
           </Label>
           <Textarea
             fieldSize="sm"
             value={feedback}
             onChange={(e) => setFeedback(e.target.value)}
-            placeholder="Optional feedback for the student..."
+            placeholder={t("assignmentEditor.grader.feedbackPlaceholder")}
             className="min-h-[50px] text-xs"
           />
         </div>
@@ -123,7 +125,7 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
           ) : (
             <Save className="h-3 w-3 mr-1" />
           )}
-          {saving ? "Saving..." : "Save Grade"}
+          {saving ? t("assignmentEditor.grader.saving") : t("assignmentEditor.grader.save")}
         </Button>
       </CardContent>
     </Card>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -451,6 +451,59 @@
       "saveGrade": "Save grade"
     }
   },
+  "assignmentEditor": {
+    "validation": {
+      "titleRequired": "Assignment title is required"
+    },
+    "toast": {
+      "created": "Assignment created",
+      "createFailed": "Failed to create assignment",
+      "updated": "Assignment updated",
+      "updateFailed": "Failed to update assignment",
+      "deleted": "Assignment deleted",
+      "deleteFailed": "Failed to delete assignment",
+      "graded": "Submission graded",
+      "gradeFailed": "Failed to grade"
+    },
+    "confirmDelete": {
+      "title": "Delete this assignment?",
+      "description": "All student submissions will also be deleted.",
+      "confirm": "Delete assignment"
+    },
+    "loadFailed": "Failed to load assignments. Please try refreshing.",
+    "heading": "Assignments ({{count}})",
+    "newAssignment": "New Assignment",
+    "empty": "No assignments for this chapter.",
+    "form": {
+      "title": "Title",
+      "titlePlaceholder": "e.g. Chapter Reflection Essay",
+      "description": "Description (optional)",
+      "descriptionPlaceholder": "Assignment instructions...",
+      "maxScore": "Max Score",
+      "dueDate": "Due Date (optional)",
+      "creating": "Creating...",
+      "create": "Create Assignment",
+      "updating": "Updating...",
+      "update": "Update Assignment",
+      "cancel": "Cancel"
+    },
+    "item": {
+      "maxPts": "Max: {{max}} pts",
+      "due": "Due: {{date}}",
+      "noSubmissions": "No submissions yet.",
+      "submissionsCount": "Submissions ({{count}})"
+    },
+    "grader": {
+      "viewFile": "View attached file",
+      "statusGrade": "Grade",
+      "statusReturn": "Return for revision",
+      "feedback": "Feedback",
+      "feedbackPlaceholder": "Optional feedback for the student...",
+      "saving": "Saving...",
+      "save": "Save Grade",
+      "studentIdPrefix": "{{prefix}}..."
+    }
+  },
   "assignment": {
     "loadFailed": "Failed to load assignments. Please try refreshing.",
     "statusSubmitted": "Submitted — Awaiting Review",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -465,6 +465,59 @@
       "saveGrade": "Сохранить оценку"
     }
   },
+  "assignmentEditor": {
+    "validation": {
+      "titleRequired": "Укажите название задания"
+    },
+    "toast": {
+      "created": "Задание создано",
+      "createFailed": "Не удалось создать задание",
+      "updated": "Задание обновлено",
+      "updateFailed": "Не удалось обновить задание",
+      "deleted": "Задание удалено",
+      "deleteFailed": "Не удалось удалить задание",
+      "graded": "Оценка сохранена",
+      "gradeFailed": "Не удалось сохранить оценку"
+    },
+    "confirmDelete": {
+      "title": "Удалить это задание?",
+      "description": "Также будут удалены все ответы студентов.",
+      "confirm": "Удалить задание"
+    },
+    "loadFailed": "Не удалось загрузить задания. Попробуйте обновить страницу.",
+    "heading": "Задания ({{count}})",
+    "newAssignment": "Новое задание",
+    "empty": "К этой главе нет заданий.",
+    "form": {
+      "title": "Название",
+      "titlePlaceholder": "напр. Размышление по главе",
+      "description": "Описание (необязательно)",
+      "descriptionPlaceholder": "Инструкции к заданию...",
+      "maxScore": "Макс. балл",
+      "dueDate": "Срок сдачи (необязательно)",
+      "creating": "Создание...",
+      "create": "Создать задание",
+      "updating": "Обновление...",
+      "update": "Обновить задание",
+      "cancel": "Отмена"
+    },
+    "item": {
+      "maxPts": "Макс.: {{max}} б.",
+      "due": "Сдать до: {{date}}",
+      "noSubmissions": "Пока нет ответов.",
+      "submissionsCount": "Ответы ({{count}})"
+    },
+    "grader": {
+      "viewFile": "Открыть прикреплённый файл",
+      "statusGrade": "Оценить",
+      "statusReturn": "Вернуть на доработку",
+      "feedback": "Отзыв",
+      "feedbackPlaceholder": "Необязательный отзыв студенту...",
+      "saving": "Сохранение...",
+      "save": "Сохранить оценку",
+      "studentIdPrefix": "{{prefix}}..."
+    }
+  },
   "assignment": {
     "loadFailed": "Не удалось загрузить задания. Обновите страницу.",
     "statusSubmitted": "Отправлено — на проверке",


### PR DESCRIPTION
## Summary
Seventh Phase-2 batch — teacher-side assignment editor (paralleling the quiz-editor work in #180). ~40 hardcoded English strings across 4 files now resolve from a new `assignmentEditor.*` namespace.

Files:
- **AssignmentEditor.tsx** — toasts (create/delete success+failure), confirm dialog, load-failed message, `Assignments ({n})` heading, New Assignment button, empty state.
- **AssignmentForm.tsx** — Title / Description / Max Score / Due Date labels and placeholders; Create / Creating / Update / Updating / Cancel button labels. Shared by both create + edit (submitLabel composed via `t()`).
- **AssignmentItem.tsx** — `Max: N pts` + `Due: {date}` metadata, "No submissions yet." empty state, `Submissions ({n})` subheading, validation + update toasts.
- **SubmissionGrader.tsx** — Grade / Return for revision status options, Feedback label + placeholder, Save Grade button (incl. Saving… state), attached-file link, graded/grade-failed toasts.

Parity now **750 EN / 774 RU**.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU: open a chapter type=assignment → editor in Russian (heading, New Assignment, form, empty state).
- [ ] Create an assignment → toast in Russian. Edit it → "Обновить задание". Delete it → confirm dialog in Russian.
- [ ] After a student submits, expand the assignment → Submissions section + grader controls in Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
