### PR TITLE
fix(courses): restore_course preserves independently-deleted children

### DIFF
--- a/backend/app/services/course_service/_courses.py
+++ b/backend/app/services/course_service/_courses.py
@@ -82,16 +82,30 @@ def delete_course(db: Session, course: Course) -> None:
 def restore_course(db: Session, course: Course) -> Course:
     """Undelete a soft-deleted course tree via bulk UPDATEs.
 
-    We rely on direct UPDATE statements rather than walking ``course.modules``
-    because the eager loader in ``_COURSE_TREE`` filters out the very rows we
-    need to flip back to live (their ``deleted_at`` is set).
+    Symmetric to ``delete_course``: we only flip cascaded rows back to
+    live, NOT rows that were independently soft-deleted before the
+    course tombstone. ``delete_course`` stamps the cascade with a single
+    ``now`` timestamp, so matching ``Module.deleted_at == course.deleted_at``
+    (captured before we null it) restores exactly the cascade set —
+    rows with an earlier ``deleted_at`` (independently deleted by a
+    teacher before the course was trashed) stay deleted.
+
+    Direct UPDATE statements rather than walking ``course.modules``
+    because the eager loader in ``_COURSE_TREE`` filters out the very
+    rows we need to flip.
     """
+    tombstone = course.deleted_at
     course.deleted_at = None
-    db.query(Module).filter(Module.course_id == course.id).update({Module.deleted_at: None}, synchronize_session=False)
-    module_ids = select(Module.id).where(Module.course_id == course.id).scalar_subquery()
-    db.query(Chapter).filter(Chapter.module_id.in_(module_ids)).update(
-        {Chapter.deleted_at: None}, synchronize_session=False
-    )
+    if tombstone is not None:
+        db.query(Module).filter(
+            Module.course_id == course.id,
+            Module.deleted_at == tombstone,
+        ).update({Module.deleted_at: None}, synchronize_session=False)
+        module_ids = select(Module.id).where(Module.course_id == course.id).scalar_subquery()
+        db.query(Chapter).filter(
+            Chapter.module_id.in_(module_ids),
+            Chapter.deleted_at == tombstone,
+        ).update({Chapter.deleted_at: None}, synchronize_session=False)
     db.commit()
     db.refresh(course)
     return course

--- a/backend/tests/test_admin_bulk_trash_and_csv.py
+++ b/backend/tests/test_admin_bulk_trash_and_csv.py
@@ -26,7 +26,7 @@ from app.api.dependencies import (
 )
 from app.core.database import get_db
 from app.main import app
-from app.models.course import Course
+from app.models.course import Chapter, Course, Module
 from app.models.enrollment import Enrollment
 from app.models.user import User, UserRole
 from tests.conftest import STUDENT_ID, TEACHER_ID
@@ -297,6 +297,77 @@ class TestTrashAndRestore:
         row = db.query(Course).filter(Course.id == "restore-me").first()
         assert row is not None
         assert row.deleted_at is None
+
+    def test_restore_preserves_independently_deleted_chapters(self, client: TestClient, db: Session):
+        """Symmetric restore: a chapter the teacher trashed BEFORE the
+        whole course was trashed must stay trashed when the course is
+        restored. The two deletes have different ``deleted_at``
+        timestamps; only rows matching the course tombstone get flipped
+        back to live."""
+        earlier = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+        course_tombstone = datetime(2026, 5, 14, 9, 0, tzinfo=UTC)
+
+        _seed_course_direct(db, course_id="restore-mix", deleted=False)
+        # Manually set the course's deleted_at to the cascade timestamp so the
+        # restore picks up the right value.
+        course = db.query(Course).filter(Course.id == "restore-mix").first()
+        assert course is not None
+        course.deleted_at = course_tombstone
+
+        # Two modules, one trashed independently before the course was.
+        live_module = Module(
+            id="mod-live",
+            course_id="restore-mix",
+            title="Live Module",
+            order_index=0,
+            deleted_at=course_tombstone,  # cascaded with the course
+        )
+        orphan_module = Module(
+            id="mod-orphan",
+            course_id="restore-mix",
+            title="Orphan Module (teacher deleted before course trash)",
+            order_index=1,
+            deleted_at=earlier,
+        )
+        db.add(live_module)
+        db.add(orphan_module)
+        db.commit()
+
+        # And one chapter that was also independently deleted.
+        orphan_chapter = Chapter(
+            id="ch-orphan",
+            module_id="mod-live",
+            title="Orphan Chapter",
+            order_index=0,
+            deleted_at=earlier,
+        )
+        live_chapter = Chapter(
+            id="ch-live",
+            module_id="mod-live",
+            title="Live Chapter",
+            order_index=1,
+            deleted_at=course_tombstone,
+        )
+        db.add(orphan_chapter)
+        db.add(live_chapter)
+        db.commit()
+
+        resp = client.post(f"{COURSES_PREFIX}/restore-mix/restore")
+        assert resp.status_code == 200
+
+        db.expire_all()
+        assert db.query(Course).filter(Course.id == "restore-mix").first().deleted_at is None
+        assert db.query(Module).filter(Module.id == "mod-live").first().deleted_at is None
+        # Compare against ``is not None`` rather than the exact ``earlier``
+        # value: SQLite's datetime roundtrip can shift microsecond
+        # precision; the invariant is "stays deleted", not "exact value".
+        assert db.query(Module).filter(Module.id == "mod-orphan").first().deleted_at is not None, (
+            "Module that was deleted before the course tombstone must stay deleted"
+        )
+        assert db.query(Chapter).filter(Chapter.id == "ch-live").first().deleted_at is None
+        assert db.query(Chapter).filter(Chapter.id == "ch-orphan").first().deleted_at is not None, (
+            "Chapter that was deleted before the course tombstone must stay deleted"
+        )
 
     def test_restore_nonexistent_returns_404(self, client: TestClient):
         resp = client.post(f"{COURSES_PREFIX}/nonexistent/restore")


### PR DESCRIPTION
## Summary

\`restore_course\` cleared \`deleted_at\` on **every** module and chapter under the course, not just the ones the cascade had stamped when the course was trashed. A chapter that a teacher soft-deleted on its own (different \`deleted_at\`) BEFORE the course got trashed silently resurrected when the course was restored — re-publishing content the teacher had intentionally removed.

## Fix

The matching delete path (\`delete_course\`) stamps every cascaded row with the course's \`now\` timestamp. Make restore symmetric: capture \`course.deleted_at\` BEFORE nulling it on the course row, then only flip \`Module\` / \`Chapter\` rows whose \`deleted_at\` equals that tombstone. Rows tombstoned at an earlier (independent) moment stay deleted.

## Test plan

- [x] Regression test seeds a mixed-timestamp tree (live module + chapter cascaded with course; orphan module + chapter trashed earlier) and verifies restore only touches the cascaded set
- [x] 537 / 537 backend tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)