### PR TITLE
fix(db): drop 4 redundant indexes + repair user-delete FK cascades

### DIFF
--- a/backend/app/models/student_grade.py
+++ b/backend/app/models/student_grade.py
@@ -20,7 +20,7 @@ class StudentGrade(Base):
     cohort_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("cohorts.id", ondelete="SET NULL"))
     grade: Mapped[str | None] = mapped_column(String(10))
     comment: Mapped[str | None] = mapped_column(Text)
-    graded_by: Mapped[uuid.UUID] = mapped_column()
+    graded_by: Mapped[uuid.UUID | None] = mapped_column()
     graded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/app/schemas/grade.py
+++ b/backend/app/schemas/grade.py
@@ -18,7 +18,7 @@ class GradeResponse(BaseModel):
     cohort_id: UUID | None = None
     grade: str | None = None
     comment: str | None = None
-    graded_by: UUID
+    graded_by: UUID | None = None
     graded_at: datetime
     updated_at: datetime | None = None
 

--- a/supabase/migrations/20260514150000_drop_redundant_indexes_and_fix_user_delete_cascades.sql
+++ b/supabase/migrations/20260514150000_drop_redundant_indexes_and_fix_user_delete_cascades.sql
@@ -1,0 +1,70 @@
+-- Tech-debt sweep follow-up to the 2026-05-14 DB audit. Two clusters:
+--
+-- 1. Drop 4 redundant left-prefix indexes — each is fully covered by
+--    an existing composite. Saves write overhead on inserts/updates.
+--    (Companion to 20260513195434_perf_indexes_and_autovacuum which
+--    dropped the first 3 such cases.)
+--
+-- 2. Fix referential integrity on user-delete paths. Four FKs against
+--    auth.users had the wrong ON DELETE rule for an LMS audit trail:
+--
+--    HIGH   - student_grades.graded_by_fkey was ON DELETE CASCADE,
+--             meaning deleting a teacher silently wiped every grade
+--             they ever issued. Change to ON DELETE SET NULL so the
+--             grade row survives with a null grader reference. The
+--             column needs to be made nullable for this.
+--
+--    MEDIUM - assignment_submissions.graded_by_fkey
+--             certificates.teacher_approved_by_fkey
+--             certificates.admin_approved_by_fkey
+--             …all had NO ACTION (the default), which means deleting
+--             a teacher fails with an FK violation. Same fix: ON
+--             DELETE SET NULL. Columns are already nullable.
+
+
+-- 1. Redundant indexes ---------------------------------------------------
+DROP INDEX IF EXISTS public.idx_submissions_assignment_id;       -- covered by assignment_submissions_assignment_id_student_id_key
+DROP INDEX IF EXISTS public.ix_content_translations_entity;      -- covered by content_translations_unique
+DROP INDEX IF EXISTS public.ix_notifications_user_id;            -- covered by ix_notifications_user_id_is_read
+DROP INDEX IF EXISTS public.idx_student_grades_student_id;       -- covered by student_grades_student_id_course_id_key
+
+
+-- 2. Fix user-delete FK behaviour ---------------------------------------
+
+-- 2a. student_grades.graded_by: allow NULL, switch CASCADE → SET NULL
+ALTER TABLE public.student_grades
+  ALTER COLUMN graded_by DROP NOT NULL;
+
+ALTER TABLE public.student_grades
+  DROP CONSTRAINT IF EXISTS student_grades_graded_by_fkey;
+
+ALTER TABLE public.student_grades
+  ADD CONSTRAINT student_grades_graded_by_fkey
+    FOREIGN KEY (graded_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- 2b. assignment_submissions.graded_by: NO ACTION → SET NULL
+ALTER TABLE public.assignment_submissions
+  DROP CONSTRAINT IF EXISTS assignment_submissions_graded_by_fkey;
+
+ALTER TABLE public.assignment_submissions
+  ADD CONSTRAINT assignment_submissions_graded_by_fkey
+    FOREIGN KEY (graded_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- 2c. certificates.teacher_approved_by: NO ACTION → SET NULL
+ALTER TABLE public.certificates
+  DROP CONSTRAINT IF EXISTS certificates_teacher_approved_by_fkey;
+
+ALTER TABLE public.certificates
+  ADD CONSTRAINT certificates_teacher_approved_by_fkey
+    FOREIGN KEY (teacher_approved_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+-- 2d. certificates.admin_approved_by: NO ACTION → SET NULL
+ALTER TABLE public.certificates
+  DROP CONSTRAINT IF EXISTS certificates_admin_approved_by_fkey;
+
+ALTER TABLE public.certificates
+  ADD CONSTRAINT certificates_admin_approved_by_fkey
+    FOREIGN KEY (admin_approved_by) REFERENCES auth.users(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary

Tech-debt sweep follow-up to the 2026-05-14 DB audit. Two clusters:

### 1. Redundant indexes (4 dropped)

Each is fully covered by an existing composite UNIQUE — safe to drop, saves write overhead:
- \`assignment_submissions.idx_submissions_assignment_id\`
- \`content_translations.ix_content_translations_entity\`
- \`notifications.ix_notifications_user_id\`
- \`student_grades.idx_student_grades_student_id\`

### 2. FK referential integrity on user-delete

Four FKs against \`auth.users\` had the wrong \`ON DELETE\` rule for an LMS audit trail:

- **HIGH** — \`student_grades.graded_by\` was \`ON DELETE CASCADE\`. Deleting a teacher silently wiped every grade they ever issued. Now \`ON DELETE SET NULL\`; column made nullable (model + Pydantic schema updated accordingly).
- **MEDIUM** — \`assignment_submissions.graded_by\`, \`certificates.teacher_approved_by\`, \`certificates.admin_approved_by\` were all \`NO ACTION\` (the default) — deleting a teacher would FAIL with FK violation. Now \`ON DELETE SET NULL\`.

## Already applied

Migration applied to prod via Supabase MCP before this PR was opened. Verified post-apply:
- All 4 target FKs now \`ON DELETE SET NULL\`
- All 4 redundant indexes confirmed dropped
- \`student_grades.graded_by\` is nullable

Migration file is idempotent (\`IF EXISTS\` / \`DROP CONSTRAINT IF EXISTS\`) so the schema-smoke CI job re-applying it against a fresh Postgres is safe.

## Test plan

- [x] \`ruff check\` clean
- [x] \`mypy app/\` — 111 source files, no issues
- [x] \`pytest tests/ --ignore=test_translation_registry\` — 513 passed
- [ ] CI schema-smoke green
- [ ] Frontend grade rendering not broken when graded_by is NULL (separate frontend follow-up if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)