### PR TITLE
chore(brand): ship canonical Equip brand assets

### DIFF
--- a/backend/app/static/favicon.svg
+++ b/backend/app/static/favicon.svg
@@ -1,6 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="8" fill="#0f172a"/>
-  <path d="M8 7h7c1.1 0 2 .9 2 2v14c0-.55-.45-1-1-1H8V7z" fill="white" opacity="0.9"/>
-  <path d="M24 7h-7c-1.1 0-2 .9-2 2v14c0-.55.45-1 1-1h8V7z" fill="white" opacity="0.7"/>
-  <path d="M16 9v13" stroke="white" stroke-width="0.5" opacity="0.5"/>
+  <!-- Equip favicon — deep violet field with inverse E mark.
+       Canonical source: equipbible-docs/design/assets/favicon.svg. -->
+  <rect width="32" height="32" rx="7" fill="#422277"/>
+  <g fill="#FAF7F1">
+    <rect x="9" y="8" width="3" height="16"/>
+    <rect x="9" y="8" width="14" height="3"/>
+    <rect x="9" y="15" width="11" height="3"/>
+    <rect x="9" y="21" width="14" height="3"/>
+  </g>
 </svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Equip — Modern Learning Management System for Bible study courses" />
-    <meta name="theme-color" content="#2563eb" />
+    <meta name="theme-color" content="#422277" />
 
     <!-- Open Graph + Twitter share-preview cards. Static defaults are
          intentional: the SPA renders client-side, so anything dynamic

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,6 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="8" fill="#2563eb"/>
-  <path d="M8 7h7c1.1 0 2 .9 2 2v14c0-.55-.45-1-1-1H8V7z" fill="white" opacity="0.9"/>
-  <path d="M24 7h-7c-1.1 0-2 .9-2 2v14c0-.55.45-1 1-1h8V7z" fill="white" opacity="0.7"/>
-  <path d="M16 9v13" stroke="white" stroke-width="0.5" opacity="0.5"/>
+  <!-- Equip favicon — deep violet field with inverse E mark.
+       Canonical source: equipbible-docs/design/assets/favicon.svg. -->
+  <rect width="32" height="32" rx="7" fill="#422277"/>
+  <g fill="#FAF7F1">
+    <rect x="9" y="8" width="3" height="16"/>
+    <rect x="9" y="8" width="14" height="3"/>
+    <rect x="9" y="15" width="11" height="3"/>
+    <rect x="9" y="21" width="14" height="3"/>
+  </g>
 </svg>

--- a/frontend/public/icon.svg
+++ b/frontend/public/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <!-- Equip icon — deep violet E on warm paper, sage foundation line.
+       Canonical source: equipbible-docs/design/assets/icon.svg. -->
+  <rect width="64" height="64" rx="12" fill="#FAF7F1"/>
+  <g fill="#422277">
+    <rect x="17" y="15" width="6" height="32"/>
+    <rect x="17" y="15" width="30" height="6"/>
+    <rect x="17" y="29" width="22" height="6"/>
+    <rect x="17" y="41" width="30" height="6"/>
+  </g>
+  <rect x="14" y="53" width="36" height="2" fill="#67A982"/>
+</svg>

--- a/frontend/public/wordmark-dark.svg
+++ b/frontend/public/wordmark-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 64" fill="none">
+  <!-- Equip wordmark, dark-background variant.
+       Lighter violet for legibility on dark surfaces; sage accent unchanged.
+       Canonical source: equipbible-docs/design/assets/wordmark-dark.svg. -->
+  <text x="0" y="46" font-family="Fraunces, Georgia, Cambria, 'Times New Roman', serif" font-size="46" font-weight="600" fill="#A98FE3" letter-spacing="-0.5">Equip</text>
+  <rect x="0" y="56" width="124" height="2" fill="#67A982"/>
+</svg>

--- a/frontend/public/wordmark.svg
+++ b/frontend/public/wordmark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 64" fill="none">
+  <!-- Equip wordmark — Fraunces serif, deep violet, sage accent line.
+       Canonical source: equipbible-docs/design/assets/wordmark.svg. -->
+  <text x="0" y="46" font-family="Fraunces, Georgia, Cambria, 'Times New Roman', serif" font-size="46" font-weight="600" fill="#422277" letter-spacing="-0.5">Equip</text>
+  <rect x="0" y="56" width="124" height="2" fill="#67A982"/>
+</svg>


### PR DESCRIPTION
## Summary
- Replaces the pre-rebrand placeholder favicon (generic Tailwind blue + abstract two-panel) with the real Equip mark from the canonical design system: deep violet #422277 field, inverse warm-paper E.
- Adds three new public assets: `icon.svg` (64×64 apple-touch / PWA), `wordmark.svg` (light bg), `wordmark-dark.svg` (dark bg).
- `apple-touch-icon` now uses the dedicated icon.svg (sharper on iOS home screens than reusing the 32-viewBox favicon).
- `theme-color` meta tag flipped from old blue `#2563eb` to brand `#422277`.

## Source of truth
The assets are the canonical placeholders from `equipbible-docs/design/assets/`. `equipbible-docs/design/logo.md` flagged "the existing blue favicon must be replaced before the rebrand goes live" — this closes that backlog item. A designer-finalized pass is still wanted per the same doc.

## Test plan
- [x] `npm run build` — green; all 4 SVGs emit to `dist/`
- [x] favicon SVG validates as valid XML
- [ ] Verify in browser after merge: tab icon shows the violet E, iOS home-screen save uses the larger icon, view-source confirms theme-color
