### PR TITLE
perf(db): composite index on chapter_blocks (chapter_id, order_index)

### DIFF
--- a/supabase/migrations/20260513161507_chapter_blocks_chapter_id_order_idx.sql
+++ b/supabase/migrations/20260513161507_chapter_blocks_chapter_id_order_idx.sql
@@ -1,0 +1,20 @@
+-- Composite index for the hot read path on chapter_blocks:
+--
+--   SELECT * FROM chapter_blocks
+--   WHERE chapter_id IN (...) ORDER BY chapter_id, order_index
+--
+-- pg_stat_statements showed this as the single slowest app query (102ms p50
+-- though most of that is Vercel-Lambda↔Supabase network RTT). The previous
+-- single-column index on chapter_id forced a separate sort step; this
+-- composite lets the planner satisfy WHERE + ORDER BY in one index walk.
+-- chapter_blocks is read-heavy; write overhead from a 2-column index is
+-- negligible.
+--
+-- The pre-existing ix_chapter_blocks_chapter_id is now redundant (left-prefix
+-- of the new index serves any chapter_id-only filter). Drop it to save write
+-- overhead on inserts/updates.
+
+CREATE INDEX IF NOT EXISTS ix_chapter_blocks_chapter_id_order
+  ON public.chapter_blocks (chapter_id, order_index);
+
+DROP INDEX IF EXISTS public.ix_chapter_blocks_chapter_id;


### PR DESCRIPTION
## Summary
- Adds composite index on `(chapter_id, order_index)` matching the hot read path `WHERE chapter_id IN (...) ORDER BY chapter_id, order_index` (~102ms p50, slowest app query in pg_stat_statements).
- Drops redundant single-column `ix_chapter_blocks_chapter_id` (left-prefix of the new index covers it).
- The SQLAlchemy model already declared this index in `__table_args__` but no migration file existed — prod Postgres was missing it. This closes the drift.

## Test plan
- [x] Migration applied to prod (verified via `SELECT * FROM pg_indexes WHERE tablename='chapter_blocks'`)
- [x] Backend tests pass (508/508 — SQLite test DB already had the index via `Base.metadata.create_all`)
- [x] No app-side changes needed; query plans are transparent