### PR TITLE
refactor(models): CourseStatus / CohortStatus / CertificateStatus / CourseAccessMode StrEnums

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import decode_access_token
-from app.models.course import Chapter, Course, Module
+from app.models.course import Chapter, Course, CourseStatus, Module
 from app.models.enrollment import Enrollment
 from app.models.user import User, UserRole
 
@@ -186,7 +186,7 @@ def verify_chapter_access(db: Session, chapter_id: str, user: User) -> Chapter:
         return chapter
     if str(course.created_by) == str(user.id):
         return chapter
-    if course.status != "published":
+    if course.status != CourseStatus.PUBLISHED:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chapter not found")
     enrolled = db.query(Enrollment).filter(Enrollment.user_id == user.id, Enrollment.course_id == course.id).first()
     if not enrolled:

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -30,8 +30,8 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_optional_user, is_owner_or_admin, require_admin
 from app.core.database import get_db
-from app.models.cohort import Cohort, CohortCourse
-from app.models.course import Course
+from app.models.cohort import Cohort, CohortCourse, CohortStatus
+from app.models.course import Course, CourseStatus
 from app.models.enrollment import Enrollment
 from app.models.user import User, UserRole
 from app.schemas.cohort import (
@@ -186,7 +186,7 @@ def update_cohort(
     # the schema, because the schema is also used by the ``complete``
     # endpoint where ``completed`` is the legitimate target.
     patch = data.model_dump(exclude_unset=True)
-    if "status" in patch and cohort.status == "completed" and patch["status"] != "completed":
+    if "status" in patch and cohort.status == CohortStatus.COMPLETED and patch["status"] != CohortStatus.COMPLETED:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot reopen a completed cohort",
@@ -223,12 +223,12 @@ def complete_cohort(
     db: Session = Depends(get_db),
 ) -> CohortResponse:
     cohort = _get_or_404(db, cohort_id)
-    if cohort.status == "completed":
+    if cohort.status == CohortStatus.COMPLETED:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cohort is already completed",
         )
-    cohort.status = "completed"
+    cohort.status = CohortStatus.COMPLETED
     db.commit()
     db.refresh(cohort)
     return _serialize(db, cohort)
@@ -495,7 +495,7 @@ def list_cohorts_for_course(
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
-    if course.status != "published" and not is_owner_or_admin(course, current_user):
+    if course.status != CourseStatus.PUBLISHED and not is_owner_or_admin(course, current_user):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 
     cohorts = (

--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_optional_user, is_owner_or_admin, require_teacher
 from app.core.database import get_db
-from app.models.course import Course
+from app.models.course import Course, CourseStatus
 from app.models.user import User, UserRole
 from app.schemas.course import CourseResponse, CourseSummary, ModuleResponse
 from app.schemas.locale import LocaleCode, normalize_locale
@@ -91,7 +91,7 @@ def get_course_detail(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Course '{course_id}' not found",
         )
-    if course.status != "published" and not is_owner_or_admin(course, current_user):
+    if course.status != CourseStatus.PUBLISHED and not is_owner_or_admin(course, current_user):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Course '{course_id}' not found",
@@ -125,7 +125,7 @@ def get_module_detail(
             detail=f"Course '{course_id}' not found",
         )
     course_status, course_owner_id, course_source_locale = course_row
-    if course_status != "published":
+    if course_status != CourseStatus.PUBLISHED:
         if not current_user or (
             str(course_owner_id) != str(current_user.id) and current_user.role != UserRole.ADMIN.value
         ):

--- a/backend/app/api/v1/courses/crud.py
+++ b/backend/app/api/v1/courses/crud.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import assert_course_owner, require_teacher
 from app.core.database import get_db
 from app.core.sanitize import sanitize_string
-from app.models.course import Course
+from app.models.course import Course, CourseStatus
 from app.models.user import User, UserRole
 from app.schemas.course import CourseCreate, CourseResponse, CourseUpdate
 from app.services.audit_service import log_action
@@ -81,7 +81,7 @@ def update_existing_course(
         details = {"old_status": old_status, "new_status": data.status}
     # Special-case draft→published so the audit log distinguishes a
     # publication event from a generic update.
-    is_publish_event = data.status == "published" and old_status != "published"
+    is_publish_event = data.status == CourseStatus.PUBLISHED and old_status != CourseStatus.PUBLISHED
     action = "publish" if is_publish_event else "update"
     log_action(db, teacher.id, action, "course", course_id, details=details or None, request=request)
 
@@ -90,7 +90,7 @@ def update_existing_course(
     # Failures must NOT block the save — failed rows are persisted for retry.
     # ``result`` is the same SQLAlchemy instance ``update_course`` mutated, so
     # there's no need to re-load the full course tree just to translate it.
-    if result.status == "published":
+    if result.status == CourseStatus.PUBLISHED:
         try:
             translate_course_content(db, result)
         except Exception:
@@ -136,7 +136,7 @@ def clone_existing_course(
     # Drafts are only visible (and therefore clonable) to their owner,
     # regardless of admin status.
     is_owner = str(course.created_by) == str(teacher.id)
-    if course.status != "published" and not is_owner:
+    if course.status != CourseStatus.PUBLISHED and not is_owner:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only the owner can clone a draft course",

--- a/backend/app/api/v1/courses/enrollment.py
+++ b/backend/app/api/v1/courses/enrollment.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_current_user
 from app.core.database import get_db
 from app.models.cohort import Cohort, CohortCourse
-from app.models.course import Course
+from app.models.course import Course, CourseAccessMode, CourseStatus
 from app.models.enrollment import Enrollment
 from app.models.user import User
 from app.schemas.course import EnrollmentResponse
@@ -128,7 +128,7 @@ def enroll_course(
             detail=f"Course '{course_id}' not found",
         )
     course_status, access_mode, enrollment_start, enrollment_end = course_row
-    if course_status != "published":
+    if course_status != CourseStatus.PUBLISHED:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot enroll in an unpublished course",
@@ -146,7 +146,7 @@ def enroll_course(
         # Solo (no-cohort) enrollment. Institute courses block this path
         # entirely (ADR-010): admin must add the student directly via
         # the cohort endpoints or the admin-direct enrollment endpoint.
-        if access_mode == "institute":
+        if access_mode == CourseAccessMode.INSTITUTE:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="This course is available only by invitation from the institute",

--- a/backend/app/api/v1/prerequisites.py
+++ b/backend/app/api/v1/prerequisites.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_teacher, verify_course_owner
 from app.core.database import get_db
-from app.models.course import Course
+from app.models.course import Course, CourseStatus
 from app.models.prerequisite import CoursePrerequisite
 from app.models.user import User, UserRole
 from app.schemas.locale import LocaleCode, normalize_locale
@@ -82,7 +82,7 @@ def get_prerequisites(
 
     is_admin = current_user.role == UserRole.ADMIN.value
     is_owner = str(course.created_by) == str(current_user.id)
-    is_published = getattr(course, "status", None) == "published"
+    is_published = getattr(course, "status", None) == CourseStatus.PUBLISHED
     if not (is_admin or is_owner or is_published):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
 

--- a/backend/app/api/v1/reviews.py
+++ b/backend/app/api/v1/reviews.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_current_user
 from app.core.database import get_db
 from app.models.certificate import Certificate
-from app.models.course import Course
+from app.models.course import Course, CourseStatus
 from app.models.review import CourseReview
 from app.models.user import User
 from app.schemas.review import ReviewCreate, ReviewResponse
@@ -23,7 +23,7 @@ def list_course_reviews(
     db: Session = Depends(get_db),
 ):
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
-    if not course or course.status != "published":
+    if not course or course.status != CourseStatus.PUBLISHED:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
     return (
         db.query(CourseReview)

--- a/backend/app/models/certificate.py
+++ b/backend/app/models/certificate.py
@@ -1,3 +1,4 @@
+import enum
 import uuid
 from datetime import datetime
 
@@ -5,6 +6,21 @@ from sqlalchemy import DateTime, ForeignKey, Index, String, UniqueConstraint, fu
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
+
+
+class CertificateStatus(enum.StrEnum):
+    """Certificate request → approve → issue state machine.
+
+    ``pending`` — student requested. Teacher must approve first.
+    ``teacher_approved`` — instructor signed off. Admin issues from here.
+    ``approved`` — admin issued; ``certificate_number`` populated.
+    ``rejected`` — either reviewer can reject before issuance.
+    """
+
+    PENDING = "pending"
+    TEACHER_APPROVED = "teacher_approved"
+    APPROVED = "approved"
+    REJECTED = "rejected"
 
 
 class Certificate(Base):

--- a/backend/app/models/cohort.py
+++ b/backend/app/models/cohort.py
@@ -10,6 +10,7 @@ Teachers do not own or manage cohorts; they only see the cohort id as
 a filter dropdown in their own course's gradebook.
 """
 
+import enum
 import uuid
 from datetime import datetime
 
@@ -17,6 +18,19 @@ from sqlalchemy import DateTime, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
+
+
+class CohortStatus(enum.StrEnum):
+    """Forward-only cohort lifecycle: ``upcoming → active → completed``.
+
+    Going back from ``completed`` is blocked at the route layer (see
+    ``update_cohort``) — a completed cohort's grades and certificates
+    are frozen.
+    """
+
+    UPCOMING = "upcoming"
+    ACTIVE = "active"
+    COMPLETED = "completed"
 
 
 class Cohort(Base):

--- a/backend/app/models/course.py
+++ b/backend/app/models/course.py
@@ -1,3 +1,4 @@
+import enum
 import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -10,6 +11,35 @@ from app.core.database import Base
 
 if TYPE_CHECKING:
     from app.models.enrollment import Enrollment
+
+
+class CourseStatus(enum.StrEnum):
+    """Publication state of a course.
+
+    ``draft`` — only the course owner + admins can see it. Self-enrollment
+    is blocked.
+    ``published`` — visible in the public catalog; students can enroll.
+
+    Stored as a raw string in Postgres (CHECK-constrained); the enum
+    just gives Python code a single source of truth so a typo in
+    ``"publshed"`` is caught at the call site instead of silently
+    excluding rows from queries.
+    """
+
+    DRAFT = "draft"
+    PUBLISHED = "published"
+
+
+class CourseAccessMode(enum.StrEnum):
+    """Whether a published course accepts solo self-enrollment.
+
+    ``public`` — anyone can enroll within the course's enrollment window.
+    ``institute`` — only admins add students via the cohort flow
+    (see ADR-010).
+    """
+
+    PUBLIC = "public"
+    INSTITUTE = "institute"
 
 
 class TSVector(TypeDecorator):
@@ -52,7 +82,7 @@ class Course(Base):
     title: Mapped[str] = mapped_column()
     description: Mapped[str | None] = mapped_column()
     image_url: Mapped[str | None] = mapped_column()
-    status: Mapped[str] = mapped_column(default="draft")
+    status: Mapped[str] = mapped_column(default=CourseStatus.DRAFT)
     # Access mode controls who can ENROLL in the course (separate from
     # status which controls whether it's published in the catalog at all).
     # See ADR-010 in equipbible-docs/product/decisions/ — institute-mode

--- a/backend/app/services/course_service/_clone.py
+++ b/backend/app/services/course_service/_clone.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from app.models.assignment import Assignment
 from app.models.chapter_block import ChapterBlock
-from app.models.course import Chapter, Course, Module
+from app.models.course import Chapter, Course, CourseStatus, Module
 from app.models.quiz import Quiz, QuizOption, QuizQuestion
 
 from ._queries import _COURSE_TREE
@@ -82,7 +82,7 @@ def clone_course(db: Session, course_id: str, teacher_id: str | uuid.UUID) -> Co
         title=f"{original.title} (Copy)",
         description=original.description,
         image_url=original.image_url,
-        status="draft",
+        status=CourseStatus.DRAFT,
         created_by=uuid.UUID(teacher_id) if isinstance(teacher_id, str) else teacher_id,
         enrollment_start=None,
         enrollment_end=None,

--- a/backend/app/services/course_service/_queries.py
+++ b/backend/app/services/course_service/_queries.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload, selectinload
 
-from app.models.course import Chapter, Course, Module
+from app.models.course import Chapter, Course, CourseStatus, Module
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -42,7 +42,11 @@ def get_courses(
     limit: int = 100,
     search: str | None = None,
 ) -> list[Course]:
-    query = db.query(Course).options(*_COURSE_TREE).filter(Course.status == "published", Course.deleted_at.is_(None))
+    query = (
+        db.query(Course)
+        .options(*_COURSE_TREE)
+        .filter(Course.status == CourseStatus.PUBLISHED, Course.deleted_at.is_(None))
+    )
     if search:
         ts_query = func.plainto_tsquery("russian", search)
         ts_query_en = func.plainto_tsquery("english", search)

--- a/backend/app/services/translation/pipeline_hooks.py
+++ b/backend/app/services/translation/pipeline_hooks.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from app.models.course import Course
+from app.models.course import Course, CourseStatus
 from app.services.course_service import get_course
 from app.services.translation.course_pipeline import translate_course_content
 from app.services.translation.registry import REGISTRY, reconcile_entity
@@ -49,7 +49,7 @@ def run_course_translation_pipeline_if_published(db: Session, course_id: str) ->
     # read ``status`` is wasted I/O. Only pay for the full tree when we
     # actually intend to translate.
     course_status = db.query(Course.status).filter(Course.id == course_id, Course.deleted_at.is_(None)).scalar()
-    if course_status != "published":
+    if course_status != CourseStatus.PUBLISHED:
         return
     course = get_course(db, course_id)
     if not course:
@@ -81,7 +81,7 @@ def reconcile_entity_if_course_published(
         return
     reg = REGISTRY[entity_type]
     course = reg.resolve_course(db, entity)
-    if not course or course.status != "published":
+    if not course or course.status != CourseStatus.PUBLISHED:
         return
     try:
         reconcile_entity(db, entity_type, entity)


### PR DESCRIPTION
## Summary

Code-quality audit flagged 25+ bare string-literal comparisons against status columns (\`course.status == \"published\"\`, \`cohort.status == \"completed\"\`, \`access_mode == \"institute\"\`). Each one is a typo waiting to happen — \`\"publshed\"\` silently excludes every row from a filter, with zero help from mypy or ruff.

## Changes

Four \`StrEnum\` classes parallel to the existing \`UserRole\`, each with a docstring explaining the state machine:

- **\`CourseStatus\`** (\`DRAFT\` / \`PUBLISHED\`) — \`models/course.py\`
- **\`CourseAccessMode\`** (\`PUBLIC\` / \`INSTITUTE\`) — same file (ADR-010)
- **\`CohortStatus\`** (\`UPCOMING\` / \`ACTIVE\` / \`COMPLETED\`) — \`models/cohort.py\`
- **\`CertificateStatus\`** (\`PENDING\` / \`TEACHER_APPROVED\` / \`APPROVED\` / \`REJECTED\`) — \`models/certificate.py\`

13 files updated to use the enums at comparison/assignment sites: pipeline_hooks, course_service (_queries + _clone), api/dependencies, reviews, prerequisites, cohorts, courses/crud + enrollment + catalog, plus the model column default.

## Out of scope

Pydantic schemas keep their \`Literal[\"draft\", \"published\"]\` definitions — those map to the OpenAPI contract and a shape-only swap would be net-negative.

\`CertificateStatus\` is defined but not yet swapped into \`certificate_service\` / cert routes; those have richer error messages that include the literal value, so the next PR will update the error strings together.

## Test plan

- [x] 545 / 545 backend tests pass
- [x] ruff + mypy clean (111 source files)
- [ ] CI green
- [ ] No regression in catalog / enrollment / cohort flows (covered by existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)