### PR TITLE
i18n(blockEditor): full block editor surface → t() (8 files)

### DIFF
--- a/frontend/src/components/editor/CalloutDropdown.tsx
+++ b/frontend/src/components/editor/CalloutDropdown.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type { Editor } from "@tiptap/react";
 import {
   Info,
@@ -13,16 +14,15 @@ import type { CalloutVariant } from "./CalloutExtension";
 
 interface CalloutChoice {
   value: CalloutVariant;
-  label: string;
   icon: typeof Info;
   color: string;
 }
 
 const CALLOUT_VARIANTS: CalloutChoice[] = [
-  { value: "info", label: "Information", icon: Info, color: "text-info" },
-  { value: "verse", label: "Bible Verse", icon: BookOpen, color: "text-accent" },
-  { value: "takeaway", label: "Key Takeaway", icon: Lightbulb, color: "text-success" },
-  { value: "warning", label: "Warning", icon: AlertTriangle, color: "text-warning" },
+  { value: "info", icon: Info, color: "text-info" },
+  { value: "verse", icon: BookOpen, color: "text-accent" },
+  { value: "takeaway", icon: Lightbulb, color: "text-success" },
+  { value: "warning", icon: AlertTriangle, color: "text-warning" },
 ];
 
 /**
@@ -37,6 +37,7 @@ export function CalloutDropdown({
   editor: Editor;
   iconSize: number;
 }) {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -68,7 +69,7 @@ export function CalloutDropdown({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        title="Callout Block"
+        title={t("blockEditor.callout.trigger")}
         className={cn(
           "flex items-center gap-0.5 rounded p-1.5 transition-colors",
           isActive
@@ -91,7 +92,7 @@ export function CalloutDropdown({
                 className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
               >
                 <Icon size={16} className={v.color} />
-                {v.label}
+                {t(`blockEditor.callout.${v.value}`)}
               </button>
             );
           })}
@@ -103,7 +104,7 @@ export function CalloutDropdown({
                 onClick={removeCallout}
                 className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-muted transition-colors text-left"
               >
-                Remove Block
+                {t("blockEditor.callout.remove")}
               </button>
             </>
           )}

--- a/frontend/src/components/editor/ChapterBlockEditor.tsx
+++ b/frontend/src/components/editor/ChapterBlockEditor.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Label } from "@/components/ui/label"
 import { Loader2 } from "lucide-react"
 import { coursesService } from "@/services/courses"
@@ -20,6 +21,7 @@ interface Props {
  */
 export default function ChapterBlockEditor({ chapterId }: Props) {
   const confirm = useConfirm()
+  const { t } = useTranslation()
   const [blocks, setBlocks] = useState<ChapterBlock[]>([])
   const [loading, setLoading] = useState(true)
   const [expandedId, setExpandedId] = useState<string | null>(null)
@@ -37,13 +39,16 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
         if (signal?.cancelled) return
         const detail = getErrorDetail(error)
         if (detail) {
-          toast({ title: `Failed to load blocks: ${detail}`, variant: "destructive" })
+          toast({
+            title: t("blockEditor.loadFailed", { detail }),
+            variant: "destructive",
+          })
         }
       } finally {
         if (!signal?.cancelled) setLoading(false)
       }
     },
-    [chapterId],
+    [chapterId, t],
   )
 
   useEffect(() => {
@@ -63,10 +68,16 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
       })
       setBlocks((prev) => [...prev, newBlock])
       setExpandedId(newBlock.id)
-      toast({ title: `${type} block added`, variant: "success" })
+      toast({
+        title: t("blockEditor.addedSuccess", { type: t(`blockEditor.types.${type}`) }),
+        variant: "success",
+      })
     } catch (error: unknown) {
-      const detail = getErrorDetail(error) || "Unknown error"
-      toast({ title: `Failed to add block: ${detail}`, variant: "destructive" })
+      const detail = getErrorDetail(error) || t("chapterEditor.unknownError")
+      toast({
+        title: t("blockEditor.addFailed", { detail }),
+        variant: "destructive",
+      })
     } finally {
       setAdding(false)
     }
@@ -78,8 +89,8 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
 
   const deleteBlock = async (id: string) => {
     const ok = await confirm({
-      title: "Delete this block?",
-      confirmLabel: "Delete",
+      title: t("blockEditor.confirmDelete.title"),
+      confirmLabel: t("blockEditor.confirmDelete.confirm"),
       tone: "destructive",
     })
     if (!ok) return
@@ -87,9 +98,9 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
       await coursesService.deleteBlock(id)
       setBlocks((prev) => prev.filter((b) => b.id !== id))
       if (expandedId === id) setExpandedId(null)
-      toast({ title: "Block deleted", variant: "success" })
+      toast({ title: t("blockEditor.deleted"), variant: "success" })
     } catch {
-      toast({ title: "Failed to delete block", variant: "destructive" })
+      toast({ title: t("blockEditor.deleteFailed"), variant: "destructive" })
     }
   }
 
@@ -114,7 +125,7 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
         withIndex.map((b) => ({ id: b.id, order_index: b.order_index })),
       )
     } catch {
-      toast({ title: "Failed to reorder blocks", variant: "destructive" })
+      toast({ title: t("blockEditor.reorderFailed"), variant: "destructive" })
       void load()
     }
   }
@@ -131,16 +142,16 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-          Content Blocks
+          {t("blockEditor.contentBlocks")}
         </Label>
         <span className="text-xs text-muted-foreground">
-          {blocks.length} block{blocks.length !== 1 ? "s" : ""}
+          {t("blockEditor.blocksCount", { count: blocks.length })}
         </span>
       </div>
 
       {blocks.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-4 border border-dashed rounded-md">
-          No blocks yet. Add your first content block below.
+          {t("blockEditor.empty")}
         </p>
       )}
 

--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -1,4 +1,5 @@
 import type { Editor } from "@tiptap/react";
+import { useTranslation } from "react-i18next";
 import {
   Bold,
   Italic,
@@ -81,12 +82,13 @@ export function EditorToolbar({
   onAddAudio,
   onSetLink,
 }: EditorToolbarProps) {
+  const { t } = useTranslation();
   return (
     <div className="flex flex-wrap items-center gap-0.5 border-b border-input px-2 py-1.5">
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleBold().run()}
         active={editor.isActive("bold")}
-        title="Bold"
+        title={t("blockEditor.toolbar.bold")}
       >
         <Bold size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -94,7 +96,7 @@ export function EditorToolbar({
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleItalic().run()}
         active={editor.isActive("italic")}
-        title="Italic"
+        title={t("blockEditor.toolbar.italic")}
       >
         <Italic size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -104,7 +106,7 @@ export function EditorToolbar({
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
         active={editor.isActive("heading", { level: 2 })}
-        title="Heading 2"
+        title={t("blockEditor.toolbar.heading2")}
       >
         <Heading2 size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -112,7 +114,7 @@ export function EditorToolbar({
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
         active={editor.isActive("heading", { level: 3 })}
-        title="Heading 3"
+        title={t("blockEditor.toolbar.heading3")}
       >
         <Heading3 size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -122,7 +124,7 @@ export function EditorToolbar({
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleBulletList().run()}
         active={editor.isActive("bulletList")}
-        title="Bullet List"
+        title={t("blockEditor.toolbar.bulletList")}
       >
         <List size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -130,7 +132,7 @@ export function EditorToolbar({
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
         active={editor.isActive("orderedList")}
-        title="Numbered List"
+        title={t("blockEditor.toolbar.numberedList")}
       >
         <ListOrdered size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -138,14 +140,14 @@ export function EditorToolbar({
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleBlockquote().run()}
         active={editor.isActive("blockquote")}
-        title="Blockquote"
+        title={t("blockEditor.toolbar.blockquote")}
       >
         <Quote size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
 
       <ToolbarButton
         onClick={() => editor.chain().focus().setHorizontalRule().run()}
-        title="Horizontal Rule"
+        title={t("blockEditor.toolbar.horizontalRule")}
       >
         <Minus size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -156,7 +158,7 @@ export function EditorToolbar({
 
       <ToolbarDivider />
 
-      <ToolbarButton onClick={onAddImage} disabled={uploading} title="Insert Image">
+      <ToolbarButton onClick={onAddImage} disabled={uploading} title={t("blockEditor.toolbar.insertImage")}>
         {uploading ? (
           <span className="inline-block h-[18px] w-[18px] animate-spin rounded-full border-2 border-current border-t-transparent" />
         ) : (
@@ -164,18 +166,18 @@ export function EditorToolbar({
         )}
       </ToolbarButton>
 
-      <ToolbarButton onClick={onAddYoutube} title="Insert YouTube Video">
+      <ToolbarButton onClick={onAddYoutube} title={t("blockEditor.toolbar.insertYoutube")}>
         <Youtube size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
 
-      <ToolbarButton onClick={onAddAudio} title="Insert Audio">
+      <ToolbarButton onClick={onAddAudio} title={t("blockEditor.toolbar.insertAudio")}>
         <Headphones size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
 
       <ToolbarButton
         onClick={onSetLink}
         active={editor.isActive("link")}
-        title="Link"
+        title={t("blockEditor.toolbar.link")}
       >
         <Link2 size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -185,7 +187,7 @@ export function EditorToolbar({
       <ToolbarButton
         onClick={() => editor.chain().focus().undo().run()}
         disabled={!editor.can().undo()}
-        title="Undo"
+        title={t("blockEditor.toolbar.undo")}
       >
         <Undo2 size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>
@@ -193,7 +195,7 @@ export function EditorToolbar({
       <ToolbarButton
         onClick={() => editor.chain().focus().redo().run()}
         disabled={!editor.can().redo()}
-        title="Redo"
+        title={t("blockEditor.toolbar.redo")}
       >
         <Redo2 size={TOOLBAR_ICON_SIZE} />
       </ToolbarButton>

--- a/frontend/src/components/editor/blocks/AddBlockMenu.tsx
+++ b/frontend/src/components/editor/blocks/AddBlockMenu.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Loader2, Plus } from "lucide-react"
 import { BLOCK_TYPES, type BlockType } from "./types"
@@ -13,6 +14,7 @@ interface Props {
  * the parent just exposes an `onAdd(type)` callback.
  */
 export function AddBlockMenu({ onAdd, adding }: Props) {
+  const { t } = useTranslation()
   const [open, setOpen] = useState(false)
 
   const pick = (type: BlockType) => {
@@ -34,7 +36,7 @@ export function AddBlockMenu({ onAdd, adding }: Props) {
         ) : (
           <Plus className="h-3.5 w-3.5 mr-1.5" />
         )}
-        Add Block
+        {t("blockEditor.addBlock")}
       </Button>
       {open && (
         <div className="absolute z-10 mt-1 w-full bg-background border rounded-md shadow-lg py-1">
@@ -47,7 +49,7 @@ export function AddBlockMenu({ onAdd, adding }: Props) {
                 className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
               >
                 <Icon className="h-4 w-4 text-muted-foreground" />
-                {bt.label}
+                {t(`blockEditor.types.${bt.value}`)}
               </button>
             )
           })}

--- a/frontend/src/components/editor/blocks/BlockRow.tsx
+++ b/frontend/src/components/editor/blocks/BlockRow.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { ChevronDown, ChevronRight, GripVertical, Trash2 } from "lucide-react"
 import QuizEditor from "@/components/quiz/QuizEditor"
@@ -5,7 +6,7 @@ import AssignmentEditor from "@/components/assignment/AssignmentEditor"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
 import type { ChapterBlock } from "@/types"
-import { blockIcon, blockLabel } from "./types"
+import { blockIcon } from "./types"
 import { TextBlockEditor } from "./TextBlockEditor"
 import { FileBlockEditor } from "./FileBlockEditor"
 
@@ -42,14 +43,16 @@ export function BlockRow({
   onDrop,
   onDragEnd,
 }: Props) {
+  const { t } = useTranslation()
   const Icon = blockIcon(block.block_type)
+  const label = t(`blockEditor.types.${block.block_type}`, { defaultValue: block.block_type })
 
   const updateField = async (field: string, value: string) => {
     try {
       const updated = await coursesService.updateBlock(block.id, { [field]: value })
       onBlockUpdated(updated)
     } catch {
-      toast({ title: "Failed to update block", variant: "destructive" })
+      toast({ title: t("blockEditor.updateFailed"), variant: "destructive" })
     }
   }
 
@@ -75,7 +78,7 @@ export function BlockRow({
           <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         )}
         <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-        <span className="text-sm font-medium flex-1">{blockLabel(block.block_type)}</span>
+        <span className="text-sm font-medium flex-1">{label}</span>
         <span className="text-[10px] text-muted-foreground">#{index + 1}</span>
         <Button
           variant="ghost"

--- a/frontend/src/components/editor/blocks/FileBlockEditor.tsx
+++ b/frontend/src/components/editor/blocks/FileBlockEditor.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { FileText, Loader2, Paperclip, Upload, X } from "lucide-react"
@@ -20,6 +21,7 @@ interface Props {
  * affected by this block's upload.
  */
 export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
+  const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
   const hasFile = Boolean(block.file_bucket && block.file_path)
@@ -34,9 +36,9 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
         file_name: name,
       })
       onUpdated(updated)
-      toast({ title: "File uploaded", variant: "success" })
+      toast({ title: t("blockEditor.file.uploaded"), variant: "success" })
     } catch (error: unknown) {
-      const detail = getErrorDetail(error) || "Upload failed"
+      const detail = getErrorDetail(error) || t("blockEditor.file.uploadFailedDefault")
       toast({ title: detail, variant: "destructive" })
     } finally {
       setUploading(false)
@@ -52,7 +54,7 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
       })
       onUpdated(updated)
     } catch {
-      toast({ title: "Failed to remove file", variant: "destructive" })
+      toast({ title: t("blockEditor.file.removeFailed"), variant: "destructive" })
     }
   }
 
@@ -60,7 +62,7 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
     <div className="space-y-2">
       <Label className="text-xs flex items-center gap-1.5">
         <Paperclip className="h-3.5 w-3.5" />
-        Attached File
+        {t("blockEditor.file.attachedFile")}
       </Label>
       {hasFile ? (
         <div className="flex items-center gap-2 rounded-md border px-3 py-2 bg-muted/30">
@@ -75,7 +77,7 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
             disabled={uploading}
             className="h-7 text-xs"
           >
-            {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : "Replace"}
+            {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : t("blockEditor.file.replace")}
           </Button>
           <Button
             size="sm"
@@ -83,7 +85,7 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
             onClick={clear}
             disabled={uploading}
             className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-            aria-label="Remove file"
+            aria-label={t("blockEditor.file.removeAria")}
           >
             <X className="h-3.5 w-3.5" />
           </Button>
@@ -101,7 +103,7 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
           ) : (
             <Upload className="h-3.5 w-3.5 mr-1.5" />
           )}
-          {uploading ? "Uploading..." : "Upload a file"}
+          {uploading ? t("blockEditor.file.uploading") : t("blockEditor.file.uploadCta")}
         </Button>
       )}
       <input

--- a/frontend/src/components/editor/blocks/TextBlockEditor.tsx
+++ b/frontend/src/components/editor/blocks/TextBlockEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Check, Loader2, Save } from "lucide-react"
 import RichTextEditor from "../RichTextEditor"
@@ -22,6 +23,7 @@ const SAVED_FLASH_MS = 2000
  * browser tab is hidden so background tabs don't hammer the API.
  */
 export function TextBlockEditor({ block, onSaved }: Props) {
+  const { t } = useTranslation()
   const [content, setContent] = useState(block.content ?? "")
   const [savingExplicit, setSavingExplicit] = useState(false)
   const [autoSaveStatus, setAutoSaveStatus] = useState<AutoSaveStatus>("idle")
@@ -63,7 +65,7 @@ export function TextBlockEditor({ block, onSaved }: Props) {
       } catch {
         if (!mountedRef.current) return
         setAutoSaveStatus("idle")
-        toast({ title: "Auto-save failed", variant: "destructive" })
+        toast({ title: t("blockEditor.text.autoSaveFailed"), variant: "destructive" })
       }
     }, AUTOSAVE_DELAY_MS)
   }
@@ -76,9 +78,9 @@ export function TextBlockEditor({ block, onSaved }: Props) {
     try {
       const updated = await coursesService.updateBlock(block.id, { content })
       onSaved(updated)
-      toast({ title: "Block saved", variant: "success" })
+      toast({ title: t("blockEditor.text.saved"), variant: "success" })
     } catch {
-      toast({ title: "Failed to save block", variant: "destructive" })
+      toast({ title: t("blockEditor.text.saveFailed"), variant: "destructive" })
     } finally {
       setSavingExplicit(false)
     }
@@ -93,7 +95,7 @@ export function TextBlockEditor({ block, onSaved }: Props) {
           contentRef.current = html
           scheduleAutoSave()
         }}
-        placeholder="Write block content..."
+        placeholder={t("blockEditor.text.placeholder")}
       />
       <div className="flex items-center gap-3">
         <Button size="sm" onClick={saveExplicit} disabled={savingExplicit}>
@@ -102,23 +104,23 @@ export function TextBlockEditor({ block, onSaved }: Props) {
           ) : (
             <Save className="h-3.5 w-3.5 mr-1.5" />
           )}
-          Save Text
+          {t("blockEditor.text.saveButton")}
         </Button>
         {autoSaveStatus === "pending" && (
           <span className="text-xs text-muted-foreground">
-            Unsaved changes...
+            {t("blockEditor.text.statusUnsaved")}
           </span>
         )}
         {autoSaveStatus === "saving" && (
           <span className="flex items-center gap-1 text-xs text-muted-foreground">
             <Loader2 className="h-3 w-3 animate-spin" />
-            Auto-saving...
+            {t("blockEditor.text.statusAutoSaving")}
           </span>
         )}
         {autoSaveStatus === "saved" && (
           <span className="flex items-center gap-1 text-xs text-success">
             <Check className="h-3 w-3" />
-            Saved
+            {t("blockEditor.text.statusSaved")}
           </span>
         )}
       </div>

--- a/frontend/src/components/editor/blocks/types.ts
+++ b/frontend/src/components/editor/blocks/types.ts
@@ -11,21 +11,18 @@ import {
  * The block "kinds" a teacher can add to a chapter. Video and audio
  * embeds live inside text blocks (the rich editor's toolbar has
  * dedicated buttons), so the block layer only needs the shapes that
- * aren't just HTML.
+ * aren't just HTML. Display labels live in i18n bundles at
+ * `blockEditor.types.{text|quiz|assignment|file}`.
  */
 export const BLOCK_TYPES = [
-  { value: "text", label: "Text", icon: Type },
-  { value: "quiz", label: "Quiz", icon: HelpCircle },
-  { value: "assignment", label: "Assignment", icon: ClipboardList },
-  { value: "file", label: "File", icon: Paperclip },
-] as const satisfies ReadonlyArray<{ value: string; label: string; icon: LucideIcon }>
+  { value: "text", icon: Type },
+  { value: "quiz", icon: HelpCircle },
+  { value: "assignment", icon: ClipboardList },
+  { value: "file", icon: Paperclip },
+] as const satisfies ReadonlyArray<{ value: string; icon: LucideIcon }>
 
 export type BlockType = (typeof BLOCK_TYPES)[number]["value"]
 
 export function blockIcon(type: string): LucideIcon {
   return BLOCK_TYPES.find((bt) => bt.value === type)?.icon ?? FileText
-}
-
-export function blockLabel(type: string): string {
-  return BLOCK_TYPES.find((bt) => bt.value === type)?.label ?? type
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -451,6 +451,74 @@
       "saveGrade": "Save grade"
     }
   },
+  "blockEditor": {
+    "loadFailed": "Failed to load blocks: {{detail}}",
+    "addedSuccess": "{{type}} block added",
+    "addFailed": "Failed to add block: {{detail}}",
+    "deleted": "Block deleted",
+    "deleteFailed": "Failed to delete block",
+    "confirmDelete": {
+      "title": "Delete this block?",
+      "confirm": "Delete"
+    },
+    "reorderFailed": "Failed to reorder blocks",
+    "updateFailed": "Failed to update block",
+    "contentBlocks": "Content Blocks",
+    "blocksCount_one": "{{count}} block",
+    "blocksCount_other": "{{count}} blocks",
+    "empty": "No blocks yet. Add your first content block below.",
+    "addBlock": "Add Block",
+    "types": {
+      "text": "Text",
+      "quiz": "Quiz",
+      "assignment": "Assignment",
+      "file": "File"
+    },
+    "text": {
+      "autoSaveFailed": "Auto-save failed",
+      "saved": "Block saved",
+      "saveFailed": "Failed to save block",
+      "placeholder": "Write block content...",
+      "saveButton": "Save Text",
+      "statusUnsaved": "Unsaved changes...",
+      "statusAutoSaving": "Auto-saving...",
+      "statusSaved": "Saved"
+    },
+    "file": {
+      "uploaded": "File uploaded",
+      "uploadFailedDefault": "Upload failed",
+      "removeFailed": "Failed to remove file",
+      "attachedFile": "Attached File",
+      "replace": "Replace",
+      "removeAria": "Remove file",
+      "uploading": "Uploading...",
+      "uploadCta": "Upload a file"
+    },
+    "toolbar": {
+      "bold": "Bold",
+      "italic": "Italic",
+      "heading2": "Heading 2",
+      "heading3": "Heading 3",
+      "bulletList": "Bullet List",
+      "numberedList": "Numbered List",
+      "blockquote": "Blockquote",
+      "horizontalRule": "Horizontal Rule",
+      "insertImage": "Insert Image",
+      "insertYoutube": "Insert YouTube Video",
+      "insertAudio": "Insert Audio",
+      "link": "Link",
+      "undo": "Undo",
+      "redo": "Redo"
+    },
+    "callout": {
+      "trigger": "Callout Block",
+      "remove": "Remove Block",
+      "info": "Information",
+      "verse": "Bible Verse",
+      "takeaway": "Key Takeaway",
+      "warning": "Warning"
+    }
+  },
   "assignmentEditor": {
     "validation": {
       "titleRequired": "Assignment title is required"

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -465,6 +465,76 @@
       "saveGrade": "Сохранить оценку"
     }
   },
+  "blockEditor": {
+    "loadFailed": "Не удалось загрузить блоки: {{detail}}",
+    "addedSuccess": "Блок «{{type}}» добавлен",
+    "addFailed": "Не удалось добавить блок: {{detail}}",
+    "deleted": "Блок удалён",
+    "deleteFailed": "Не удалось удалить блок",
+    "confirmDelete": {
+      "title": "Удалить этот блок?",
+      "confirm": "Удалить"
+    },
+    "reorderFailed": "Не удалось изменить порядок блоков",
+    "updateFailed": "Не удалось обновить блок",
+    "contentBlocks": "Блоки содержимого",
+    "blocksCount_one": "{{count}} блок",
+    "blocksCount_few": "{{count}} блока",
+    "blocksCount_many": "{{count}} блоков",
+    "blocksCount_other": "{{count}} блоков",
+    "empty": "Пока нет блоков. Добавьте первый блок ниже.",
+    "addBlock": "Добавить блок",
+    "types": {
+      "text": "Текст",
+      "quiz": "Тест",
+      "assignment": "Задание",
+      "file": "Файл"
+    },
+    "text": {
+      "autoSaveFailed": "Не удалось автосохранить",
+      "saved": "Блок сохранён",
+      "saveFailed": "Не удалось сохранить блок",
+      "placeholder": "Введите содержимое блока...",
+      "saveButton": "Сохранить текст",
+      "statusUnsaved": "Несохранённые изменения...",
+      "statusAutoSaving": "Автосохранение...",
+      "statusSaved": "Сохранено"
+    },
+    "file": {
+      "uploaded": "Файл загружен",
+      "uploadFailedDefault": "Не удалось загрузить",
+      "removeFailed": "Не удалось удалить файл",
+      "attachedFile": "Прикреплённый файл",
+      "replace": "Заменить",
+      "removeAria": "Удалить файл",
+      "uploading": "Загрузка...",
+      "uploadCta": "Загрузить файл"
+    },
+    "toolbar": {
+      "bold": "Жирный",
+      "italic": "Курсив",
+      "heading2": "Заголовок 2",
+      "heading3": "Заголовок 3",
+      "bulletList": "Маркированный список",
+      "numberedList": "Нумерованный список",
+      "blockquote": "Цитата",
+      "horizontalRule": "Горизонтальная линия",
+      "insertImage": "Вставить изображение",
+      "insertYoutube": "Вставить YouTube видео",
+      "insertAudio": "Вставить аудио",
+      "link": "Ссылка",
+      "undo": "Отменить",
+      "redo": "Повторить"
+    },
+    "callout": {
+      "trigger": "Блок-выноска",
+      "remove": "Удалить блок",
+      "info": "Информация",
+      "verse": "Библейский стих",
+      "takeaway": "Ключевая мысль",
+      "warning": "Предупреждение"
+    }
+  },
   "assignmentEditor": {
     "validation": {
       "titleRequired": "Укажите название задания"


### PR DESCRIPTION
## Summary
Eighth Phase-2 batch — chapter content-block editor + rich-text toolbar + callout dropdown. ~50 hardcoded English strings across **8 files** now resolve from a new `blockEditor.*` namespace.

Files:
- **ChapterBlockEditor.tsx** — load/add/delete/reorder/update toasts, confirm-delete dialog, "Content Blocks" label, blocks-count plural, empty state.
- **TextBlockEditor.tsx** — auto-save status indicators (pending / auto-saving / saved), explicit-save toasts, RichTextEditor placeholder, "Save Text" button.
- **FileBlockEditor.tsx** — upload/replace/remove toasts, "Attached File" label, Replace button, remove-file aria, upload CTA (idle + uploading).
- **BlockRow.tsx** — block-type label (Text / Quiz / Assignment / File) now translated, plus update-failed toast.
- **AddBlockMenu.tsx** — "Add Block" CTA + type-list labels.
- **blocks/types.ts** — drops the hardcoded `label` field on `BLOCK_TYPES`; labels now live in i18n at `blockEditor.types.*`. Also removes the now-unused `blockLabel()` helper.
- **EditorToolbar.tsx** — **all 13 toolbar `title` / `aria-label` strings translated** (Bold / Italic / Heading 2 / Heading 3 / Bullet List / Numbered List / Blockquote / Horizontal Rule / Insert Image / Insert YouTube Video / Insert Audio / Link / Undo / Redo).
- **CalloutDropdown.tsx** — trigger title, four variant labels (Information / Bible Verse / Key Takeaway / Warning) keyed by enum, and "Remove Block" action.

Plural-aware: `blocksCount` uses i18next plural rules so Russian gets `_one`/`_few`/`_many`.

Parity now **804 EN / 830 RU**.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU: open a chapter type=reading → block editor in Russian (Content Blocks label, empty state, Add Block menu, block-row titles).
- [ ] Add a text block → save/auto-save indicators in Russian. Hover toolbar buttons — tooltips in Russian.
- [ ] Open Callout dropdown → all 4 variants + Remove Block in Russian.
- [ ] Add a file block → upload UI in Russian.
- [ ] Cohort student-count + similar plurals still work after en.json restructuring (107 tests cover this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
