### PR TITLE
perf(assignments): dedupe in-flight chapter-assignment fetches

### DIFF
--- a/frontend/src/components/assignment/AssignmentPanel.tsx
+++ b/frontend/src/components/assignment/AssignmentPanel.tsx
@@ -8,6 +8,26 @@ import { coursesService } from "@/services/courses"
 import { getErrorDetail } from "@/lib/errorDetail"
 import { toast } from "@/lib/toast"
 import type { Assignment, AssignmentSubmission } from "@/types"
+
+// Per-chapter request dedup. A reading chapter with N assignment blocks
+// mounts N AssignmentPanel instances simultaneously, each one
+// requesting the same `/api/v1/chapters/{id}/assignments` list. Without
+// this map every block fires its own identical network call. The entry
+// is dropped once the promise settles so subsequent mounts refetch
+// fresh data.
+const inflightChapterAssignments = new Map<string, Promise<Assignment[]>>()
+
+function fetchChapterAssignmentsDeduped(chapterId: string): Promise<Assignment[]> {
+  const existing = inflightChapterAssignments.get(chapterId)
+  if (existing) return existing
+  const promise = coursesService.getChapterAssignments(chapterId).finally(() => {
+    if (inflightChapterAssignments.get(chapterId) === promise) {
+      inflightChapterAssignments.delete(chapterId)
+    }
+  })
+  inflightChapterAssignments.set(chapterId, promise)
+  return promise
+}
 import PageSpinner from "@/components/ui/PageSpinner"
 import { formatDate } from "@/i18n/format"
 import {
@@ -45,7 +65,7 @@ export default function AssignmentPanel({ chapterId, assignmentId, onSubmitted, 
       setLoading(true)
       setFetchError(false)
       try {
-        const all = await coursesService.getChapterAssignments(chapterId)
+        const all = await fetchChapterAssignmentsDeduped(chapterId)
         if (cancelled) return
         const data = assignmentId ? all.filter((a) => a.id === assignmentId) : all
         setAssignments(data)


### PR DESCRIPTION
## Summary

Reading chapters can render multiple \`AssignmentPanel\` instances at once — one per \`assignment\` block — and every instance fired its own \`/api/v1/chapters/{id}/assignments\` request on mount. With three assignment blocks in a chapter that's three identical network round trips, three identical Pydantic serializations, three identical chapter→course joins.

## Fix

Tiny module-level \`Map<chapterId, Promise>\` dedup in \`AssignmentPanel.tsx\`. The first panel to mount kicks off the fetch and stores its promise; sibling panels mounting in the same tick reuse the same promise; the entry is dropped once the promise settles so a later remount refetches fresh data (no stale-cache surface).

## Scope

Scoped change to \`AssignmentPanel.tsx\` only — no contract change. Cohort UI memoization + course-catalog re-fetch (also flagged by the audit) deferred: at the current 3-course catalog and 0-student cohorts the wins are theoretical; revisit when scale catches up.

## Test plan

- [x] \`npm run lint\` (zero warnings)
- [x] \`npx tsc --noEmit\` (strict)
- [x] \`npm run test:run\` — 112 passed
- [ ] CI green
- [ ] Manual: open a reading chapter that has 2+ assignment blocks, confirm in DevTools Network tab that only ONE \`/chapters/{id}/assignments\` call fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)