### PR TITLE
docs: contributor onboarding fixes + restore ADR-010 publicly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ makes a real difference.
 
 | Tool       | Version  | Notes |
 |------------|----------|-------|
-| Node.js    | >= 20    | `node -v` to check |
-| npm        | >= 10    | ships with Node 20+ |
+| Node.js    | >= 22.12 | matches CI (`22.18.0`); `node -v` to check |
+| npm        | >= 10    | ships with Node 22+ |
 | Python     | 3.12     | must match CI and Vercel runtime |
 | Git        | any      | |
 
@@ -40,8 +40,11 @@ cd equip
 # Frontend
 cd frontend && npm ci && cd ..
 
-# Backend
-cd backend && pip install -r requirements.txt && cd ..
+# Backend (runtime + tooling)
+# requirements-ci.txt is a superset of requirements.txt; installing it
+# mirrors the CI environment so `pytest`, `mypy`, `ruff`, `pip-audit`
+# all work locally.
+cd backend && pip install -r requirements-ci.txt && cd ..
 ```
 
 ### 3. Configure environment
@@ -67,11 +70,18 @@ cd frontend && npm run dev                     # http://localhost:5173
 ### 5. Run tests
 
 ```bash
-cd backend  && python -m pytest tests/   # 396+ tests
+cd backend  && python -m pytest tests/   # 540+ tests, ~10s
 cd frontend && npm run test:run           # Vitest + jsdom
 ```
 
 If all tests pass, you're ready to contribute!
+
+### Architecture decision records
+
+Major architectural decisions live under [`docs/adr/`](docs/adr/).
+Read the index before changing anything that crosses module
+boundaries (cohorts, translation pipeline, soft-delete behaviour,
+etc.).
 
 ## Project structure
 
@@ -184,8 +194,27 @@ the [ROADMAP](ROADMAP.md) for bigger-picture direction.
 ### General
 
 - Code, comments, commit messages, and docs are in **English**.
-- The application UI is in **Russian** (target audience).
-- No Docker — the project intentionally avoids container-based workflows.
+- The application UI is **bilingual** RU↔EN with the design language
+  targeting Russian-speaking Bible schools first. Every user-facing
+  string goes through `t(...)` — see `.cursor/rules/frontend-react.mdc`.
+- No Docker — the project intentionally avoids container-based
+  workflows today. A potential self-hosted installer (which may use
+  Docker Compose) is on the long-term roadmap; if/when that lands the
+  rule changes only for that path. Until then: deploy via Vercel,
+  develop natively.
+
+### Conventions library
+
+The canonical conventions live under [`.cursor/rules/*.mdc`](.cursor/rules/).
+These files are written for the Cursor editor's AI features but they're
+plain Markdown — read them in any editor:
+
+- `project-overview.mdc` — stack, scale targets, established patterns
+- `backend-python.mdc` — FastAPI / SQLAlchemy / Pydantic conventions
+- `frontend-react.mdc` — design system, one-per-job library policy
+- `supabase-migrations.mdc` — append-only migration workflow
+- `git-ci.mdc` — Conventional Commits + CI matrix
+- `agent-autonomy.mdc` — testing expectations before declaring done
 
 ## Getting help
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,8 +99,12 @@ block types, grading logic, or integrations without forking.
 :thought_balloon: **API v2** — GraphQL or tRPC for more efficient data
 fetching as the feature set grows.
 
-:thought_balloon: **Self-hosted installer** — one-command Docker Compose
-setup for organizations that want to run their own instance.
+:thought_balloon: **Self-hosted installer** — a one-command setup
+(scripted Vercel + Supabase provisioning, OR a packaged Docker
+Compose stack — to be decided when the demand is real) for
+organizations that want to run their own instance. _Note: until
+this is on the active roadmap, the project intentionally avoids
+container-based workflows everywhere else; see CONTRIBUTING._
 
 ---
 

--- a/docs/adr/0010-cohorts-as-top-level-entities.md
+++ b/docs/adr/0010-cohorts-as-top-level-entities.md
@@ -1,0 +1,150 @@
+# ADR-010: Cohorts as top-level admin entities
+
+- **Status**: Accepted (2026-05-13)
+- **Date**: 2026-05-13
+- **Decision-makers**: @ArVaViT (owner), @claude (Equip agent)
+
+## Context
+
+The first cohort prototype (pre-2026-05-13) attached a cohort to a
+single course: each course owned its cohorts, and teachers managed
+their cohorts inside their course editor. This shape worked for the
+first user (one school, one teacher per course), but broke as soon
+as we tried to model real Bible schools:
+
+1. **Cross-course cohorts are the norm.** A class of students taking
+   "Genesis Overview" together also takes "Pastoral Theology" with
+   the same instructor in the next semester. A course-scoped cohort
+   model forces creating two parallel cohorts with the same roster.
+
+2. **Teachers do not own cohort membership.** In every nonprofit
+   Bible school we surveyed, the **director / registrar** decides
+   who is in which cohort and which courses that cohort takes that
+   term. Teachers handle the academic content; admins handle
+   scheduling and rosters. A teacher-scoped UI made the wrong person
+   responsible for student enrollment.
+
+3. **Public courses and institute courses need different gates.** A
+   public discipleship course should accept solo self-enrollment. A
+   credentialed program course should accept enrollment **only**
+   through a cohort the registrar created. The cohort model had no
+   way to express "this course is invitation-only".
+
+## Decision
+
+Cohorts become **top-level admin entities**.
+
+- A cohort has its own table (`cohorts`) with `name`, `start_date`,
+  `end_date`, `enrollment_start/end`, `max_students`, `status`
+  (`upcoming → active → completed`, forward-only).
+- The relationship to courses is **many-to-many** through a junction
+  table `cohort_courses(cohort_id, course_id)`. A single cohort
+  can span any number of courses; a single course can be taught to
+  any number of cohorts.
+- Student membership is the existing `enrollments` table extended
+  with a nullable `cohort_id`. A student in a cohort that includes
+  N courses gets N enrollment rows that all share the same
+  `cohort_id`.
+- All cohort write surfaces (`POST /cohorts`, `PATCH /cohorts/{id}`,
+  `POST /cohorts/{id}/courses`, `POST /cohorts/{id}/students`, etc.)
+  require `require_admin`. Teachers get a **read-only** filter (e.g.
+  gradebook "show cohort X") and the public catalog gets a
+  read-only "enroll into cohort Y" dropdown.
+- Courses gain an `access_mode` column with values `public` and
+  `institute`. Solo self-enrollment (`POST /courses/{id}/enroll`
+  without a `cohort_id`) is gated: `institute` 403s; `public`
+  applies the existing enrollment-window check. Cohort-based
+  enrollment works for either access mode — joining a cohort is
+  the director's intent regardless of access mode.
+- The legacy course-scoped create endpoint
+  (`POST /cohorts/course/{id}` from before this ADR) was deleted.
+
+## Consequences
+
+### Easier
+
+- One cohort across multiple courses: the registrar creates a cohort
+  once and attaches as many courses as the semester needs.
+- Clear authorship line: admin owns rosters, teacher owns content.
+- The public catalog enroll dialog gets a clean dropdown of "join
+  this course as part of cohort X" with no special-casing for
+  teacher-scoped cohorts.
+- Soft-delete and undo flows simplify — a cohort has its own
+  lifecycle independent of its courses.
+
+### Harder
+
+- The `enrollments` table now serves both solo (cohort_id IS NULL)
+  and cohort (cohort_id IS NOT NULL) students. Every query against
+  it must consider both shapes. We accepted this rather than
+  splitting into two tables because the surface area (grades,
+  progress, certificates) attaches to enrollment, not to membership
+  type.
+- Forward-only status (`upcoming → active → completed`) is enforced
+  at the route layer because the schema is reused by the
+  `POST /cohorts/{id}/complete` endpoint where "completed" is the
+  legitimate target. See `update_cohort` in
+  `backend/app/api/v1/cohorts.py`.
+- The frontend admin section now has a cohort CRUD UI that did not
+  exist before. See `frontend/src/pages/Admin/cohorts/`.
+
+### Explicitly deferred
+
+- **Cohort templates.** A "Spring template" that pre-seeds a new
+  cohort with the same course set as last spring's would be useful
+  but not blocking. Pattern: clone-from-existing.
+- **Bulk roster import.** CSV upload to add 30 students at once.
+  The single-student endpoint is the building block; admin UI can
+  layer a CSV parser on top without API changes.
+- **Cohort-scoped announcements.** Today announcements are
+  course-scoped or global. A cohort-scoped variant would let a
+  registrar notify just one cohort's students; not implemented yet.
+
+## Alternatives considered
+
+### A. Keep cohorts course-scoped, add cross-course "groups"
+
+Build a separate "group" abstraction on top of course-scoped cohorts.
+Rejected: doubles the conceptual surface and the database schema for
+the same outcome.
+
+### B. Use Supabase RLS groups instead of a `cohorts` table
+
+Lean on a Supabase auth feature rather than rolling our own table.
+Rejected: RLS groups don't carry the date-window / capacity / status
+semantics we need; modelling them inside Supabase would require
+storing the same data in two places.
+
+### C. Soft-link cohorts through enrollment metadata only
+
+Don't create a dedicated `cohorts` table — express "cohort
+membership" as a string tag on `enrollments`. Rejected: every
+cohort-level operation (capacity, date windows, status transitions)
+would degrade to a tag-based scan. The dedicated table is more
+honest about the semantics.
+
+## Reference
+
+- Backend: `backend/app/api/v1/cohorts.py`,
+  `backend/app/services/course_service/_enrollment.py`,
+  `backend/app/models/cohort.py`, `backend/app/models/enrollment.py`,
+  `backend/app/models/course.py` (the `access_mode` column).
+- Migrations: `supabase/migrations/20260513205435_cohort_top_level.sql`,
+  `supabase/migrations/20260513215743_cohort_courses_rls.sql`.
+- Frontend: `frontend/src/pages/Admin/cohorts/`,
+  `frontend/src/services/cohorts.ts`,
+  `frontend/src/types/index.ts` (the `Cohort` + `AccessMode` types).
+- Tests: `backend/tests/test_cohorts_calendar_notifications.py`.
+
+## Follow-up decisions (post-acceptance)
+
+- 2026-05-14: Forward-only status enforced at the route layer (PR
+  #233). The schema accepts any of `upcoming|active|completed`
+  because the same `CohortUpdate` body type is reused by the
+  `complete` endpoint; the regression-protection lives in
+  `update_cohort`.
+- 2026-05-14: Date-window invariants validated at the schema layer
+  (PR #233): `enrollment_start ≤ enrollment_end ≤ start_date <
+  end_date`.
+- 2026-05-14: Course `access_mode` change is admin-only (PR #230);
+  a teacher cannot promote their own institute course to public.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records
+
+This directory captures the **why** behind decisions that cross module
+boundaries or are hard to discover from the code alone. Each ADR is a
+self-contained Markdown file in numbered order.
+
+Read these before touching the systems they describe — the code may
+look like it could be simpler, but an ADR usually explains why the
+simpler shape was rejected.
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| [010](0010-cohorts-as-top-level-entities.md) | Cohorts as top-level admin entities | Accepted (2026-05-13) |
+
+## Format
+
+Loosely based on [Michael Nygard's ADR template](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/locales/en/templates/decision-record-template-by-michael-nygard/index.md).
+Each file:
+
+```
+# ADR-NNNN: Short title
+
+- **Status**: Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+- **Date**: YYYY-MM-DD
+- **Decision-makers**: (initials / handles)
+
+## Context
+What problem are we solving? What constraints apply?
+
+## Decision
+What did we choose? In one sentence at the top, with detail below.
+
+## Consequences
+What becomes easier? What becomes harder? What did we explicitly
+defer?
+
+## Alternatives considered
+What else did we look at, and why did we reject it?
+```
+
+## When to write an ADR
+
+- A new feature that changes the data model in a way other features
+  must accommodate (e.g., adding a join table that ties existing
+  entities together).
+- A choice that another contributor might reasonably reverse without
+  knowing the trade-offs ("why not just use Alembic for migrations?").
+- A "no" you want to remember — declined ideas with a documented reason
+  prevent re-litigation.
+
+If you find yourself writing a long code comment explaining a
+non-local decision, it probably belongs in an ADR instead.


### PR DESCRIPTION
## Summary

Contributor-experience audit surfaced three traps for a new dev opening the repo for the first time. None were bugs, but each cost minutes-to-hours of confusion.

### 1. Publish ADR-010

14 places in the code (cohort routes, models, migrations, frontend types, \`AccessModeModal\`, comments) reference \"ADR-010\". The ADR lived in a private docs repo — a contributor following those references hit a 404. Publish it as \`docs/adr/0010-cohorts-as-top-level-entities.md\` with the full context, alternatives considered, and deferred items. Add \`docs/adr/README.md\` as the index + template.

### 2. CONTRIBUTING accuracy

- Node version \`>= 20\` → \`>= 22.12\` to match CI (\`22.18.0\`)
- Switch backend install from \`requirements.txt\` to \`requirements-ci.txt\` (so \`pytest\`/\`mypy\`/\`ruff\` work locally)
- Test-count footnote: \"540+ tests, ~10s\"
- New \"Architecture decision records\" section linking \`docs/adr/\`
- New \"Conventions library\" section linking \`.cursor/rules/*.mdc\` (non-Cursor users would never find these otherwise)
- \"No Docker\" expanded to reflect the long-term roadmap line; the bilingual UI rule made explicit

### 3. ROADMAP / Docker contradiction

\"Self-hosted installer\" said \"one-command Docker Compose\"; CONTRIBUTING said \"intentionally avoids containers\"; CLAUDE.md said \"No Docker.\" Soften the roadmap line: \"scripted Vercel + Supabase OR a packaged Docker Compose stack — to be decided.\" Today's stance is unchanged.

## Test plan

- [x] Pure-docs PR; no runtime impact
- [x] Markdown renders correctly in GitHub preview
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)