### PR TITLE
perf(translation): per-entity reconcile on write hooks (drop full-tree walks)

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -16,7 +16,7 @@ from app.schemas.announcement import (
 )
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.notification_service import create_notifications_bulk
-from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
+from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import localize_announcement_rows
 
 router = APIRouter(prefix="/announcements", tags=["announcements"])
@@ -148,7 +148,7 @@ def create_announcement(
     db.commit()
     db.refresh(announcement)
     if data.course_id:
-        run_course_translation_pipeline_if_published(db, data.course_id)
+        reconcile_entity_if_course_published(db, "announcement", announcement)
     return announcement
 
 
@@ -179,7 +179,7 @@ def update_announcement(
     db.commit()
     db.refresh(announcement)
     if announcement.course_id:
-        run_course_translation_pipeline_if_published(db, str(announcement.course_id))
+        reconcile_entity_if_course_published(db, "announcement", announcement)
     return announcement
 
 

--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -28,7 +28,7 @@ from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.audit_service import log_action
 from app.services.course_service import sync_enrollment_progress
 from app.services.notification_service import create_notification
-from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
+from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
     get_course_source_locale_for_chapter,
     localize_assignment_rows,
@@ -67,8 +67,7 @@ def create_assignment(
     db.add(assignment)
     db.commit()
     db.refresh(assignment)
-    course_id = resolve_chapter_course_id(db, data.chapter_id)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "assignment", assignment)
     return assignment
 
 
@@ -89,8 +88,7 @@ def update_assignment(
 
     db.commit()
     db.refresh(assignment)
-    course_id = resolve_chapter_course_id(db, assignment.chapter_id)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "assignment", assignment)
     return assignment
 
 

--- a/backend/app/api/v1/blocks.py
+++ b/backend/app/api/v1/blocks.py
@@ -11,7 +11,7 @@ from app.models.chapter_block import ChapterBlock
 from app.models.user import User
 from app.schemas.chapter_block import BlockCreate, BlockReorderItem, BlockResponse, BlockUpdate
 from app.schemas.locale import LocaleCode, normalize_locale
-from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
+from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
     get_course_source_locale_for_chapter,
     localize_chapter_block_rows,
@@ -46,7 +46,7 @@ def create_block(
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ):
-    _, course_id = verify_chapter_owner(db, chapter_id, teacher)
+    verify_chapter_owner(db, chapter_id, teacher)
     # Defence-in-depth: the frontend runs DOMPurify before sending, but a
     # direct API caller can bypass that. We re-sanitize here so stored block
     # HTML is safe to render for every downstream consumer (admin preview,
@@ -76,7 +76,7 @@ def create_block(
             detail="Referenced quiz or assignment no longer exists",
         ) from exc
     db.refresh(block)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "chapter_block", block)
     return block
 
 
@@ -90,7 +90,7 @@ def update_block(
     block = db.query(ChapterBlock).filter(ChapterBlock.id == block_id).first()
     if not block:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Block not found")
-    _, course_id = verify_chapter_owner(db, block.chapter_id, teacher)
+    verify_chapter_owner(db, block.chapter_id, teacher)
     for field, value in data.model_dump(exclude_unset=True).items():
         if field == "content" and value:
             value = sanitize_string(value)
@@ -104,7 +104,7 @@ def update_block(
             detail="Referenced quiz or assignment no longer exists",
         ) from exc
     db.refresh(block)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "chapter_block", block)
     return block
 
 
@@ -117,10 +117,11 @@ def delete_block(
     block = db.query(ChapterBlock).filter(ChapterBlock.id == block_id).first()
     if not block:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Block not found")
-    _, course_id = verify_chapter_owner(db, block.chapter_id, teacher)
+    verify_chapter_owner(db, block.chapter_id, teacher)
     db.delete(block)
     db.commit()
-    run_course_translation_pipeline_if_published(db, course_id)
+    # No reconcile after delete — the entity is gone; translation rows
+    # cascade out via FK ON DELETE on content_translations.
 
 
 @router.put("/chapter/{chapter_id}/reorder", response_model=list[BlockResponse])

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -15,7 +15,7 @@ from app.schemas.calendar import (
     CourseEventUpdate,
 )
 from app.schemas.locale import LocaleCode, normalize_locale
-from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
+from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
     fetch_overlay_triples_bulk,
     localize_course_event_rows,
@@ -216,7 +216,7 @@ def create_course_event(
     db.add(event)
     db.commit()
     db.refresh(event)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "course_event", event)
     return event
 
 
@@ -289,7 +289,7 @@ def update_course_event(
         setattr(event, field, value)
     db.commit()
     db.refresh(event)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "course_event", event)
     return event
 
 

--- a/backend/app/api/v1/courses/chapters.py
+++ b/backend/app/api/v1/courses/chapters.py
@@ -16,7 +16,7 @@ from app.services.course_service import (
     get_module,
     update_chapter,
 )
-from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
+from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 
 from ._router import router
 
@@ -43,7 +43,7 @@ def create_new_chapter(
     if data.title:
         data.title = sanitize_string(data.title)
     created = create_chapter(db, module_id, data)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "chapter", created)
     return created
 
 
@@ -69,7 +69,7 @@ def update_existing_chapter(
     if data.title:
         data.title = sanitize_string(data.title)
     updated = update_chapter(db, chapter, data)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "chapter", updated)
     return updated
 
 

--- a/backend/app/api/v1/courses/modules.py
+++ b/backend/app/api/v1/courses/modules.py
@@ -14,7 +14,7 @@ from app.services.course_service import (
     get_module,
     update_module,
 )
-from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
+from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 
 from ._router import router
 
@@ -32,7 +32,7 @@ def create_new_module(
 ) -> Module:
     verify_course_owner(db, course_id, teacher.id, allow_admin=False)
     created = create_module(db, course_id, data)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "module", created)
     return created
 
 
@@ -52,7 +52,7 @@ def update_existing_module(
             detail=f"Module '{module_id}' not found in course '{course_id}'",
         )
     updated = update_module(db, module, data)
-    run_course_translation_pipeline_if_published(db, course_id)
+    reconcile_entity_if_course_published(db, "module", updated)
     return updated
 
 

--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Session, selectinload
 from app.api.dependencies import (
     get_current_user,
     require_teacher,
-    resolve_chapter_course_id,
     verify_chapter_access,
     verify_chapter_owner,
 )
@@ -26,7 +25,10 @@ from app.schemas.quiz import (
     QuizStudentResponse,
     QuizUpdate,
 )
-from app.services.translation.pipeline_hooks import run_course_translation_pipeline_if_published
+from app.services.translation.pipeline_hooks import (
+    reconcile_entity_if_course_published,
+    run_course_translation_pipeline_if_published,
+)
 from app.services.translation.resolve_for_display import (
     build_localized_quiz_student_response,
     get_course_source_locale_for_chapter,
@@ -152,6 +154,9 @@ def create_quiz(
     )
     if reloaded is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+    # Create flow seeds the quiz + every question + every option in one go.
+    # Full-tree pipeline is cheaper here than N+1 per-entity reconcile calls
+    # because the course gets loaded once and every child re-walks once.
     run_course_translation_pipeline_if_published(db, course_id)
     return reloaded
 
@@ -183,8 +188,9 @@ def update_quiz(
     )
     if reloaded is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
-    course_id = resolve_chapter_course_id(db, reloaded.chapter_id)
-    run_course_translation_pipeline_if_published(db, course_id)
+    # ``update_quiz`` only mutates the quiz row itself; questions + options
+    # have their own endpoints. Per-entity reconcile is enough.
+    reconcile_entity_if_course_published(db, "quiz", reloaded)
     return reloaded
 
 
@@ -198,7 +204,6 @@ def delete_quiz(
     if not quiz:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
     verify_quiz_owner(db, quiz, teacher.id)
-    course_id = resolve_chapter_course_id(db, quiz.chapter_id)
     db.delete(quiz)
     db.commit()
-    run_course_translation_pipeline_if_published(db, course_id)
+    # No reconcile after delete — content_translations rows cascade via FK.


### PR DESCRIPTION
## Summary

Verification pass after PR #223 surfaced 14 call sites firing \`run_course_translation_pipeline_if_published\` — a full module/chapter/quiz/block/announcement/event re-walk — every time a single entity got created, updated, or deleted on a published course. The \`source_hash\` short-circuit kept the network cost bounded, but the course-tree load itself was unconditional waste on every save.

## Changes

Switch each write hook to the per-entity equivalent \`reconcile_entity_if_course_published(db, \"<type>\", entity)\`:

| File | Endpoint | Entity |
|---|---|---|
| announcements.py | create / update | \`announcement\` |
| calendar.py | create / update event | \`course_event\` |
| assignments.py | create / update | \`assignment\` |
| blocks.py | create / update | \`chapter_block\` |
| courses/chapters.py | create / update | \`chapter\` |
| courses/modules.py | create / update | \`module\` |
| quizzes/crud.py | update | \`quiz\` |

Delete handlers (blocks, quizzes) drop the call entirely — entity is gone, \`content_translations\` rows cascade via FK ON DELETE.

## Exception

\`quizzes/crud.py:create_quiz\` keeps the full pipeline. Create seeds the quiz + every question + every option in one shot; walking them via N+M per-entity reconciles would re-resolve the course N+M times. Single full-tree walk wins for that path. Comment in place explaining why.

## Test plan

- [x] \`ruff check\` clean
- [x] \`mypy --config-file mypy.ini app/api/v1/\` — 32 source files, no issues
- [x] \`pytest tests/ --ignore=test_translation_registry\` — 513 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)