### PR TITLE
feat(cohorts): top-level admin model + course access_mode (ADR-010)

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -1,15 +1,46 @@
+"""Top-level admin cohort API.
+
+Implements ADR-010. Cohorts are admin-owned batches of students that
+take some set of courses together over a date window. The director
+creates an empty cohort, attaches courses + students via the junction
+endpoints, and the backend auto-creates the per-(student, course)
+enrollment rows so the director never has to do that by hand.
+
+Visibility rules:
+
+- All write surfaces (create / update / delete / attach / add student /
+  complete) require admin role. Teachers do not manage cohorts.
+- ``GET /cohorts/course/{course_id}`` is kept as a public-ish read so
+  the catalog (for the enroll dialog cohort dropdown) and a teacher's
+  gradebook filter can list cohorts that include their course. Same
+  visibility gate as before: course must be published OR viewer is
+  owner / admin.
+
+The legacy course-scoped create endpoint (``POST /cohorts/course/{id}``)
+is intentionally removed. Frontend that called it is being migrated to
+the top-level admin UI.
+"""
+
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_optional_user, require_teacher, verify_course_owner
+from app.api.dependencies import get_optional_user, require_admin
 from app.core.database import get_db
-from app.models.cohort import Cohort
+from app.models.cohort import Cohort, CohortCourse
 from app.models.course import Course
 from app.models.enrollment import Enrollment
-from app.models.student_grade import StudentGrade
 from app.models.user import User, UserRole
-from app.schemas.cohort import CohortCreate, CohortResponse, CohortUpdate
+from app.schemas.cohort import (
+    CohortCourseAttach,
+    CohortCreate,
+    CohortResponse,
+    CohortStudentAdd,
+    CohortUpdate,
+)
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
@@ -20,37 +51,394 @@ from app.services.translation.resolve_for_display import (
 router = APIRouter(prefix="/cohorts", tags=["cohorts"])
 
 
-def _cohort_to_response(cohort: Cohort, student_count: int) -> CohortResponse:
-    """Serialize a cohort with its pre-computed student count.
+# ----------------------------- helpers --------------------------------
 
-    ``student_count`` is a computed field not stored on the model, so callers
-    must count enrollments themselves (one query per cohort, or a single
-    batched ``group_by`` for lists — see :func:`list_cohorts`).
-    """
+
+def _course_ids_for_cohort(db: Session, cohort_id: UUID) -> list[str]:
+    """Return course_ids attached to the cohort via the junction."""
+    return [row[0] for row in db.query(CohortCourse.course_id).filter(CohortCourse.cohort_id == cohort_id).all()]
+
+
+def _student_count(db: Session, cohort_id: UUID) -> int:
+    """Distinct users enrolled in this cohort. A cohort student typically
+    has N enrollment rows (one per attached course), so we COUNT DISTINCT
+    rather than count enrollment rows."""
+    return (
+        db.query(func.count(func.distinct(Enrollment.user_id))).filter(Enrollment.cohort_id == cohort_id).scalar() or 0
+    )
+
+
+def _serialize(db: Session, cohort: Cohort) -> CohortResponse:
     resp = CohortResponse.model_validate(cohort)
-    resp.student_count = student_count
+    resp.course_ids = _course_ids_for_cohort(db, cohort.id)
+    resp.student_count = _student_count(db, cohort.id)
     return resp
 
 
-def _count_students_in_cohort(db: Session, cohort_id: object) -> int:
-    return db.query(func.count(Enrollment.id)).filter(Enrollment.cohort_id == cohort_id).scalar() or 0
-
-
-def _get_cohort_or_404(db: Session, cohort_id: str) -> Cohort:
+def _get_or_404(db: Session, cohort_id: UUID) -> Cohort:
     cohort = db.query(Cohort).filter(Cohort.id == cohort_id).first()
     if not cohort:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cohort not found")
     return cohort
 
 
-@router.get("/course/{course_id}", response_model=list[CohortResponse])
+def _course_or_404(db: Session, course_id: str) -> Course:
+    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
+    if not course:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+    return course
+
+
+# ----------------------------- admin CRUD -----------------------------
+
+
+@router.get("", response_model=list[CohortResponse])
 def list_cohorts(
+    status_filter: str | None = Query(None, alias="status"),
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> list[CohortResponse]:
+    """Admin-wide cohort list. Optional ``status`` filter
+    (``upcoming|active|completed``)."""
+    q = db.query(Cohort)
+    if status_filter:
+        q = q.filter(Cohort.status == status_filter)
+    cohorts = q.order_by(Cohort.start_date.desc()).all()
+    return [_serialize(db, c) for c in cohorts]
+
+
+@router.post("", response_model=CohortResponse, status_code=status.HTTP_201_CREATED)
+def create_cohort(
+    data: CohortCreate,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> CohortResponse:
+    """Create an empty cohort. Courses and students attach via the
+    separate junction endpoints — keeps each step independently
+    auditable."""
+    cohort = Cohort(
+        name=data.name,
+        start_date=data.start_date,
+        end_date=data.end_date,
+        enrollment_start=data.enrollment_start,
+        enrollment_end=data.enrollment_end,
+        max_students=data.max_students,
+        created_by=admin.id,
+    )
+    db.add(cohort)
+    db.commit()
+    db.refresh(cohort)
+    return _serialize(db, cohort)
+
+
+@router.get("/{cohort_id}", response_model=CohortResponse)
+def get_cohort(
+    cohort_id: UUID,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> CohortResponse:
+    cohort = _get_or_404(db, cohort_id)
+    return _serialize(db, cohort)
+
+
+@router.patch("/{cohort_id}", response_model=CohortResponse)
+def update_cohort(
+    cohort_id: UUID,
+    data: CohortUpdate,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> CohortResponse:
+    cohort = _get_or_404(db, cohort_id)
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(cohort, field, value)
+    db.commit()
+    db.refresh(cohort)
+    # Translation reconcile for each course this cohort is attached to —
+    # cohort name is teacher/director-authored, so each course-locale
+    # pair gets a translation overlay row.
+    for cid in _course_ids_for_cohort(db, cohort.id):
+        course = db.query(Course).filter(Course.id == cid).first()
+        if course is not None:
+            reconcile_entity_if_course_published(db, "cohort", cohort)
+    return _serialize(db, cohort)
+
+
+@router.delete("/{cohort_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_cohort(
+    cohort_id: UUID,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete the cohort. ``ON DELETE CASCADE`` on the junction removes
+    course attachments; the enrollment rows survive with their
+    ``cohort_id`` set to NULL (``ON DELETE SET NULL`` on the FK) — that
+    way historical grade data is preserved as orphaned solo enrollments."""
+    cohort = _get_or_404(db, cohort_id)
+    db.delete(cohort)
+    db.commit()
+
+
+@router.post("/{cohort_id}/complete", response_model=CohortResponse)
+def complete_cohort(
+    cohort_id: UUID,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> CohortResponse:
+    cohort = _get_or_404(db, cohort_id)
+    if cohort.status == "completed":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cohort is already completed",
+        )
+    cohort.status = "completed"
+    db.commit()
+    db.refresh(cohort)
+    return _serialize(db, cohort)
+
+
+# ---------------------- junction: cohort x courses --------------------
+
+
+@router.get("/{cohort_id}/courses", response_model=list[str])
+def list_cohort_courses(
+    cohort_id: UUID,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> list[str]:
+    _get_or_404(db, cohort_id)
+    return _course_ids_for_cohort(db, cohort_id)
+
+
+@router.post(
+    "/{cohort_id}/courses",
+    response_model=CohortResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def attach_course(
+    cohort_id: UUID,
+    body: CohortCourseAttach,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> CohortResponse:
+    """Attach a course to the cohort. Any students already in the cohort
+    are auto-enrolled in this course (one enrollment row per student,
+    all sharing the same ``cohort_id``)."""
+    cohort = _get_or_404(db, cohort_id)
+    course = _course_or_404(db, body.course_id)
+
+    # Already attached? Idempotent.
+    existing = (
+        db.query(CohortCourse).filter(CohortCourse.cohort_id == cohort.id, CohortCourse.course_id == course.id).first()
+    )
+    if existing is None:
+        db.add(CohortCourse(cohort_id=cohort.id, course_id=course.id))
+        db.flush()
+
+    # Auto-enroll every existing cohort student in this course.
+    existing_students = db.query(Enrollment.user_id).filter(Enrollment.cohort_id == cohort.id).distinct().all()
+    for (user_id,) in existing_students:
+        already = (
+            db.query(Enrollment)
+            .filter(
+                Enrollment.user_id == user_id,
+                Enrollment.course_id == course.id,
+                Enrollment.cohort_id == cohort.id,
+            )
+            .first()
+        )
+        if already is None:
+            db.add(
+                Enrollment(
+                    id=f"enr-{cohort.id}-{user_id}-{course.id}",
+                    user_id=user_id,
+                    course_id=course.id,
+                    cohort_id=cohort.id,
+                )
+            )
+
+    try:
+        db.commit()
+    except IntegrityError:
+        # A concurrent attach raced us; safe to roll back and re-read.
+        db.rollback()
+    db.refresh(cohort)
+    reconcile_entity_if_course_published(db, "cohort", cohort)
+    return _serialize(db, cohort)
+
+
+@router.delete(
+    "/{cohort_id}/courses/{course_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def detach_course(
+    cohort_id: UUID,
+    course_id: str,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> None:
+    """Detach a course from the cohort. Enrollment rows for cohort
+    students in this course are NOT deleted — their ``cohort_id`` is
+    set to NULL so grades survive as orphaned solo enrollments."""
+    cohort = _get_or_404(db, cohort_id)
+    link = (
+        db.query(CohortCourse).filter(CohortCourse.cohort_id == cohort.id, CohortCourse.course_id == course_id).first()
+    )
+    if link is None:
+        return
+    db.query(Enrollment).filter(
+        Enrollment.cohort_id == cohort.id,
+        Enrollment.course_id == course_id,
+    ).update({Enrollment.cohort_id: None}, synchronize_session=False)
+    db.delete(link)
+    db.commit()
+
+
+# ---------------------- junction: cohort x students -------------------
+
+
+@router.get("/{cohort_id}/students")
+def list_cohort_students(
+    cohort_id: UUID,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    """One row per student in the cohort. Per-course progress is the
+    union of their enrollment rows in this cohort, summarized by
+    course_id so the cohort overview can show a matrix."""
+    cohort = _get_or_404(db, cohort_id)
+    rows = (
+        db.query(Enrollment)
+        .filter(Enrollment.cohort_id == cohort.id)
+        .order_by(Enrollment.user_id, Enrollment.course_id)
+        .all()
+    )
+    by_user: dict[str, dict] = {}
+    for e in rows:
+        key = str(e.user_id)
+        by_user.setdefault(
+            key,
+            {
+                "user_id": key,
+                "per_course": {},
+            },
+        )
+        by_user[key]["per_course"][e.course_id] = {
+            "enrollment_id": str(e.id),
+            "enrolled_at": e.enrolled_at.isoformat() if e.enrolled_at else None,
+            "progress": e.progress,
+        }
+    return list(by_user.values())
+
+
+@router.post(
+    "/{cohort_id}/students",
+    status_code=status.HTTP_201_CREATED,
+)
+def add_student(
+    cohort_id: UUID,
+    body: CohortStudentAdd,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Add a student to the cohort. Resolves ``user_id`` (preferred) or
+    ``email`` to an existing platform user, then auto-creates enrollment
+    rows for every course already attached to this cohort. Idempotent —
+    re-adding the same student is a no-op."""
+    cohort = _get_or_404(db, cohort_id)
+    if not body.user_id and not body.email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide user_id or email",
+        )
+
+    if body.user_id:
+        user = db.query(User).filter(User.id == body.user_id).first()
+    else:
+        user = db.query(User).filter(User.email == body.email).first()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found — ask them to sign up first",
+        )
+
+    if cohort.max_students:
+        current_count = _student_count(db, cohort.id)
+        already_in = (
+            db.query(Enrollment).filter(Enrollment.cohort_id == cohort.id, Enrollment.user_id == user.id).first()
+            is not None
+        )
+        if not already_in and current_count >= cohort.max_students:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Cohort has reached maximum capacity",
+            )
+
+    course_ids = _course_ids_for_cohort(db, cohort.id)
+    for course_id in course_ids:
+        already = (
+            db.query(Enrollment)
+            .filter(
+                Enrollment.user_id == user.id,
+                Enrollment.course_id == course_id,
+                Enrollment.cohort_id == cohort.id,
+            )
+            .first()
+        )
+        if already is None:
+            db.add(
+                Enrollment(
+                    id=f"enr-{cohort.id}-{user.id}-{course_id}",
+                    user_id=user.id,
+                    course_id=course_id,
+                    cohort_id=cohort.id,
+                )
+            )
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+    return {"user_id": str(user.id), "course_ids": course_ids}
+
+
+@router.delete(
+    "/{cohort_id}/students/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def remove_student(
+    cohort_id: UUID,
+    user_id: UUID,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> None:
+    """Remove a student from the cohort. Enrollment rows survive with
+    ``cohort_id`` nulled so grades stay accessible."""
+    cohort = _get_or_404(db, cohort_id)
+    db.query(Enrollment).filter(Enrollment.cohort_id == cohort.id, Enrollment.user_id == user_id).update(
+        {Enrollment.cohort_id: None}, synchronize_session=False
+    )
+    db.commit()
+
+
+# -------------------------- public-ish read ---------------------------
+
+
+@router.get("/course/{course_id}", response_model=list[CohortResponse])
+def list_cohorts_for_course(
     response: Response,
     course_id: str,
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User | None = Depends(get_optional_user),
     db: Session = Depends(get_db),
 ) -> list[CohortResponse]:
+    """Cohorts that include this course (junction-based). Used by:
+
+    - Catalog course-detail page → cohort dropdown in the enroll dialog.
+    - Teacher gradebook → filter dropdown for "show cohort X".
+
+    Visibility: course must be ``published`` OR the viewer is its
+    owner or an admin. Cohort name is localized via the translation
+    overlay just like the legacy endpoint did."""
     response.headers["Vary"] = "Accept-Language"
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
@@ -60,27 +448,21 @@ def list_cohorts(
             str(course.created_by) != str(current_user.id) and current_user.role != UserRole.ADMIN.value
         ):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
-    cohorts = db.query(Cohort).filter(Cohort.course_id == course_id).order_by(Cohort.start_date.desc()).all()
+
+    cohorts = (
+        db.query(Cohort)
+        .join(CohortCourse, Cohort.id == CohortCourse.cohort_id)
+        .filter(CohortCourse.course_id == course_id)
+        .order_by(Cohort.start_date.desc())
+        .all()
+    )
     if not cohorts:
         return []
 
-    cohort_ids = [c.id for c in cohorts]
-    counts = (
-        db.query(Enrollment.cohort_id, func.count(Enrollment.id))
-        .filter(Enrollment.cohort_id.in_(cohort_ids))
-        .group_by(Enrollment.cohort_id)
-        .all()
-    )
-    count_map = {row[0]: row[1] for row in counts}
-
-    # Owner + admin see source for editorial accuracy; everyone else
-    # gets the locale overlay (cohort.name is teacher-authored, so when
-    # a student in EN reads a course list whose cohorts were created in
-    # RU we'd otherwise display the source name).
     is_owner = current_user is not None and str(course.created_by) == str(current_user.id)
     is_admin = current_user is not None and current_user.role == UserRole.ADMIN.value
     if is_owner or is_admin:
-        return [_cohort_to_response(c, count_map.get(c.id, 0)) for c in cohorts]
+        return [_serialize(db, c) for c in cohorts]
 
     display_locale: LocaleCode = normalize_locale(accept_language)
     source_locale: LocaleCode = normalize_locale(course.source_locale)
@@ -88,152 +470,16 @@ def list_cohorts(
     overlay = fetch_overlay_triples_bulk(db, overlay_specs, display_locale)
     out: list[CohortResponse] = []
     for c in cohorts:
-        localized_name = (
-            pick_overlay_value(
-                overlay,
-                "cohort",
-                str(c.id),
-                "title",
-                c.name,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or c.name
+        localized = pick_overlay_value(
+            overlay,
+            "cohort",
+            str(c.id),
+            "title",
+            c.name,
+            source_locale=source_locale,
+            display_locale=display_locale,
         )
-        resp = CohortResponse.model_validate(c)
-        resp.name = localized_name
-        resp.student_count = count_map.get(c.id, 0)
+        resp = _serialize(db, c)
+        resp.name = localized or c.name
         out.append(resp)
     return out
-
-
-@router.post(
-    "/course/{course_id}",
-    response_model=CohortResponse,
-    status_code=status.HTTP_201_CREATED,
-)
-def create_cohort(
-    course_id: str,
-    data: CohortCreate,
-    teacher: User = Depends(require_teacher),
-    db: Session = Depends(get_db),
-) -> CohortResponse:
-    verify_course_owner(db, course_id, teacher)
-
-    cohort = Cohort(
-        course_id=course_id,
-        name=data.name,
-        start_date=data.start_date,
-        end_date=data.end_date,
-        enrollment_start=data.enrollment_start,
-        enrollment_end=data.enrollment_end,
-        max_students=data.max_students,
-    )
-    db.add(cohort)
-    db.commit()
-    db.refresh(cohort)
-    reconcile_entity_if_course_published(db, "cohort", cohort)
-    return _cohort_to_response(cohort, 0)
-
-
-@router.put("/{cohort_id}", response_model=CohortResponse)
-def update_cohort(
-    cohort_id: str,
-    data: CohortUpdate,
-    teacher: User = Depends(require_teacher),
-    db: Session = Depends(get_db),
-) -> CohortResponse:
-    cohort = _get_cohort_or_404(db, cohort_id)
-    verify_course_owner(db, cohort.course_id, teacher)
-
-    for field, value in data.model_dump(exclude_unset=True).items():
-        setattr(cohort, field, value)
-
-    db.commit()
-    db.refresh(cohort)
-    reconcile_entity_if_course_published(db, "cohort", cohort)
-    return _cohort_to_response(cohort, _count_students_in_cohort(db, cohort.id))
-
-
-@router.delete("/{cohort_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_cohort(
-    cohort_id: str,
-    teacher: User = Depends(require_teacher),
-    db: Session = Depends(get_db),
-) -> None:
-    cohort = _get_cohort_or_404(db, cohort_id)
-    verify_course_owner(db, cohort.course_id, teacher)
-    db.delete(cohort)
-    db.commit()
-
-
-@router.get("/{cohort_id}/students")
-def list_cohort_students(
-    cohort_id: str,
-    skip: int = Query(0, ge=0),
-    limit: int = Query(200, ge=1, le=500),
-    teacher: User = Depends(require_teacher),
-    db: Session = Depends(get_db),
-):
-    cohort = _get_cohort_or_404(db, cohort_id)
-    verify_course_owner(db, cohort.course_id, teacher)
-
-    enrollments = (
-        db.query(Enrollment)
-        .filter(Enrollment.cohort_id == cohort.id)
-        .order_by(Enrollment.enrolled_at.desc())
-        .offset(skip)
-        .limit(limit)
-        .all()
-    )
-
-    student_ids = [e.user_id for e in enrollments]
-    grades_map: dict[str, StudentGrade] = {}
-    if student_ids:
-        grades = (
-            db.query(StudentGrade)
-            .filter(
-                StudentGrade.student_id.in_(student_ids),
-                StudentGrade.course_id == cohort.course_id,
-                StudentGrade.cohort_id == cohort.id,
-            )
-            .all()
-        )
-        grades_map = {str(g.student_id): g for g in grades}
-
-    results = []
-    for enrollment in enrollments:
-        grade = grades_map.get(str(enrollment.user_id))
-        results.append(
-            {
-                "enrollment_id": str(enrollment.id),
-                "user_id": str(enrollment.user_id),
-                "enrolled_at": enrollment.enrolled_at.isoformat() if enrollment.enrolled_at else None,
-                "progress": enrollment.progress,
-                "grade": grade.grade if grade else None,
-                "grade_comment": grade.comment if grade else None,
-            }
-        )
-
-    return results
-
-
-@router.post("/{cohort_id}/complete", response_model=CohortResponse)
-def complete_cohort(
-    cohort_id: str,
-    teacher: User = Depends(require_teacher),
-    db: Session = Depends(get_db),
-) -> CohortResponse:
-    cohort = _get_cohort_or_404(db, cohort_id)
-    verify_course_owner(db, cohort.course_id, teacher)
-
-    if cohort.status == "completed":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cohort is already completed",
-        )
-
-    cohort.status = "completed"
-    db.commit()
-    db.refresh(cohort)
-    return _cohort_to_response(cohort, _count_students_in_cohort(db, cohort.id))

--- a/backend/app/api/v1/courses/enrollment.py
+++ b/backend/app/api/v1/courses/enrollment.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user
 from app.core.database import get_db
-from app.models.cohort import Cohort
+from app.models.cohort import Cohort, CohortCourse
 from app.models.enrollment import Enrollment
 from app.models.user import User
 from app.schemas.course import EnrollmentResponse
@@ -54,14 +54,26 @@ def _enforce_cohort_gates(db: Session, course_id: str, cohort_id: str, now: date
     """Validate that the student can enroll into the requested cohort.
 
     Returns nothing on success; raises the appropriate HTTPException on
-    any gate failure (unknown cohort, inactive status, window not open,
-    window closed, or capacity reached).
+    any gate failure (cohort doesn't include this course, inactive
+    status, window not open, window closed, or capacity reached).
+
+    Cohort-course membership is checked through the ``cohort_courses``
+    junction (ADR-010): a cohort is valid for this course iff there's
+    a junction row tying the two.
     """
-    cohort = db.query(Cohort).filter(Cohort.id == cohort_id, Cohort.course_id == course_id).with_for_update().first()
+    cohort = db.query(Cohort).filter(Cohort.id == cohort_id).with_for_update().first()
     if not cohort:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Cohort not found for this course",
+            detail="Cohort not found",
+        )
+    junction = (
+        db.query(CohortCourse).filter(CohortCourse.cohort_id == cohort.id, CohortCourse.course_id == course_id).first()
+    )
+    if junction is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Cohort does not include this course",
         )
     if cohort.status != "active":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cohort is not active")
@@ -76,7 +88,12 @@ def _enforce_cohort_gates(db: Session, course_id: str, cohort_id: str, now: date
             detail="Cohort enrollment period has ended",
         )
     if cohort.max_students:
-        current_count = db.query(sa_func.count(Enrollment.id)).filter(Enrollment.cohort_id == cohort.id).scalar() or 0
+        current_count = (
+            db.query(sa_func.count(sa_func.distinct(Enrollment.user_id)))
+            .filter(Enrollment.cohort_id == cohort.id)
+            .scalar()
+            or 0
+        )
         if current_count >= cohort.max_students:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -107,10 +124,21 @@ def enroll_course(
 
     cohort_id: str | None = None
     if body.cohort_id:
+        # Cohort-route self-enrollment works for either access mode —
+        # joining the cohort is the director's intent regardless of
+        # whether the course is institute or public.
         _enforce_cohort_gates(db, course_id, body.cohort_id, now)
         cohort_id = body.cohort_id
     else:
-        # Cohort-less enrollment is gated by the course-level window only.
+        # Solo (no-cohort) enrollment. Institute courses block this path
+        # entirely (ADR-010): admin must add the student directly via
+        # the cohort endpoints or the admin-direct enrollment endpoint.
+        if course.access_mode == "institute":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This course is available only by invitation from the institute",
+            )
+        # Public courses are gated by the course-level enrollment window.
         if course.enrollment_start and now < course.enrollment_start:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/app/models/cohort.py
+++ b/backend/app/models/cohort.py
@@ -1,3 +1,15 @@
+"""Cohort + CohortCourse models.
+
+Cohort is a **top-level admin entity** (ADR-010): a named batch of
+students that takes some set of courses together over a date window.
+The director creates an empty cohort, then independently adds courses
+to it (via the ``cohort_courses`` junction) and students to it (via the
+``enrollments`` rows whose ``cohort_id`` points at this cohort).
+
+Teachers do not own or manage cohorts; they only see the cohort id as
+a filter dropdown in their own course's gradebook.
+"""
+
 import uuid
 from datetime import datetime
 
@@ -10,23 +22,52 @@ from app.core.database import Base
 class Cohort(Base):
     __tablename__ = "cohorts"
     __table_args__ = (
-        Index("ix_cohorts_course_id", "course_id"),
         Index("ix_cohorts_status", "status"),
+        Index("ix_cohorts_created_by", "created_by"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    course_id: Mapped[str] = mapped_column(ForeignKey("courses.id", ondelete="CASCADE"))
     name: Mapped[str] = mapped_column(String(200))
     start_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     end_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     enrollment_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     enrollment_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # 'upcoming' before start_date, 'active' inside the window, 'completed'
+    # after end_date or when director marks it done early. Transitions are
+    # currently manual via the cohorts API; auto-transition on dates is a
+    # follow-up if it ever matters.
     status: Mapped[str] = mapped_column(String(20), default="upcoming")
     max_students: Mapped[int | None] = mapped_column()
+    # Director / admin who set the cohort up. NULL means the creator was
+    # deleted from the platform — cohort survives so historical
+    # enrollments and grades stay intact.
+    created_by: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("profiles.id", ondelete="SET NULL"))
     created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
     def __repr__(self) -> str:
-        return f"<Cohort id={self.id} name='{self.name}' course_id='{self.course_id}'>"
+        return f"<Cohort id={self.id} name='{self.name}'>"
+
+
+class CohortCourse(Base):
+    """Junction: which courses run in which cohorts.
+
+    When a course is added to a cohort that already has students, the
+    cohort service is responsible for backfilling enrollment rows for
+    every existing cohort student (and vice versa: adding a student to
+    a cohort enrolls them in all already-attached courses). Removing
+    detaches but keeps historical enrollment rows with ``cohort_id``
+    nulled — see ADR-010 §5.
+    """
+
+    __tablename__ = "cohort_courses"
+    __table_args__ = (Index("ix_cohort_courses_course_id", "course_id"),)
+
+    cohort_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("cohorts.id", ondelete="CASCADE"), primary_key=True)
+    course_id: Mapped[str] = mapped_column(ForeignKey("courses.id", ondelete="CASCADE"), primary_key=True)
+    added_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    def __repr__(self) -> str:
+        return f"<CohortCourse cohort_id={self.cohort_id} course_id={self.course_id!r}>"

--- a/backend/app/models/course.py
+++ b/backend/app/models/course.py
@@ -30,7 +30,13 @@ class Course(Base):
     __tablename__ = "courses"
     __table_args__ = (
         Index("ix_courses_created_by", "created_by"),
-        Index("ix_courses_status", "status"),
+        Index(
+            "ix_courses_status_created_at",
+            "status",
+            text("created_at DESC"),
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        Index("ix_courses_access_mode", "access_mode"),
         Index(
             "ix_courses_created_by_active",
             "created_by",
@@ -47,6 +53,11 @@ class Course(Base):
     description: Mapped[str | None] = mapped_column()
     image_url: Mapped[str | None] = mapped_column()
     status: Mapped[str] = mapped_column(default="draft")
+    # Access mode controls who can ENROLL in the course (separate from
+    # status which controls whether it's published in the catalog at all).
+    # See ADR-010 in equipbible-docs/product/decisions/ — institute-mode
+    # courses are visible but solo-enrollment is gated to admin.
+    access_mode: Mapped[str] = mapped_column(default="public", server_default="public")
     created_by: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("profiles.id", ondelete="SET NULL"))
     enrollment_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     enrollment_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/models/enrollment.py
+++ b/backend/app/models/enrollment.py
@@ -15,10 +15,14 @@ if TYPE_CHECKING:
 class Enrollment(Base):
     __tablename__ = "enrollments"
     __table_args__ = (
-        UniqueConstraint("user_id", "course_id", name="uq_enrollment_user_course"),
-        # The unique ``(user_id, course_id)`` already indexes ``user_id`` via
-        # its leading column, so we only need an explicit index for the
-        # access patterns it doesn't cover.
+        # Uniqueness is on (user, course, cohort) — ADR-010 §3. Retake in a
+        # later cohort writes a NEW row, preserving the historical attempt.
+        # The PROD partial UNIQUE INDEX (with COALESCE for the NULL cohort_id
+        # sentinel) lives in the migration; SQLAlchemy can't express that
+        # directly so we declare a plain three-column UniqueConstraint here
+        # which is enough for the SQLite test path (NULL is treated as a
+        # distinct value by SQLite UNIQUE, matching the COALESCE semantics).
+        UniqueConstraint("user_id", "course_id", "cohort_id", name="uq_enrollment_user_course_cohort"),
         Index("ix_enrollments_course_id", "course_id"),
         Index("ix_enrollments_cohort_id", "cohort_id"),
     )

--- a/backend/app/schemas/cohort.py
+++ b/backend/app/schemas/cohort.py
@@ -1,3 +1,11 @@
+"""Cohort schemas — top-level admin entity (ADR-010).
+
+A cohort is a named batch of students that takes some set of courses
+together over a date window. The director creates an empty cohort,
+then independently attaches courses (via ``cohort_courses``) and
+students (via ``enrollments`` with ``cohort_id`` set).
+"""
+
 from datetime import datetime
 from typing import Literal
 from uuid import UUID
@@ -6,6 +14,9 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class CohortCreate(BaseModel):
+    """Inputs for creating an empty cohort. Courses and students are
+    attached via the junction endpoints; this body is just the metadata."""
+
     name: str = Field(..., min_length=1, max_length=200)
     start_date: datetime
     end_date: datetime
@@ -20,15 +31,18 @@ class CohortUpdate(BaseModel):
     end_date: datetime | None = None
     enrollment_start: datetime | None = None
     enrollment_end: datetime | None = None
-    status: Literal["upcoming", "active", "completed", "archived"] | None = None
+    status: Literal["upcoming", "active", "completed"] | None = None
     max_students: int | None = Field(None, ge=1)
 
 
 class CohortResponse(BaseModel):
+    """Cohort overview. ``course_ids`` and ``student_count`` are computed
+    fields populated by the route handler from the junction + enrollments
+    tables — they are not stored on the model itself."""
+
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
-    course_id: str
     name: str
     start_date: datetime
     end_date: datetime
@@ -36,6 +50,39 @@ class CohortResponse(BaseModel):
     enrollment_end: datetime | None = None
     status: str
     max_students: int | None = None
+    created_by: UUID | None = None
     created_at: datetime
     updated_at: datetime | None = None
+
+    # Computed:
+    course_ids: list[str] = Field(default_factory=list)
     student_count: int = 0
+
+
+class CohortCourseAttach(BaseModel):
+    """POST /cohorts/{id}/courses — attach a course to a cohort."""
+
+    course_id: str = Field(..., min_length=1)
+
+
+class CohortStudentAdd(BaseModel):
+    """POST /cohorts/{id}/students — add a student to a cohort.
+
+    Either ``user_id`` (existing platform user) or ``email`` (invite-by-
+    email, the backend resolves to user). Exactly one must be set.
+    """
+
+    user_id: UUID | None = None
+    email: str | None = None
+
+
+class CohortStudentRow(BaseModel):
+    """One row in the per-cohort students listing — enrollment summary
+    plus the student's identity. Used by the cohort overview page."""
+
+    user_id: UUID
+    enrolled_at: datetime | None = None
+    progress: int
+    # Per-course rows: this cohort spans N courses, so a student has N
+    # enrollments. Aggregated client-side from the per-course response.
+    per_course: dict[str, dict] = Field(default_factory=dict)

--- a/backend/app/services/translation/course_pipeline.py
+++ b/backend/app/services/translation/course_pipeline.py
@@ -171,7 +171,18 @@ def _translate_course_side_entities(
             total,
             reconcile_entity(db, "course_event", ev, provider=provider),
         )
-    for co in db.query(Cohort).filter(Cohort.course_id == course.id).all():
+    # Cohorts now live independently of courses (ADR-010) and attach via
+    # the ``cohort_courses`` junction. Reconcile every cohort that
+    # currently includes this course — each course-locale pair gets its
+    # own translation overlay row for the cohort name.
+    from app.models.cohort import CohortCourse
+
+    for co in (
+        db.query(Cohort)
+        .join(CohortCourse, Cohort.id == CohortCourse.cohort_id)
+        .filter(CohortCourse.course_id == course.id)
+        .all()
+    ):
         total = merge_orchestrator_reports(
             total,
             reconcile_entity(db, "cohort", co, provider=provider),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -48,6 +48,7 @@ TestSessionFactory = sessionmaker(bind=test_engine, autocommit=False, autoflush=
 # Stable UUIDs so tests can reference them predictably
 TEACHER_ID = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 STUDENT_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+ADMIN_ID = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
 
 # ---------------------------------------------------------------------------
 # Per-test table lifecycle — drop/create keeps every test fully isolated
@@ -117,6 +118,15 @@ def _make_student() -> User:
     )
 
 
+def _make_admin() -> User:
+    return User(
+        id=ADMIN_ID,
+        email="admin@example.com",
+        full_name="Test Admin",
+        role=UserRole.ADMIN.value,
+    )
+
+
 @pytest.fixture()
 def teacher(db: Session) -> User:
     user = _make_teacher()
@@ -129,6 +139,15 @@ def teacher(db: Session) -> User:
 @pytest.fixture()
 def student(db: Session) -> User:
     user = _make_student()
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def admin(db: Session) -> User:
+    user = _make_admin()
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -169,6 +188,27 @@ def student_client(db: Session, teacher: User, student: User) -> TestClient:
 
     def _override_user():
         return student
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_user] = _override_user
+    app.dependency_overrides[get_optional_user] = _override_user
+
+    with TestClient(app, raise_server_exceptions=False) as tc:
+        yield tc
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def admin_client(db: Session, teacher: User, admin: User) -> TestClient:
+    """TestClient authenticated as a seeded admin (teacher also seeded
+    for course-authorship scenarios where admin manages teacher's courses)."""
+
+    def _override_db():
+        yield db
+
+    def _override_user():
+        return admin
 
     app.dependency_overrides[get_db] = _override_db
     app.dependency_overrides[get_current_user] = _override_user

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -9,12 +9,12 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.models.announcement import Announcement
-from app.models.cohort import Cohort
+from app.models.cohort import Cohort, CohortCourse
 from app.models.course import Course, Module
 from app.models.course_event import CourseEvent
 from app.models.enrollment import Enrollment
 from app.models.notification import Notification
-from tests.conftest import STUDENT_ID, TEACHER_ID
+from tests.conftest import ADMIN_ID, STUDENT_ID, TEACHER_ID
 
 # ---------------------------------------------------------------------------
 # SQLite compatibility: Uuid.bind_processor expects uuid.UUID objects but
@@ -125,258 +125,379 @@ def _announcement_payload(**overrides) -> dict:
 
 
 # ===========================================================================
-# COHORT TESTS
+# COHORT TESTS — ADR-010 top-level admin model
 # ===========================================================================
+#
+# Cohorts are admin-owned. Creation is a two-step intent: first create an
+# empty cohort (POST /cohorts), then attach courses + students via
+# the junction endpoints. Teacher and student roles can READ the
+# course-scoped listing (for gradebook filter / enroll dialog) but not
+# write anything.
 
 
-class TestListCohorts:
+def _attach_course_via_junction(db: Session, cohort_id, course_id: str) -> None:
+    """Test helper — bypass the API to attach a course directly. Use when
+    a test only needs the junction row in place and doesn't care about the
+    auto-enroll side effect of the public POST endpoint."""
+    db.add(CohortCourse(cohort_id=cohort_id, course_id=course_id))
+    db.commit()
+
+
+def _seed_cohort_with_course(db: Session, *, course_id: str = "test-course-1", **kw) -> Cohort:
+    # ``created_by`` defaults to NULL — only set it explicitly in tests
+    # that pull in the ``admin`` fixture. Otherwise the FK to profiles
+    # would fail on tests that only seed teacher/student users.
+    cohort = Cohort(
+        name=kw.get("name", "X"),
+        start_date=kw.get("start_date", NOW),
+        end_date=kw.get("end_date", NEXT_WEEK),
+        status=kw.get("status", "upcoming"),
+        max_students=kw.get("max_students"),
+        created_by=kw.get("created_by"),
+    )
+    db.add(cohort)
+    db.commit()
+    db.refresh(cohort)
+    db.add(CohortCourse(cohort_id=cohort.id, course_id=course_id))
+    db.commit()
+    return cohort
+
+
+class TestListCohortsForCourse:
+    """``GET /cohorts/course/{id}`` — read-only, returns cohorts whose
+    junction includes the course. Used by the catalog enroll dialog and
+    a teacher's gradebook filter."""
+
     def test_empty_list(self, client: TestClient, db: Session):
         _seed_course(db)
         resp = client.get(f"{COHORT_PREFIX}/course/test-course-1")
         assert resp.status_code == 200
         assert resp.json() == []
 
-    def test_returns_cohorts_for_course(self, client: TestClient, db: Session):
-        course = _create_course_via_api(client)
-        cid = course["id"]
-        client.post(f"{COHORT_PREFIX}/course/{cid}", json=_cohort_payload(name="Cohort A"))
-        client.post(f"{COHORT_PREFIX}/course/{cid}", json=_cohort_payload(name="Cohort B"))
+    def test_returns_cohorts_via_junction(self, client: TestClient, db: Session):
+        _seed_course(db)
+        _seed_cohort_with_course(db, course_id="test-course-1", name="Cohort A")
+        _seed_cohort_with_course(db, course_id="test-course-1", name="Cohort B")
 
-        resp = client.get(f"{COHORT_PREFIX}/course/{cid}")
+        resp = client.get(f"{COHORT_PREFIX}/course/test-course-1")
         assert resp.status_code == 200
         names = {c["name"] for c in resp.json()}
         assert names == {"Cohort A", "Cohort B"}
 
-    def test_does_not_return_cohorts_from_other_courses(self, client: TestClient, db: Session):
-        c1 = _create_course_via_api(client)
-        c2_resp = client.post(COURSES_PREFIX, json={"title": "Other", "description": "other"})
-        c2 = c2_resp.json()
+    def test_does_not_return_cohorts_from_unrelated_courses(self, client: TestClient, db: Session):
+        _seed_course(db, course_id="course-1")
+        _seed_course(db, course_id="course-2")
+        _seed_cohort_with_course(db, course_id="course-1", name="One")
+        _seed_cohort_with_course(db, course_id="course-2", name="Two")
 
-        client.post(f"{COHORT_PREFIX}/course/{c1['id']}", json=_cohort_payload(name="C1 Cohort"))
-        client.post(f"{COHORT_PREFIX}/course/{c2['id']}", json=_cohort_payload(name="C2 Cohort"))
-
-        resp = client.get(f"{COHORT_PREFIX}/course/{c1['id']}")
+        resp = client.get(f"{COHORT_PREFIX}/course/course-1")
         names = [c["name"] for c in resp.json()]
-        assert names == ["C1 Cohort"]
+        assert names == ["One"]
 
 
 class TestCreateCohort:
-    def test_create_returns_201(self, client: TestClient):
-        course = _create_course_via_api(client)
-        resp = client.post(
-            f"{COHORT_PREFIX}/course/{course['id']}",
-            json=_cohort_payload(),
-        )
+    """``POST /cohorts`` — admin-only, creates an empty cohort. Courses
+    and students are attached separately."""
+
+    def test_admin_creates_empty_cohort(self, admin_client: TestClient):
+        resp = admin_client.post(COHORT_PREFIX, json=_cohort_payload())
         assert resp.status_code == 201
         body = resp.json()
         assert body["name"] == "Spring 2026"
         assert body["status"] == "upcoming"
-        assert body["course_id"] == course["id"]
+        assert body["course_ids"] == []
         assert body["student_count"] == 0
+        assert body["created_by"] == str(ADMIN_ID)
 
-    def test_create_with_optional_fields(self, client: TestClient):
-        course = _create_course_via_api(client)
-        payload = _cohort_payload(
-            enrollment_start=NOW.isoformat(),
-            enrollment_end=TOMORROW.isoformat(),
-            max_students=30,
-        )
-        resp = client.post(f"{COHORT_PREFIX}/course/{course['id']}", json=payload)
-        assert resp.status_code == 201
-        body = resp.json()
-        assert body["max_students"] == 30
-        assert body["enrollment_start"] is not None
-
-    def test_student_cannot_create_cohort(self, student_client: TestClient, db: Session):
-        _seed_course(db)
-        resp = student_client.post(
-            f"{COHORT_PREFIX}/course/test-course-1",
-            json=_cohort_payload(),
-        )
+    def test_teacher_cannot_create(self, client: TestClient):
+        resp = client.post(COHORT_PREFIX, json=_cohort_payload())
         assert resp.status_code == 403
 
-    def test_create_for_nonexistent_course_returns_404(self, client: TestClient):
-        resp = client.post(
-            f"{COHORT_PREFIX}/course/no-such-course",
-            json=_cohort_payload(),
-        )
-        assert resp.status_code == 404
+    def test_student_cannot_create(self, student_client: TestClient):
+        resp = student_client.post(COHORT_PREFIX, json=_cohort_payload())
+        assert resp.status_code == 403
 
-    def test_create_missing_name_returns_422(self, client: TestClient):
-        course = _create_course_via_api(client)
-        resp = client.post(
-            f"{COHORT_PREFIX}/course/{course['id']}",
+    def test_missing_name_returns_422(self, admin_client: TestClient):
+        resp = admin_client.post(
+            COHORT_PREFIX,
             json={"start_date": NOW.isoformat(), "end_date": NEXT_WEEK.isoformat()},
         )
         assert resp.status_code == 422
 
 
 class TestUpdateCohort:
-    def _create_cohort(self, client, course_id):
-        resp = client.post(f"{COHORT_PREFIX}/course/{course_id}", json=_cohort_payload())
-        assert resp.status_code == 201
-        return resp.json()
-
-    def test_update_name(self, client: TestClient):
-        course = _create_course_via_api(client)
-        cohort = self._create_cohort(client, course["id"])
-        resp = client.put(
-            f"{COHORT_PREFIX}/{cohort['id']}",
-            json={"name": "Fall 2026"},
-        )
+    def test_admin_updates_name(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db, name="Old")
+        resp = admin_client.patch(f"{COHORT_PREFIX}/{cohort.id}", json={"name": "Fall 2026"})
         assert resp.status_code == 200
         assert resp.json()["name"] == "Fall 2026"
 
-    def test_update_status(self, client: TestClient):
-        course = _create_course_via_api(client)
-        cohort = self._create_cohort(client, course["id"])
-        resp = client.put(
-            f"{COHORT_PREFIX}/{cohort['id']}",
-            json={"status": "active"},
-        )
+    def test_admin_updates_status(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        resp = admin_client.patch(f"{COHORT_PREFIX}/{cohort.id}", json={"status": "active"})
         assert resp.status_code == 200
         assert resp.json()["status"] == "active"
 
-    def test_update_nonexistent_returns_404(self, client: TestClient):
-        resp = client.put(
-            f"{COHORT_PREFIX}/{uuid.uuid4()}",
-            json={"name": "Nope"},
-        )
+    def test_update_nonexistent_returns_404(self, admin_client: TestClient):
+        resp = admin_client.patch(f"{COHORT_PREFIX}/{uuid.uuid4()}", json={"name": "Nope"})
         assert resp.status_code == 404
 
-    def test_student_cannot_update(self, student_client: TestClient, db: Session):
+    def test_teacher_cannot_update(self, client: TestClient, db: Session):
         _seed_course(db)
-        cohort = Cohort(
-            course_id="test-course-1",
-            name="X",
-            start_date=NOW,
-            end_date=NEXT_WEEK,
-        )
-        db.add(cohort)
-        db.commit()
-        db.refresh(cohort)
-
-        resp = student_client.put(
-            f"{COHORT_PREFIX}/{cohort.id}",
-            json={"name": "Hacked"},
-        )
+        cohort = _seed_cohort_with_course(db)
+        resp = client.patch(f"{COHORT_PREFIX}/{cohort.id}", json={"name": "Hacked"})
         assert resp.status_code == 403
 
 
 class TestDeleteCohort:
-    def test_delete_returns_204(self, client: TestClient):
-        course = _create_course_via_api(client)
-        resp = client.post(f"{COHORT_PREFIX}/course/{course['id']}", json=_cohort_payload())
-        cohort_id = resp.json()["id"]
+    def test_admin_deletes_cohort_and_orphans_enrollments(self, admin_client: TestClient, db: Session, student):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        _seed_enrollment(db, course_id="test-course-1", cohort_id=cohort.id)
 
-        resp = client.delete(f"{COHORT_PREFIX}/{cohort_id}")
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort.id}")
         assert resp.status_code == 204
 
-        resp = client.get(f"{COHORT_PREFIX}/course/{course['id']}")
-        assert resp.json() == []
+        # Cohort row gone, junction cascaded, but enrollment row survives
+        # with cohort_id set to NULL (orphan = solo) — historical grade
+        # data is intentionally preserved.
+        assert db.query(Cohort).filter(Cohort.id == cohort.id).first() is None
+        assert db.query(CohortCourse).filter(CohortCourse.cohort_id == cohort.id).count() == 0
+        surviving = db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID).all()
+        assert len(surviving) == 1
+        assert surviving[0].cohort_id is None
 
-    def test_delete_nonexistent_returns_404(self, client: TestClient):
-        resp = client.delete(f"{COHORT_PREFIX}/{uuid.uuid4()}")
+    def test_delete_nonexistent_returns_404(self, admin_client: TestClient):
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{uuid.uuid4()}")
         assert resp.status_code == 404
 
     def test_student_cannot_delete(self, student_client: TestClient, db: Session):
         _seed_course(db)
-        cohort = Cohort(
-            course_id="test-course-1",
-            name="X",
-            start_date=NOW,
-            end_date=NEXT_WEEK,
-        )
-        db.add(cohort)
-        db.commit()
-        db.refresh(cohort)
-
+        cohort = _seed_cohort_with_course(db)
         resp = student_client.delete(f"{COHORT_PREFIX}/{cohort.id}")
         assert resp.status_code == 403
 
 
-class TestCohortStudents:
-    def test_empty_roster(self, client: TestClient):
-        course = _create_course_via_api(client)
-        resp = client.post(f"{COHORT_PREFIX}/course/{course['id']}", json=_cohort_payload())
-        cohort_id = resp.json()["id"]
+class TestAttachCourse:
+    def test_attach_creates_junction_row(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort_resp = admin_client.post(COHORT_PREFIX, json=_cohort_payload())
+        cohort_id = cohort_resp.json()["id"]
 
-        resp = client.get(f"{COHORT_PREFIX}/{cohort_id}/students")
+        resp = admin_client.post(
+            f"{COHORT_PREFIX}/{cohort_id}/courses",
+            json={"course_id": "test-course-1"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["course_ids"] == ["test-course-1"]
+
+    def test_attach_auto_enrolls_existing_cohort_students(self, admin_client: TestClient, db: Session, student):
+        # Two courses exist. Cohort starts attached to course-1 with one
+        # student. Attaching course-2 should auto-create an enrollment.
+        _seed_course(db, course_id="course-1")
+        _seed_course(db, course_id="course-2")
+        cohort = _seed_cohort_with_course(db, course_id="course-1")
+        _seed_enrollment(db, course_id="course-1", cohort_id=cohort.id)
+
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/courses", json={"course_id": "course-2"})
+        assert resp.status_code == 201
+        new_enrollment = (
+            db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == "course-2").first()
+        )
+        assert new_enrollment is not None
+        assert new_enrollment.cohort_id == cohort.id
+
+    def test_attach_is_idempotent(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)  # course already attached
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/courses", json={"course_id": "test-course-1"})
+        assert resp.status_code == 201
+        assert resp.json()["course_ids"] == ["test-course-1"]
+
+    def test_attach_nonexistent_course_returns_404(self, admin_client: TestClient, db: Session):
+        cohort_resp = admin_client.post(COHORT_PREFIX, json=_cohort_payload())
+        resp = admin_client.post(
+            f"{COHORT_PREFIX}/{cohort_resp.json()['id']}/courses",
+            json={"course_id": "no-such-course"},
+        )
+        assert resp.status_code == 404
+
+
+class TestDetachCourse:
+    def test_detach_orphans_enrollments_to_null_cohort(self, admin_client: TestClient, db: Session, student):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        _seed_enrollment(db, course_id="test-course-1", cohort_id=cohort.id)
+
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort.id}/courses/test-course-1")
+        assert resp.status_code == 204
+
+        # Junction row removed
+        assert db.query(CohortCourse).filter(CohortCourse.cohort_id == cohort.id).count() == 0
+        # Enrollment survives with cohort_id nulled — grades preserved
+        surviving = db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID).all()
+        assert len(surviving) == 1
+        assert surviving[0].cohort_id is None
+
+    def test_detach_nonexistent_link_is_noop(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort_resp = admin_client.post(COHORT_PREFIX, json=_cohort_payload())
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort_resp.json()['id']}/courses/test-course-1")
+        assert resp.status_code == 204
+
+
+class TestAddStudent:
+    def test_add_by_user_id_auto_enrolls_in_all_cohort_courses(self, admin_client: TestClient, db: Session, student):
+        _seed_course(db, course_id="course-1")
+        _seed_course(db, course_id="course-2")
+        cohort = _seed_cohort_with_course(db, course_id="course-1")
+        _attach_course_via_junction(db, cohort.id, "course-2")
+
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/students", json={"user_id": str(STUDENT_ID)})
+        assert resp.status_code == 201
+        enrollments = (
+            db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID, Enrollment.cohort_id == cohort.id).all()
+        )
+        assert {e.course_id for e in enrollments} == {"course-1", "course-2"}
+
+    def test_add_by_email(self, admin_client: TestClient, db: Session, student):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/students", json={"email": "student@example.com"})
+        assert resp.status_code == 201
+
+    def test_add_unknown_email_returns_404(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/students", json={"email": "nobody@example.com"})
+        assert resp.status_code == 404
+
+    def test_add_without_user_id_or_email_returns_400(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/students", json={})
+        assert resp.status_code == 400
+
+    def test_max_students_capacity_rejects_new(self, admin_client: TestClient, db: Session, student, teacher):
+        # Capacity = 1. Pre-seed one enrollment so the cohort is full,
+        # then try to add a different student via the API → 403.
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db, max_students=1)
+        _seed_enrollment(db, user_id=TEACHER_ID, course_id="test-course-1", cohort_id=cohort.id)
+
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/students", json={"user_id": str(STUDENT_ID)})
+        assert resp.status_code == 403
+        assert "capacity" in resp.json()["detail"].lower()
+
+
+class TestRemoveStudent:
+    def test_remove_nulls_cohort_id_on_enrollments(self, admin_client: TestClient, db: Session, student):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        _seed_enrollment(db, course_id="test-course-1", cohort_id=cohort.id)
+
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort.id}/students/{STUDENT_ID}")
+        assert resp.status_code == 204
+        surviving = db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID).all()
+        assert len(surviving) == 1
+        assert surviving[0].cohort_id is None
+
+
+class TestCohortStudents:
+    def test_empty_roster(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        resp = admin_client.get(f"{COHORT_PREFIX}/{cohort.id}/students")
         assert resp.status_code == 200
         assert resp.json() == []
 
-    def test_roster_includes_enrolled_student(self, client: TestClient, db: Session, student):
-        course = _create_course_via_api(client)
-        cid = course["id"]
-        resp = client.post(f"{COHORT_PREFIX}/course/{cid}", json=_cohort_payload())
-        cohort_id = resp.json()["id"]
+    def test_roster_per_course_shape(self, admin_client: TestClient, db: Session, student):
+        _seed_course(db, course_id="course-1")
+        _seed_course(db, course_id="course-2")
+        cohort = _seed_cohort_with_course(db, course_id="course-1")
+        _attach_course_via_junction(db, cohort.id, "course-2")
+        _seed_enrollment(db, course_id="course-1", cohort_id=cohort.id)
+        _seed_enrollment(db, course_id="course-2", cohort_id=cohort.id)
 
-        _seed_enrollment(db, course_id=cid, cohort_id=cohort_id)
-
-        resp = client.get(f"{COHORT_PREFIX}/{cohort_id}/students")
+        resp = admin_client.get(f"{COHORT_PREFIX}/{cohort.id}/students")
         assert resp.status_code == 200
-        students = resp.json()
-        assert len(students) == 1
-        assert students[0]["user_id"] == str(STUDENT_ID)
+        rows = resp.json()
+        assert len(rows) == 1
+        assert rows[0]["user_id"] == str(STUDENT_ID)
+        assert set(rows[0]["per_course"].keys()) == {"course-1", "course-2"}
 
-    def test_nonexistent_cohort_returns_404(self, client: TestClient):
-        resp = client.get(f"{COHORT_PREFIX}/{uuid.uuid4()}/students")
+    def test_nonexistent_cohort_returns_404(self, admin_client: TestClient):
+        resp = admin_client.get(f"{COHORT_PREFIX}/{uuid.uuid4()}/students")
         assert resp.status_code == 404
 
     def test_student_cannot_view_roster(self, student_client: TestClient, db: Session):
         _seed_course(db)
-        cohort = Cohort(
-            course_id="test-course-1",
-            name="X",
-            start_date=NOW,
-            end_date=NEXT_WEEK,
-        )
-        db.add(cohort)
-        db.commit()
-        db.refresh(cohort)
-
+        cohort = _seed_cohort_with_course(db)
         resp = student_client.get(f"{COHORT_PREFIX}/{cohort.id}/students")
         assert resp.status_code == 403
 
 
 class TestCompleteCohort:
-    def test_complete_sets_status(self, client: TestClient):
-        course = _create_course_via_api(client)
-        resp = client.post(f"{COHORT_PREFIX}/course/{course['id']}", json=_cohort_payload())
-        cohort_id = resp.json()["id"]
-
-        resp = client.post(f"{COHORT_PREFIX}/{cohort_id}/complete")
+    def test_admin_completes_cohort(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/complete")
         assert resp.status_code == 200
         assert resp.json()["status"] == "completed"
 
-    def test_complete_already_completed_returns_400(self, client: TestClient):
-        course = _create_course_via_api(client)
-        resp = client.post(f"{COHORT_PREFIX}/course/{course['id']}", json=_cohort_payload())
-        cohort_id = resp.json()["id"]
-
-        client.post(f"{COHORT_PREFIX}/{cohort_id}/complete")
-        resp = client.post(f"{COHORT_PREFIX}/{cohort_id}/complete")
+    def test_already_completed_returns_400(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db, status="completed")
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/complete")
         assert resp.status_code == 400
-        assert "already completed" in resp.json()["detail"].lower()
 
-    def test_complete_nonexistent_returns_404(self, client: TestClient):
-        resp = client.post(f"{COHORT_PREFIX}/{uuid.uuid4()}/complete")
+    def test_nonexistent_returns_404(self, admin_client: TestClient):
+        resp = admin_client.post(f"{COHORT_PREFIX}/{uuid.uuid4()}/complete")
         assert resp.status_code == 404
 
     def test_student_cannot_complete(self, student_client: TestClient, db: Session):
         _seed_course(db)
-        cohort = Cohort(
-            course_id="test-course-1",
-            name="X",
-            start_date=NOW,
-            end_date=NEXT_WEEK,
-        )
-        db.add(cohort)
-        db.commit()
-        db.refresh(cohort)
-
+        cohort = _seed_cohort_with_course(db)
         resp = student_client.post(f"{COHORT_PREFIX}/{cohort.id}/complete")
         assert resp.status_code == 403
+
+
+class TestSoloEnrollmentAccessMode:
+    """ADR-010 §1: ``access_mode='institute'`` blocks the solo-enroll
+    path (no cohort_id in the request body). Cohort-route enrollment
+    still works — that's the director's explicit invitation."""
+
+    def test_solo_enroll_on_institute_course_returns_403(self, student_client: TestClient, db: Session, student):
+        course = Course(
+            id="institute-course",
+            title="Greek 1",
+            status="published",
+            access_mode="institute",
+            created_by=TEACHER_ID,
+        )
+        db.add(course)
+        db.commit()
+
+        resp = student_client.post(f"{COURSES_PREFIX}/{course.id}/enroll", json={})
+        assert resp.status_code == 403
+        assert "invitation" in resp.json()["detail"].lower()
+
+    def test_solo_enroll_on_public_course_succeeds(self, student_client: TestClient, db: Session, student):
+        course = Course(
+            id="public-course",
+            title="Jubilee Overview",
+            status="published",
+            access_mode="public",
+            created_by=TEACHER_ID,
+        )
+        db.add(course)
+        db.commit()
+
+        resp = student_client.post(f"{COURSES_PREFIX}/{course.id}/enroll", json={})
+        assert resp.status_code == 200, resp.text
 
 
 # ===========================================================================

--- a/supabase/migrations/20260513205435_cohort_top_level.sql
+++ b/supabase/migrations/20260513205435_cohort_top_level.sql
@@ -1,0 +1,67 @@
+-- ADR-010: Cohorts become top-level admin entities; courses gain access_mode.
+--
+-- Full design + rationale in equipbible-docs/product/decisions/ADR-010.
+-- Summary of schema deltas, in dependency order:
+--   1. courses.access_mode (public | institute) — solo-enrollment gate
+--   2. cohorts: drop course_id (was 1:1 FK), add created_by
+--   3. cohort_courses: new junction (cohort × course)
+--   4. enrollments: relax UNIQUE so retake-in-another-cohort works
+--
+-- All four are safe on current prod data (0 cohort rows, 16 enrollments
+-- all with cohort_id=NULL, every existing course defaults to 'public').
+
+
+-- 1. Course access mode -------------------------------------------------
+-- 'public'    = catalog Enroll button works for any student (subject to
+--               course.enrollment_start/_end window)
+-- 'institute' = catalog shows description but Enroll is disabled; access
+--               only via admin (cohort enrollment or direct add)
+ALTER TABLE public.courses
+  ADD COLUMN access_mode text NOT NULL DEFAULT 'public'
+  CHECK (access_mode IN ('public', 'institute'));
+
+CREATE INDEX IF NOT EXISTS ix_courses_access_mode ON public.courses (access_mode);
+
+
+-- 2. Cohorts: drop course_id, add created_by ---------------------------
+-- The FK + index on course_id are orphans after this — cohort is no longer
+-- scoped to a single course. The N:N relationship lives in cohort_courses
+-- (created below).
+DROP INDEX IF EXISTS public.ix_cohorts_course_id;
+ALTER TABLE public.cohorts DROP CONSTRAINT IF EXISTS cohorts_course_id_fkey;
+ALTER TABLE public.cohorts DROP COLUMN course_id;
+
+ALTER TABLE public.cohorts
+  ADD COLUMN created_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS ix_cohorts_created_by ON public.cohorts (created_by);
+
+
+-- 3. cohort_courses junction (cohort × course, N:N) --------------------
+CREATE TABLE IF NOT EXISTS public.cohort_courses (
+  cohort_id uuid    NOT NULL REFERENCES public.cohorts(id) ON DELETE CASCADE,
+  course_id text    NOT NULL REFERENCES public.courses(id) ON DELETE CASCADE,
+  added_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (cohort_id, course_id)
+);
+
+-- Most queries land on cohort_id (list courses of a cohort); the PK's
+-- left-prefix covers that. The reverse direction (which cohorts contain
+-- course X) is rarer but worth one explicit index.
+CREATE INDEX IF NOT EXISTS ix_cohort_courses_course_id
+  ON public.cohort_courses (course_id);
+
+
+-- 4. Enrollment UNIQUE: (user, course) → (user, course, cohort) ---------
+-- Retake-in-a-different-cohort needs to write a NEW enrollment row
+-- rather than overwrite the old one. COALESCE maps NULL cohort_id to a
+-- sentinel UUID so two solo enrollments to the same course are still
+-- rejected (we don't want a user accidentally enrolling themselves twice).
+ALTER TABLE public.enrollments DROP CONSTRAINT IF EXISTS uq_enrollment_user_course;
+
+CREATE UNIQUE INDEX uq_enrollment_user_course_cohort
+  ON public.enrollments (
+    user_id,
+    course_id,
+    COALESCE(cohort_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  );


### PR DESCRIPTION
## Summary

Implements [ADR-010](https://github.com/ArVaViT/equipbible-docs/blob/main/product/decisions/ADR-010-cohort-top-level.md) cleanly. No deprecated fields, no compatibility shims — full clean cut on the cohort model.

## What changes

- **Cohort** becomes a top-level admin entity. Drops the old 1:1 `cohorts.course_id` FK, replaces with the `cohort_courses` junction so one cohort spans N courses.
- **Course** gains `access_mode` (`public` or `institute`). Public = solo-enrollable. Institute = visible in catalog but solo-enroll is blocked with "Доступно только по приглашению" — admin must add the student via the cohort or direct-enroll path.
- **Enrollment** `UNIQUE` relaxes from `(user, course)` to `(user, course, cohort)` so a student who failed Greek-1 in one cohort can retake it in a later cohort without overwriting the historical attempt.
- **Cohort routes** completely rewritten — admin-only top-level CRUD plus separate junction endpoints for attaching courses and adding students. Attach/add operations auto-create the per-(student, course) enrollment rows so the director never has to write 30×3=90 enrollments by hand.
- **Solo enrollment** path now rejects 403 when the course is `access_mode=institute`. Cohort-route enrollment still works for any access mode (the director's invitation is the gate).
- **Translation pipeline** reconciles cohort overlays through the junction (was: filter by Cohort.course_id).

## Test coverage

- 22 old cohort tests → 25 new tests covering: top-level CRUD, attach/detach with auto-enroll, orphan-on-detach-with-grades-preserved, add student by user_id and by email, capacity check via DISTINCT count, access_mode block on solo institute enroll.
- Full suite: **522 passed** (was 509).
- New `admin_client` fixture in conftest for the admin-only endpoints.

## Migration & rollout

The schema migration is applied to prod (zero data backfill — the cohorts table was empty). Frontend admin UI for cohort CRUD ships as separate PRs once this lands — issues will be filed.

## Test plan
- [x] ruff format + check clean
- [x] mypy clean
- [x] pytest 522/522
- [ ] After merge: verify catalog still loads, institute course enroll button labels correctly, admin can create+populate a cohort end-to-end