### PR TITLE
chore(brand): backend favicon — sage variant for tab differentiation

### DIFF
--- a/backend/app/static/favicon.svg
+++ b/backend/app/static/favicon.svg
@@ -1,7 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <!-- Equip favicon — deep violet field with inverse E mark.
-       Canonical source: equipbible-docs/design/assets/favicon.svg. -->
-  <rect width="32" height="32" rx="7" fill="#422277"/>
+  <!-- Equip API favicon — deep sage field (success token #2F7A53) with
+       warm-paper E mark. Inverse of the frontend favicon so that the
+       api.equipbible.com browser tab is visually distinct from
+       equipbible.com at a glance, while staying inside the brand palette.
+       Canonical source: equipbible-docs/design/assets/favicon.svg with
+       --primary swapped for --success. -->
+  <rect width="32" height="32" rx="7" fill="#2F7A53"/>
   <g fill="#FAF7F1">
     <rect x="9" y="8" width="3" height="16"/>
     <rect x="9" y="8" width="14" height="3"/>


### PR DESCRIPTION
## Summary
- Swaps the backend's `/favicon.svg` background from `--primary` violet (`#422277`) to `--success` deep sage (`#2F7A53`), keeping the same warm-paper E mark.
- Frontend favicon untouched.

## Why
When `equipbible.com` and `api.equipbible.com` are open in adjacent tabs, the tabs were visually identical. Sage variant makes them instantly distinguishable while staying inside the canonical brand palette.

## Test plan
- [x] Backend serves `/favicon.svg` and `/favicon.ico` from `backend/app/static/favicon.svg` (verified in `app/main.py:147-148`).
- [ ] After merge: open `https://api.equipbible.com/` in a browser tab — favicon should be sage green; `https://equipbible.com/` next to it should be violet.