### PR TITLE
fix(security): sanitize announcements + gate access_mode flip to admin

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import assert_course_owner, get_current_user, require_teacher
 from app.core.database import get_db
+from app.core.sanitize import sanitize_string
 from app.models.announcement import Announcement
 from app.models.course import Course
 from app.models.enrollment import Enrollment
@@ -121,10 +122,17 @@ def create_announcement(
     else:
         course = None
 
+    # Defence-in-depth: the React app sanitizes via DOMPurify before
+    # sending, but a direct API caller can bypass that. Announcements
+    # fan out to every enrolled student via create_notifications_bulk
+    # below — an unsanitized payload would persist stored XSS into the
+    # notification feed and the announcement banner.
+    safe_title = sanitize_string(data.title)
+    safe_content = sanitize_string(data.content)
     announcement = Announcement(
         id=uuid.uuid4(),
-        title=data.title,
-        content=data.content,
+        title=safe_title,
+        content=safe_content,
         course_id=data.course_id,
         created_by=teacher.id,
     )
@@ -172,9 +180,9 @@ def update_announcement(
         )
 
     if data.title is not None:
-        announcement.title = data.title
+        announcement.title = sanitize_string(data.title)
     if data.content is not None:
-        announcement.content = data.content
+        announcement.content = sanitize_string(data.content)
 
     db.commit()
     db.refresh(announcement)

--- a/backend/app/api/v1/courses/crud.py
+++ b/backend/app/api/v1/courses/crud.py
@@ -9,7 +9,7 @@ from app.api.dependencies import assert_course_owner, require_teacher
 from app.core.database import get_db
 from app.core.sanitize import sanitize_string
 from app.models.course import Course
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.schemas.course import CourseCreate, CourseResponse, CourseUpdate
 from app.services.audit_service import log_action
 from app.services.course_service import (
@@ -63,6 +63,15 @@ def update_existing_course(
             detail=f"Course '{course_id}' not found",
         )
     assert_course_owner(course, teacher, allow_admin=False)
+    # ``access_mode`` (public vs institute) controls solo-enrollment
+    # access per ADR-010. Letting any course owner flip it would let a
+    # teacher promote their institute course to public, bypassing the
+    # invitation-only gate. Restrict the field to admins.
+    if data.access_mode is not None and teacher.role != UserRole.ADMIN.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admins can change course access mode",
+        )
     if data.title:
         data.title = sanitize_string(data.title)
     old_status = course.status


### PR DESCRIPTION
## Summary

Security audit pass 3 surfaced two HIGH-severity findings.

### 1. Stored-XSS in announcements

\`AnnouncementCreate.content\` (and \`.title\`) was written verbatim without \`sanitize_string\` — every other rich-text surface (chapter blocks, course titles) passes through bleach-backed sanitization as defence-in-depth. An attacker with a teacher account could persist \`<script>\` / \`onerror=\` payloads that fan out via \`create_notifications_bulk\` to every enrolled student.

Fix: \`sanitize_string\` on both \`title\` and \`content\` in create + update flows.

### 2. \`access_mode\` mass-assignment bypassing ADR-010

\`CourseUpdate.access_mode\` (\`public\` vs \`institute\`) was applied via the \`update_course\` \`setattr\` loop while the route uses \`require_teacher\`. ADR-010 specifies institute courses are invitation-only — admin must add students via cohort endpoints. A teacher could silently flip their own institute course to \`public\`, enabling solo self-enrollment and bypassing the gate.

Fix: route-level admin gate on \`data.access_mode is not None\`.

## Audit finding intentionally NOT fixed

Pass 3 also flagged \`submit_quiz\` for a per-user attempt-cap race. Tracing the code: \`with_for_update()\` on the Quiz row plus Postgres READ COMMITTED isolation means two parallel submits serialize on the lock — the second request acquires it only after the first commits, and \`ensure_attempts_available\` re-reads the latest count under that lock. The audit's analysis missed this ordering. No fix needed; commit message documents the decision.

## Test plan

- [x] \`ruff check\` / \`mypy\` clean
- [x] \`pytest tests/ --ignore=test_translation_registry\` — 513 passed
- [ ] CI green
- [ ] Manual: teacher tries to PATCH a course with \`access_mode\` set → 403. Admin can. Announcement with \`<img src=x onerror=alert(1)>\` is persisted with the \`onerror\` stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)