### PR TITLE
perf(courses): narrow Course probes on three hot paths (skip full tree)

### DIFF
--- a/backend/app/api/v1/courses/crud.py
+++ b/backend/app/api/v1/courses/crud.py
@@ -79,11 +79,11 @@ def update_existing_course(
     # Full-course translation when published (initial publish or edits while live).
     # Runs synchronously so the catalog and chapter surfaces stay consistent.
     # Failures must NOT block the save — failed rows are persisted for retry.
+    # ``result`` is the same SQLAlchemy instance ``update_course`` mutated, so
+    # there's no need to re-load the full course tree just to translate it.
     if result.status == "published":
         try:
-            to_translate = get_course(db, course_id)
-            if to_translate:
-                translate_course_content(db, to_translate)
+            translate_course_content(db, result)
         except Exception:
             logger.exception("Translation hook failed for course %s", course_id)
 

--- a/backend/app/api/v1/courses/enrollment.py
+++ b/backend/app/api/v1/courses/enrollment.py
@@ -10,11 +10,12 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_current_user
 from app.core.database import get_db
 from app.models.cohort import Cohort, CohortCourse
+from app.models.course import Course
 from app.models.enrollment import Enrollment
 from app.models.user import User
 from app.schemas.course import EnrollmentResponse
 from app.services.audit_service import log_action
-from app.services.course_service import enroll_user_in_course, get_course
+from app.services.course_service import enroll_user_in_course
 
 from ._router import router
 
@@ -109,13 +110,25 @@ def enroll_course(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> Enrollment:
-    course = get_course(db, course_id)
-    if not course:
+    # Narrow probe — enrollment policy only reads four columns, no need
+    # to pull the full module + chapter tree for a yes/no check.
+    course_row = (
+        db.query(
+            Course.status,
+            Course.access_mode,
+            Course.enrollment_start,
+            Course.enrollment_end,
+        )
+        .filter(Course.id == course_id, Course.deleted_at.is_(None))
+        .first()
+    )
+    if course_row is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Course '{course_id}' not found",
         )
-    if course.status != "published":
+    course_status, access_mode, enrollment_start, enrollment_end = course_row
+    if course_status != "published":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot enroll in an unpublished course",
@@ -133,18 +146,18 @@ def enroll_course(
         # Solo (no-cohort) enrollment. Institute courses block this path
         # entirely (ADR-010): admin must add the student directly via
         # the cohort endpoints or the admin-direct enrollment endpoint.
-        if course.access_mode == "institute":
+        if access_mode == "institute":
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="This course is available only by invitation from the institute",
             )
         # Public courses are gated by the course-level enrollment window.
-        if course.enrollment_start and now < course.enrollment_start:
+        if enrollment_start and now < enrollment_start:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Enrollment has not started yet",
             )
-        if course.enrollment_end and now > course.enrollment_end:
+        if enrollment_end and now > enrollment_end:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Enrollment period has ended",

--- a/backend/app/services/translation/pipeline_hooks.py
+++ b/backend/app/services/translation/pipeline_hooks.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from app.models.course import Course
 from app.services.course_service import get_course
 from app.services.translation.course_pipeline import translate_course_content
 from app.services.translation.registry import REGISTRY, reconcile_entity
@@ -43,8 +44,17 @@ def run_course_translation_pipeline_if_published(db: Session, course_id: str) ->
     """
     if not is_translation_enabled():
         return
+    # Narrow probe first — most write hooks fire during course building when
+    # the course is still a draft, and loading the full course tree just to
+    # read ``status`` is wasted I/O. Only pay for the full tree when we
+    # actually intend to translate.
+    course_status = (
+        db.query(Course.status).filter(Course.id == course_id, Course.deleted_at.is_(None)).scalar()
+    )
+    if course_status != "published":
+        return
     course = get_course(db, course_id)
-    if not course or course.status != "published":
+    if not course:
         return
     try:
         translate_course_content(db, course)

--- a/backend/app/services/translation/pipeline_hooks.py
+++ b/backend/app/services/translation/pipeline_hooks.py
@@ -48,9 +48,7 @@ def run_course_translation_pipeline_if_published(db: Session, course_id: str) ->
     # the course is still a draft, and loading the full course tree just to
     # read ``status`` is wasted I/O. Only pay for the full tree when we
     # actually intend to translate.
-    course_status = (
-        db.query(Course.status).filter(Course.id == course_id, Course.deleted_at.is_(None)).scalar()
-    )
+    course_status = db.query(Course.status).filter(Course.id == course_id, Course.deleted_at.is_(None)).scalar()
     if course_status != "published":
         return
     course = get_course(db, course_id)


### PR DESCRIPTION
## Summary

Three call sites pulled the full \`_COURSE_TREE\` (Course + modules + chapters with their soft-delete filters) when they only needed two to four columns. Each is on a frequently-hit path.

1. **\`run_course_translation_pipeline_if_published\`** (\`services/translation/pipeline_hooks.py\`) — called from every chapter/module/block/quiz/assignment/announcement/event write, then immediately bails out if the course is still a draft. Most course-building writes hit a draft, so the full tree is pure waste. Probe \`Course.status\` only first; load the full tree only when we actually intend to translate.

2. **\`update_existing_course\`** (\`api/v1/courses/crud.py\`) — after \`update_course\` mutates the row, the publish-event branch was re-loading the entire course tree just to pass it to \`translate_course_content\`. \`update_course\` already returned the same SQLAlchemy instance with the new state — reuse \`result\`.

3. **\`enroll_course\`** (\`api/v1/courses/enrollment.py\`) — the enrollment policy only reads \`status\`, \`access_mode\`, \`enrollment_start\`, \`enrollment_end\`. Narrow probe to those four columns instead of pulling every module + chapter for a yes/no check.

No behavior change in any path.

## Test plan

- [x] \`ruff check\` clean
- [x] \`mypy --config-file mypy.ini ...\` — no issues
- [x] \`pytest tests/ --ignore=test_translation_registry\` — 513 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)