### PR TITLE
chore(rebrand): final cleanup — drop all biblie-school stragglers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # Roadmap
 
-This document outlines the planned direction for Bible School LMS. It is a
+This document outlines the planned direction for Equip. It is a
 living document — priorities may shift based on community feedback and
 contributor interest.
 
 Have an idea? Open a
-[feature request](https://github.com/ArVaViT/biblie-school/issues/new?template=feature_request.yml)
-or start a [discussion](https://github.com/ArVaViT/biblie-school/discussions).
+[feature request](https://github.com/ArVaViT/equip/issues/new?template=feature_request.yml)
+or start a [discussion](https://github.com/ArVaViT/equip/discussions).
 
 ## Legend
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -48,12 +48,9 @@ JWT_ALGORITHM=HS256
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173,https://equipbible.com,https://www.equipbible.com,https://equip-frontend.vercel.app
 
 # Regex matched against the Origin header. Covers Vercel preview/branch aliases
-# (equip-frontend-<hash>.vercel.app) and any localhost port, so PR previews
-# and local dev Just Work without updating CORS_ORIGINS on each deploy. The
-# `(?:equip-frontend|biblie-school-frontend)` alternation keeps the legacy
-# slug accepted during the rebrand transition; drop the `biblie-school-` arm
-# once any old preview URLs have stopped circulating.
-# CORS_ORIGIN_REGEX=^https://(?:equip-frontend|biblie-school-frontend)(?:-[\w-]+)?\.vercel\.app$|^https://(?:www\.)?equipbible\.com$|^http://localhost:\d+$
+# (equip-frontend-<hash>.vercel.app) and any localhost port, so PR previews and
+# local dev Just Work without updating CORS_ORIGINS on each deploy.
+# CORS_ORIGIN_REGEX=^https://equip-frontend(?:-[\w-]+)?\.vercel\.app$|^https://(?:www\.)?equipbible\.com$|^http://localhost:\d+$
 
 # ──── Gemini (machine translation) ───────────────────────────────────────────
 # Google AI Studio API key for content translation (RU↔EN). Server-only;

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,12 +27,8 @@ class Settings(BaseSettings):
         "https://equipbible.com,https://www.equipbible.com,"
         "https://equip-frontend.vercel.app"
     )
-    # Accept both the new `equip-frontend` slug AND the legacy
-    # `biblie-school-frontend` slug during the rebrand transition. Drop the
-    # legacy alternation once the rename has settled and any old preview
-    # URLs have stopped circulating.
     CORS_ORIGIN_REGEX: str = (
-        r"^https://(?:equip-frontend|biblie-school-frontend)(?:-[\w-]+)?\.vercel\.app$"
+        r"^https://equip-frontend(?:-[\w-]+)?\.vercel\.app$"
         r"|^https://(?:www\.)?equipbible\.com$"
         r"|^http://localhost:\d+$"
     )

--- a/docs/marketing/README.md
+++ b/docs/marketing/README.md
@@ -6,7 +6,7 @@ consumed.
 
 | File | Used by |
 |---|---|
-| `devto-bible-school-lms-cover.png` (1376×768) | The single DEV.to post Vadym wrote promoting the project (then called "Bible School LMS") in April 2026. Source for the OpenGraph share-card at `frontend/public/og-image.jpg` (1200×630, q=85 JPEG, ~29 KB). |
+| `devto-bible-school-lms-cover.png` (1376×768) | The single DEV.to post Vadym wrote promoting Equip in April 2026 (filename kept for asset-history continuity). Source for the OpenGraph share-card at `frontend/public/og-image.jpg` (1200×630, q=85 JPEG, ~29 KB). |
 
 If the cover changes, regenerate the OG card with a one-shot Pillow
 script — JPEG at q=85 is the sweet spot for share previews:


### PR DESCRIPTION
## Summary
Cleans the last 4 places that still mentioned `biblie-school` / `Bible School LMS` after the main rebrand PR (#188) and the Vercel/GitHub renames.

**Code changes (this PR):**
- `backend/app/core/config.py` — drop the `equip-frontend|biblie-school-frontend` alternation from `CORS_ORIGIN_REGEX`. Rename done, no preview URLs on the legacy slug exist anymore.
- `backend/.env.example` — matching regex example + comment.
- `ROADMAP.md` — line 3 prose + lines 8/9 issue/discussion URLs (initial sweep missed these).
- `docs/marketing/README.md` — historic "then called Bible School LMS" → mentions Equip directly (filename of the cover image kept for asset-history continuity).

**Out-of-band, no code (listed for the record):**
- Vercel backend env `CORS_ORIGINS` updated — dropped the legacy `biblie-school-frontend.vercel.app` value.
- Datadog renamed:
  - 4 synthetics (`equip backend /health`, `equip frontend /`, `equip backend /api/v1/courses`, `equip supabase /rest/v1/`) — URLs flipped to `equipbible.com` / `api.equipbible.com`, body assertion "Bible School" → "Equip", tags `service:equip-*` + `project:equip`, plus `options.monitor_name` so the auto-generated synthetic monitors also read `Synthetic: equip *`.
  - 5 manual RUM + log monitors (`equip frontend: RUM error spike`, etc.).
  - 2 dashboards (`equip overview`, `equip backend`).
  - RUM application renamed.

**Verification:**
- `grep -r "biblie-school\|Bible School LMS"` on tracked source returns nothing.
- Backend regex now `^https://equip-frontend(?:-[\w-]+)?\.vercel\.app$|^https://(?:www\.)?equipbible\.com$|^http://localhost:\d+$`.

## Test plan
- [x] `frontend: npm run lint` (0 warnings)
- [x] `frontend: npx tsc --noEmit`
- [x] `frontend: npm run test:run` (107 tests pass)
- [x] `frontend: npm run i18n:check` (parity)
- [x] CORS regex value verified at runtime via `python -c "from app.core.config import settings"`
- [ ] After merge: visit `https://equipbible.com` — still 200 with Equip branding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
