### PR TITLE
fix(security): enable RLS on cohort_courses (clears ERROR-level lint)

### DIFF
--- a/supabase/migrations/20260513215743_cohort_courses_rls.sql
+++ b/supabase/migrations/20260513215743_cohort_courses_rls.sql
@@ -1,0 +1,53 @@
+-- Enable RLS on cohort_courses (created in 20260513205435_cohort_top_level
+-- without policies — flagged by the Supabase database linter as an
+-- ERROR-level rls_disabled_in_public lint).
+--
+-- The FastAPI backend uses the service-role key and bypasses RLS, so this
+-- is defense in depth against direct PostgREST access via the anon key.
+--
+-- Policy shape mirrors `public.cohorts`:
+--   - SELECT open to everyone (the catalog enroll dialog reads cohorts
+--     attached to a course via this junction).
+--   - INSERT / UPDATE / DELETE gated to authenticated users whose
+--     `profiles.role` is admin. ADR-010 makes cohort management admin-only;
+--     RLS enforces that even if the API layer were ever bypassed.
+
+ALTER TABLE public.cohort_courses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY cohort_courses_select_all
+  ON public.cohort_courses
+  FOR SELECT
+  USING (true);
+
+CREATE POLICY cohort_courses_insert_admin
+  ON public.cohort_courses
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = (SELECT auth.uid())
+        AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY cohort_courses_update_admin
+  ON public.cohort_courses
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = (SELECT auth.uid())
+        AND p.role = 'admin'
+    )
+  );
+
+CREATE POLICY cohort_courses_delete_admin
+  ON public.cohort_courses
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = (SELECT auth.uid())
+        AND p.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
Enable RLS on `public.cohort_courses` (the junction created in `20260513205435_cohort_top_level`). The Supabase database linter flagged this as an **ERROR-level** `rls_disabled_in_public` lint.

- Production app traffic is unaffected — the FastAPI backend uses the service-role key, which bypasses RLS by design.
- This is defense-in-depth against direct PostgREST access via the anon key.
- Policy shape mirrors `public.cohorts`: open SELECT, admin-only writes (per ADR-010, which made cohort management admin-only at the API layer).

## Apply
Already applied to prod via `supabase apply_migration cohort_courses_rls`. The table is empty (no admin UI ships rows yet), so the migration is purely additive. Verified post-apply: ERROR lint is cleared, only the `auth_leaked_password_protection` WARN remains (Pro-plan feature, intentionally deferred).

## Test plan
- [x] `mcp__plugin_supabase_supabase__get_advisors` — `rls_disabled_in_public` lint no longer present
- [x] Migration file checked into `supabase/migrations/` so a fresh DB / `db push --linked` will reproduce the state
- [ ] CI postgres schema-smoke job confirms the migration applies on a blank DB
