### PR TITLE
i18n(studentProgress + analytics): teacher reporting → t()

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -646,6 +646,85 @@
       }
     }
   },
+  "studentProgress": {
+    "loadFailed": "Failed to load student progress",
+    "loadFailedDescription": "The server may be temporarily unavailable. Please try again.",
+    "retry": "Retry",
+    "backToCourses": "Back to courses",
+    "breadcrumb": {
+      "myCourses": "My Courses",
+      "courseFallback": "Course"
+    },
+    "heading": "Student Progress",
+    "analytics": "Analytics",
+    "gradebook": "Gradebook",
+    "searchPlaceholder": "Search students by name or email...",
+    "table": {
+      "heading": "Students",
+      "description": "Click a row to view detailed breakdown",
+      "name": "Name",
+      "email": "Email",
+      "progress": "Progress",
+      "chapters": "Chapters",
+      "quizAvg": "Quiz Avg",
+      "assignAvg": "Assign. Avg",
+      "lastActive": "Last Active",
+      "emptyNoMatch": "No students match your search",
+      "emptyNoStudents": "No students enrolled yet"
+    },
+    "row": {
+      "markedIncomplete": "Marked as incomplete",
+      "markedComplete": "Marked as complete",
+      "toggleFailed": "Failed to update completion",
+      "extraAttemptGranted": "Extra attempt granted",
+      "extraAttemptFailed": "Failed to grant extra attempt",
+      "overallGrade": "Overall Grade",
+      "overallGradeNa": "N/A",
+      "enrolled": "Enrolled",
+      "chaptersCompleted": "Chapters Completed",
+      "chaptersCompletedValue": "{{done}} of {{total}}",
+      "progress": "Progress",
+      "chapterBreakdown": "Chapter Breakdown",
+      "gradebookButton": "Gradebook",
+      "viewAnalytics": "View Analytics"
+    },
+    "chapterRow": {
+      "notCompleted": "Not completed",
+      "quizScore": "Quiz: {{score}}/{{max}}",
+      "extraAttemptTitle": "Grant extra attempt",
+      "completedByTeacher": "Completed by teacher",
+      "completedByQuiz": "Completed via quiz",
+      "completedBySubmission": "Completed via submission",
+      "undo": "Undo",
+      "complete": "Complete"
+    }
+  },
+  "teacherAnalytics": {
+    "courseFallback": "Course",
+    "loadFailed": "Failed to load analytics",
+    "backToCourses": "Back to courses",
+    "backToDashboard": "Back to dashboard",
+    "heading": "Course Analytics",
+    "studentProgress": "Student Progress",
+    "gradebook": "Gradebook",
+    "stats": {
+      "totalStudents": "Total Students",
+      "averageProgress": "Average Progress",
+      "completed": "Completed (100%)",
+      "enrolledThisMonth": "Enrolled This Month"
+    },
+    "enrollments": {
+      "heading": "Student Enrollments",
+      "subheadingCount_one": "{{count}} student enrolled",
+      "subheadingCount_other": "{{count}} students enrolled",
+      "emptyText": "No students have enrolled yet.",
+      "name": "Name",
+      "email": "Email",
+      "progress": "Progress",
+      "enrolled": "Enrolled",
+      "unknown": "Unknown"
+    }
+  },
   "reviews": {
     "loadFailed": "Failed to load reviews",
     "deleted": "Review deleted",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -662,6 +662,87 @@
       }
     }
   },
+  "studentProgress": {
+    "loadFailed": "Не удалось загрузить прогресс студентов",
+    "loadFailedDescription": "Сервер временно недоступен. Попробуйте позже.",
+    "retry": "Повторить",
+    "backToCourses": "К моим курсам",
+    "breadcrumb": {
+      "myCourses": "Мои курсы",
+      "courseFallback": "Курс"
+    },
+    "heading": "Прогресс студентов",
+    "analytics": "Аналитика",
+    "gradebook": "Журнал оценок",
+    "searchPlaceholder": "Поиск студентов по имени или email...",
+    "table": {
+      "heading": "Студенты",
+      "description": "Нажмите на строку, чтобы увидеть детали",
+      "name": "Имя",
+      "email": "Email",
+      "progress": "Прогресс",
+      "chapters": "Главы",
+      "quizAvg": "Сред. тест",
+      "assignAvg": "Сред. задание",
+      "lastActive": "Активность",
+      "emptyNoMatch": "Нет студентов по запросу",
+      "emptyNoStudents": "Пока нет записанных студентов"
+    },
+    "row": {
+      "markedIncomplete": "Отмечено как не выполнено",
+      "markedComplete": "Отмечено как выполнено",
+      "toggleFailed": "Не удалось обновить статус",
+      "extraAttemptGranted": "Дополнительная попытка выдана",
+      "extraAttemptFailed": "Не удалось выдать попытку",
+      "overallGrade": "Общая оценка",
+      "overallGradeNa": "—",
+      "enrolled": "Записан",
+      "chaptersCompleted": "Глав завершено",
+      "chaptersCompletedValue": "{{done}} из {{total}}",
+      "progress": "Прогресс",
+      "chapterBreakdown": "По главам",
+      "gradebookButton": "Журнал оценок",
+      "viewAnalytics": "Аналитика"
+    },
+    "chapterRow": {
+      "notCompleted": "Не завершено",
+      "quizScore": "Тест: {{score}}/{{max}}",
+      "extraAttemptTitle": "Выдать дополнительную попытку",
+      "completedByTeacher": "Засчитано преподавателем",
+      "completedByQuiz": "Завершено через тест",
+      "completedBySubmission": "Завершено через задание",
+      "undo": "Отменить",
+      "complete": "Засчитать"
+    }
+  },
+  "teacherAnalytics": {
+    "courseFallback": "Курс",
+    "loadFailed": "Не удалось загрузить аналитику",
+    "backToCourses": "К моим курсам",
+    "backToDashboard": "К панели",
+    "heading": "Аналитика курса",
+    "studentProgress": "Прогресс студентов",
+    "gradebook": "Журнал оценок",
+    "stats": {
+      "totalStudents": "Всего студентов",
+      "averageProgress": "Средний прогресс",
+      "completed": "Завершили (100%)",
+      "enrolledThisMonth": "Записались за месяц"
+    },
+    "enrollments": {
+      "heading": "Записи на курс",
+      "subheadingCount_one": "{{count}} студент записан",
+      "subheadingCount_few": "{{count}} студента записано",
+      "subheadingCount_many": "{{count}} студентов записано",
+      "subheadingCount_other": "{{count}} студентов записано",
+      "emptyText": "Пока никто не записался.",
+      "name": "Имя",
+      "email": "Email",
+      "progress": "Прогресс",
+      "enrolled": "Записан",
+      "unknown": "Неизвестно"
+    }
+  },
   "reviews": {
     "loadFailed": "Не удалось загрузить отзывы",
     "deleted": "Отзыв удалён",

--- a/frontend/src/pages/Teacher/StudentProgress.tsx
+++ b/frontend/src/pages/Teacher/StudentProgress.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Link, useParams } from "react-router-dom"
+import { useTranslation } from "react-i18next"
 import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -36,6 +37,7 @@ import {
  */
 export default function StudentProgress() {
   const { courseId } = useParams<{ courseId: string }>()
+  const { t } = useTranslation()
   const {
     input: searchInput,
     setInput: setSearchInput,
@@ -61,14 +63,14 @@ export default function StudentProgress() {
       } catch (err) {
         if (signal?.cancelled) return
         toast({
-          title: getErrorDetail(err, "Failed to load student progress"),
+          title: getErrorDetail(err, t("studentProgress.loadFailed")),
           variant: "destructive",
         })
       } finally {
         if (!signal?.cancelled) setLoading(false)
       }
     },
-    [courseId],
+    [courseId, t],
   )
 
   useEffect(() => {
@@ -154,18 +156,18 @@ export default function StudentProgress() {
       <div className="container mx-auto px-4 py-8 max-w-6xl">
         <ErrorState
           icon={<Users />}
-          title="Failed to load student progress"
-          description="The server may be temporarily unavailable. Please try again."
+          title={t("studentProgress.loadFailed")}
+          description={t("studentProgress.loadFailedDescription")}
           action={
             <Button variant="outline" onClick={() => load()}>
-              Retry
+              {t("studentProgress.retry")}
             </Button>
           }
           secondaryAction={
             <Link to="/teacher">
               <Button variant="ghost">
                 <ArrowLeft className="h-4 w-4 mr-1.5" />
-                Back to courses
+                {t("studentProgress.backToCourses")}
               </Button>
             </Link>
           }
@@ -177,35 +179,35 @@ export default function StudentProgress() {
     <div className="container mx-auto px-4 py-8 max-w-6xl">
       <div className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
         <Link to="/teacher" className="hover:text-foreground transition-colors">
-          My Courses
+          {t("studentProgress.breadcrumb.myCourses")}
         </Link>
         <ChevronRight className="h-3.5 w-3.5" />
         <Link
           to={`/teacher/courses/${courseId}`}
           className="hover:text-foreground transition-colors"
         >
-          {data.course_title || "Course"}
+          {data.course_title || t("studentProgress.breadcrumb.courseFallback")}
         </Link>
         <ChevronRight className="h-3.5 w-3.5" />
-        <span className="text-foreground font-medium">Student Progress</span>
+        <span className="text-foreground font-medium">{t("studentProgress.heading")}</span>
       </div>
 
       <div className="flex items-center gap-3 mb-8">
         <div className="flex-1">
-          <h1 className="text-3xl font-bold tracking-tight">Student Progress</h1>
+          <h1 className="text-3xl font-bold tracking-tight">{t("studentProgress.heading")}</h1>
           <p className="text-muted-foreground mt-1">{data.course_title}</p>
         </div>
         <div className="flex items-center gap-2">
           <Link to={`/teacher/courses/${courseId}/analytics`}>
             <Button size="sm" variant="outline">
               <BarChart3 className="h-4 w-4 mr-1.5" />
-              Analytics
+              {t("studentProgress.analytics")}
             </Button>
           </Link>
           <Link to={`/teacher/courses/${courseId}/gradebook`}>
             <Button size="sm" variant="outline">
               <ClipboardList className="h-4 w-4 mr-1.5" />
-              Gradebook
+              {t("studentProgress.gradebook")}
             </Button>
           </Link>
         </div>
@@ -220,7 +222,7 @@ export default function StudentProgress() {
       <div className="relative mb-6">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
         <Input
-          placeholder="Search students by name or email..."
+          placeholder={t("studentProgress.searchPlaceholder")}
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value.slice(0, maxLength))}
           maxLength={maxLength}

--- a/frontend/src/pages/Teacher/TeacherAnalytics.tsx
+++ b/frontend/src/pages/Teacher/TeacherAnalytics.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { useParams, Link } from "react-router-dom"
+import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import PageSpinner from "@/components/ui/PageSpinner"
 import { Button } from "@/components/ui/button"
@@ -37,6 +38,7 @@ interface Analytics {
 
 export default function TeacherAnalytics() {
   const { courseId } = useParams<{ courseId: string }>()
+  const { t } = useTranslation()
   const [analytics, setAnalytics] = useState<Analytics | null>(null)
   const [courseTitle, setCourseTitle] = useState("")
   const [loading, setLoading] = useState(true)
@@ -57,7 +59,7 @@ export default function TeacherAnalytics() {
           avgProgress: raw.avg_progress ?? raw.avgProgress ?? 0,
           completedCount: raw.completion_count ?? raw.completedCount ?? 0,
         })
-        setCourseTitle(raw.course_title ?? "Course")
+        setCourseTitle(raw.course_title ?? t("teacherAnalytics.courseFallback"))
       } catch {
         // analytics remains null — fallback UI handles this
       } finally {
@@ -66,7 +68,7 @@ export default function TeacherAnalytics() {
     }
     load()
     return () => { cancelled = true }
-  }, [courseId])
+  }, [courseId, t])
 
   const enrolledThisMonth = analytics?.enrollments.filter((e) => {
     if (!e.enrolled_at) return false
@@ -85,12 +87,12 @@ export default function TeacherAnalytics() {
       <div className="container mx-auto px-4 py-8 max-w-5xl">
         <ErrorState
           icon={<BarChart3 />}
-          title="Failed to load analytics"
+          title={t("teacherAnalytics.loadFailed")}
           action={
             <Link to="/teacher">
               <Button variant="ghost">
                 <ArrowLeft className="h-4 w-4 mr-1.5" />
-                Back to courses
+                {t("teacherAnalytics.backToCourses")}
               </Button>
             </Link>
           }
@@ -100,24 +102,24 @@ export default function TeacherAnalytics() {
   }
 
   const stats = [
-    { label: "Total Students", value: analytics.totalStudents, icon: Users },
-    { label: "Average Progress", value: `${analytics.avgProgress}%`, icon: TrendingUp },
-    { label: "Completed (100%)", value: analytics.completedCount, icon: Award },
-    { label: "Enrolled This Month", value: enrolledThisMonth, icon: Calendar },
+    { label: t("teacherAnalytics.stats.totalStudents"), value: analytics.totalStudents, icon: Users },
+    { label: t("teacherAnalytics.stats.averageProgress"), value: `${analytics.avgProgress}%`, icon: TrendingUp },
+    { label: t("teacherAnalytics.stats.completed"), value: analytics.completedCount, icon: Award },
+    { label: t("teacherAnalytics.stats.enrolledThisMonth"), value: enrolledThisMonth, icon: Calendar },
   ]
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-5xl">
       <div className="flex items-center gap-3 mb-8">
         <Link to="/teacher">
-          <Button variant="ghost" size="icon" className="shrink-0" aria-label="Back to dashboard">
+          <Button variant="ghost" size="icon" className="shrink-0" aria-label={t("teacherAnalytics.backToDashboard")}>
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>
         <div className="flex-1">
           <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
             <BarChart3 className="h-7 w-7 text-primary" />
-            Course Analytics
+            {t("teacherAnalytics.heading")}
           </h1>
           {courseTitle && (
             <p className="text-muted-foreground mt-1">{courseTitle}</p>
@@ -126,13 +128,13 @@ export default function TeacherAnalytics() {
         <Link to={`/teacher/courses/${courseId}/progress`}>
           <Button size="sm" variant="outline">
             <UserCheck className="h-4 w-4 mr-1.5" />
-            Student Progress
+            {t("teacherAnalytics.studentProgress")}
           </Button>
         </Link>
         <Link to={`/teacher/courses/${courseId}/gradebook`}>
           <Button size="sm" variant="outline">
             <ClipboardList className="h-4 w-4 mr-1.5" />
-            Gradebook
+            {t("teacherAnalytics.gradebook")}
           </Button>
         </Link>
       </div>
@@ -155,32 +157,32 @@ export default function TeacherAnalytics() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Student Enrollments</CardTitle>
+          <CardTitle>{t("teacherAnalytics.enrollments.heading")}</CardTitle>
           <CardDescription>
-            {analytics.totalStudents} student{analytics.totalStudents !== 1 && "s"} enrolled
+            {t("teacherAnalytics.enrollments.subheadingCount", { count: analytics.totalStudents })}
           </CardDescription>
         </CardHeader>
         <CardContent>
           {analytics.enrollments.length === 0 ? (
             <p className="text-sm text-muted-foreground py-8 text-center">
-              No students have enrolled yet.
+              {t("teacherAnalytics.enrollments.emptyText")}
             </p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b text-left">
-                    <th className="pb-3 font-medium text-muted-foreground">Name</th>
-                    <th className="pb-3 font-medium text-muted-foreground">Email</th>
-                    <th className="pb-3 font-medium text-muted-foreground">Progress</th>
-                    <th className="pb-3 font-medium text-muted-foreground">Enrolled</th>
+                    <th className="pb-3 font-medium text-muted-foreground">{t("teacherAnalytics.enrollments.name")}</th>
+                    <th className="pb-3 font-medium text-muted-foreground">{t("teacherAnalytics.enrollments.email")}</th>
+                    <th className="pb-3 font-medium text-muted-foreground">{t("teacherAnalytics.enrollments.progress")}</th>
+                    <th className="pb-3 font-medium text-muted-foreground">{t("teacherAnalytics.enrollments.enrolled")}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {analytics.enrollments.map((e) => (
                     <tr key={e.user_id} className="border-b last:border-0">
                       <td className="py-3 font-medium">
-                        {e.full_name ?? e.student?.full_name ?? "Unknown"}
+                        {e.full_name ?? e.student?.full_name ?? t("teacherAnalytics.enrollments.unknown")}
                       </td>
                       <td className="py-3 text-muted-foreground">
                         {e.email ?? e.student?.email ?? "—"}

--- a/frontend/src/pages/Teacher/progress/ChapterBreakdownRow.tsx
+++ b/frontend/src/pages/Teacher/progress/ChapterBreakdownRow.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import {
   CheckCircle,
@@ -35,6 +36,7 @@ export function ChapterBreakdownRow({
   onToggleComplete,
   onGrantExtraAttempt,
 }: Props) {
+  const { t } = useTranslation()
   const title =
     chapterInfo?.title ?? quiz?.chapter_title ?? assignment?.chapter_title ?? chapterId
   const gradable = chapterInfo ? isGradableChapterType(chapterInfo.chapter_type) : false
@@ -51,7 +53,9 @@ export function ChapterBreakdownRow({
             {completed ? (
               <CompletionLabel completedBy={chapterInfo.completed_by} />
             ) : (
-              <span className="text-muted-foreground">Not completed</span>
+              <span className="text-muted-foreground">
+                {t("studentProgress.chapterRow.notCompleted")}
+              </span>
             )}
           </p>
         )}
@@ -65,7 +69,10 @@ export function ChapterBreakdownRow({
             <XCircle className="h-3.5 w-3.5 text-destructive" />
           )}
           <span>
-            Quiz: {quiz.score}/{quiz.max_score}
+            {t("studentProgress.chapterRow.quizScore", {
+              score: quiz.score,
+              max: quiz.max_score,
+            })}
           </span>
           {quiz.quiz_id && (
             <Button
@@ -77,7 +84,7 @@ export function ChapterBreakdownRow({
                 e.stopPropagation()
                 onGrantExtraAttempt(quiz.quiz_id!)
               }}
-              title="Grant extra attempt"
+              title={t("studentProgress.chapterRow.extraAttemptTitle")}
             >
               {grantingQuizId === quiz.quiz_id ? (
                 <Loader2 className="h-3 w-3 animate-spin" />
@@ -123,7 +130,9 @@ export function ChapterBreakdownRow({
           ) : (
             <CheckCircle className="h-3 w-3 mr-1" />
           )}
-          {completed ? "Undo" : "Complete"}
+          {completed
+            ? t("studentProgress.chapterRow.undo")
+            : t("studentProgress.chapterRow.complete")}
         </Button>
       )}
     </div>
@@ -135,11 +144,12 @@ function CompletionLabel({
 }: {
   completedBy: ChapterInfo["completed_by"]
 }) {
+  const { t } = useTranslation()
   if (completedBy === "teacher") {
-    return <span className="text-info">Completed by teacher</span>
+    return <span className="text-info">{t("studentProgress.chapterRow.completedByTeacher")}</span>
   }
   if (completedBy === "quiz") {
-    return <span className="text-success">Completed via quiz</span>
+    return <span className="text-success">{t("studentProgress.chapterRow.completedByQuiz")}</span>
   }
-  return <span className="text-success">Completed via submission</span>
+  return <span className="text-success">{t("studentProgress.chapterRow.completedBySubmission")}</span>
 }

--- a/frontend/src/pages/Teacher/progress/StudentRow.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentRow.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react"
 import { Link } from "react-router-dom"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { toast } from "@/lib/toast"
 import { coursesService } from "@/services/courses"
@@ -59,6 +60,7 @@ export function StudentRow({
   courseId,
   onChapterUpdate,
 }: Props) {
+  const { t } = useTranslation()
   const [togglingChapter, setTogglingChapter] = useState<string | null>(null)
   const [grantingQuiz, setGrantingQuiz] = useState<string | null>(null)
 
@@ -82,14 +84,14 @@ export function StudentRow({
       if (chapterInfo.completed) {
         await coursesService.teacherMarkIncomplete(chapterInfo.id, student.id)
         onChapterUpdate(student.id, chapterInfo.id, false, null)
-        toast({ title: "Marked as incomplete", variant: "success" })
+        toast({ title: t("studentProgress.row.markedIncomplete"), variant: "success" })
       } else {
         await coursesService.teacherMarkComplete(chapterInfo.id, student.id)
         onChapterUpdate(student.id, chapterInfo.id, true, "teacher")
-        toast({ title: "Marked as complete", variant: "success" })
+        toast({ title: t("studentProgress.row.markedComplete"), variant: "success" })
       }
     } catch {
-      toast({ title: "Failed to update completion", variant: "destructive" })
+      toast({ title: t("studentProgress.row.toggleFailed"), variant: "destructive" })
     } finally {
       setTogglingChapter(null)
     }
@@ -99,9 +101,9 @@ export function StudentRow({
     setGrantingQuiz(quizId)
     try {
       await coursesService.grantExtraAttempts(quizId, student.id, 1)
-      toast({ title: "Extra attempt granted", variant: "success" })
+      toast({ title: t("studentProgress.row.extraAttemptGranted"), variant: "success" })
     } catch {
-      toast({ title: "Failed to grant extra attempt", variant: "destructive" })
+      toast({ title: t("studentProgress.row.extraAttemptFailed"), variant: "destructive" })
     } finally {
       setGrantingQuiz(null)
     }
@@ -143,20 +145,25 @@ export function StudentRow({
           <td colSpan={8} className="p-0">
             <div className="bg-muted/30 border-y px-6 py-5 space-y-5">
               <div className="flex flex-wrap gap-6">
-                <SummaryStat label="Overall Grade">
+                <SummaryStat label={t("studentProgress.row.overallGrade")}>
                   <p className="text-xl font-bold">
-                    {overallGrade !== null ? `${overallGrade}%` : "N/A"}
+                    {overallGrade !== null
+                      ? `${overallGrade}%`
+                      : t("studentProgress.row.overallGradeNa")}
                   </p>
                 </SummaryStat>
-                <SummaryStat label="Enrolled">
+                <SummaryStat label={t("studentProgress.row.enrolled")}>
                   <p className="text-sm font-medium">{formatDate(student.enrolled_at)}</p>
                 </SummaryStat>
-                <SummaryStat label="Chapters Completed">
+                <SummaryStat label={t("studentProgress.row.chaptersCompleted")}>
                   <p className="text-sm font-medium">
-                    {student.chapters_completed} of {student.total_chapters}
+                    {t("studentProgress.row.chaptersCompletedValue", {
+                      done: student.chapters_completed,
+                      total: student.total_chapters,
+                    })}
                   </p>
                 </SummaryStat>
-                <SummaryStat label="Progress">
+                <SummaryStat label={t("studentProgress.row.progress")}>
                   <ProgressBar value={student.progress} />
                 </SummaryStat>
               </div>
@@ -165,7 +172,7 @@ export function StudentRow({
                 <div>
                   <h4 className="text-sm font-semibold mb-3 flex items-center gap-1.5">
                     <BookOpen className="h-4 w-4" />
-                    Chapter Breakdown
+                    {t("studentProgress.row.chapterBreakdown")}
                   </h4>
                   <div className="space-y-2">
                     {Array.from(allChapters.entries()).map(([id, entry]) => (
@@ -189,13 +196,13 @@ export function StudentRow({
                 <Link to={`/teacher/courses/${courseId}/gradebook`}>
                   <Button size="sm" variant="outline">
                     <ClipboardList className="h-3.5 w-3.5 mr-1.5" />
-                    Gradebook
+                    {t("studentProgress.row.gradebookButton")}
                   </Button>
                 </Link>
                 <Link to={`/teacher/courses/${courseId}/analytics`}>
                   <Button size="sm" variant="ghost">
                     <FileText className="h-3.5 w-3.5 mr-1.5" />
-                    View Analytics
+                    {t("studentProgress.row.viewAnalytics")}
                   </Button>
                 </Link>
               </div>

--- a/frontend/src/pages/Teacher/progress/StudentTable.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentTable.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import {
   Card,
   CardContent,
@@ -44,17 +45,18 @@ export function StudentTable({
   onToggleSort,
   onChapterUpdate,
 }: Props) {
+  const { t } = useTranslation()
   return (
     <Card>
       <CardHeader className="pb-3">
         <CardTitle className="text-lg flex items-center gap-2">
           <Users className="h-5 w-5" />
-          Students
+          {t("studentProgress.table.heading")}
           <span className="text-sm font-normal text-muted-foreground">
             ({students.length})
           </span>
         </CardTitle>
-        <CardDescription>Click a row to view detailed breakdown</CardDescription>
+        <CardDescription>{t("studentProgress.table.description")}</CardDescription>
       </CardHeader>
       <CardContent>
         {students.length === 0 ? (
@@ -66,25 +68,25 @@ export function StudentTable({
                 <tr className="border-b text-left">
                   <th className="pb-3 pr-2 w-8" />
                   <SortableHeader
-                    label="Name"
+                    label={t("studentProgress.table.name")}
                     col="name"
                     sortBy={sortBy}
                     sortDir={sortDir}
                     onToggle={onToggleSort}
                   />
-                  <th className="pb-3 font-medium text-muted-foreground">Email</th>
+                  <th className="pb-3 font-medium text-muted-foreground">{t("studentProgress.table.email")}</th>
                   <SortableHeader
-                    label="Progress"
+                    label={t("studentProgress.table.progress")}
                     col="progress"
                     sortBy={sortBy}
                     sortDir={sortDir}
                     onToggle={onToggleSort}
                   />
-                  <th className="pb-3 font-medium text-muted-foreground">Chapters</th>
-                  <th className="pb-3 font-medium text-muted-foreground">Quiz Avg</th>
-                  <th className="pb-3 font-medium text-muted-foreground">Assign. Avg</th>
+                  <th className="pb-3 font-medium text-muted-foreground">{t("studentProgress.table.chapters")}</th>
+                  <th className="pb-3 font-medium text-muted-foreground">{t("studentProgress.table.quizAvg")}</th>
+                  <th className="pb-3 font-medium text-muted-foreground">{t("studentProgress.table.assignAvg")}</th>
                   <SortableHeader
-                    label="Last Active"
+                    label={t("studentProgress.table.lastActive")}
                     col="last_activity"
                     sortBy={sortBy}
                     sortDir={sortDir}
@@ -116,11 +118,14 @@ export function StudentTable({
 }
 
 function EmptyState({ hasSearch }: { hasSearch: boolean }) {
+  const { t } = useTranslation()
   return (
     <div className="text-center py-12 text-muted-foreground">
       <Users className="h-10 w-10 mx-auto mb-3 opacity-30" />
       <p className="text-sm">
-        {hasSearch ? "No students match your search" : "No students enrolled yet"}
+        {hasSearch
+          ? t("studentProgress.table.emptyNoMatch")
+          : t("studentProgress.table.emptyNoStudents")}
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary
10th Phase-2 batch — teacher reporting pages (the two pages a teacher uses to monitor a class).

**Student-progress page** (4 files, ~40 strings):
- **StudentProgress.tsx** — ErrorState body, Retry, back-to-courses, breadcrumb, page heading, Analytics + Gradebook buttons, search placeholder.
- **StudentTable.tsx** — "Students ({n})" card heading + description, every column header (Name / Email / Progress / Chapters / Quiz Avg / Assign. Avg / Last Active), empty states.
- **StudentRow.tsx** — mark-complete/incomplete toasts, extra-attempt granted/failed, four summary stats (Overall Grade / Enrolled / Chapters Completed with `{{done}} of {{total}}` / Progress), Chapter Breakdown heading, footer buttons.
- **ChapterBreakdownRow.tsx** — Not completed, `Quiz: {{score}}/{{max}}`, Grant extra attempt title, three CompletionLabel variants (teacher / quiz / submission), Undo / Complete.

**Teacher analytics page** (1 file, ~15 strings):
- **TeacherAnalytics.tsx** — Course fallback, load-failed ErrorState, back-to-courses + back-to-dashboard aria-label, page heading, Student Progress + Gradebook nav buttons, all 4 stat tiles (Total Students / Average Progress / Completed (100%) / Enrolled This Month), "Student Enrollments" with pluralised subhead, empty state, four column headers, Unknown-name fallback.

Plural-aware: `subheadingCount` uses i18next plural rules so Russian gets `_one`/`_few`/`_many`.

Parity now **912 EN / 942 RU**.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU: `/teacher/courses/:id/progress` — entire table + breadcrumb + page heading in Russian. Expand a row → summary stats + chapter breakdown in Russian incl. completion-label variants.
- [ ] `/teacher/courses/:id/analytics` — heading, 4 stat tiles, enrollments table, plural subhead all in Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
