### PR TITLE
i18n(admin): full admin dashboard surface → t() (6 files)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1122,7 +1122,70 @@
     "title": "Admin Dashboard",
     "subtitle": "Manage users, roles, and monitor platform activity",
     "tabOverview": "Overview",
-    "tabAudit": "Audit Log"
+    "tabAudit": "Audit Log",
+    "users": {
+      "title": "Users",
+      "selectAllAria": "Select all users",
+      "selectAriaPrefix": "Select {{name}}",
+      "deleteAriaPrefix": "Delete {{name}}",
+      "deleteSelfTooltip": "You cannot delete your own account",
+      "deleteTooltip": "Delete user",
+      "avatarAltPrefix": "{{name}} avatar",
+      "searchPlaceholder": "Search by name or email…",
+      "thName": "Name",
+      "thEmail": "Email",
+      "thRole": "Role",
+      "thJoined": "Joined",
+      "thActions": "Actions",
+      "selectAllN": "Select all {{count}}",
+      "selected": "{{count}} selected",
+      "bulkUpdating": "Updating...",
+      "bulkApply": "Apply",
+      "bulkClear": "Clear",
+      "emptyNoMatch": "No users match your search",
+      "emptyNoUsers": "No users found",
+      "showing": "Showing {{shown}} of {{total}} users",
+      "missingName": "—"
+    },
+    "pendingTeachers": {
+      "title": "Pending Teacher Approvals",
+      "missingName": "No name",
+      "registered": "Registered {{date}}",
+      "approve": "Approve",
+      "deny": "Deny"
+    },
+    "pendingCerts": {
+      "title": "Certificate Approvals",
+      "studentFallback": "Student",
+      "courseFallback": "Course",
+      "approvedBy": "Approved by {{name}}",
+      "approve": "Approve",
+      "reject": "Reject"
+    },
+    "overview": {
+      "totalUsers": "Total Users",
+      "totalCourses": "Total Courses",
+      "totalEnrollments": "Total Enrollments"
+    },
+    "audit": {
+      "filterAction": "Action",
+      "filterResource": "Resource",
+      "filterFrom": "From",
+      "filterTo": "To",
+      "filterClear": "Clear filters",
+      "filterAllActions": "All actions",
+      "filterAllResources": "All resources",
+      "title": "Audit Log",
+      "entriesCount": "{{count}} entries",
+      "empty": "No audit logs found",
+      "page": "Page {{page}} of {{total}}",
+      "thDate": "Date",
+      "thUser": "User",
+      "thAction": "Action",
+      "thResource": "Resource",
+      "thResourceId": "Resource ID",
+      "thIp": "IP"
+    }
   },
   "roles": {
     "student": "Student",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1154,7 +1154,70 @@
     "title": "Админ-панель",
     "subtitle": "Пользователи, роли и активность платформы",
     "tabOverview": "Обзор",
-    "tabAudit": "Журнал аудита"
+    "tabAudit": "Журнал аудита",
+    "users": {
+      "title": "Пользователи",
+      "selectAllAria": "Выбрать всех пользователей",
+      "selectAriaPrefix": "Выбрать {{name}}",
+      "deleteAriaPrefix": "Удалить {{name}}",
+      "deleteSelfTooltip": "Нельзя удалить собственный аккаунт",
+      "deleteTooltip": "Удалить пользователя",
+      "avatarAltPrefix": "Аватар {{name}}",
+      "searchPlaceholder": "Поиск по имени или email…",
+      "thName": "Имя",
+      "thEmail": "Email",
+      "thRole": "Роль",
+      "thJoined": "Дата регистрации",
+      "thActions": "Действия",
+      "selectAllN": "Выбрать все {{count}}",
+      "selected": "Выбрано: {{count}}",
+      "bulkUpdating": "Обновление...",
+      "bulkApply": "Применить",
+      "bulkClear": "Очистить",
+      "emptyNoMatch": "Нет пользователей по запросу",
+      "emptyNoUsers": "Пользователи не найдены",
+      "showing": "Показано {{shown}} из {{total}} пользователей",
+      "missingName": "—"
+    },
+    "pendingTeachers": {
+      "title": "Заявки преподавателей",
+      "missingName": "Без имени",
+      "registered": "Зарегистрирован {{date}}",
+      "approve": "Одобрить",
+      "deny": "Отклонить"
+    },
+    "pendingCerts": {
+      "title": "Сертификаты на финальное одобрение",
+      "studentFallback": "Студент",
+      "courseFallback": "Курс",
+      "approvedBy": "Одобрено: {{name}}",
+      "approve": "Одобрить",
+      "reject": "Отклонить"
+    },
+    "overview": {
+      "totalUsers": "Всего пользователей",
+      "totalCourses": "Всего курсов",
+      "totalEnrollments": "Всего записей"
+    },
+    "audit": {
+      "filterAction": "Действие",
+      "filterResource": "Объект",
+      "filterFrom": "С",
+      "filterTo": "По",
+      "filterClear": "Сбросить фильтры",
+      "filterAllActions": "Все действия",
+      "filterAllResources": "Все объекты",
+      "title": "Журнал аудита",
+      "entriesCount": "{{count}} записей",
+      "empty": "Записи журнала не найдены",
+      "page": "Стр. {{page}} из {{total}}",
+      "thDate": "Дата",
+      "thUser": "Пользователь",
+      "thAction": "Действие",
+      "thResource": "Объект",
+      "thResourceId": "ID объекта",
+      "thIp": "IP"
+    }
   },
   "roles": {
     "student": "Студент",

--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -1,4 +1,5 @@
 import { List, type RowComponentProps } from "react-window"
+import { useTranslation } from "react-i18next"
 import { Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { NativeSelect } from "@/components/ui/native-select"
@@ -44,9 +45,11 @@ function UserRow({
   onRoleChange,
   onDeleteUser,
 }: RowComponentProps<RowProps>) {
+  const { t } = useTranslation()
   const u = users[index]
   if (!u) return null
   const selected = selectedIds.has(u.id)
+  const displayName = u.full_name || u.email
   return (
     <div
       role="row"
@@ -61,14 +64,14 @@ function UserRow({
           checked={selected}
           onChange={() => onToggleSelect(u.id)}
           className="h-4 w-4 rounded border-input"
-          aria-label={`Select ${u.full_name || u.email}`}
+          aria-label={t("admin.users.selectAriaPrefix", { name: displayName })}
         />
       </div>
       <div role="cell" className="flex items-center gap-3 px-3 min-w-0">
         {u.avatar_url ? (
           <img
             src={toProxyImage(u.avatar_url)}
-            alt={`${u.full_name ?? u.email} avatar`}
+            alt={t("admin.users.avatarAltPrefix", { name: u.full_name ?? u.email })}
             className="h-8 w-8 rounded-full object-cover shrink-0"
             loading="lazy"
           />
@@ -77,7 +80,7 @@ function UserRow({
             {(u.full_name?.[0] ?? u.email[0] ?? "?").toUpperCase()}
           </div>
         )}
-        <span className="font-medium truncate">{u.full_name || "—"}</span>
+        <span className="font-medium truncate">{u.full_name || t("admin.users.missingName")}</span>
       </div>
       <div role="cell" className="px-3 text-muted-foreground truncate">
         {u.email}
@@ -94,10 +97,10 @@ function UserRow({
           disabled={updatingId === u.id || u.id === currentUserId}
           onChange={(e) => onRoleChange(u.id, e.target.value as UserRole)}
         >
-          <option value="student">Student</option>
-          <option value="pending_teacher">Pending Teacher</option>
-          <option value="teacher">Teacher</option>
-          <option value="admin">Admin</option>
+          <option value="student">{t("roles.student")}</option>
+          <option value="pending_teacher">{t("roles.pendingTeacher")}</option>
+          <option value="teacher">{t("roles.teacher")}</option>
+          <option value="admin">{t("roles.admin")}</option>
         </NativeSelect>
       </div>
       <div role="cell" className="px-3 text-muted-foreground">
@@ -110,8 +113,8 @@ function UserRow({
           className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
           disabled={updatingId === u.id || u.id === currentUserId}
           onClick={() => onDeleteUser(u)}
-          aria-label={`Delete ${u.full_name || u.email}`}
-          title={u.id === currentUserId ? "You cannot delete your own account" : "Delete user"}
+          aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
+          title={u.id === currentUserId ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
         >
           <Trash2 className="h-4 w-4" />
         </Button>
@@ -131,6 +134,7 @@ export default function VirtualAdminUsers({
   onRoleChange,
   onDeleteUser,
 }: VirtualAdminUsersProps) {
+  const { t } = useTranslation()
   // Height budget: enough to show ~10 rows before the window scrolls. Keeps the
   // admin dashboard from running off the viewport on long tenant lists.
   const height = Math.min(users.length * ROW_HEIGHT, 640)
@@ -142,11 +146,11 @@ export default function VirtualAdminUsers({
         className="grid grid-cols-[40px_2fr_2fr_2fr_1fr_40px] items-center border-b px-3 py-3 text-xs font-medium text-muted-foreground"
       >
         <div role="columnheader" />
-        <div role="columnheader" className="px-3">Name</div>
-        <div role="columnheader" className="px-3">Email</div>
-        <div role="columnheader" className="px-3">Role</div>
-        <div role="columnheader" className="px-3">Joined</div>
-        <div role="columnheader" aria-label="Actions" />
+        <div role="columnheader" className="px-3">{t("admin.users.thName")}</div>
+        <div role="columnheader" className="px-3">{t("admin.users.thEmail")}</div>
+        <div role="columnheader" className="px-3">{t("admin.users.thRole")}</div>
+        <div role="columnheader" className="px-3">{t("admin.users.thJoined")}</div>
+        <div role="columnheader" aria-label={t("admin.users.thActions")} />
       </div>
       <List
         rowComponent={UserRow}

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { NativeSelect } from "@/components/ui/native-select"
@@ -50,6 +51,7 @@ export function AuditLogTab({
   onReset,
   onPageChange,
 }: Props) {
+  const { t } = useTranslation()
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
 
   return (
@@ -57,12 +59,12 @@ export function AuditLogTab({
       <Card>
         <CardContent className="p-4">
           <div className="flex flex-wrap items-end gap-3">
-            <FilterSelect label="Action" value={action} onChange={onAction} options={ACTION_OPTIONS} placeholder="All actions" />
-            <FilterSelect label="Resource" value={resource} onChange={onResource} options={RESOURCE_OPTIONS} placeholder="All resources" />
-            <FilterDate label="From" value={dateFrom} onChange={onDateFrom} />
-            <FilterDate label="To" value={dateTo} onChange={onDateTo} />
+            <FilterSelect label={t("admin.audit.filterAction")} value={action} onChange={onAction} options={ACTION_OPTIONS} placeholder={t("admin.audit.filterAllActions")} />
+            <FilterSelect label={t("admin.audit.filterResource")} value={resource} onChange={onResource} options={RESOURCE_OPTIONS} placeholder={t("admin.audit.filterAllResources")} />
+            <FilterDate label={t("admin.audit.filterFrom")} value={dateFrom} onChange={onDateFrom} />
+            <FilterDate label={t("admin.audit.filterTo")} value={dateTo} onChange={onDateTo} />
             <Button variant="ghost" size="sm" onClick={onReset} className="h-9">
-              Clear filters
+              {t("admin.audit.filterClear")}
             </Button>
           </div>
         </CardContent>
@@ -72,9 +74,9 @@ export function AuditLogTab({
         <CardHeader>
           <CardTitle className="text-xl flex items-center gap-2">
             <FileText className="h-5 w-5 shrink-0" strokeWidth={1.75} aria-hidden />
-            Audit Log
+            {t("admin.audit.title")}
             <span className="text-sm font-normal text-muted-foreground ml-2">
-              {total.toLocaleString()} entries
+              {t("admin.audit.entriesCount", { count: total })}
             </span>
           </CardTitle>
         </CardHeader>
@@ -84,14 +86,14 @@ export function AuditLogTab({
           ) : logs.length === 0 ? (
             <div className="flex flex-col items-center py-16 text-center">
               <FileText className="mb-3 h-12 w-12 text-muted-foreground/40" strokeWidth={1.75} aria-hidden />
-              <p className="text-muted-foreground">No audit logs found</p>
+              <p className="text-muted-foreground">{t("admin.audit.empty")}</p>
             </div>
           ) : (
             <>
               <AuditTable logs={logs} userMap={userMap} />
               <div className="flex items-center justify-between px-5 pb-1 pt-4">
                 <p className="text-xs text-muted-foreground">
-                  Page {page} of {totalPages}
+                  {t("admin.audit.page", { page, total: totalPages })}
                 </p>
                 <div className="flex items-center gap-2">
                   <Button
@@ -178,17 +180,18 @@ function AuditTable({
   logs: AuditLogEntry[]
   userMap: Record<string, string>
 }) {
+  const { t } = useTranslation()
   return (
     <div className="overflow-x-auto -mx-6">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b text-left">
-            <th className="px-6 py-3 font-medium text-muted-foreground">Date</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">User</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">Action</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">Resource</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">Resource ID</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">IP</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thDate")}</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thUser")}</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thAction")}</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thResource")}</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thResourceId")}</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thIp")}</th>
           </tr>
         </thead>
         <tbody className="divide-y">

--- a/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
+++ b/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Card, CardContent } from "@/components/ui/card"
 import { Users, BookOpen, GraduationCap } from "lucide-react"
 import type { AdminStats } from "./constants"
@@ -8,23 +9,24 @@ interface Props {
 }
 
 const CARDS = [
-  { key: "users", label: "Total Users", icon: Users },
-  { key: "courses", label: "Total Courses", icon: BookOpen },
-  { key: "enrollments", label: "Total Enrollments", icon: GraduationCap },
+  { key: "users", i18nKey: "admin.overview.totalUsers", icon: Users },
+  { key: "courses", i18nKey: "admin.overview.totalCourses", icon: BookOpen },
+  { key: "enrollments", i18nKey: "admin.overview.totalEnrollments", icon: GraduationCap },
 ] as const
 
 /** Three-card stats row on the admin overview tab. */
 export function OverviewStats({ stats, loading }: Props) {
+  const { t } = useTranslation()
   return (
     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-      {CARDS.map(({ key, label, icon: Icon }) => (
-        <Card key={label}>
+      {CARDS.map(({ key, i18nKey, icon: Icon }) => (
+        <Card key={key}>
           <CardContent className="flex items-center gap-4 p-5">
             <div className="rounded-md bg-muted p-3">
               <Icon className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} aria-hidden />
             </div>
             <div>
-              <p className="text-sm text-muted-foreground">{label}</p>
+              <p className="text-sm text-muted-foreground">{t(i18nKey)}</p>
               <p className="text-2xl font-bold">
                 {loading ? "—" : stats[key].toLocaleString()}
               </p>

--- a/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -21,6 +22,7 @@ interface Props {
 
 /** Certificates pending final admin approval after a teacher signed off. */
 export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props) {
+  const { t } = useTranslation()
   if (certs.length === 0) return null
 
   return (
@@ -28,7 +30,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
       <CardHeader>
         <CardTitle className="text-xl flex items-center gap-2">
           <Award className="h-5 w-5 text-primary" strokeWidth={1.75} aria-hidden />
-          Certificate Approvals
+          {t("admin.pendingCerts.title")}
           <Badge variant="default" className="font-normal">
             {certs.length}
           </Badge>
@@ -42,15 +44,15 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
               className="flex items-center justify-between rounded-md border border-l-[3px] border-l-primary/60 bg-primary/5 p-4"
             >
               <div className="min-w-0">
-                <p className="font-medium truncate">{cert.student_name || "Student"}</p>
+                <p className="font-medium truncate">{cert.student_name || t("admin.pendingCerts.studentFallback")}</p>
                 <p className="text-sm text-muted-foreground truncate">
-                  {cert.course_title || "Course"}
+                  {cert.course_title || t("admin.pendingCerts.courseFallback")}
                 </p>
                 <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
                   {cert.approved_by_name && (
                     <span className="flex items-center gap-1">
                       <CheckCircle className="h-3.5 w-3.5 text-success" strokeWidth={1.75} aria-hidden />
-                      Approved by {cert.approved_by_name}
+                      {t("admin.pendingCerts.approvedBy", { name: cert.approved_by_name })}
                     </span>
                   )}
                   {cert.approved_at && (
@@ -68,7 +70,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
                   disabled={actionId === cert.id}
                 >
                   <CheckCircle className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
-                  Approve
+                  {t("admin.pendingCerts.approve")}
                 </Button>
                 <Button
                   size="sm"
@@ -78,7 +80,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
                   className="text-destructive hover:text-destructive"
                 >
                   <XCircle className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
-                  Reject
+                  {t("admin.pendingCerts.reject")}
                 </Button>
               </div>
             </div>

--- a/frontend/src/pages/Admin/dashboard/PendingTeachersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingTeachersCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -15,6 +16,7 @@ interface Props {
 
 /** Warning-accented list of users whose role is `pending_teacher`. */
 export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: Props) {
+  const { t } = useTranslation()
   if (pending.length === 0) return null
 
   return (
@@ -22,7 +24,7 @@ export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: 
       <CardHeader>
         <CardTitle className="text-xl flex items-center gap-2">
           <Clock className="h-5 w-5 text-warning" strokeWidth={1.75} aria-hidden />
-          Pending Teacher Approvals
+          {t("admin.pendingTeachers.title")}
           <Badge variant="warning" className="font-normal">
             {pending.length}
           </Badge>
@@ -39,7 +41,7 @@ export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: 
                 {u.avatar_url ? (
                   <img
                     src={toProxyImage(u.avatar_url)}
-                    alt={`${u.full_name ?? u.email} avatar`}
+                    alt={t("admin.users.avatarAltPrefix", { name: u.full_name ?? u.email })}
                     className="h-10 w-10 rounded-full object-cover"
                   />
                 ) : (
@@ -48,17 +50,17 @@ export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: 
                   </div>
                 )}
                 <div className="min-w-0">
-                  <p className="font-medium truncate">{u.full_name || "No name"}</p>
+                  <p className="font-medium truncate">{u.full_name || t("admin.pendingTeachers.missingName")}</p>
                   <p className="text-sm text-muted-foreground truncate">{u.email}</p>
                   <p className="text-xs text-muted-foreground">
-                    Registered {formatDate(u.created_at)}
+                    {t("admin.pendingTeachers.registered", { date: formatDate(u.created_at) })}
                   </p>
                 </div>
               </div>
               <div className="flex items-center gap-2 shrink-0 ml-4">
                 <Button size="sm" onClick={() => onApprove(u)} disabled={updatingId === u.id}>
                   <CheckCircle className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
-                  Approve
+                  {t("admin.pendingTeachers.approve")}
                 </Button>
                 <Button
                   size="sm"
@@ -68,7 +70,7 @@ export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: 
                   className="text-destructive hover:text-destructive"
                 >
                   <XCircle className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
-                  Deny
+                  {t("admin.pendingTeachers.deny")}
                 </Button>
               </div>
             </div>

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { NativeSelect } from "@/components/ui/native-select"
@@ -65,26 +66,27 @@ export function UsersCard({
   onRoleChange,
   onDeleteUser,
 }: Props) {
+  const { t } = useTranslation()
   const allFilteredSelected =
     filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
 
   return (
     <Card>
       <CardHeader className="flex-row items-center justify-between gap-4 space-y-0 flex-wrap">
-        <CardTitle className="text-xl">Users</CardTitle>
+        <CardTitle className="text-xl">{t("admin.users.title")}</CardTitle>
         <div className="flex items-center gap-3 flex-wrap">
           {selectedIds.size > 0 && (
             <div className="flex items-center gap-2 bg-primary/5 border border-primary/20 rounded-lg px-3 py-1.5">
-              <span className="text-xs font-medium">{selectedIds.size} selected</span>
+              <span className="text-xs font-medium">{t("admin.users.selected", { count: selectedIds.size })}</span>
               <NativeSelect
                 fieldSize="xs"
                 value={bulkRole}
                 onChange={(e) => onBulkRoleChange(e.target.value as UserRole)}
               >
-                <option value="student">Student</option>
-                <option value="pending_teacher">Pending Teacher</option>
-                <option value="teacher">Teacher</option>
-                <option value="admin">Admin</option>
+                <option value="student">{t("roles.student")}</option>
+                <option value="pending_teacher">{t("roles.pendingTeacher")}</option>
+                <option value="teacher">{t("roles.teacher")}</option>
+                <option value="admin">{t("roles.admin")}</option>
               </NativeSelect>
               <Button
                 size="sm"
@@ -92,7 +94,7 @@ export function UsersCard({
                 onClick={onApplyBulkRole}
                 disabled={bulkUpdating}
               >
-                {bulkUpdating ? "Updating..." : "Apply"}
+                {bulkUpdating ? t("admin.users.bulkUpdating") : t("admin.users.bulkApply")}
               </Button>
               <Button
                 size="sm"
@@ -100,14 +102,14 @@ export function UsersCard({
                 className="h-7 text-xs"
                 onClick={onClearSelection}
               >
-                Clear
+                {t("admin.users.bulkClear")}
               </Button>
             </div>
           )}
           <div className="relative w-full max-w-xs">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
             <Input
-              placeholder="Search by name or email…"
+              placeholder={t("admin.users.searchPlaceholder")}
               value={searchInput}
               onChange={(e) => onSearchInputChange(e.target.value.slice(0, searchMaxLength))}
               maxLength={searchMaxLength}
@@ -129,10 +131,10 @@ export function UsersCard({
                 checked={allFilteredSelected}
                 onChange={onToggleSelectAll}
                 className="h-4 w-4 rounded border-input"
-                aria-label="Select all users"
+                aria-label={t("admin.users.selectAllAria")}
               />
               <span className="text-xs text-muted-foreground">
-                Select all {filtered.length}
+                {t("admin.users.selectAllN", { count: filtered.length })}
               </span>
             </div>
             <VirtualAdminUsers
@@ -161,7 +163,7 @@ export function UsersCard({
         )}
         {!loading && filtered.length > 0 && (
           <p className="text-xs text-muted-foreground mt-4 px-6">
-            Showing {filtered.length} of {users.length} users
+            {t("admin.users.showing", { shown: filtered.length, total: users.length })}
           </p>
         )}
       </CardContent>
@@ -170,11 +172,14 @@ export function UsersCard({
 }
 
 function EmptyUsers({ hasQuery }: { hasQuery: boolean }) {
+  const { t } = useTranslation()
   return (
     <div className="flex flex-col items-center py-16 text-center">
       <Users className="h-12 w-12 text-muted-foreground/40 mb-3" />
       <p className="text-muted-foreground">
-        {hasQuery ? "No users match your search" : "No users found"}
+        {hasQuery
+          ? t("admin.users.emptyNoMatch")
+          : t("admin.users.emptyNoUsers")}
       </p>
     </div>
   )
@@ -201,6 +206,7 @@ function UsersTable({
   onRoleChange,
   onDeleteUser,
 }: UsersTableProps) {
+  const { t } = useTranslation()
   const allFilteredSelected =
     filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
 
@@ -215,14 +221,14 @@ function UsersTable({
                 checked={allFilteredSelected}
                 onChange={onToggleSelectAll}
                 className="h-4 w-4 rounded border-input"
-                aria-label="Select all users"
+                aria-label={t("admin.users.selectAllAria")}
               />
             </th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">Name</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">Email</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">Role</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">Joined</th>
-            <th className="px-6 py-3 w-10" aria-label="Actions" />
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thName")}</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thEmail")}</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thRole")}</th>
+            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thJoined")}</th>
+            <th className="px-6 py-3 w-10" aria-label={t("admin.users.thActions")} />
           </tr>
         </thead>
         <tbody className="divide-y">
@@ -263,6 +269,8 @@ function UserRow({
   onRoleChange,
   onDeleteUser,
 }: UserRowProps) {
+  const { t } = useTranslation()
+  const displayName = user.full_name || user.email
   return (
     <tr
       className={`hover:bg-muted/50 transition-colors ${
@@ -275,7 +283,7 @@ function UserRow({
           checked={selected}
           onChange={() => onToggleSelect(user.id)}
           className="h-4 w-4 rounded border-input"
-          aria-label={`Select ${user.full_name || user.email}`}
+          aria-label={t("admin.users.selectAriaPrefix", { name: displayName })}
         />
       </td>
       <td className="px-6 py-3">
@@ -283,7 +291,7 @@ function UserRow({
           {user.avatar_url ? (
             <img
               src={toProxyImage(user.avatar_url)}
-              alt={`${user.full_name ?? user.email} avatar`}
+              alt={t("admin.users.avatarAltPrefix", { name: user.full_name ?? user.email })}
               className="h-8 w-8 rounded-full object-cover"
             />
           ) : (
@@ -291,7 +299,7 @@ function UserRow({
               {(user.full_name?.[0] ?? user.email[0] ?? "?").toUpperCase()}
             </div>
           )}
-          <span className="font-medium">{user.full_name || "—"}</span>
+          <span className="font-medium">{user.full_name || t("admin.users.missingName")}</span>
         </div>
       </td>
       <td className="px-6 py-3 text-muted-foreground">{user.email}</td>
@@ -308,10 +316,10 @@ function UserRow({
             disabled={updating || isSelf}
             onChange={(e) => onRoleChange(user.id, e.target.value as UserRole)}
           >
-            <option value="student">Student</option>
-            <option value="pending_teacher">Pending Teacher</option>
-            <option value="teacher">Teacher</option>
-            <option value="admin">Admin</option>
+            <option value="student">{t("roles.student")}</option>
+            <option value="pending_teacher">{t("roles.pendingTeacher")}</option>
+            <option value="teacher">{t("roles.teacher")}</option>
+            <option value="admin">{t("roles.admin")}</option>
           </NativeSelect>
         </div>
       </td>
@@ -325,8 +333,8 @@ function UserRow({
           className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
           disabled={updating || isSelf}
           onClick={() => onDeleteUser(user)}
-          aria-label={`Delete ${user.full_name || user.email}`}
-          title={isSelf ? "You cannot delete your own account" : "Delete user"}
+          aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
+          title={isSelf ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
         >
           <Trash2 className="h-4 w-4" />
         </Button>


### PR DESCRIPTION
## Summary
12th Phase-2 batch — **entire admin dashboard** surface. Every column, button, dialog, filter, aria-label, and fallback now routes through `t()`.

- **OverviewStats** — 3 stat cards (Total Users / Total Courses / Total Enrollments) keyed by i18n string instead of hardcoded label array.
- **PendingTeachersCard** — section title with badge count, missing-name fallback, "Registered {{date}}", Approve / Deny buttons, avatar alt shared with UsersCard.
- **PendingCertsCard (admin variant)** — section title, student/course fallbacks, "Approved by {{name}}" line, Approve / Reject.
- **UsersCard** — section title, search placeholder, all 5 column headers + Actions sr-only header, select-all aria, bulk-action bar (`{{count}} selected` / Updating… / Apply / Clear), four role `<option>`s via existing `roles.*` keys, every fallback (— / no-match / no-users / "Showing {n} of {total} users"), delete-aria with name interpolation, delete-self vs delete-user tooltips.
- **VirtualAdminUsers** (react-window list variant of UsersCard) — same column headers + per-row strings, all driven by the same `admin.users.*` keys.
- **AuditLogTab** — 4 filter labels + 2 "All …" placeholders + Clear filters, section title, `{{count}} entries`, empty state, "Page X of Y" pagination, all 6 column headers.

New i18n nesting under `admin.{users,pendingTeachers,pendingCerts,overview,audit}.*`. Existing top-level `roles.*` reused for the 4 role `<option>`s wherever they appear (no duplication).

Parity now **1019 EN / 1051 RU** — crossed the 1000-key mark.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU as admin: `/admin` overview tab — 3 stat cards, pending sections (if any), users table all in Russian.
- [ ] Bulk-select users → bulk-action bar in Russian incl. role dropdown.
- [ ] Switch to Audit Log tab → filters + table + pagination in Russian.
- [ ] With >50 users in the system: virtualized list renders Russian headers too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
