### PR TITLE
perf(backend): kill N+1 in user-purge, dedup calendar fetches, O(n²)→dict in progress

### DIFF
--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -46,13 +46,19 @@ def get_calendar_events(
 
     # Drop trashed courses — users may still have enrollments pointing to
     # deleted courses, but their calendar should not advertise deadlines
-    # from content that has been removed from the catalog.
+    # from content that has been removed from the catalog. We fetch title
+    # AND source_locale in the same query (previously two separate fetches);
+    # source_locale is needed below for the translation overlay.
     course_titles: dict[str, str] = {}
-    courses = (
-        db.query(Course.id, Course.title).filter(Course.id.in_(enrolled_course_ids), Course.deleted_at.is_(None)).all()
+    course_source_locales: dict[str, LocaleCode] = {}
+    course_rows = (
+        db.query(Course.id, Course.title, Course.source_locale)
+        .filter(Course.id.in_(enrolled_course_ids), Course.deleted_at.is_(None))
+        .all()
     )
-    for cid, ctitle in courses:
+    for cid, ctitle, csrc in course_rows:
         course_titles[cid] = ctitle
+        course_source_locales[cid] = normalize_locale(csrc)
     enrolled_course_ids = list(course_titles.keys())
     if not enrolled_course_ids:
         return []
@@ -129,13 +135,6 @@ def get_calendar_events(
             )
 
     course_events = db.query(CourseEvent).filter(CourseEvent.course_id.in_(enrolled_course_ids)).all()
-
-    # Pre-fetch source locales per course so the overlay picks the right
-    # row (translation rows are keyed by display locale; fallback uses the
-    # course's source locale).
-    course_source_locales: dict[str, LocaleCode] = {}
-    for cid, src in db.query(Course.id, Course.source_locale).filter(Course.id.in_(enrolled_course_ids)).all():
-        course_source_locales[cid] = normalize_locale(src)
 
     # Bulk-fetch overlay rows for every course_event title + non-empty description
     # so non-admin students see the localized version. Admins always see source.

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -135,9 +135,14 @@ def _purge_user(db: Session, uid: UUID) -> None:
     db.query(ChapterProgress).filter(ChapterProgress.user_id == uid).delete(synchronize_session=False)
     db.query(Notification).filter(Notification.user_id == uid).delete(synchronize_session=False)
 
-    attempt_ids = [a.id for a in db.query(QuizAttempt.id).filter(QuizAttempt.user_id == uid).all()]
-    if attempt_ids:
-        db.query(QuizAnswer).filter(QuizAnswer.attempt_id.in_(attempt_ids)).delete(synchronize_session=False)
+    # Delete every QuizAnswer whose parent QuizAttempt belongs to this user,
+    # then the QuizAttempts themselves. The answer delete is a single SQL
+    # round-trip (subquery against QuizAttempt) instead of pulling all
+    # attempt IDs into Python first — same result, one fewer query and no
+    # memory overhead proportional to attempt count.
+    db.query(QuizAnswer).filter(
+        QuizAnswer.attempt_id.in_(db.query(QuizAttempt.id).filter(QuizAttempt.user_id == uid))
+    ).delete(synchronize_session=False)
     db.query(QuizAttempt).filter(QuizAttempt.user_id == uid).delete(synchronize_session=False)
 
     db.query(AssignmentSubmission).filter(AssignmentSubmission.student_id == uid).delete(synchronize_session=False)

--- a/backend/app/services/student_progress_service.py
+++ b/backend/app/services/student_progress_service.py
@@ -287,12 +287,15 @@ def build_course_student_progress(db: Session, course: Course, course_id: str) -
         for ch_id, assignments in assignment_map.items():
             ch_key = (uid, str(ch_id))
             submissions = subs_by_user_chapter.get(ch_key, [])
+            # Build assignment_id -> latest-submission dict once per chapter
+            # so the per-assignment lookup is O(1) instead of an O(M) list
+            # comprehension. Submissions are already filtered to the latest
+            # per assignment upstream in _aggregate_assignment_submissions.
+            sub_by_assignment: dict[str, dict[str, Any]] = {s["assignment_id"]: s for s in submissions}
             for a in assignments:
-                a_id = str(a.id)
-                matching = [s for s in submissions if s["assignment_id"] == a_id]
-                if not matching:
+                latest = sub_by_assignment.get(str(a.id))
+                if latest is None:
                     continue
-                latest = matching[0]
                 assignment_results.append(
                     {
                         "chapter_title": chapter_title_map.get(str(ch_id), ""),


### PR DESCRIPTION
## Summary
Three independent backend perf fixes surfaced by the 2026-05-13 audit. All purely structural — same semantics, fewer queries / smaller complexity.

1. **`users.py` `_purge_user`** — fold the QuizAnswer + QuizAttempt deletion into a single SQL subquery instead of a two-step Python materialization.
2. **`calendar.py` `get_calendar_events`** — was issuing two separate `SELECT FROM courses` for the same enrolled-course set (once for title, once for source_locale). Now one query returns both.
3. **`student_progress_service.py` `build_course_student_progress`** — replace inline `[s for s in submissions if s.assignment_id == a_id]` with a pre-built dict lookup. O(K\*M) → O(K+M) per chapter.

## Test plan
- [x] 509/509 pytest
- [x] ruff format + lint clean on touched files
- [x] mypy clean on touched files
- [x] No client-visible behavior change
