### PR TITLE
refactor: is_owner_or_admin(entity, user) predicate replaces 4 inline copies

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -91,6 +91,26 @@ def _resolve_admin_flag(db: Session, teacher: User | str | UUID) -> bool:
     return bool(db.query(User.id).filter(User.id == teacher, User.role == UserRole.ADMIN.value).first())
 
 
+def is_owner_or_admin(entity: object, user: User | None) -> bool:
+    """Non-raising predicate: does ``user`` own ``entity`` (via
+    ``entity.created_by``) or have the admin role?
+
+    Use this when the access rule must influence flow control rather
+    than raise a 403 — listing surfaces that hide unpublished rows from
+    everyone except the owner / admin, branch on visibility. For the
+    raising form, use ``assert_course_owner`` instead.
+
+    ``entity`` is anything with a ``created_by`` attribute; works on
+    Course, Announcement, CourseEvent, etc.
+    """
+    if user is None:
+        return False
+    created_by = getattr(entity, "created_by", None)
+    if created_by is not None and str(created_by) == str(user.id):
+        return True
+    return user.role == UserRole.ADMIN.value
+
+
 def assert_course_owner(
     course: Course,
     user: User,
@@ -103,6 +123,9 @@ def assert_course_owner(
     Callers can override ``detail`` to return a more specific 403 message
     (e.g. "You can only approve certificates for your own courses"), which
     avoids wrapping this call in a ``try/except HTTPException`` block.
+
+    For the non-raising form (predicate that returns ``bool``), use
+    ``is_owner_or_admin``.
     """
     if str(course.created_by) == str(user.id):
         return

--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -3,7 +3,12 @@ import uuid
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import assert_course_owner, get_current_user, require_teacher
+from app.api.dependencies import (
+    assert_course_owner,
+    get_current_user,
+    is_owner_or_admin,
+    require_teacher,
+)
 from app.core.database import get_db
 from app.core.sanitize import sanitize_string
 from app.models.announcement import Announcement
@@ -173,7 +178,7 @@ def update_announcement(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Announcement not found",
         )
-    if str(announcement.created_by) != str(teacher.id) and teacher.role != UserRole.ADMIN.value:
+    if not is_owner_or_admin(announcement, teacher):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You can only edit your own announcements",
@@ -203,7 +208,7 @@ def delete_announcement(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Announcement not found",
         )
-    if str(announcement.created_by) != str(teacher.id) and teacher.role != UserRole.ADMIN.value:
+    if not is_owner_or_admin(announcement, teacher):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You can only delete your own announcements",

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -28,7 +28,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_optional_user, require_admin
+from app.api.dependencies import get_optional_user, is_owner_or_admin, require_admin
 from app.core.database import get_db
 from app.models.cohort import Cohort, CohortCourse
 from app.models.course import Course
@@ -495,11 +495,8 @@ def list_cohorts_for_course(
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
-    if course.status != "published":
-        if not current_user or (
-            str(course.created_by) != str(current_user.id) and current_user.role != UserRole.ADMIN.value
-        ):
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+    if course.status != "published" and not is_owner_or_admin(course, current_user):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 
     cohorts = (
         db.query(Cohort)

--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -3,7 +3,7 @@
 from fastapi import Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_optional_user, require_teacher
+from app.api.dependencies import get_optional_user, is_owner_or_admin, require_teacher
 from app.core.database import get_db
 from app.models.course import Course
 from app.models.user import User, UserRole
@@ -91,14 +91,11 @@ def get_course_detail(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Course '{course_id}' not found",
         )
-    if course.status != "published":
-        if not current_user or (
-            str(course.created_by) != str(current_user.id) and current_user.role != UserRole.ADMIN.value
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Course '{course_id}' not found",
-            )
+    if course.status != "published" and not is_owner_or_admin(course, current_user):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Course '{course_id}' not found",
+        )
     response.headers["Vary"] = "Accept-Language"
     if not should_apply_course_translation_overlay(course=course, current_user=current_user):
         return CourseResponse.model_validate(course, from_attributes=True)


### PR DESCRIPTION
## Summary

Code-quality audit flagged the same owner-or-admin check duplicated four times:

\`\`\`python
str(entity.created_by) != str(user.id) and user.role != UserRole.ADMIN.value
\`\`\`

(announcements update, announcements delete, courses/catalog get_course, cohorts list_cohorts_for_course). A reader has to mentally unwrap the double-negative each time.

## Fix

Add a non-raising \`is_owner_or_admin(entity, user)\` predicate next to \`assert_course_owner\` in \`app/api/dependencies.py\`. Works on any object with a \`created_by\` attribute, handles \`user is None\` by returning \`False\`. The raising variant (\`assert_course_owner\`) is kept — different ergonomics (throws 403 with custom \`detail\`) for write surfaces.

Each callsite drops to \`if not is_owner_or_admin(entity, user):\` — the rule is obvious at the read.

## Test plan

- [x] No behaviour change; 545 / 545 backend tests pass
- [x] ruff + mypy clean (111 source files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)