### PR TITLE
docs(api): docstrings + OpenAPI metadata on 8 more load-bearing routes

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -106,12 +106,38 @@ def list_announcements(
     return out
 
 
-@router.post("", response_model=AnnouncementResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=AnnouncementResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Post an announcement (course-scoped or global admin-only)",
+    responses={
+        201: {
+            "description": "Announcement saved, sanitized; fan-out notifications "
+            "queued for every enrolled student (course-scoped only)."
+        },
+        403: {"description": "Caller does not own the target course"},
+        404: {"description": "Target course does not exist"},
+    },
+)
 def create_announcement(
     data: AnnouncementCreate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> Announcement:
+    """Two flavors, picked by ``data.course_id``:
+
+    - **Course-scoped** (``course_id`` set): only the course owner can
+      post. Triggers a notification fan-out to every enrolled student
+      (minus the author).
+    - **Global** (``course_id`` is None): admin-only authoring path
+      (gated by ``require_teacher`` + the route's own check elsewhere
+      — admins satisfy ``require_teacher``).
+
+    Both flavors sanitize ``title`` and ``content`` server-side as
+    defence-in-depth against direct API callers that bypass the
+    frontend's DOMPurify.
+    """
     if data.course_id:
         course = db.query(Course).filter(Course.id == data.course_id).first()
         if not course:

--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -106,13 +106,34 @@ def delete_assignment(
     db.commit()
 
 
-@router.post("/{assignment_id}/submit", response_model=SubmissionResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/{assignment_id}/submit",
+    response_model=SubmissionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Student submits an assignment response",
+    responses={
+        201: {
+            "description": "Submission persisted in ``pending`` state; chapter "
+            "progress flipped to completed; enrollment percent re-synced."
+        },
+        403: {"description": "Student is not enrolled in the assignment's course"},
+        404: {"description": "Assignment not found"},
+    },
+)
 def submit_assignment(
     assignment_id: UUID,
     data: SubmissionCreate,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
+    """Submit a response to an assignment.
+
+    Resubmissions are allowed (a student can submit multiple times
+    before the teacher grades). The chapter-progress side effect runs
+    on every submit so a student who later resubmits doesn't lose
+    their "this chapter is done" badge. Grading then happens through
+    ``grade_submission`` on the teacher side.
+    """
     assignment = db.query(Assignment).filter(Assignment.id == assignment_id).first()
     if not assignment:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Assignment not found")

--- a/backend/app/api/v1/blocks.py
+++ b/backend/app/api/v1/blocks.py
@@ -39,13 +39,31 @@ def list_blocks(
     return rows
 
 
-@router.post("/chapter/{chapter_id}", response_model=BlockResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/chapter/{chapter_id}",
+    response_model=BlockResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a chapter block (text / quiz / assignment / file)",
+    responses={
+        201: {"description": "Block persisted; translation reconcile fires async"},
+        403: {"description": "Caller does not own the chapter's course"},
+        404: {"description": "Chapter not found"},
+        409: {"description": "Referenced ``quiz_id`` / ``assignment_id`` no longer exists"},
+    },
+)
 def create_block(
     chapter_id: str,
     data: BlockCreate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ):
+    """Append a block to the chapter. ``order_index`` is provided by the
+    client so multi-block writes preserve the intended ordering even
+    when the frontend optimistically reorders before save.
+
+    Rich text (``content``) is sanitized server-side with ``bleach``
+    even though the frontend already DOMPurifies — defence-in-depth
+    for direct API callers."""
     verify_chapter_owner(db, chapter_id, teacher)
     # Defence-in-depth: the frontend runs DOMPurify before sending, but a
     # direct API caller can bypass that. We re-sanitize here so stored block
@@ -80,13 +98,29 @@ def create_block(
     return block
 
 
-@router.put("/{block_id}", response_model=BlockResponse)
+@router.put(
+    "/{block_id}",
+    response_model=BlockResponse,
+    summary="Update a block in place",
+    responses={
+        200: {"description": "Block updated and translation overlay reconciled"},
+        403: {"description": "Caller does not own the chapter's course"},
+        404: {"description": "Block not found"},
+        409: {"description": "Referenced ``quiz_id`` / ``assignment_id`` no longer exists"},
+    },
+)
 def update_block(
     block_id: UUID,
     data: BlockUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ):
+    """Patch any subset of block fields. ``content`` is sanitized
+    server-side. Changing ``block_type`` is allowed (e.g. text → quiz)
+    but the client should clear / set the type-specific fields
+    (``quiz_id``, ``assignment_id``, ``file_*``) consistently;
+    constraints aren't enforced at the schema layer because writes from
+    the editor never mix types in the same patch."""
     block = db.query(ChapterBlock).filter(ChapterBlock.id == block_id).first()
     if not block:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Block not found")

--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -195,42 +195,105 @@ def list_admin_pending_certificates(
     )
 
 
-@router.put("/{cert_id}/teacher-approve", response_model=CertificateResponse)
+@router.put(
+    "/{cert_id}/teacher-approve",
+    response_model=CertificateResponse,
+    summary="Teacher signs off on a pending certificate request",
+    responses={
+        200: {"description": "Certificate moved from ``pending`` to ``teacher_approved``"},
+        400: {"description": "Certificate is not in ``pending`` state"},
+        403: {"description": "Caller does not own the certificate's course"},
+        404: {"description": "Certificate not found"},
+    },
+)
 def teacher_approve_certificate(
     cert_id: UUID,
     request: Request,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> Certificate:
+    """First step of the two-stage approval workflow.
+
+    The teacher who owns the course must confirm the student earned the
+    certificate before an admin can issue it. This call is idempotent
+    against concurrent reviewer clicks: a ``FOR UPDATE`` lock on the
+    certificate row serializes parallel approvers (see
+    ``certificate_service._load_cert_or_404``).
+    """
     return certificate_service.teacher_approve(db, cert_id, teacher, request)
 
 
-@router.put("/{cert_id}/admin-approve", response_model=CertificateResponse)
+@router.put(
+    "/{cert_id}/admin-approve",
+    response_model=CertificateResponse,
+    summary="Admin issues a teacher-approved certificate",
+    responses={
+        200: {"description": "Certificate issued with a unique ``certificate_number``"},
+        400: {"description": "Certificate is not in ``teacher_approved`` state"},
+        403: {"description": "Caller is not an admin"},
+        404: {"description": "Certificate not found"},
+    },
+)
 def admin_approve_certificate(
     cert_id: UUID,
     request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> Certificate:
+    """Second step. Generates the public ``certificate_number`` and
+    fires a ``certificate_approved`` notification to the student. The
+    ``FOR UPDATE`` lock prevents double-issuance from concurrent admin
+    clicks."""
     return certificate_service.admin_approve(db, cert_id, admin, request)
 
 
-@router.put("/{cert_id}/reject", response_model=CertificateResponse)
+@router.put(
+    "/{cert_id}/reject",
+    response_model=CertificateResponse,
+    summary="Reject a certificate request (teacher or admin)",
+    responses={
+        200: {"description": "Certificate moved to ``rejected`` state"},
+        400: {"description": "Certificate is already in a terminal state"},
+        403: {"description": "Caller does not own the course"},
+        404: {"description": "Certificate not found"},
+    },
+)
 def reject_certificate(
     cert_id: UUID,
     request: Request,
     current_user: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> Certificate:
-    """Teacher or admin can reject a certificate."""
+    """Either reviewer (teacher or admin) can reject up until issuance.
+    Cannot be reversed — a rejected certificate stays rejected and the
+    student must re-request."""
     return certificate_service.reject(db, cert_id, current_user, request)
 
 
-@router.get("/verify/{certificate_number}", response_model=CertificateVerifyResponse)
+@router.get(
+    "/verify/{certificate_number}",
+    response_model=CertificateVerifyResponse,
+    summary="Public lookup by certificate number",
+    responses={
+        200: {
+            "description": "``valid=true`` with issuee + course info if the number "
+            "matches an issued certificate, else ``valid=false`` with no PII."
+        },
+    },
+)
 def verify_certificate(
     certificate_number: str,
     db: Session = Depends(get_db),
 ) -> CertificateVerifyResponse:
+    """Unauthenticated certificate verification.
+
+    Used by recipients to share their credential — the URL is something
+    like ``https://equipbible.com/verify/{number}`` that the SPA hits
+    this endpoint from. Returns a minimal PII surface (``user_name`` +
+    ``course_title``) only for valid numbers; invalid numbers return
+    ``valid=false`` with the number echoed so the caller can show a
+    "not found" page without confirming what other numbers exist.
+    """
     row = (
         db.query(Certificate, User, Course)
         .outerjoin(User, Certificate.user_id == User.id)


### PR DESCRIPTION
## Summary

Continuation of PR #237. Adds full docstrings + \`summary\` / \`responses\` to the next batch of high-traffic / high-complexity endpoints so \`/docs\` is genuinely useful to a new contributor.

## Routes

- \`PUT /certificates/{id}/teacher-approve\` — documents the FOR UPDATE serialization
- \`PUT /certificates/{id}/admin-approve\` — issues \`certificate_number\` + notification
- \`PUT /certificates/{id}/reject\` — either reviewer; terminal state
- \`GET /certificates/verify/{number}\` — public unauthenticated; minimal PII surface
- \`POST /blocks/chapter/{id}\` — bleach sanitization + 409 on stale FK refs
- \`PUT /blocks/{id}\` — type-mix caveat
- \`POST /assignments/{id}/submit\` — resubmission semantics + chapter-progress side effect
- \`POST /announcements\` — course-scoped vs global flavors

## Test plan

- [x] 545 / 545 backend tests pass
- [x] ruff + mypy clean (32 source files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)