### PR TITLE
refactor(translation): Localizer captures per-request locale pair (4-arg pick)

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -41,12 +41,9 @@ from app.schemas.cohort import (
     CohortStudentAdd,
     CohortUpdate,
 )
-from app.schemas.locale import LocaleCode, normalize_locale
+from app.schemas.locale import normalize_locale
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
-from app.services.translation.resolve_for_display import (
-    fetch_overlay_triples_bulk,
-    pick_overlay_value,
-)
+from app.services.translation.resolve_for_display import Localizer
 
 router = APIRouter(prefix="/cohorts", tags=["cohorts"])
 
@@ -513,20 +510,13 @@ def list_cohorts_for_course(
     if is_owner or is_admin:
         return _serialize_many(db, cohorts)
 
-    display_locale: LocaleCode = normalize_locale(accept_language)
-    source_locale: LocaleCode = normalize_locale(course.source_locale)
-    overlay_specs = [("cohort", str(c.id), "title") for c in cohorts]
-    overlay = fetch_overlay_triples_bulk(db, overlay_specs, display_locale)
+    loc = Localizer.build(
+        db,
+        [("cohort", str(c.id), "title") for c in cohorts],
+        source_locale=normalize_locale(course.source_locale),
+        display_locale=normalize_locale(accept_language),
+    )
     serialized = _serialize_many(db, cohorts)
     for resp, c in zip(serialized, cohorts, strict=True):
-        localized = pick_overlay_value(
-            overlay,
-            "cohort",
-            str(c.id),
-            "title",
-            c.name,
-            source_locale=source_locale,
-            display_locale=display_locale,
-        )
-        resp.name = localized or c.name
+        resp.name = loc.pick("cohort", str(c.id), "title", c.name) or c.name
     return serialized

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -15,6 +15,7 @@ not surprised by machine translations when the UI is in another language.
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from typing import cast
 
 from sqlalchemy import tuple_
@@ -190,6 +191,54 @@ def pick_overlay_value(
     return overlay.get(key, base)
 
 
+@dataclass(frozen=True, slots=True)
+class Localizer:
+    """Per-request translation-overlay lookup.
+
+    Captures the overlay map plus the ``source_locale`` / ``display_locale``
+    pair so every call site drops from the 7-arg ``pick_overlay_value`` to
+    a 4-arg ``loc.pick(entity_type, id, field, base)``. The per-request
+    constants live on the instance; the call site only carries what
+    actually varies between rows.
+
+    Construct one per response; pass it down to inner row-builders.
+    """
+
+    overlay: dict[tuple[str, str, str], str]
+    source_locale: LocaleCode
+    display_locale: LocaleCode
+
+    def pick(self, entity_type: str, entity_id: str, field: str, base: str | None) -> str | None:
+        return pick_overlay_value(
+            self.overlay,
+            entity_type,
+            entity_id,
+            field,
+            base,
+            source_locale=self.source_locale,
+            display_locale=self.display_locale,
+        )
+
+    @classmethod
+    def build(
+        cls,
+        db: Session,
+        specs: list[tuple[str, str, str]],
+        *,
+        source_locale: LocaleCode,
+        display_locale: LocaleCode,
+    ) -> Localizer:
+        """Bulk-fetch the overlay rows for ``specs`` and wrap them in a
+        ``Localizer``. Convenience constructor for the common pattern of
+        ``Localizer(fetch_overlay_triples_bulk(...), source, display)``.
+        """
+        return cls(
+            overlay=fetch_overlay_triples_bulk(db, specs, display_locale),
+            source_locale=source_locale,
+            display_locale=display_locale,
+        )
+
+
 def get_course_source_locale_for_chapter(db: Session, chapter_id: str) -> LocaleCode:
     """Return ``courses.source_locale`` for the chapter's course (fallback ``ru``)."""
     row = (
@@ -253,68 +302,23 @@ def build_localized_course_response_with_tree(
         for ch in mod.chapters:
             specs.append(("chapter", str(ch.id), "title"))
 
-    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
-    source_locale = normalize_locale(course.source_locale)
-
-    ct = (
-        pick_overlay_value(
-            overlay_t,
-            "course",
-            course.id,
-            "title",
-            course.title,
-            source_locale=source_locale,
-            display_locale=display_locale,
-        )
-        or course.title
-    )
-    cd = pick_overlay_value(
-        overlay_t,
-        "course",
-        course.id,
-        "description",
-        course.description,
-        source_locale=source_locale,
+    loc = Localizer.build(
+        db,
+        specs,
+        source_locale=normalize_locale(course.source_locale),
         display_locale=display_locale,
     )
 
+    ct = loc.pick("course", course.id, "title", course.title) or course.title
+    cd = loc.pick("course", course.id, "description", course.description)
+
     new_modules: list[ModuleResponse] = []
     for mod in course.modules:
-        mt = (
-            pick_overlay_value(
-                overlay_t,
-                "module",
-                str(mod.id),
-                "title",
-                mod.title,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or mod.title
-        )
-        md = pick_overlay_value(
-            overlay_t,
-            "module",
-            str(mod.id),
-            "description",
-            mod.description,
-            source_locale=source_locale,
-            display_locale=display_locale,
-        )
+        mt = loc.pick("module", str(mod.id), "title", mod.title) or mod.title
+        md = loc.pick("module", str(mod.id), "description", mod.description)
         new_chapters: list[ChapterResponse] = []
         for ch in mod.chapters:
-            cht = (
-                pick_overlay_value(
-                    overlay_t,
-                    "chapter",
-                    str(ch.id),
-                    "title",
-                    ch.title,
-                    source_locale=source_locale,
-                    display_locale=display_locale,
-                )
-                or ch.title
-            )
+            cht = loc.pick("chapter", str(ch.id), "title", ch.title) or ch.title
             ch_base = ChapterResponse.model_validate(ch, from_attributes=True)
             new_chapters.append(ch_base.model_copy(update={"title": cht}))
         mod_base = ModuleResponse.model_validate(mod, from_attributes=True)
@@ -340,56 +344,16 @@ def build_localized_quiz_student_response(
         specs.append(("quiz_question", str(qn.id), "question_text"))
         for opt in qn.options:
             specs.append(("quiz_option", str(opt.id), "option_text"))
-    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
-    new_title = (
-        pick_overlay_value(
-            overlay_t,
-            "quiz",
-            str(quiz.id),
-            "title",
-            quiz.title,
-            source_locale=source_locale,
-            display_locale=display_locale,
-        )
-        or quiz.title
-    )
-    new_desc = pick_overlay_value(
-        overlay_t,
-        "quiz",
-        str(quiz.id),
-        "description",
-        quiz.description,
-        source_locale=source_locale,
-        display_locale=display_locale,
-    )
+    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
+
+    new_title = loc.pick("quiz", str(quiz.id), "title", quiz.title) or quiz.title
+    new_desc = loc.pick("quiz", str(quiz.id), "description", quiz.description)
     new_questions: list[QuizQuestionStudentResponse] = []
     for qn in quiz.questions:
-        qt = (
-            pick_overlay_value(
-                overlay_t,
-                "quiz_question",
-                str(qn.id),
-                "question_text",
-                qn.question_text,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or qn.question_text
-        )
+        qt = loc.pick("quiz_question", str(qn.id), "question_text", qn.question_text) or qn.question_text
         new_opts: list[QuizOptionStudentResponse] = []
         for opt in qn.options:
-            ot = (
-                pick_overlay_value(
-                    overlay_t,
-                    "quiz_option",
-                    str(opt.id),
-                    "option_text",
-                    opt.option_text,
-                    source_locale=source_locale,
-                    display_locale=display_locale,
-                )
-                or opt.option_text
-            )
+            ot = loc.pick("quiz_option", str(opt.id), "option_text", opt.option_text) or opt.option_text
             ob = QuizOptionStudentResponse.model_validate(opt, from_attributes=True)
             new_opts.append(ob.model_copy(update={"option_text": ot}))
         qb = QuizQuestionStudentResponse.model_validate(qn, from_attributes=True)
@@ -415,31 +379,12 @@ def localize_assignment_rows(
                 ("assignment", str(a.id), "description"),
             ]
         )
-    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
+    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
     out: list[AssignmentResponse] = []
     for a in assignments:
         base = AssignmentResponse.model_validate(a, from_attributes=True)
-        t = (
-            pick_overlay_value(
-                overlay_t,
-                "assignment",
-                str(a.id),
-                "title",
-                a.title,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or a.title
-        )
-        d = pick_overlay_value(
-            overlay_t,
-            "assignment",
-            str(a.id),
-            "description",
-            a.description,
-            source_locale=source_locale,
-            display_locale=display_locale,
-        )
+        t = loc.pick("assignment", str(a.id), "title", a.title) or a.title
+        d = loc.pick("assignment", str(a.id), "description", a.description)
         out.append(base.model_copy(update={"title": t, "description": d}))
     return out
 
@@ -454,11 +399,10 @@ def localize_chapter_block_rows(
     """Apply stored translations to TipTap HTML stored on chapter blocks."""
     if not blocks:
         return []
-    specs: list[tuple[str, str, str]] = []
-    for b in blocks:
-        if b.content and str(b.content).strip():
-            specs.append(("chapter_block", str(b.id), "content"))
-    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
+    specs: list[tuple[str, str, str]] = [
+        ("chapter_block", str(b.id), "content") for b in blocks if b.content and str(b.content).strip()
+    ]
+    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
     out: list[BlockResponse] = []
     for b in blocks:
         base = BlockResponse.model_validate(b, from_attributes=True)
@@ -466,18 +410,7 @@ def localize_chapter_block_rows(
         if not content or not str(content).strip():
             out.append(base)
             continue
-        ct = (
-            pick_overlay_value(
-                overlay_t,
-                "chapter_block",
-                str(b.id),
-                "content",
-                content,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or content
-        )
+        ct = loc.pick("chapter_block", str(b.id), "content", content) or content
         out.append(base.model_copy(update={"content": ct}))
     return out
 
@@ -500,46 +433,15 @@ def build_localized_module_response(
     specs: list[tuple[str, str, str]] = [
         ("module", str(module.id), "title"),
         ("module", str(module.id), "description"),
+        *(("chapter", str(ch.id), "title") for ch in module.chapters),
     ]
-    for ch in module.chapters:
-        specs.append(("chapter", str(ch.id), "title"))
-    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
+    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
 
-    mt = (
-        pick_overlay_value(
-            overlay_t,
-            "module",
-            str(module.id),
-            "title",
-            module.title,
-            source_locale=source_locale,
-            display_locale=display_locale,
-        )
-        or module.title
-    )
-    md = pick_overlay_value(
-        overlay_t,
-        "module",
-        str(module.id),
-        "description",
-        module.description,
-        source_locale=source_locale,
-        display_locale=display_locale,
-    )
+    mt = loc.pick("module", str(module.id), "title", module.title) or module.title
+    md = loc.pick("module", str(module.id), "description", module.description)
     new_chapters: list[ChapterResponse] = []
     for ch in module.chapters:
-        cht = (
-            pick_overlay_value(
-                overlay_t,
-                "chapter",
-                str(ch.id),
-                "title",
-                ch.title,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or ch.title
-        )
+        cht = loc.pick("chapter", str(ch.id), "title", ch.title) or ch.title
         ch_base = ChapterResponse.model_validate(ch, from_attributes=True)
         new_chapters.append(ch_base.model_copy(update={"title": cht}))
     base = ModuleResponse.model_validate(module, from_attributes=True)
@@ -561,34 +463,12 @@ def localize_announcement_rows(
         specs.append(("announcement", str(a.id), "title"))
         if a.content and str(a.content).strip():
             specs.append(("announcement", str(a.id), "content"))
-    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
+    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
     out: list[AnnouncementResponse] = []
     for a in announcements:
         base = AnnouncementResponse.model_validate(a, from_attributes=True)
-        title = (
-            pick_overlay_value(
-                overlay_t,
-                "announcement",
-                str(a.id),
-                "title",
-                a.title,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or a.title
-        )
-        content = (
-            pick_overlay_value(
-                overlay_t,
-                "announcement",
-                str(a.id),
-                "content",
-                a.content,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or a.content
-        )
+        title = loc.pick("announcement", str(a.id), "title", a.title) or a.title
+        content = loc.pick("announcement", str(a.id), "content", a.content) or a.content
         out.append(base.model_copy(update={"title": title, "content": content}))
     return out
 
@@ -608,31 +488,12 @@ def localize_course_event_rows(
         specs.append(("course_event", str(e.id), "title"))
         if e.description and str(e.description).strip():
             specs.append(("course_event", str(e.id), "description"))
-    overlay_t = fetch_overlay_triples_bulk(db, specs, display_locale)
+    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
     out: list[CourseEventResponse] = []
     for e in events:
         base = CourseEventResponse.model_validate(e, from_attributes=True)
-        title = (
-            pick_overlay_value(
-                overlay_t,
-                "course_event",
-                str(e.id),
-                "title",
-                e.title,
-                source_locale=source_locale,
-                display_locale=display_locale,
-            )
-            or e.title
-        )
-        description = pick_overlay_value(
-            overlay_t,
-            "course_event",
-            str(e.id),
-            "description",
-            e.description,
-            source_locale=source_locale,
-            display_locale=display_locale,
-        )
+        title = loc.pick("course_event", str(e.id), "title", e.title) or e.title
+        description = loc.pick("course_event", str(e.id), "description", e.description)
         out.append(base.model_copy(update={"title": title, "description": description}))
     return out
 


### PR DESCRIPTION
## Summary

Audit flagged the 7-arg \`pick_overlay_value(overlay, entity_type, id, field, base, source_locale=, display_locale=)\` invoked 20+ times in \`resolve_for_display.py\` and once in \`cohorts.py\`, with \`source_locale\` / \`display_locale\` constant across every call in a given response. A typo on one call would silently produce wrong text.

## Fix

\`Localizer(overlay, source_locale, display_locale)\` — frozen dataclass that captures the per-request constants and exposes \`loc.pick(entity_type, id, field, base)\`. Plus a \`Localizer.build(db, specs, source_locale=, display_locale=)\` convenience constructor for the common \`fetch_overlay_triples_bulk(...)\` + wrap pattern.

## Refactored call sites

Every internal call site that has a request-wide locale pair (8 functions, ~20 picks):
- \`build_localized_course_response_with_tree\`, \`build_localized_quiz_student_response\`, \`build_localized_module_response\`, \`localize_assignment_rows\`, \`localize_chapter_block_rows\`, \`localize_announcement_rows\`, \`localize_course_event_rows\` (internal)
- \`cohorts.list_cohorts_for_course\` (external)

The four call sites with **per-row** source_locale (\`calendar.get_calendar_events\` aggregating events from multiple courses; \`certificates.list_my_certificates\`; \`prerequisites\`) keep \`pick_overlay_value\` directly — that's the legitimate 7-arg use case (every row's \`source_locale\` is genuinely different).

## Test plan

- [x] 545 / 545 backend tests pass
- [x] ruff + mypy clean (111 files)
- [ ] CI green

Second of three duplication-collapse wins in \`resolve_for_display.py\` (after PR #240). Third (the \`localize_*_rows\` template) deferred — each helper has a small but legitimate per-field variation that resists generic extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)