### PR TITLE
fix(i18n): localize editor hooks + teacher editor sections + InlineEditCover

### DIFF
--- a/frontend/src/components/editor/useImageUpload.ts
+++ b/frontend/src/components/editor/useImageUpload.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type { Editor } from "@tiptap/react";
 import type { EditorView } from "@tiptap/pm/view";
 
@@ -14,19 +15,23 @@ import { toast } from "@/lib/toast";
  * the user triggered.
  */
 export function useImageUpload() {
+  const { t } = useTranslation();
   const [uploading, setUploading] = useState(false);
 
-  const upload = useCallback(async (file: File): Promise<string | null> => {
-    setUploading(true);
-    try {
-      return await storageService.uploadContentImage(file);
-    } catch {
-      toast({ title: "Image upload failed", variant: "destructive" });
-      return null;
-    } finally {
-      setUploading(false);
-    }
-  }, []);
+  const upload = useCallback(
+    async (file: File): Promise<string | null> => {
+      setUploading(true);
+      try {
+        return await storageService.uploadContentImage(file);
+      } catch {
+        toast({ title: t("editor.toast.imageUploadFailed"), variant: "destructive" });
+        return null;
+      } finally {
+        setUploading(false);
+      }
+    },
+    [t],
+  );
 
   /**
    * Upload an image and insert it at the current editor cursor. Used by

--- a/frontend/src/components/editor/useMediaPrompts.ts
+++ b/frontend/src/components/editor/useMediaPrompts.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import type { Editor } from "@tiptap/react";
 
 import { usePrompt } from "@/components/ui/alert-dialog";
@@ -17,19 +18,19 @@ export function useMediaPrompts(
   editor: Editor | null,
   imageUpload: ReturnType<typeof useImageUpload>,
 ) {
+  const { t } = useTranslation();
   const prompt = usePrompt();
 
   const setLink = useCallback(async () => {
     if (!editor) return;
     const previousUrl = editor.getAttributes("link").href as string | undefined;
     const url = await prompt({
-      title: "Add link",
-      description:
-        "Paste or type the URL you want to link to. Leave empty to remove an existing link.",
+      title: t("editor.prompt.addLinkTitle"),
+      description: t("editor.prompt.addLinkDescription"),
       defaultValue: previousUrl ?? "https://",
-      placeholder: "https://…",
+      placeholder: t("editor.prompt.imageUrlPlaceholder"),
       inputType: "url",
-      confirmLabel: "Apply",
+      confirmLabel: t("editor.prompt.addLinkConfirm"),
     });
     if (url === null) return;
     if (url === "") {
@@ -37,7 +38,7 @@ export function useMediaPrompts(
       return;
     }
     editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
-  }, [editor, prompt]);
+  }, [editor, prompt, t]);
 
   const addImage = useCallback(() => {
     if (!editor) return;
@@ -52,43 +53,43 @@ export function useMediaPrompts(
       // Upload failed: give the user an escape hatch so they can paste
       // an existing URL instead of silently losing their action.
       const url = await prompt({
-        title: "Upload failed",
-        description: "We couldn't upload the file. Paste an image URL instead, or cancel.",
-        placeholder: "https://…",
+        title: t("editor.prompt.uploadFailedTitle"),
+        description: t("editor.prompt.uploadFailedDescription"),
+        placeholder: t("editor.prompt.imageUrlPlaceholder"),
         inputType: "url",
-        confirmLabel: "Insert",
+        confirmLabel: t("editor.prompt.uploadFailedConfirm"),
       });
       if (url) editor.chain().focus().setImage({ src: url }).run();
     };
     input.click();
-  }, [editor, imageUpload, prompt]);
+  }, [editor, imageUpload, prompt, t]);
 
   const addYoutube = useCallback(async () => {
     if (!editor) return;
     const url = await prompt({
-      title: "Embed YouTube video",
-      description: "Paste the full YouTube URL (https://www.youtube.com/watch?v=…).",
-      placeholder: "https://www.youtube.com/watch?v=…",
+      title: t("editor.prompt.youtubeTitle"),
+      description: t("editor.prompt.youtubeDescription"),
+      placeholder: t("editor.prompt.youtubePlaceholder"),
       inputType: "url",
-      confirmLabel: "Embed",
+      confirmLabel: t("editor.prompt.youtubeConfirm"),
     });
     if (!url) return;
     editor.chain().focus().setYoutubeVideo({ src: url }).run();
-  }, [editor, prompt]);
+  }, [editor, prompt, t]);
 
   const addAudio = useCallback(async () => {
     if (!editor) return;
     const url = await prompt({
-      title: "Embed audio",
-      description: "Paste a direct https:// URL to an audio file (mp3, m4a, ogg).",
-      placeholder: "https://example.com/lesson.mp3",
+      title: t("editor.prompt.audioTitle"),
+      description: t("editor.prompt.audioDescription"),
+      placeholder: t("editor.prompt.audioPlaceholder"),
       inputType: "url",
-      confirmLabel: "Embed",
+      confirmLabel: t("editor.prompt.audioConfirm"),
     });
     if (!url) return;
     const ok = editor.chain().focus().setAudio({ src: url }).run();
-    if (!ok) toast({ title: "Audio URL must start with http(s)", variant: "destructive" });
-  }, [editor, prompt]);
+    if (!ok) toast({ title: t("editor.toast.audioUrlInvalid"), variant: "destructive" });
+  }, [editor, prompt, t]);
 
   return { setLink, addImage, addYoutube, addAudio };
 }

--- a/frontend/src/components/patterns/InlineEditCover.tsx
+++ b/frontend/src/components/patterns/InlineEditCover.tsx
@@ -43,13 +43,17 @@ export function InlineEditCover({
   const handleFile = async (file: File | undefined | null) => {
     if (!file) return
     if (!file.type.startsWith("image/")) {
-      toast({ title: "Unsupported file", description: "Pick an image file.", variant: "destructive" })
+      toast({
+        title: t("inlineEdit.cover.unsupportedTitle"),
+        description: t("inlineEdit.cover.unsupportedDescription"),
+        variant: "destructive",
+      })
       return
     }
     if (file.size > maxSizeMB * 1024 * 1024) {
       toast({
-        title: "Image too large",
-        description: `Max ${maxSizeMB} MB.`,
+        title: t("inlineEdit.cover.tooLargeTitle"),
+        description: t("inlineEdit.cover.tooLargeDescription", { max: maxSizeMB }),
         variant: "destructive",
       })
       return
@@ -58,8 +62,8 @@ export function InlineEditCover({
       setBusy(true)
       await onUpload(file)
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Upload failed"
-      toast({ title: "Upload failed", description: msg, variant: "destructive" })
+      const msg = err instanceof Error ? err.message : t("inlineEdit.cover.uploadFailedTitle")
+      toast({ title: t("inlineEdit.cover.uploadFailedTitle"), description: msg, variant: "destructive" })
     } finally {
       setBusy(false)
     }
@@ -68,10 +72,10 @@ export function InlineEditCover({
   const remove = async () => {
     if (!onRemove) return
     const ok = await confirm({
-      title: "Remove cover?",
-      description: "This will clear the course cover image.",
+      title: t("inlineEdit.cover.removeConfirmTitle"),
+      description: t("inlineEdit.cover.removeConfirmDescription"),
       tone: "destructive",
-      confirmLabel: "Remove",
+      confirmLabel: t("inlineEdit.cover.removeConfirmAction"),
     })
     if (!ok) return
     try {
@@ -120,7 +124,7 @@ export function InlineEditCover({
             <>
               <ImagePlus className="h-6 w-6" />
               <span className="text-sm">
-                {disabled ? "No cover" : "Click or drop image"}
+                {disabled ? t("inlineEdit.cover.disabled") : t("inlineEdit.cover.empty")}
               </span>
             </>
           )}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -20,7 +20,17 @@
     "editAria": "Edit {{what}}",
     "cover": {
       "replace": "Replace",
-      "remove": "Remove"
+      "remove": "Remove",
+      "empty": "Click or drop image",
+      "disabled": "No cover",
+      "unsupportedTitle": "Unsupported file",
+      "unsupportedDescription": "Pick an image file.",
+      "tooLargeTitle": "Image too large",
+      "tooLargeDescription": "Max {{max}} MB.",
+      "uploadFailedTitle": "Upload failed",
+      "removeConfirmTitle": "Remove cover?",
+      "removeConfirmDescription": "This will clear the course cover image.",
+      "removeConfirmAction": "Remove"
     }
   },
   "header": {
@@ -880,6 +890,43 @@
           "other": "Other"
         }
       }
+    },
+    "toast": {
+      "saved": "Saved",
+      "saveFailed": "Failed to save",
+      "coverUpdated": "Cover updated",
+      "coverRemoved": "Cover removed",
+      "coverRemoveFailed": "Failed to remove cover",
+      "enrollmentSaved": "Enrollment saved",
+      "published": "Published",
+      "unpublished": "Unpublished",
+      "publishFailed": "Failed to update publish status",
+      "moduleAdded": "Module added",
+      "moduleAddFailed": "Failed to add module",
+      "moduleRemoveFailed": "Failed to remove module",
+      "moduleOrderFailed": "Failed to save module order",
+      "announcementPostFailed": "Failed to post announcement",
+      "announcementDeleteFailed": "Failed to delete announcement",
+      "eventCreated": "Event created",
+      "eventUpdated": "Event updated",
+      "eventDeleted": "Event deleted",
+      "eventSaveFailed": "Failed to save event",
+      "eventDeleteFailed": "Failed to delete event",
+      "materialUploadFailed": "Upload failed",
+      "materialDownloadFailed": "Download failed",
+      "materialDeleteFailed": "Failed to delete material"
+    },
+    "confirm": {
+      "deleteModuleTitle": "Delete this module?",
+      "deleteModuleDescription": "All chapters inside the module will also be removed.",
+      "deleteModuleAction": "Delete",
+      "deleteAnnouncementTitle": "Delete this announcement?",
+      "deleteAnnouncementAction": "Delete",
+      "deleteEventTitle": "Delete this event?",
+      "deleteEventAction": "Delete",
+      "deleteMaterialTitle": "Delete material?",
+      "deleteMaterialDescription": "\"{{name}}\" will be permanently removed.",
+      "deleteMaterialAction": "Delete"
     }
   },
   "moduleEditor": {
@@ -1362,5 +1409,28 @@
     "titleRequired": "Title is required",
     "titleTooLong": "Title must be 300 characters or fewer",
     "nameTooShort": "Name must be at least 2 characters"
+  },
+  "editor": {
+    "toast": {
+      "imageUploadFailed": "Image upload failed",
+      "audioUrlInvalid": "Audio URL must start with http(s)"
+    },
+    "prompt": {
+      "addLinkTitle": "Add link",
+      "addLinkDescription": "Paste or type the URL you want to link to. Leave empty to remove an existing link.",
+      "addLinkConfirm": "Apply",
+      "uploadFailedTitle": "Upload failed",
+      "uploadFailedDescription": "We couldn't upload the file. Paste an image URL instead, or cancel.",
+      "uploadFailedConfirm": "Insert",
+      "youtubeTitle": "Embed YouTube video",
+      "youtubeDescription": "Paste the full YouTube URL (https://www.youtube.com/watch?v=…).",
+      "youtubePlaceholder": "https://www.youtube.com/watch?v=…",
+      "youtubeConfirm": "Embed",
+      "audioTitle": "Embed audio",
+      "audioDescription": "Paste a direct https:// URL to an audio file (mp3, m4a, ogg).",
+      "audioPlaceholder": "https://example.com/lesson.mp3",
+      "audioConfirm": "Embed",
+      "imageUrlPlaceholder": "https://…"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -20,7 +20,17 @@
     "editAria": "Изменить {{what}}",
     "cover": {
       "replace": "Заменить",
-      "remove": "Удалить"
+      "remove": "Удалить",
+      "empty": "Нажмите или перетащите изображение",
+      "disabled": "Без обложки",
+      "unsupportedTitle": "Неподдерживаемый файл",
+      "unsupportedDescription": "Выберите изображение.",
+      "tooLargeTitle": "Изображение слишком большое",
+      "tooLargeDescription": "Максимум {{max}} МБ.",
+      "uploadFailedTitle": "Загрузка не удалась",
+      "removeConfirmTitle": "Удалить обложку?",
+      "removeConfirmDescription": "Обложка курса будет очищена.",
+      "removeConfirmAction": "Удалить"
     }
   },
   "header": {
@@ -906,6 +916,43 @@
           "other": "Другое"
         }
       }
+    },
+    "toast": {
+      "saved": "Сохранено",
+      "saveFailed": "Не удалось сохранить",
+      "coverUpdated": "Обложка обновлена",
+      "coverRemoved": "Обложка удалена",
+      "coverRemoveFailed": "Не удалось удалить обложку",
+      "enrollmentSaved": "Период записи сохранён",
+      "published": "Опубликовано",
+      "unpublished": "Снято с публикации",
+      "publishFailed": "Не удалось изменить статус публикации",
+      "moduleAdded": "Модуль добавлен",
+      "moduleAddFailed": "Не удалось добавить модуль",
+      "moduleRemoveFailed": "Не удалось удалить модуль",
+      "moduleOrderFailed": "Не удалось сохранить порядок модулей",
+      "announcementPostFailed": "Не удалось опубликовать объявление",
+      "announcementDeleteFailed": "Не удалось удалить объявление",
+      "eventCreated": "Событие создано",
+      "eventUpdated": "Событие обновлено",
+      "eventDeleted": "Событие удалено",
+      "eventSaveFailed": "Не удалось сохранить событие",
+      "eventDeleteFailed": "Не удалось удалить событие",
+      "materialUploadFailed": "Загрузка не удалась",
+      "materialDownloadFailed": "Скачивание не удалось",
+      "materialDeleteFailed": "Не удалось удалить материал"
+    },
+    "confirm": {
+      "deleteModuleTitle": "Удалить этот модуль?",
+      "deleteModuleDescription": "Все главы внутри модуля также будут удалены.",
+      "deleteModuleAction": "Удалить",
+      "deleteAnnouncementTitle": "Удалить это объявление?",
+      "deleteAnnouncementAction": "Удалить",
+      "deleteEventTitle": "Удалить это событие?",
+      "deleteEventAction": "Удалить",
+      "deleteMaterialTitle": "Удалить материал?",
+      "deleteMaterialDescription": "«{{name}}» будет удалён безвозвратно.",
+      "deleteMaterialAction": "Удалить"
     }
   },
   "moduleEditor": {
@@ -1394,5 +1441,28 @@
     "titleRequired": "Укажите название",
     "titleTooLong": "Название не должно превышать 300 символов",
     "nameTooShort": "Имя должно содержать минимум 2 символа"
+  },
+  "editor": {
+    "toast": {
+      "imageUploadFailed": "Не удалось загрузить изображение",
+      "audioUrlInvalid": "URL аудио должен начинаться с http(s)"
+    },
+    "prompt": {
+      "addLinkTitle": "Добавить ссылку",
+      "addLinkDescription": "Вставьте или введите URL для ссылки. Оставьте пустым, чтобы удалить существующую ссылку.",
+      "addLinkConfirm": "Применить",
+      "uploadFailedTitle": "Загрузка не удалась",
+      "uploadFailedDescription": "Не удалось загрузить файл. Вставьте URL изображения вручную или отмените.",
+      "uploadFailedConfirm": "Вставить",
+      "youtubeTitle": "Встроить видео YouTube",
+      "youtubeDescription": "Вставьте полный YouTube-URL (https://www.youtube.com/watch?v=…).",
+      "youtubePlaceholder": "https://www.youtube.com/watch?v=…",
+      "youtubeConfirm": "Встроить",
+      "audioTitle": "Встроить аудио",
+      "audioDescription": "Вставьте прямой https://-URL к аудиофайлу (mp3, m4a, ogg).",
+      "audioPlaceholder": "https://example.com/lesson.mp3",
+      "audioConfirm": "Встроить",
+      "imageUrlPlaceholder": "https://…"
+    }
   }
 }

--- a/frontend/src/pages/Teacher/editor/useAnnouncementsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useAnnouncementsSection.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
 import type { Announcement } from "@/types"
@@ -26,6 +27,7 @@ export function useAnnouncementsSection(
   courseId: string | undefined,
   confirm: Confirm,
 ): AnnouncementsSection {
+  const { t } = useTranslation()
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [title, setTitle] = useState("")
   const [content, setContent] = useState("")
@@ -64,17 +66,17 @@ export function useAnnouncementsSection(
       setAnnouncements((p) => [a, ...p])
       resetForm()
     } catch {
-      toast({ title: "Failed", variant: "destructive" })
+      toast({ title: t("teacherEditor.toast.announcementPostFailed"), variant: "destructive" })
     } finally {
       setPosting(false)
     }
-  }, [courseId, title, content, resetForm])
+  }, [courseId, title, content, resetForm, t])
 
   const remove = useCallback(
     async (id: string) => {
       const ok = await confirm({
-        title: "Delete this announcement?",
-        confirmLabel: "Delete",
+        title: t("teacherEditor.confirm.deleteAnnouncementTitle"),
+        confirmLabel: t("teacherEditor.confirm.deleteAnnouncementAction"),
         tone: "destructive",
       })
       if (!ok) return
@@ -82,10 +84,10 @@ export function useAnnouncementsSection(
         await coursesService.deleteAnnouncement(id)
         setAnnouncements((p) => p.filter((a) => a.id !== id))
       } catch {
-        toast({ title: "Failed", variant: "destructive" })
+        toast({ title: t("teacherEditor.toast.announcementDeleteFailed"), variant: "destructive" })
       }
     },
-    [confirm],
+    [confirm, t],
   )
 
   return {

--- a/frontend/src/pages/Teacher/editor/useCourseData.ts
+++ b/frontend/src/pages/Teacher/editor/useCourseData.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 import type { DropResult } from "@hello-pangea/dnd"
 import { coursesService } from "@/services/courses"
 import { storageService } from "@/services/storage"
@@ -44,6 +45,7 @@ export function useCourseData(
   confirm: Confirm,
   onNotFound: () => void,
 ): CourseData {
+  const { t } = useTranslation()
   const [course, setCourse] = useState<Course | null>(null)
   const [loading, setLoading] = useState(true)
   const [enrollStart, setEnrollStart] = useState("")
@@ -84,13 +86,13 @@ export function useCourseData(
       try {
         const updated = await coursesService.updateCourse(courseId, patch)
         setCourse((p) => (p ? { ...p, ...updated } : p))
-        toast({ title: "Saved", variant: "success" })
+        toast({ title: t("teacherEditor.toast.saved"), variant: "success" })
       } catch {
-        toast({ title: "Failed to save", variant: "destructive" })
+        toast({ title: t("teacherEditor.toast.saveFailed"), variant: "destructive" })
         throw new Error("save failed")
       }
     },
-    [courseId],
+    [courseId, t],
   )
 
   const uploadCover = useCallback(
@@ -99,10 +101,10 @@ export function useCourseData(
       const url = await storageService.uploadCourseImage(courseId, file)
       await coursesService.updateCourse(courseId, { image_url: url })
       setCourse((p) => (p ? { ...p, image_url: url } : p))
-      toast({ title: "Cover updated", variant: "success" })
+      toast({ title: t("teacherEditor.toast.coverUpdated"), variant: "success" })
       return url
     },
-    [courseId],
+    [courseId, t],
   )
 
   const removeCover = useCallback(async () => {
@@ -110,11 +112,11 @@ export function useCourseData(
     try {
       await coursesService.updateCourse(courseId, { image_url: null })
       setCourse((p) => (p ? { ...p, image_url: null } : p))
-      toast({ title: "Cover removed", variant: "success" })
+      toast({ title: t("teacherEditor.toast.coverRemoved"), variant: "success" })
     } catch {
-      toast({ title: "Failed to remove cover", variant: "destructive" })
+      toast({ title: t("teacherEditor.toast.coverRemoveFailed"), variant: "destructive" })
     }
-  }, [courseId])
+  }, [courseId, t])
 
   const saveEnrollment = useCallback(async () => {
     if (!courseId) return false
@@ -126,15 +128,15 @@ export function useCourseData(
       }
       await coursesService.updateCourse(courseId, payload)
       setCourse((p) => (p ? { ...p, ...payload } : p))
-      toast({ title: "Enrollment saved", variant: "success" })
+      toast({ title: t("teacherEditor.toast.enrollmentSaved"), variant: "success" })
       return true
     } catch {
-      toast({ title: "Failed to save", variant: "destructive" })
+      toast({ title: t("teacherEditor.toast.saveFailed"), variant: "destructive" })
       return false
     } finally {
       setSavingEnrollment(false)
     }
-  }, [courseId, enrollStart, enrollEnd])
+  }, [courseId, enrollStart, enrollEnd, t])
 
   const togglePublish = useCallback(async () => {
     if (!courseId || !course) return
@@ -143,13 +145,16 @@ export function useCourseData(
       await coursesService.updateCourse(courseId, { status: next })
       setCourse((p) => (p ? { ...p, status: next } : p))
       toast({
-        title: next === "published" ? "Published" : "Unpublished",
+        title:
+          next === "published"
+            ? t("teacherEditor.toast.published")
+            : t("teacherEditor.toast.unpublished"),
         variant: "success",
       })
     } catch {
-      toast({ title: "Failed", variant: "destructive" })
+      toast({ title: t("teacherEditor.toast.publishFailed"), variant: "destructive" })
     }
-  }, [courseId, course])
+  }, [courseId, course, t])
 
   const addModule = useCallback(async () => {
     if (!courseId) return
@@ -162,19 +167,19 @@ export function useCourseData(
       setCourse((p) =>
         p ? { ...p, modules: [...(p.modules ?? []), { ...m, chapters: [] }] } : p,
       )
-      toast({ title: "Module added", variant: "success" })
+      toast({ title: t("teacherEditor.toast.moduleAdded"), variant: "success" })
     } catch {
-      toast({ title: "Failed", variant: "destructive" })
+      toast({ title: t("teacherEditor.toast.moduleAddFailed"), variant: "destructive" })
     }
-  }, [courseId, course?.modules?.length])
+  }, [courseId, course?.modules?.length, t])
 
   const removeModule = useCallback(
     async (id: string) => {
       if (!courseId) return
       const ok = await confirm({
-        title: "Delete this module?",
-        description: "All chapters inside the module will also be removed.",
-        confirmLabel: "Delete",
+        title: t("teacherEditor.confirm.deleteModuleTitle"),
+        description: t("teacherEditor.confirm.deleteModuleDescription"),
+        confirmLabel: t("teacherEditor.confirm.deleteModuleAction"),
         tone: "destructive",
       })
       if (!ok) return
@@ -182,10 +187,10 @@ export function useCourseData(
         await coursesService.deleteModule(courseId, id)
         setCourse((p) => (p ? { ...p, modules: p.modules?.filter((m) => m.id !== id) } : p))
       } catch {
-        toast({ title: "Failed", variant: "destructive" })
+        toast({ title: t("teacherEditor.toast.moduleRemoveFailed"), variant: "destructive" })
       }
     },
-    [courseId, confirm],
+    [courseId, confirm, t],
   )
 
   const sortedModules = useMemo(
@@ -223,13 +228,13 @@ export function useCourseData(
             .filter(Boolean),
         )
       } catch {
-        toast({ title: "Failed to save module order", variant: "destructive" })
+        toast({ title: t("teacherEditor.toast.moduleOrderFailed"), variant: "destructive" })
         void loadCourse({ cancelled: false })
       } finally {
         setReordering(false)
       }
     },
-    [sortedModules, courseId, loadCourse, reordering],
+    [sortedModules, courseId, loadCourse, reordering, t],
   )
 
   return {

--- a/frontend/src/pages/Teacher/editor/useEventsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useEventsSection.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
 import type { CourseEvent } from "@/types"
@@ -27,6 +28,7 @@ export function useEventsSection(
   courseId: string | undefined,
   confirm: Confirm,
 ): EventsSection {
+  const { t } = useTranslation()
   const [events, setEvents] = useState<CourseEvent[]>([])
   const [form, setForm] = useState<EventFormState>(EMPTY_EVENT_FORM)
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -76,38 +78,38 @@ export function useEventsSection(
       if (editingId) {
         const updated = await coursesService.updateCourseEvent(courseId, editingId, payload)
         setEvents((p) => p.map((ev) => (ev.id === editingId ? updated : ev)))
-        toast({ title: "Event updated", variant: "success" })
+        toast({ title: t("teacherEditor.toast.eventUpdated"), variant: "success" })
       } else {
         const created = await coursesService.createCourseEvent(courseId, payload)
         setEvents((p) => [...p, created])
-        toast({ title: "Event created", variant: "success" })
+        toast({ title: t("teacherEditor.toast.eventCreated"), variant: "success" })
       }
       resetForm()
     } catch {
-      toast({ title: "Failed to save event", variant: "destructive" })
+      toast({ title: t("teacherEditor.toast.eventSaveFailed"), variant: "destructive" })
     } finally {
       setSaving(false)
     }
-  }, [courseId, form, editingId, resetForm])
+  }, [courseId, form, editingId, resetForm, t])
 
   const remove = useCallback(
     async (id: string) => {
       if (!courseId) return
       const ok = await confirm({
-        title: "Delete this event?",
-        confirmLabel: "Delete",
+        title: t("teacherEditor.confirm.deleteEventTitle"),
+        confirmLabel: t("teacherEditor.confirm.deleteEventAction"),
         tone: "destructive",
       })
       if (!ok) return
       try {
         await coursesService.deleteCourseEvent(courseId, id)
         setEvents((p) => p.filter((e) => e.id !== id))
-        toast({ title: "Event deleted", variant: "success" })
+        toast({ title: t("teacherEditor.toast.eventDeleted"), variant: "success" })
       } catch {
-        toast({ title: "Failed", variant: "destructive" })
+        toast({ title: t("teacherEditor.toast.eventDeleteFailed"), variant: "destructive" })
       }
     },
-    [courseId, confirm],
+    [courseId, confirm, t],
   )
 
   return {

--- a/frontend/src/pages/Teacher/editor/useMaterialsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useMaterialsSection.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { storageService } from "@/services/storage"
 import { toast } from "@/lib/toast"
 import type { useConfirm } from "@/components/ui/alert-dialog"
@@ -24,6 +25,7 @@ export function useMaterialsSection(
   courseId: string | undefined,
   confirm: Confirm,
 ): MaterialsSection {
+  const { t } = useTranslation()
   const [materials, setMaterials] = useState<MaterialFile[]>([])
   const [uploading, setUploading] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -57,33 +59,36 @@ export function useMaterialsSection(
         await storageService.uploadCourseMaterial(courseId, file)
         setMaterials(await storageService.listCourseMaterials(courseId))
       } catch {
-        toast({ title: "Upload failed", variant: "destructive" })
+        toast({ title: t("teacherEditor.toast.materialUploadFailed"), variant: "destructive" })
       } finally {
         setUploading(false)
         if (inputRef.current) inputRef.current.value = ""
       }
     },
-    [courseId],
+    [courseId, t],
   )
 
-  const download = useCallback(async (m: MaterialFile) => {
-    try {
-      window.open(
-        await storageService.getSignedMaterialUrl(m.path),
-        "_blank",
-        "noopener,noreferrer",
-      )
-    } catch {
-      toast({ title: "Download failed", variant: "destructive" })
-    }
-  }, [])
+  const download = useCallback(
+    async (m: MaterialFile) => {
+      try {
+        window.open(
+          await storageService.getSignedMaterialUrl(m.path),
+          "_blank",
+          "noopener,noreferrer",
+        )
+      } catch {
+        toast({ title: t("teacherEditor.toast.materialDownloadFailed"), variant: "destructive" })
+      }
+    },
+    [t],
+  )
 
   const remove = useCallback(
     async (m: MaterialFile) => {
       const ok = await confirm({
-        title: "Delete material?",
-        description: `"${m.name}" will be permanently removed.`,
-        confirmLabel: "Delete",
+        title: t("teacherEditor.confirm.deleteMaterialTitle"),
+        description: t("teacherEditor.confirm.deleteMaterialDescription", { name: m.name }),
+        confirmLabel: t("teacherEditor.confirm.deleteMaterialAction"),
         tone: "destructive",
       })
       if (!ok) return
@@ -91,10 +96,10 @@ export function useMaterialsSection(
         await storageService.deleteCourseMaterial(m.path)
         setMaterials((p) => p.filter((x) => x.path !== m.path))
       } catch {
-        toast({ title: "Failed", variant: "destructive" })
+        toast({ title: t("teacherEditor.toast.materialDeleteFailed"), variant: "destructive" })
       }
     },
-    [confirm],
+    [confirm, t],
   )
 
   return {


### PR DESCRIPTION
## Summary

Verification pass 2 surfaced 9 files with hardcoded EN strings — same shape as PR #222 — that bypass the bilingual policy. RU users would see Russian admin/calendar surfaces but English everywhere they actually do work (course editor, announcements, events, materials, the rich-text editor's media prompts, the inline cover upload).

## Files

Hooks switched to \`useTranslation()\`:

- \`components/editor/useImageUpload.ts\` — image upload toast
- \`components/editor/useMediaPrompts.ts\` — link / image-fallback / YouTube / audio prompts + audio URL validation toast
- \`components/patterns/InlineEditCover.tsx\` — already had \`t()\` for replace/remove labels; now covers the entire upload/remove flow (unsupported, too-large, upload-failed, remove-confirm, empty + disabled labels)
- \`pages/Teacher/editor/useCourseData.ts\` — every toast and the delete-module confirm
- \`pages/Teacher/editor/useAnnouncementsSection.ts\` — post + delete confirm + failure toasts
- \`pages/Teacher/editor/useEventsSection.ts\` — create/update/delete + save-failed toasts + delete confirm
- \`pages/Teacher/editor/useMaterialsSection.ts\` — upload/download/delete toasts + delete confirm with file-name interpolation

## i18n surface

New namespaces: \`editor.toast.*\`, \`editor.prompt.*\`, \`teacherEditor.toast.*\`, \`teacherEditor.confirm.*\`. Extended \`inlineEdit.cover.*\` with 10 new keys. EN + RU added together; locale parity preserved.

## Note on the merge

JSON edits applied via a deep-merge Python script. A first attempt accidentally overwrote the existing \`teacherEditor.modals.*\` / \`badges.*\` keys used by the editor's UI components — caught by the \`i18n key coverage\` vitest guard, reverted, and re-applied as a proper merge. Final 112-test suite green.

## Test plan

- [x] \`npm run lint\` (zero warnings)
- [x] \`npx tsc --noEmit\` (strict)
- [x] \`npm run test:run\` — 112 passed (including \`keyCoverage.test.ts\`)
- [ ] CI green
- [ ] Manual smoke: switch locale to RU → open a course in teacher editor → exercise cover upload (drag a non-image, an >8MB image), publish/unpublish, add module / delete module, open announcements / events / materials sub-modals → every string renders in Russian

🤖 Generated with [Claude Code](https://claude.com/claude-code)