### PR TITLE
fix: audit log 500 on bad UUID + certificate transition race

### DIFF
--- a/backend/app/api/v1/audit.py
+++ b/backend/app/api/v1/audit.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
@@ -49,7 +49,18 @@ def list_audit_logs(
     q = db.query(AuditLog)
 
     if user_id:
-        q = q.filter(AuditLog.user_id == user_id)
+        # The column is a typed UUID; a malformed query-string value
+        # would raise ``invalid input syntax for type uuid`` from
+        # Postgres and surface as a 500. Validate up-front and 400
+        # so clients get an actionable error.
+        try:
+            parsed_user_id = UUID(user_id)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="user_id must be a valid UUID",
+            ) from exc
+        q = q.filter(AuditLog.user_id == parsed_user_id)
     if resource_type:
         q = q.filter(AuditLog.resource_type == resource_type)
     if action:

--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -42,8 +42,22 @@ def generate_certificate_number() -> str:
     return "CERT-" + hashlib.sha256(raw.encode()).hexdigest()[:12].upper()
 
 
-def _load_cert_or_404(db: Session, cert_id: UUID) -> Certificate:
-    cert = db.query(Certificate).filter(Certificate.id == cert_id).first()
+def _load_cert_or_404(db: Session, cert_id: UUID, *, for_update: bool = False) -> Certificate:
+    """Load a certificate row, optionally with ``FOR UPDATE``.
+
+    Transition helpers (``teacher_approve`` / ``admin_approve`` /
+    ``reject``) pass ``for_update=True`` so concurrent reviewer clicks
+    serialize on the row. Without it, two parallel approve clicks both
+    pass the ``_assert_status`` gate, both regenerate
+    ``certificate_number``, both fire the ``certificate_approved``
+    notification, and both write an audit row. Read paths use the
+    default ``for_update=False`` — no need to hold a lock for a view.
+    SQLite (test path) treats ``with_for_update`` as a no-op.
+    """
+    q = db.query(Certificate).filter(Certificate.id == cert_id)
+    if for_update:
+        q = q.with_for_update()
+    cert = q.first()
     if not cert:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -86,7 +100,7 @@ def _status_error_message(cert: Certificate, allowed: tuple[str, ...]) -> str:
 
 
 def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request) -> Certificate:
-    cert = _load_cert_or_404(db, cert_id)
+    cert = _load_cert_or_404(db, cert_id, for_update=True)
     _assert_status(cert, "pending")
 
     ownership_detail = "You can only approve certificates for your own courses"
@@ -112,7 +126,7 @@ def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request)
 
 
 def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> Certificate:
-    cert = _load_cert_or_404(db, cert_id)
+    cert = _load_cert_or_404(db, cert_id, for_update=True)
     _assert_status(cert, "teacher_approved")
 
     cert.status = "approved"
@@ -152,7 +166,7 @@ def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> 
 
 
 def reject(db: Session, cert_id: UUID, user: User, request: Request) -> Certificate:
-    cert = _load_cert_or_404(db, cert_id)
+    cert = _load_cert_or_404(db, cert_id, for_update=True)
     if cert.status in ("approved", "rejected"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/tests/test_users_reviews_misc.py
+++ b/backend/tests/test_users_reviews_misc.py
@@ -631,6 +631,14 @@ class TestAuditLog:
         assert resp.status_code == 200
         assert resp.json()["total"] >= 1
 
+    def test_invalid_user_id_returns_400(self, admin_client: TestClient):
+        # Used to surface a Postgres ``invalid input syntax for type uuid``
+        # 500. Validate up-front and 400 so a typo in the query string is
+        # a recoverable client error.
+        resp = admin_client.get("/api/v1/audit?user_id=not-a-uuid")
+        assert resp.status_code == 400
+        assert "uuid" in resp.json()["detail"].lower()
+
     def test_anon_rejected(self, anon_client: TestClient):
         resp = anon_client.get("/api/v1/audit")
         assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Summary

Two correctness fixes from bug-hunt pass 3.

### 1. \`GET /audit?user_id=<bad>\` returned 500

\`q.filter(AuditLog.user_id == user_id)\` passed a raw string into a UUID-typed column. Postgres raised \`invalid input syntax for type uuid\` and surfaced as 500. Now validate up-front: parse the string, 400 with \"user_id must be a valid UUID\" on failure.

### 2. Certificate transition race

\`teacher_approve\` / \`admin_approve\` / \`reject\` all read the \`Certificate\` row without \`FOR UPDATE\` and re-wrote status after a check. Two parallel approve clicks (admin double-click, or a tabbed-out admin + a second admin landing at the same time) both passed the status gate, both regenerated \`certificate_number\`, both fired the \`certificate_approved\` notification to the student, both wrote an audit row.

Add a \`for_update\` parameter to \`_load_cert_or_404\` and pass \`True\` from the three transition helpers. SQLite test path no-ops; Postgres serializes. Read paths keep \`for_update=False\`.

## Test plan

- [x] New regression test for the audit 400 (\`test_invalid_user_id_returns_400\`)
- [x] 537 / 537 backend tests pass
- [x] Cert race not directly testable in pytest (no real concurrency); FOR UPDATE shape mirrors PR #219 cohort capacity fix which has the same property
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)