### PR TITLE
i18n(calendar + tail): finish Phase-2 — last hardcoded surfaces

### DIFF
--- a/frontend/src/components/announcements/AnnouncementBanner.tsx
+++ b/frontend/src/components/announcements/AnnouncementBanner.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react"
+import { useTranslation } from "react-i18next"
 import { coursesService } from "@/services/courses"
 import { useAuth } from "@/context/useAuth"
 import type { Announcement } from "@/types"
@@ -6,6 +7,7 @@ import { Megaphone, X } from "lucide-react"
 
 export default function AnnouncementBanner() {
   const { user } = useAuth()
+  const { t } = useTranslation()
   const [announcement, setAnnouncement] = useState<Announcement | null>(null)
   const [dismissed, setDismissed] = useState(false)
 
@@ -44,7 +46,7 @@ export default function AnnouncementBanner() {
         <button
           onClick={() => setDismissed(true)}
           className="rounded p-1 text-muted-foreground hover:bg-muted"
-          aria-label="Dismiss announcement"
+          aria-label={t("common.dismissAnnouncement")}
         >
           <X className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
         </button>

--- a/frontend/src/components/layout/ScrollToTop.tsx
+++ b/frontend/src/components/layout/ScrollToTop.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ChevronUp } from "lucide-react";
 
 export default function ScrollToTop() {
+  const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -26,7 +28,7 @@ export default function ScrollToTop() {
   return (
     <button
       onClick={scrollToTop}
-      aria-label="Scroll to top"
+      aria-label={t("common.scrollToTop")}
       className={`
         fixed bottom-6 right-6 z-50
         flex items-center justify-center

--- a/frontend/src/components/patterns/InlineEdit.tsx
+++ b/frontend/src/components/patterns/InlineEdit.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { useTranslation } from "react-i18next"
 import { Check, Pencil, X, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -27,7 +28,7 @@ const sizeClasses: Record<Size, string> = {
 export function InlineEdit({
   value,
   onSave,
-  placeholder = "Click to edit",
+  placeholder,
   size = "body",
   multiline = false,
   maxLength,
@@ -37,6 +38,8 @@ export function InlineEdit({
   textClassName,
   ariaLabel,
 }: InlineEditProps) {
+  const { t } = useTranslation()
+  const resolvedPlaceholder = placeholder ?? t("inlineEdit.defaultPlaceholder")
   const [editing, setEditing] = React.useState(false)
   const [draft, setDraft] = React.useState(value)
   const [saving, setSaving] = React.useState(false)
@@ -128,7 +131,7 @@ export function InlineEdit({
       onKeyDown,
       onBlur,
       maxLength,
-      placeholder,
+      placeholder: resolvedPlaceholder,
       disabled: saving,
       "aria-label": ariaLabel,
       className: cn(
@@ -163,7 +166,7 @@ export function InlineEdit({
                 className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => void commit()}
-                aria-label="Save"
+                aria-label={t("inlineEdit.save")}
               >
                 <Check className="h-4 w-4" />
               </button>
@@ -172,7 +175,7 @@ export function InlineEdit({
                 className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={cancel}
-                aria-label="Cancel"
+                aria-label={t("inlineEdit.cancel")}
               >
                 <X className="h-4 w-4" />
               </button>
@@ -184,7 +187,7 @@ export function InlineEdit({
   }
 
   const isEmpty = !value.trim()
-  const displayText = isEmpty ? placeholder : value
+  const displayText = isEmpty ? resolvedPlaceholder : value
 
   if (disabled) {
     return (
@@ -209,7 +212,7 @@ export function InlineEdit({
       <button
         type="button"
         onClick={start}
-        aria-label={ariaLabel ?? `Edit ${placeholder.toLowerCase()}`}
+        aria-label={ariaLabel ?? t("inlineEdit.editAria", { what: resolvedPlaceholder.toLowerCase() })}
         className={cn(
           "flex-1 min-w-0 cursor-text rounded-md px-2 py-1 text-left transition-colors text-wrap-safe hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           multiline && "whitespace-pre-line",

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { useTranslation } from "react-i18next"
 import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -24,25 +25,28 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
+>(({ className, children, ...props }, ref) => {
+  const { t } = useTranslation()
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+          <span className="sr-only">{t("common.close")}</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+})
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { useTranslation } from "react-i18next"
 import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
@@ -50,18 +51,21 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ComponentRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
-      {children}
-      <SheetPrimitive.Close className="absolute right-3 top-3 rounded-md p-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
-        <X className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
+>(({ side = "right", className, children, ...props }, ref) => {
+  const { t } = useTranslation()
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+        {children}
+        <SheetPrimitive.Close className="absolute right-3 top-3 rounded-md p-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+          <X className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          <span className="sr-only">{t("common.close")}</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+})
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -12,7 +12,16 @@
     "search": "Search",
     "signIn": "Sign In",
     "signOut": "Sign Out",
-    "register": "Register"
+    "register": "Register",
+    "close": "Close",
+    "scrollToTop": "Scroll to top",
+    "dismissAnnouncement": "Dismiss announcement"
+  },
+  "inlineEdit": {
+    "defaultPlaceholder": "Click to edit",
+    "save": "Save",
+    "cancel": "Cancel",
+    "editAria": "Edit {{what}}"
   },
   "header": {
     "courses": "Courses",
@@ -748,7 +757,21 @@
     "subtitle": "Your deadlines, events, and schedule in one place",
     "filterByCourse": "Filter by course",
     "allCourses": "All Courses",
-    "retry": "Retry"
+    "retry": "Retry",
+    "prevMonth": "Previous month",
+    "nextMonth": "Next month",
+    "today": "Today",
+    "moreEvents": "+{{count}} more",
+    "selectedDayEmpty": "No events on this day",
+    "upcomingTitle": "Upcoming (14 days)",
+    "upcomingEmpty": "No upcoming events",
+    "overdue": "Overdue",
+    "eventTypes": {
+      "deadline": "Deadline",
+      "live_session": "Live session",
+      "exam": "Exam",
+      "other": "Other"
+    }
   },
   "teacher": {
     "dashboardTitle": "My Courses",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -12,7 +12,16 @@
     "search": "Поиск",
     "signIn": "Войти",
     "signOut": "Выйти",
-    "register": "Регистрация"
+    "register": "Регистрация",
+    "close": "Закрыть",
+    "scrollToTop": "Наверх",
+    "dismissAnnouncement": "Закрыть объявление"
+  },
+  "inlineEdit": {
+    "defaultPlaceholder": "Нажмите для редактирования",
+    "save": "Сохранить",
+    "cancel": "Отмена",
+    "editAria": "Изменить {{what}}"
   },
   "header": {
     "courses": "Курсы",
@@ -768,7 +777,21 @@
     "subtitle": "Сроки, события и расписание в одном месте",
     "filterByCourse": "Фильтр по курсу",
     "allCourses": "Все курсы",
-    "retry": "Повторить"
+    "retry": "Повторить",
+    "prevMonth": "Предыдущий месяц",
+    "nextMonth": "Следующий месяц",
+    "today": "Сегодня",
+    "moreEvents": "+ещё {{count}}",
+    "selectedDayEmpty": "В этот день событий нет",
+    "upcomingTitle": "Ближайшие (14 дней)",
+    "upcomingEmpty": "Нет предстоящих событий",
+    "overdue": "Просрочено",
+    "eventTypes": {
+      "deadline": "Дедлайн",
+      "live_session": "Прямая сессия",
+      "exam": "Экзамен",
+      "other": "Другое"
+    }
   },
   "teacher": {
     "dashboardTitle": "Мои курсы",

--- a/frontend/src/pages/Calendar/MonthGrid.tsx
+++ b/frontend/src/pages/Calendar/MonthGrid.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -35,6 +36,7 @@ export function MonthGrid({
   onNextMonth,
   onGoToday,
 }: MonthGridProps) {
+  const { t } = useTranslation();
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -48,19 +50,19 @@ export function MonthGrid({
               size="sm"
               className="h-8 w-8 p-0"
               onClick={onPrevMonth}
-              aria-label="Previous month"
+              aria-label={t("calendar.prevMonth")}
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
             <Button variant="outline" size="sm" className="h-8 text-xs" onClick={onGoToday}>
-              Today
+              {t("calendar.today")}
             </Button>
             <Button
               variant="ghost"
               size="sm"
               className="h-8 w-8 p-0"
               onClick={onNextMonth}
-              aria-label="Next month"
+              aria-label={t("calendar.nextMonth")}
             >
               <ChevronRight className="h-4 w-4" />
             </Button>
@@ -122,7 +124,7 @@ export function MonthGrid({
                     })}
                     {dayEvents.length > 3 && (
                       <span className="text-[9px] text-muted-foreground pl-1">
-                        +{dayEvents.length - 3} more
+                        {t("calendar.moreEvents", { count: dayEvents.length - 3 })}
                       </span>
                     )}
                   </div>
@@ -136,8 +138,8 @@ export function MonthGrid({
           {Object.entries(EVENT_COLORS).map(([type, color]) => (
             <span key={type} className="flex items-center gap-1">
               <span className={`w-2 h-2 rounded-full ${color.dot}`} />
-              <span className="capitalize text-muted-foreground">
-                {type.replace("_", " ")}
+              <span className="text-muted-foreground">
+                {t(`calendar.eventTypes.${type}`, { defaultValue: type.replace("_", " ") })}
               </span>
             </span>
           ))}

--- a/frontend/src/pages/Calendar/SelectedDayPanel.tsx
+++ b/frontend/src/pages/Calendar/SelectedDayPanel.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { BookOpen, CalendarDays, Clock } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -13,6 +14,7 @@ interface SelectedDayPanelProps {
 }
 
 export function SelectedDayPanel({ selectedDay, events }: SelectedDayPanelProps) {
+  const { t } = useTranslation();
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -28,7 +30,7 @@ export function SelectedDayPanel({ selectedDay, events }: SelectedDayPanelProps)
       <CardContent>
         {events.length === 0 ? (
           <p className="text-sm text-muted-foreground py-3 text-center">
-            No events on this day
+            {t("calendar.selectedDayEmpty")}
           </p>
         ) : (
           <div className="space-y-2">
@@ -48,7 +50,7 @@ export function SelectedDayPanel({ selectedDay, events }: SelectedDayPanelProps)
                           <Clock className="h-2.5 w-2.5" />
                           {formatTime(evt.event_date)}
                         </span>
-                        <span className="capitalize">{evt.event_type.replace("_", " ")}</span>
+                        <span>{t(`calendar.eventTypes.${evt.event_type}`, { defaultValue: evt.event_type.replace("_", " ") })}</span>
                       </div>
                       {evt.course_title && (
                         <Link

--- a/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
+++ b/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
@@ -1,4 +1,5 @@
 import { Clock } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { CalendarEvent } from "@/types";
@@ -14,17 +15,18 @@ interface UpcomingEventsPanelProps {
  * get flagged as overdue so the student can act on them.
  */
 export function UpcomingEventsPanel({ events }: UpcomingEventsPanelProps) {
+  const { t } = useTranslation();
   return (
     <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium flex items-center gap-2">
           <Clock className="h-4 w-4 text-muted-foreground" />
-          Upcoming (14 days)
+          {t("calendar.upcomingTitle")}
         </CardTitle>
       </CardHeader>
       <CardContent>
         {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-4 text-center">No upcoming events</p>
+          <p className="text-sm text-muted-foreground py-4 text-center">{t("calendar.upcomingEmpty")}</p>
         ) : (
           <div className="space-y-2">
             {events.map((evt) => {
@@ -52,7 +54,7 @@ export function UpcomingEventsPanel({ events }: UpcomingEventsPanelProps) {
                       <span>{formatShortDate(evt.event_date)}</span>
                       <span>{formatTime(evt.event_date)}</span>
                       {overdue && (
-                        <span className="font-medium text-destructive">Overdue</span>
+                        <span className="font-medium text-destructive">{t("calendar.overdue")}</span>
                       )}
                     </div>
                     {evt.course_title && (


### PR DESCRIPTION
## Summary
**Phase-2 final batch.** Last hardcoded surfaces — Calendar page trio + small UI primitives tail.

Calendar (3 files):
- **MonthGrid** — prev/next month aria-labels, "Today" button, "+N more" overflow line with `{{count}}` interpolation, legend labels via `calendar.eventTypes.*`.
- **SelectedDayPanel** — "No events on this day" empty state, per-event event-type label reusing the same `calendar.eventTypes.*` keys.
- **UpcomingEventsPanel** — "Upcoming (14 days)" title, empty state, "Overdue" deadline marker.

Misc / UI primitives:
- **ui/dialog.tsx** — close-button sr-only label via `common.close`.
- **ui/sheet.tsx** — same.
- **layout/ScrollToTop.tsx** — aria-label.
- **announcements/AnnouncementBanner.tsx** — dismiss aria-label.
- **patterns/InlineEdit.tsx** — Save / Cancel button aria-labels, default placeholder ("Click to edit"), synthesised "Edit {{what}}" aria-label — all flow through new `inlineEdit.*` namespace.

Added shared `common.{close,scrollToTop,dismissAnnouncement}` so any future UI primitive can reuse.

**Phase-2 i18n cleanup is now done.** Parity now **1038 EN / 1070 RU**.

## Test plan
- [x] `npm run lint` (0 warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (107 tests pass)
- [x] `npm run i18n:check` (✓ parity)
- [ ] Visual smoke RU: `/calendar` — month grid + selected day + upcoming panel in Russian; event-type labels (Дедлайн / Прямая сессия / Экзамен / Другое) consistent everywhere.
- [ ] Any modal/sheet — close button has Russian sr-only "Закрыть".
- [ ] Scroll the page → "Наверх" floating button aria-label in Russian.
- [ ] Teacher / admin inline-edit fields with no explicit placeholder fall back to "Нажмите для редактирования".

## Next
Now that no hardcoded strings remain (per the prior audit), the foundation is ready for the planned **Phase 3 ESLint rule** that blocks new hardcoded JSX text. That's a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
