### PR TITLE
chore(i18n): prune 50 dead keys from en.json + ru.json

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,15 +1,11 @@
 {
   "common": {
     "appName": "Equip",
-    "save": "Save",
-    "saving": "Saving...",
-    "saved": "Saved",
     "cancel": "Cancel",
     "continue": "Continue",
     "tryAgain": "Try again",
     "loading": "Loading...",
     "view": "View",
-    "search": "Search",
     "signIn": "Sign In",
     "signOut": "Sign Out",
     "register": "Register",
@@ -45,8 +41,6 @@
   },
   "footer": {
     "tagline": "Structured biblical teaching for learners who take Scripture seriously.",
-    "explore": "Explore",
-    "teaching": "Teaching",
     "teacherDashboard": "Teacher dashboard",
     "support": "Contact support",
     "rightsReserved": "All rights reserved."
@@ -133,9 +127,6 @@
     }
   },
   "profile": {
-    "title": "Profile",
-    "pageEyebrow": "Your account",
-    "pageLead": "Name, avatar, progress, and preferences in one place.",
     "fullName": "Full Name",
     "changeAvatar": "Change avatar",
     "uploadFailed": "Failed to upload avatar",
@@ -227,8 +218,6 @@
     "loadChapterFailed": "Failed to load chapter. Please try again.",
     "loadModuleFailed": "Failed to load module. Please try again.",
     "loadCourseFailed": "Failed to load course. Please try again.",
-    "loadGradebookFailed": "Failed to load gradebook. Please try again.",
-    "genericLoadFailed": "Something went wrong",
     "loadTeacherCoursesFailed": "Failed to load your courses. Please try again.",
     "boundary": {
       "heading": "Something went wrong",
@@ -264,37 +253,25 @@
     "certificatesLoadFailed": "Failed to load certificates",
     "openFileFailed": "Could not open file. Please try again.",
     "assignmentTitleRequired": "Assignment title is required",
-    "assignmentUpdated": "Assignment updated",
     "assignmentUpdateFailed": "Failed to update assignment",
     "assignmentSubmitFailed": "Failed to submit assignment",
     "unsupportedFile": "Unsupported file",
     "pickImageFile": "Pick an image file.",
     "uploadFailed": "Upload failed",
-    "markedIncomplete": "Marked as incomplete",
-    "markedComplete": "Marked as complete",
     "completionUpdateFailed": "Failed to update completion",
-    "extraAttemptGranted": "Extra attempt granted",
-    "extraAttemptFailed": "Failed to grant extra attempt",
     "autosaveFailed": "Auto-save failed",
-    "blockSaved": "Block saved",
     "blockSaveFailed": "Failed to save block",
-    "assignmentCreated": "Assignment created",
     "assignmentCreateFailed": "Failed to create assignment",
-    "assignmentDeleted": "Assignment deleted",
     "assignmentDeleteFailed": "Failed to delete assignment",
     "invalidScore": "Enter a valid score (0 or higher)",
     "submissionGraded": "Submission graded",
     "gradeFailed": "Failed to grade",
     "selectRating": "Please select a rating",
-    "reviewSubmitted": "Review submitted!",
     "reviewSubmitFailed": "Failed to submit review",
-    "certificateRequested": "Certificate requested!",
     "certificateRequestFailed": "Failed to request certificate",
     "copyFailed": "Failed to copy",
     "blocksLoadFailedPrefix": "Failed to load blocks:",
-    "blockAdded": "{{type}} block added",
     "blockAddFailedPrefix": "Failed to add block:",
-    "blockDeleted": "Block deleted",
     "blockDeleteFailed": "Failed to delete block",
     "reorderBlocksFailed": "Failed to reorder blocks",
     "chapterSaved": "Chapter saved",
@@ -307,20 +284,15 @@
     "quizNeedsQuestion": "Add at least one question",
     "quizSaved": "Quiz saved",
     "quizSaveFailed": "Failed to save quiz",
-    "quizDeleted": "Quiz deleted",
-    "quizDeleteFailed": "Failed to delete quiz",
-    "fileUploaded": "File uploaded",
     "fileRemoveFailed": "Failed to remove file",
     "blockUpdateFailed": "Failed to update block",
     "reviewsLoadFailed": "Failed to load reviews",
-    "reviewDeleted": "Review deleted",
     "reviewDeleteFailed": "Failed to delete review",
     "chapterLoadFailed": "Failed to load chapter"
   },
   "module": {
     "overdue": "Overdue",
     "due": "Due",
-    "dueAt": "{{date}} at {{time}}",
     "moduleComplete": "Module complete — well done!",
     "completedProgress": "{{done}}/{{total}} completed",
     "chaptersHeading": "Chapters",
@@ -330,10 +302,7 @@
     "backToCourses": "Back to Courses",
     "backToCourse": "Back to Course",
     "backToModule": "Back to Module",
-    "goHome": "Go Home",
-    "enrollSuccess": "Enrolled successfully",
-    "enrollFailed": "Failed to enroll. Please try again.",
-    "allCourses": "All Courses"
+    "goHome": "Go Home"
   },
   "chapter": {
     "lockedTitle": "Chapter Locked",
@@ -371,8 +340,6 @@
     "previousAttempts": "Previous attempts",
     "questionPoints_one": "{{count}} pt",
     "questionPoints_other": "{{count}} pts",
-    "true": "True",
-    "false": "False",
     "typeAnswerPlaceholder": "Type your answer...",
     "nQuestions_one": "{{count}} question",
     "nQuestions_other": "{{count}} questions",
@@ -593,8 +560,7 @@
       "feedback": "Feedback",
       "feedbackPlaceholder": "Optional feedback for the student...",
       "saving": "Saving...",
-      "save": "Save Grade",
-      "studentIdPrefix": "{{prefix}}..."
+      "save": "Save Grade"
     }
   },
   "assignment": {
@@ -605,11 +571,8 @@
     "maxPoints": "Max: {{max}} pts",
     "due": "Due:",
     "overdue": "(overdue)",
-    "linkLabel": "Link",
     "submit": "Submit Assignment",
     "resubmit": "Resubmit",
-    "placeholder": "Write your response or paste a link…",
-    "feedbackFromTeacher": "Feedback from teacher",
     "points": "points",
     "instructorFeedback": "Instructor Feedback",
     "yourSubmission": "Your Submission",
@@ -623,13 +586,10 @@
   "certificates": {
     "dashboard": "Dashboard",
     "title": "My Certificates",
-    "subtitle": "Certificates you've earned for completing courses",
     "emptyTitle": "No certificates yet",
     "emptyDescription": "Complete a course to earn your first certificate. Keep learning and collecting achievements!",
     "browseCourses": "Browse Courses",
     "badge": "Certificate",
-    "issued": "Issued",
-    "failedLoad": "Failed to load certificates",
     "courseFallback": "Course {{id}}",
     "certificateNo": "Certificate No.",
     "issuedOrStatus": "Issued",
@@ -793,7 +753,6 @@
   },
   "teacher": {
     "dashboardTitle": "My Courses",
-    "dashboardSubtitle": "Create and manage your course content",
     "newCourse": "New Course",
     "searchPlaceholder": "Search courses...",
     "somethingWrong": "Something went wrong",
@@ -816,8 +775,6 @@
       "actionPublish": "Publish",
       "actionUnpublish": "Unpublish",
       "actionClone": "Clone course",
-      "actionCloneShort": "Clone",
-      "actionEdit": "Edit",
       "actionEditCourse": "Edit course",
       "actionDelete": "Delete",
       "actionMore": "More actions"
@@ -1370,7 +1327,6 @@
     "orRegisterEmail": "or register with email",
     "fullName": "Full name",
     "fullNamePlaceholder": "John Doe",
-    "confirmPassword": "Confirm password",
     "confirmPasswordShort": "Confirm",
     "alreadyHaveAccount": "Already have an account?",
     "creatingAccount": "Creating account...",
@@ -1406,17 +1362,5 @@
     "titleRequired": "Title is required",
     "titleTooLong": "Title must be 300 characters or fewer",
     "nameTooShort": "Name must be at least 2 characters"
-  },
-  "confirm": {
-    "deleteBlock": "Delete this block?",
-    "delete": "Delete"
-  },
-  "editor": {
-    "blockTypes": {
-      "text": "Text",
-      "quiz": "Quiz",
-      "assignment": "Assignment",
-      "file": "File"
-    }
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1,15 +1,11 @@
 {
   "common": {
     "appName": "Equip",
-    "save": "Сохранить",
-    "saving": "Сохранение...",
-    "saved": "Сохранено",
     "cancel": "Отмена",
     "continue": "Продолжить",
     "tryAgain": "Повторить",
     "loading": "Загрузка...",
     "view": "Открыть",
-    "search": "Поиск",
     "signIn": "Войти",
     "signOut": "Выйти",
     "register": "Регистрация",
@@ -45,8 +41,6 @@
   },
   "footer": {
     "tagline": "Системное изучение Библии для тех, кто относится к Писанию серьёзно.",
-    "explore": "Разделы",
-    "teaching": "Преподавание",
     "teacherDashboard": "Панель преподавателя",
     "support": "Связаться с поддержкой",
     "rightsReserved": "Все права защищены."
@@ -133,9 +127,6 @@
     }
   },
   "profile": {
-    "title": "Профиль",
-    "pageEyebrow": "Ваш аккаунт",
-    "pageLead": "Имя, аватар, прогресс и настройки в одном месте.",
     "fullName": "Полное имя",
     "changeAvatar": "Изменить аватар",
     "uploadFailed": "Не удалось загрузить аватар",
@@ -229,8 +220,6 @@
     "loadChapterFailed": "Не удалось загрузить главу. Попробуйте снова.",
     "loadModuleFailed": "Не удалось загрузить модуль. Попробуйте снова.",
     "loadCourseFailed": "Не удалось загрузить курс. Попробуйте снова.",
-    "loadGradebookFailed": "Не удалось загрузить журнал оценок. Попробуйте снова.",
-    "genericLoadFailed": "Что-то пошло не так",
     "loadTeacherCoursesFailed": "Не удалось загрузить ваши курсы. Попробуйте снова.",
     "boundary": {
       "heading": "Что-то пошло не так",
@@ -266,37 +255,25 @@
     "certificatesLoadFailed": "Не удалось загрузить сертификаты",
     "openFileFailed": "Не удалось открыть файл. Попробуйте снова.",
     "assignmentTitleRequired": "Укажите название задания",
-    "assignmentUpdated": "Задание обновлено",
     "assignmentUpdateFailed": "Не удалось обновить задание",
     "assignmentSubmitFailed": "Не удалось отправить задание",
     "unsupportedFile": "Неподдерживаемый файл",
     "pickImageFile": "Выберите файл изображения.",
     "uploadFailed": "Не удалось загрузить",
-    "markedIncomplete": "Отмечено как непройденное",
-    "markedComplete": "Отмечено как выполненное",
     "completionUpdateFailed": "Не удалось обновить статус прохождения",
-    "extraAttemptGranted": "Дополнительная попытка предоставлена",
-    "extraAttemptFailed": "Не удалось выдать дополнительную попытку",
     "autosaveFailed": "Автосохранение не удалось",
-    "blockSaved": "Блок сохранён",
     "blockSaveFailed": "Не удалось сохранить блок",
-    "assignmentCreated": "Задание создано",
     "assignmentCreateFailed": "Не удалось создать задание",
-    "assignmentDeleted": "Задание удалено",
     "assignmentDeleteFailed": "Не удалось удалить задание",
     "invalidScore": "Введите корректный балл (0 или больше)",
     "submissionGraded": "Ответ оценён",
     "gradeFailed": "Не удалось выставить оценку",
     "selectRating": "Выберите оценку",
-    "reviewSubmitted": "Отзыв отправлен!",
     "reviewSubmitFailed": "Не удалось отправить отзыв",
-    "certificateRequested": "Запрос на сертификат отправлен!",
     "certificateRequestFailed": "Не удалось запросить сертификат",
     "copyFailed": "Не удалось скопировать",
     "blocksLoadFailedPrefix": "Не удалось загрузить блоки:",
-    "blockAdded": "Добавлен блок: {{type}}",
     "blockAddFailedPrefix": "Не удалось добавить блок:",
-    "blockDeleted": "Блок удалён",
     "blockDeleteFailed": "Не удалось удалить блок",
     "reorderBlocksFailed": "Не удалось изменить порядок блоков",
     "chapterSaved": "Глава сохранена",
@@ -309,20 +286,15 @@
     "quizNeedsQuestion": "Добавьте хотя бы один вопрос",
     "quizSaved": "Тест сохранён",
     "quizSaveFailed": "Не удалось сохранить тест",
-    "quizDeleted": "Тест удалён",
-    "quizDeleteFailed": "Не удалось удалить тест",
-    "fileUploaded": "Файл загружен",
     "fileRemoveFailed": "Не удалось удалить файл",
     "blockUpdateFailed": "Не удалось обновить блок",
     "reviewsLoadFailed": "Не удалось загрузить отзывы",
-    "reviewDeleted": "Отзыв удалён",
     "reviewDeleteFailed": "Не удалось удалить отзыв",
     "chapterLoadFailed": "Не удалось загрузить главу"
   },
   "module": {
     "overdue": "Просрочено",
     "due": "Срок",
-    "dueAt": "{{date}} в {{time}}",
     "moduleComplete": "Модуль завершён — отлично!",
     "completedProgress": "{{done}}/{{total}} завершено",
     "chaptersHeading": "Главы",
@@ -332,10 +304,7 @@
     "backToCourses": "Все курсы",
     "backToCourse": "К курсу",
     "backToModule": "К модулю",
-    "goHome": "На главную",
-    "enrollSuccess": "Вы успешно записались",
-    "enrollFailed": "Не удалось записаться. Попробуйте снова.",
-    "allCourses": "Все курсы"
+    "goHome": "На главную"
   },
   "chapter": {
     "lockedTitle": "Глава заблокирована",
@@ -377,8 +346,6 @@
     "questionPoints_few": "{{count}} балла",
     "questionPoints_many": "{{count}} баллов",
     "questionPoints_other": "{{count}} балла",
-    "true": "Верно",
-    "false": "Неверно",
     "typeAnswerPlaceholder": "Введите ответ…",
     "nQuestions_one": "{{count}} вопрос",
     "nQuestions_few": "{{count}} вопроса",
@@ -611,8 +578,7 @@
       "feedback": "Отзыв",
       "feedbackPlaceholder": "Необязательный отзыв студенту...",
       "saving": "Сохранение...",
-      "save": "Сохранить оценку",
-      "studentIdPrefix": "{{prefix}}..."
+      "save": "Сохранить оценку"
     }
   },
   "assignment": {
@@ -623,11 +589,8 @@
     "maxPoints": "Макс.: {{max}} б.",
     "due": "Срок:",
     "overdue": "(просрочено)",
-    "linkLabel": "Ссылка",
     "submit": "Отправить задание",
     "resubmit": "Отправить снова",
-    "placeholder": "Напишите ответ или вставьте ссылку…",
-    "feedbackFromTeacher": "Комментарий преподавателя",
     "points": "баллов",
     "instructorFeedback": "Комментарий преподавателя",
     "yourSubmission": "Ваша работа",
@@ -641,13 +604,10 @@
   "certificates": {
     "dashboard": "Главная",
     "title": "Мои сертификаты",
-    "subtitle": "Сертификаты за завершённые курсы",
     "emptyTitle": "Пока нет сертификатов",
     "emptyDescription": "Завершите курс, чтобы получить первый сертификат. Продолжайте учиться!",
     "browseCourses": "Каталог курсов",
     "badge": "Сертификат",
-    "issued": "Выдан",
-    "failedLoad": "Не удалось загрузить сертификаты",
     "courseFallback": "Курс {{id}}",
     "certificateNo": "№ сертификата",
     "issuedOrStatus": "Выдан",
@@ -815,7 +775,6 @@
   },
   "teacher": {
     "dashboardTitle": "Мои курсы",
-    "dashboardSubtitle": "Создавайте и управляйте содержимым курсов",
     "newCourse": "Новый курс",
     "searchPlaceholder": "Поиск курсов...",
     "somethingWrong": "Что-то пошло не так",
@@ -840,8 +799,6 @@
       "actionPublish": "Опубликовать",
       "actionUnpublish": "Снять с публикации",
       "actionClone": "Скопировать курс",
-      "actionCloneShort": "Копия",
-      "actionEdit": "Редактировать",
       "actionEditCourse": "Редактировать курс",
       "actionDelete": "Удалить",
       "actionMore": "Ещё действия"
@@ -1402,7 +1359,6 @@
     "orRegisterEmail": "или регистрация по email",
     "fullName": "Полное имя",
     "fullNamePlaceholder": "Иван Иванов",
-    "confirmPassword": "Подтверждение пароля",
     "confirmPasswordShort": "Подтверждение",
     "alreadyHaveAccount": "Уже есть аккаунт?",
     "creatingAccount": "Создание аккаунта...",
@@ -1438,17 +1394,5 @@
     "titleRequired": "Укажите название",
     "titleTooLong": "Название не должно превышать 300 символов",
     "nameTooShort": "Имя должно содержать минимум 2 символа"
-  },
-  "confirm": {
-    "deleteBlock": "Удалить этот блок?",
-    "delete": "Удалить"
-  },
-  "editor": {
-    "blockTypes": {
-      "text": "Текст",
-      "quiz": "Тест",
-      "assignment": "Задание",
-      "file": "Файл"
-    }
   }
 }


### PR DESCRIPTION
## Summary

Dead-code audit (2026-05-14) flagged ~70 unused i18n keys. An Opus subagent verified each candidate against the codebase: 50 are truly dead (zero \`t(...)\`, zero \`<Trans i18nKey=\"...\">\`, zero dynamic key construction, zero test / backend reference). The remaining ~20 were either flagged as KEEP (live in \`TeacherDashboard.tsx\` / \`AssignmentPanel.tsx\`) or already covered by yesterday's PR #191 rebrand sweep.

## Removed (50 keys × 2 locales = 100 JSON lines)

- **\`toast.*\` (16):** \`assignmentCreated/Deleted/Updated\`, \`blockAdded/Saved/Deleted\`, \`reviewSubmitted/Deleted\`, \`certificateRequested\`, \`markedComplete/Incomplete\`, \`fileUploaded\`, \`extraAttemptGranted/Failed\`, \`quizDeleted/DeleteFailed\` — all superseded by module-namespaced equivalents (\`chapterEditor.toast.*\`, \`quizEditor.toast.*\`, \`admin.cohorts.toast.*\`).
- **\`editor.blockTypes.*\` (4):** superseded by \`blockEditor.types.*\`.
- **\`assignment.*\` (3):** \`feedbackFromTeacher\`, \`linkLabel\`, \`placeholder\`.
- **\`certificates.*\` (3):** \`failedLoad\`, \`issued\`, \`subtitle\`.
- **\`profile.*\` (3):** \`title\`, \`pageEyebrow\`, \`pageLead\`.
- **\`quiz.*\` (2):** \`true\`, \`false\`.
- **\`course.*\` (3):** \`allCourses\`, \`enrollFailed\`, \`enrollSuccess\`.
- **\`footer.*\` (2):** \`explore\`, \`teaching\`.
- **\`module.dueAt\` (1).**
- **\`confirm.*\` (2):** \`delete\`, \`deleteBlock\`.
- **\`errors.*\` (2):** \`genericLoadFailed\`, \`loadGradebookFailed\`.
- **\`common.*\` (4):** \`save\`, \`saved\`, \`saving\`, \`search\`.
- **\`teacher.dashboardSubtitle\` (1).**
- **\`teacherDashboard.courseCard.*\` (2):** \`actionEdit\`, \`actionCloneShort\`.
- **\`authRegister.confirmPassword\` (1).**
- **\`assignmentEditor.grader.studentIdPrefix\` (1).**

## Notes

- Parity preserved across en/ru (identical key sets after pruning).
- Empty parent containers collapsed (e.g. the now-empty \`editor.blockTypes\` object goes too).
- 50 vs the audit's ~70 estimate — the agent flagged \`toast.assignmentSubmitFailed\` and 4 cert toasts as KEEP after finding live call sites, and a few keys were already removed in PR #191.

## Test plan

- [x] \`npm run lint\` (zero warnings)
- [x] \`npx tsc --noEmit\` (strict)
- [x] \`npm run test:run\` — 112 passed
- [ ] CI green
- [ ] Visual smoke after deploy: switch locale, exercise every page — no key showing as raw \`\"xxx.yyy\"\` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)