### PR TITLE
chore: switch support email residue to equipbible.com via shared constant

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import AnnouncementBanner from "./components/announcements/AnnouncementBanner"
 import PageSpinner from "./components/ui/PageSpinner"
 import ScrollToTop from "./components/layout/ScrollToTop";
 import { TooltipProvider } from "@/components/ui/tooltip"
+import { SUPPORT_EMAIL } from "@/lib/brand"
 
 const NotFound = lazy(() => import("./pages/NotFound"))
 
@@ -71,7 +72,7 @@ function PendingTeacherBanner() {
             components={{
               supportLink: (
                 <a
-                  href="mailto:support@bibleschool.com"
+                  href={`mailto:${SUPPORT_EMAIL}`}
                   className="underline font-medium hover:no-underline"
                 />
               ),

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -2,8 +2,7 @@ import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { Mail } from "lucide-react"
 import { useAuth } from "@/context/useAuth"
-
-const SUPPORT_EMAIL = "support@bibleschool.com"
+import { SUPPORT_EMAIL } from "@/lib/brand"
 
 export default function Footer() {
   const { t } = useTranslation()

--- a/frontend/src/lib/brand.ts
+++ b/frontend/src/lib/brand.ts
@@ -1,0 +1,1 @@
+export const SUPPORT_EMAIL = "support@equipbible.com"

--- a/frontend/src/pages/Auth/register/DuplicateEmailView.tsx
+++ b/frontend/src/pages/Auth/register/DuplicateEmailView.tsx
@@ -3,6 +3,7 @@ import { Mail } from "lucide-react"
 import { Trans, useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import AuthLayout from "@/components/layout/AuthLayout"
+import { SUPPORT_EMAIL } from "@/lib/brand"
 
 /**
  * Terminal state shown when the register endpoint reports a duplicate
@@ -46,7 +47,7 @@ export function DuplicateEmailView({ email }: { email: string }) {
               {t("authRegister.duplicate.forgotPassword")}
             </Button>
           </Link>
-          <a href="mailto:support@bibleschool.com" className="block">
+          <a href={`mailto:${SUPPORT_EMAIL}`} className="block">
             <Button variant="ghost" size="lg" className="w-full text-muted-foreground">
               {t("authRegister.duplicate.contactSupport")}
             </Button>


### PR DESCRIPTION
## Summary

- Three sites still pointed at `support@bibleschool.com` (Footer, `App` PendingTeacherBanner, `DuplicateEmailView`) after the rebrand sweep.
- Hoist into a single `SUPPORT_EMAIL` constant in `frontend/src/lib/brand.ts` so future brand changes land in one place.

## Note on mailbox provisioning

The mailbox `support@equipbible.com` is **not yet provisioned** on the verified domain. Only `noreply@equipbible.com` is wired (Resend sending-only key for the Supabase Edge Function). Set up a Vercel DNS catch-all or Cloudflare email routing to `arvavitcorp@gmail.com` so incoming \`mailto:support@equipbible.com\` actually reaches an inbox.

## Test plan

- [x] \`npm run lint\` (zero warnings)
- [x] \`npx tsc --noEmit\` (strict)
- [x] Manual grep: zero remaining \`@bibleschool.com\` strings in \`frontend/src/\`
- [ ] CI green
- [ ] Mailbox provisioned (separate task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)