### PR TITLE
chore(deps): drop unused python-dotenv from backend requirements

### DIFF
--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -6,7 +6,6 @@ pydantic==2.13.4
 pydantic-settings==2.14.1
 email-validator==2.3.0
 PyJWT==2.12.1
-python-dotenv==1.2.2
 bleach==6.3.0
 pytest==9.0.3
 pytest-cov==7.1.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,5 @@ pydantic==2.13.4
 pydantic-settings==2.14.1
 email-validator==2.3.0
 PyJWT==2.12.1
-python-dotenv==1.2.2
 httpx==0.28.1
 bleach==6.3.0


### PR DESCRIPTION
## Summary

Dead-code audit flagged \`python-dotenv==1.2.2\` as listed in both \`requirements.txt\` and \`requirements-ci.txt\` but never imported. \`pydantic-settings\` (already declared) loads \`.env\` natively via its \`SettingsConfigDict(env_file=\".env\")\` setup in \`app/core/config.py\`, so the standalone dotenv package is pure surface area we ship and audit.

## Test plan

- [x] Verified no \`import dotenv\` / \`from dotenv\` anywhere in backend
- [ ] CI green (pytest still loads \`.env\` via pydantic-settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)