### PR TITLE
docs(api): docstrings + OpenAPI metadata on four load-bearing routes

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -10,7 +10,15 @@ from app.models.user import User
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
 
-@router.get("/course/{course_id}")
+@router.get(
+    "/course/{course_id}",
+    summary="Course-level analytics for the teacher dashboard",
+    responses={
+        200: {"description": "Course title + aggregate stats + paginated enrollment list"},
+        403: {"description": "Caller is not the course owner (or admin)"},
+        404: {"description": "Course not found"},
+    },
+)
 def get_course_analytics(
     course_id: str,
     skip: int = Query(0, ge=0),
@@ -18,6 +26,15 @@ def get_course_analytics(
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ):
+    """Return aggregates + a paginated student list for one course.
+
+    Used by the Teacher Analytics page. The aggregate (``total_students``,
+    ``avg_progress``, ``completion_count``) is one SQL ``count``/``avg``
+    round-trip so a course with thousands of students still loads in
+    milliseconds; only the paginated ``enrollments`` slice fans out into
+    rows. ``skip`` / ``limit`` follow the same convention as the rest of
+    the API.
+    """
     course = verify_course_owner(db, course_id, teacher)
 
     # Aggregates in one round-trip instead of loading everything into Python.

--- a/backend/app/api/v1/audit.py
+++ b/backend/app/api/v1/audit.py
@@ -34,7 +34,16 @@ class AuditLogPage(BaseModel):
     page_size: int
 
 
-@router.get("", response_model=AuditLogPage)
+@router.get(
+    "",
+    response_model=AuditLogPage,
+    summary="Paginated audit log query (admin-only)",
+    responses={
+        200: {"description": "Paginated audit-log rows matching the filters"},
+        400: {"description": "Malformed ``user_id`` (not a UUID)"},
+        403: {"description": "Caller is not an admin"},
+    },
+)
 def list_audit_logs(
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=200),
@@ -46,6 +55,17 @@ def list_audit_logs(
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> dict:
+    """Read the audit log. Every write that goes through ``log_action``
+    leaves a row here; this endpoint is how admins reconstruct
+    timelines for incident response or just routine sanity checks.
+
+    Filters are AND-combined: passing both ``action=create`` and
+    ``resource_type=course`` returns only course-create rows. Date
+    filters are inclusive on both ends. The default ``page_size`` of
+    50 matches the admin UI; the 200 cap exists to protect against an
+    inadvertent ``page_size=999999`` that would page the whole table
+    into memory.
+    """
     q = db.query(AuditLog)
 
     if user_id:

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -7,8 +7,22 @@ from app.schemas.user import UserResponse
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-@router.get("/me", response_model=UserResponse)
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    summary="Get the caller's profile",
+    responses={
+        200: {"description": "Profile of the JWT-authenticated user"},
+        401: {"description": "Missing or invalid bearer token"},
+    },
+)
 def get_current_user_info(
     current_user: User = Depends(get_current_user),
 ):
+    """Return the profile of whoever the bearer token belongs to.
+
+    The frontend hits this once after sign-in to populate the in-memory
+    user context (role, ``preferred_locale``, ``full_name``). It does
+    NOT trigger any side effect — repeated calls are free.
+    """
     return UserResponse.model_validate(current_user)

--- a/backend/app/api/v1/quizzes/attempts.py
+++ b/backend/app/api/v1/quizzes/attempts.py
@@ -24,13 +24,43 @@ from ._deps import verify_quiz_owner
 from ._router import router
 
 
-@router.post("/{quiz_id}/submit", response_model=QuizAttemptResponse)
+@router.post(
+    "/{quiz_id}/submit",
+    response_model=QuizAttemptResponse,
+    summary="Submit a quiz attempt (student)",
+    responses={
+        200: {"description": "Attempt persisted with per-answer feedback"},
+        403: {
+            "description": "Student is not enrolled, or has used all allowed attempts "
+            "(``max_attempts`` + any ``quiz_extra_attempts`` grant)."
+        },
+        404: {"description": "Quiz not found"},
+    },
+)
 def submit_quiz(
     quiz_id: UUID,
     data: QuizSubmitRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
+    """Submit one quiz attempt and persist the per-answer feedback.
+
+    Concurrency: the ``Quiz`` row is locked ``FOR UPDATE`` so two
+    parallel submits from the same student serialize on the lock —
+    ``ensure_attempts_available`` re-counts inside the lock and the
+    second request gets 403 if the first one consumed the last
+    attempt.
+
+    Scoring: auto-gradable question types (``multiple_choice``,
+    ``true_false``) score immediately; manual types
+    (``short_answer``, ``essay``) persist with ``points_earned = 0``
+    and need a teacher to grade them later via
+    ``PATCH /quizzes/answers/{answer_id}``. The returned ``passed``
+    flag therefore stays ``False`` for any quiz with at least one
+    manual question until the teacher grades enough of them to clear
+    ``passing_score``. Exam attempts deliberately don't leak the
+    ``correct_option_id`` back to the student.
+    """
     quiz = (
         db.query(Quiz)
         .options(selectinload(Quiz.questions).selectinload(QuizQuestion.options))


### PR DESCRIPTION
## Summary

Contributor audit flagged ~60% of routes as having neither a docstring nor \`summary\`/\`responses\` — so the FastAPI auto-doc \`/docs\` page (dev only) is half-empty. A new contributor looking at the API surface had to grep the source.

Add full docstrings, \`summary\`, and \`responses\` on four of the most load-bearing routes:

- **\`GET /auth/me\`** — entry to the bearer-token flow; side-effect-free.
- **\`GET /analytics/course/{id}\`** — aggregates + paginated enrollment list; documents perf shape + 403 contract.
- **\`GET /audit\`** — admin-only timeline; documents AND filter combinator, date inclusiveness, the new 400 on malformed \`user_id\`, and why the page cap exists.
- **\`POST /quizzes/{id}/submit\`** — most complex student write. Documents \`FOR UPDATE\` serialization, auto-graded-vs-manual split, exam-answer-leak guard.

Follow-up PR can sweep the remaining ~50 routes (announcements, calendar, blocks, assignments, certificates, cohorts) on the same shape.

## Test plan

- [x] No behaviour change; 543 / 543 tests pass
- [x] ruff + mypy clean
- [ ] CI green
- [ ] Manual: hit \`http://localhost:8000/docs\` in dev and confirm the 4 routes render with full descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)