### PR TITLE
perf(quiz): drop per-row db.flush() in persist_answers (single commit at end)

### DIFF
--- a/backend/app/services/quiz_service.py
+++ b/backend/app/services/quiz_service.py
@@ -7,6 +7,7 @@ serialize the response" lives here.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -122,19 +123,24 @@ def persist_answers(
         is_correct, points_earned = grade_auto_answer(question, ans.selected_option_id, options_by_id)
         total_score += points_earned
 
-        answer_row = QuizAnswer(
-            attempt_id=attempt.id,
-            question_id=ans.question_id,
-            selected_option_id=ans.selected_option_id,
-            text_answer=ans.text_answer,
-            is_correct=is_correct,
-            points_earned=points_earned,
+        # Pre-generate the PK so we can build QuizAnswerResult without
+        # round-tripping a flush per row. The caller (`submit_quiz`)
+        # commits once at the end, which flushes everything.
+        answer_id = uuid.uuid4()
+        db.add(
+            QuizAnswer(
+                id=answer_id,
+                attempt_id=attempt.id,
+                question_id=ans.question_id,
+                selected_option_id=ans.selected_option_id,
+                text_answer=ans.text_answer,
+                is_correct=is_correct,
+                points_earned=points_earned,
+            )
         )
-        db.add(answer_row)
-        db.flush()
         answer_results.append(
             QuizAnswerResult(
-                id=answer_row.id,
+                id=answer_id,
                 question_id=ans.question_id,
                 selected_option_id=ans.selected_option_id,
                 text_answer=ans.text_answer,
@@ -150,19 +156,21 @@ def persist_answers(
     for q in quiz.questions:
         if q.id in answered:
             continue
-        skip_row = QuizAnswer(
-            attempt_id=attempt.id,
-            question_id=q.id,
-            selected_option_id=None,
-            text_answer=None,
-            is_correct=False,
-            points_earned=0,
+        skip_id = uuid.uuid4()
+        db.add(
+            QuizAnswer(
+                id=skip_id,
+                attempt_id=attempt.id,
+                question_id=q.id,
+                selected_option_id=None,
+                text_answer=None,
+                is_correct=False,
+                points_earned=0,
+            )
         )
-        db.add(skip_row)
-        db.flush()
         answer_results.append(
             QuizAnswerResult(
-                id=skip_row.id,
+                id=skip_id,
                 question_id=q.id,
                 selected_option_id=None,
                 text_answer=None,


### PR DESCRIPTION
## Summary

\`persist_answers\` was issuing \`db.flush()\` after every \`QuizAnswer\` it added — both on the submitted-answers loop and the skipped-questions loop — to materialize the auto-generated PK so the returned \`QuizAnswerResult\` could carry the id. On a 30-question exam under load that's 30 extra round-trips per submit. Quiz submit is on every chapter-complete path.

## Fix

Pre-generate the PK in Python via \`uuid.uuid4()\` (same factory the column already declares as \`default=\`) and assign it explicitly to the row. The caller (\`submit_quiz\` in \`attempts.py\`) commits once at the end, which flushes every row in a single round-trip.

## No behavior change

- \`QuizAnswerResult.id\` carries the same value, just resolved earlier
- DB sees the same column default-resolution semantics (Python-side default in both cases)

## Test plan

- [x] \`ruff check\` clean
- [x] \`mypy --config-file mypy.ini app/services/quiz_service.py\` — no issues
- [x] \`pytest tests/ -k quiz\` — 87 passed
- [ ] CI green
- [ ] Manual: submit a 5-question quiz on prod after merge, verify result screen renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)