### PR TITLE
fix(i18n): chapter type labels + role badges + progress stats bilingual sweep

### DIFF
--- a/frontend/src/components/course/ChapterTypeBadge.tsx
+++ b/frontend/src/components/course/ChapterTypeBadge.tsx
@@ -1,4 +1,5 @@
-import { getChapterTypeMeta } from "@/lib/chapterTypes"
+import { useTranslation } from "react-i18next"
+import { getChapterTypeMeta, normalizeChapterType } from "@/lib/chapterTypes"
 
 interface Props {
   type: string
@@ -6,6 +7,8 @@ interface Props {
 }
 
 export default function ChapterTypeBadge({ type, size = "md" }: Props) {
+  const { t } = useTranslation()
+  const normalized = normalizeChapterType(type)
   const meta = getChapterTypeMeta(type)
   const Icon = meta.icon
   const sizing =
@@ -15,8 +18,8 @@ export default function ChapterTypeBadge({ type, size = "md" }: Props) {
   const iconSize = size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5"
   return (
     <span className={`inline-flex items-center rounded-full font-medium ${sizing} ${meta.color}`}>
-      <Icon className={iconSize} />
-      {meta.label}
+      <Icon className={iconSize} strokeWidth={1.75} aria-hidden />
+      {t(`chapterTypes.${normalized}.label`)}
     </span>
   )
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -693,6 +693,20 @@
       "completedBySubmission": "Completed via submission",
       "undo": "Undo",
       "complete": "Complete"
+    },
+    "stats": {
+      "totalStudents": "Total Students",
+      "averageProgress": "Average Progress",
+      "completionRate": "Completion Rate"
+    },
+    "relative": {
+      "never": "Never",
+      "minutesAgo_one": "{{count}}m ago",
+      "minutesAgo_other": "{{count}}m ago",
+      "hoursAgo_one": "{{count}}h ago",
+      "hoursAgo_other": "{{count}}h ago",
+      "daysAgo_one": "{{count}}d ago",
+      "daysAgo_other": "{{count}}d ago"
     }
   },
   "teacherAnalytics": {
@@ -969,7 +983,11 @@
       "description": "Add your first chapter to start building this module.",
       "action": "Add chapter"
     },
-    "addChapter": "Add chapter"
+    "addChapter": "Add chapter",
+    "lockChapterTooltip": "Lock chapter",
+    "unlockChapterTooltip": "Unlock chapter",
+    "editChapterAria": "Edit chapter {{title}}",
+    "deleteChapterAria": "Delete chapter {{title}}"
   },
   "courseEditor": {
     "notFound": {
@@ -1431,6 +1449,24 @@
       "audioPlaceholder": "https://example.com/lesson.mp3",
       "audioConfirm": "Embed",
       "imageUrlPlaceholder": "https://…"
+    }
+  },
+  "chapterTypes": {
+    "reading": {
+      "label": "Lesson",
+      "description": "Mix text, video, audio, files and more into a single lesson"
+    },
+    "quiz": {
+      "label": "Quiz",
+      "description": "Test student knowledge"
+    },
+    "exam": {
+      "label": "Exam",
+      "description": "Final assessment with attempts limit"
+    },
+    "assignment": {
+      "label": "Assignment",
+      "description": "Submit work for grading"
     }
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -711,6 +711,26 @@
       "completedBySubmission": "Завершено через задание",
       "undo": "Отменить",
       "complete": "Засчитать"
+    },
+    "stats": {
+      "totalStudents": "Всего студентов",
+      "averageProgress": "Средний прогресс",
+      "completionRate": "Процент завершения"
+    },
+    "relative": {
+      "never": "Никогда",
+      "minutesAgo_one": "{{count}} мин назад",
+      "minutesAgo_few": "{{count}} мин назад",
+      "minutesAgo_many": "{{count}} мин назад",
+      "minutesAgo_other": "{{count}} мин назад",
+      "hoursAgo_one": "{{count}} ч назад",
+      "hoursAgo_few": "{{count}} ч назад",
+      "hoursAgo_many": "{{count}} ч назад",
+      "hoursAgo_other": "{{count}} ч назад",
+      "daysAgo_one": "{{count}} д назад",
+      "daysAgo_few": "{{count}} д назад",
+      "daysAgo_many": "{{count}} д назад",
+      "daysAgo_other": "{{count}} д назад"
     }
   },
   "teacherAnalytics": {
@@ -995,7 +1015,11 @@
       "description": "Добавьте первую главу, чтобы начать наполнять модуль.",
       "action": "Добавить главу"
     },
-    "addChapter": "Добавить главу"
+    "addChapter": "Добавить главу",
+    "lockChapterTooltip": "Заблокировать главу",
+    "unlockChapterTooltip": "Разблокировать главу",
+    "editChapterAria": "Редактировать главу {{title}}",
+    "deleteChapterAria": "Удалить главу {{title}}"
   },
   "courseEditor": {
     "notFound": {
@@ -1463,6 +1487,24 @@
       "audioPlaceholder": "https://example.com/lesson.mp3",
       "audioConfirm": "Встроить",
       "imageUrlPlaceholder": "https://…"
+    }
+  },
+  "chapterTypes": {
+    "reading": {
+      "label": "Урок",
+      "description": "Текст, видео, аудио и файлы в одном уроке"
+    },
+    "quiz": {
+      "label": "Тест",
+      "description": "Проверка знаний студентов"
+    },
+    "exam": {
+      "label": "Экзамен",
+      "description": "Финальная аттестация с ограничением попыток"
+    },
+    "assignment": {
+      "label": "Задание",
+      "description": "Работа на проверку преподавателю"
     }
   }
 }

--- a/frontend/src/lib/chapterTypes.ts
+++ b/frontend/src/lib/chapterTypes.ts
@@ -27,8 +27,6 @@ export const CHAPTER_TYPES = [
 export type ChapterType = (typeof CHAPTER_TYPES)[number]
 
 type ChapterTypeMeta = {
-  label: string
-  description: string
   icon: LucideIcon
   /** Tailwind pill classes (editorial: muted surface, neutral text). */
   color: string
@@ -41,35 +39,15 @@ type ChapterTypeMeta = {
 // light/dark and matches the rest of the token-based design system.
 const PILL = "bg-muted text-muted-foreground"
 
+// ``label`` and ``description`` are NOT on this map — they're rendered via
+// the i18n keys under ``chapterTypes.{reading|quiz|exam|assignment}`` so
+// RU and EN stay in lockstep. The map is only the locale-neutral icon +
+// style metadata.
 export const CHAPTER_TYPE_META: Record<ChapterType, ChapterTypeMeta> = {
-  reading: {
-    label: "Lesson",
-    description: "Mix text, video, audio, files and more into a single lesson",
-    icon: FileText,
-    color: PILL,
-    badgeColor: PILL,
-  },
-  quiz: {
-    label: "Quiz",
-    description: "Test student knowledge",
-    icon: HelpCircle,
-    color: PILL,
-    badgeColor: PILL,
-  },
-  exam: {
-    label: "Exam",
-    description: "Final assessment with attempts limit",
-    icon: GraduationCap,
-    color: PILL,
-    badgeColor: PILL,
-  },
-  assignment: {
-    label: "Assignment",
-    description: "Submit work for grading",
-    icon: ClipboardList,
-    color: PILL,
-    badgeColor: PILL,
-  },
+  reading: { icon: FileText, color: PILL, badgeColor: PILL },
+  quiz: { icon: HelpCircle, color: PILL, badgeColor: PILL },
+  exam: { icon: GraduationCap, color: PILL, badgeColor: PILL },
+  assignment: { icon: ClipboardList, color: PILL, badgeColor: PILL },
 }
 
 /** Chapter types whose completion gates the next chapter when ``is_locked`` is on. */

--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -22,7 +22,7 @@ interface VirtualAdminUsersProps {
   updatingId: string | null
   currentUserId: string | undefined
   roleBadgeClass: Record<string, string>
-  roleDisplayNames: Record<string, string>
+  roleI18nKey: Record<string, string>
   onToggleSelect: (id: string) => void
   onRoleChange: (userId: string, role: UserRole) => void
   onDeleteUser: (user: ProfileRow) => void
@@ -40,7 +40,7 @@ function UserRow({
   updatingId,
   currentUserId,
   roleBadgeClass,
-  roleDisplayNames,
+  roleI18nKey,
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
@@ -89,7 +89,7 @@ function UserRow({
         <span
           className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${roleBadgeClass[u.role] ?? ""}`}
         >
-          {roleDisplayNames[u.role] ?? u.role}
+          {t(roleI18nKey[u.role] ?? "")}
         </span>
         <NativeSelect
           fieldSize="sm"
@@ -129,7 +129,7 @@ export default function VirtualAdminUsers({
   updatingId,
   currentUserId,
   roleBadgeClass,
-  roleDisplayNames,
+  roleI18nKey,
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
@@ -162,7 +162,7 @@ export default function VirtualAdminUsers({
           updatingId,
           currentUserId,
           roleBadgeClass,
-          roleDisplayNames,
+          roleI18nKey,
           onToggleSelect,
           onRoleChange,
           onDeleteUser,

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -12,7 +12,7 @@ import { formatDate } from "@/i18n/format"
 import {
   type ProfileRow,
   ROLE_BADGE_CLASS,
-  ROLE_DISPLAY_NAMES,
+  ROLE_I18N_KEY,
 } from "./constants"
 
 /**
@@ -143,7 +143,7 @@ export function UsersCard({
               updatingId={updatingId}
               currentUserId={currentUserId}
               roleBadgeClass={ROLE_BADGE_CLASS}
-              roleDisplayNames={ROLE_DISPLAY_NAMES}
+              roleI18nKey={ROLE_I18N_KEY}
               onToggleSelect={onToggleSelect}
               onRoleChange={onRoleChange}
               onDeleteUser={onDeleteUser}
@@ -308,7 +308,7 @@ function UserRow({
           <span
             className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${ROLE_BADGE_CLASS[user.role]}`}
           >
-            {ROLE_DISPLAY_NAMES[user.role]}
+            {t(ROLE_I18N_KEY[user.role])}
           </span>
           <NativeSelect
             fieldSize="sm"

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -38,12 +38,20 @@ export const ACTION_BADGE_CLASS: Record<string, string> = {
   grade: "bg-warning/15 text-warning",
 }
 
-/** Human-readable role names for dropdowns and badges. */
-export const ROLE_DISPLAY_NAMES: Record<UserRole, string> = {
-  student: "Student",
-  pending_teacher: "Pending Teacher",
-  teacher: "Teacher",
-  admin: "Admin",
+/** Maps each role to its i18n key. Use with ``useTranslation().t`` to
+ * render localized role labels — never hardcode the English values.
+ *
+ * The camelCase keys (``pendingTeacher``) are i18next conventions; the
+ * snake_case role values (``pending_teacher``) mirror the Pydantic /
+ * Postgres CHECK constraint. The mapping lives here so the bridge is
+ * a single source of truth instead of being re-derived in every
+ * component that needs to render a role.
+ */
+export const ROLE_I18N_KEY: Record<UserRole, string> = {
+  student: "roles.student",
+  pending_teacher: "roles.pendingTeacher",
+  teacher: "roles.teacher",
+  admin: "roles.admin",
 }
 
 /** Role-pill color classes. */

--- a/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
@@ -9,14 +9,7 @@ import { getErrorDetail } from "@/lib/errorDetail"
 import { useConfirm } from "@/components/ui/alert-dialog"
 import { ROLES, type UserRole } from "@/types"
 import type { AdminCert } from "./PendingCertsCard"
-import type { AdminStats, ProfileRow } from "./constants"
-
-const ROLE_I18N_KEY: Record<UserRole, string> = {
-  student: "roles.student",
-  pending_teacher: "roles.pendingTeacher",
-  teacher: "roles.teacher",
-  admin: "roles.admin",
-}
+import { ROLE_I18N_KEY, type AdminStats, type ProfileRow } from "./constants"
 
 interface UseAdminOverviewArgs {
   /** Current signed-in user id — excluded from bulk operations and delete confirmations. */

--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -26,15 +26,10 @@ import {
 import { ErrorState } from "@/components/patterns"
 import { Skeleton } from "@/components/ui/skeleton"
 
-const EDITOR_OPTIONS = CHAPTER_TYPES.map((value) => {
-  const meta = CHAPTER_TYPE_META[value]
-  return {
-    value,
-    label: meta.label,
-    desc: meta.description,
-    icon: meta.icon,
-  }
-})
+const EDITOR_OPTIONS = CHAPTER_TYPES.map((value) => ({
+  value,
+  icon: CHAPTER_TYPE_META[value].icon,
+}))
 
 type ChapterUpdatePayload = Parameters<typeof coursesService.updateChapter>[3]
 
@@ -286,10 +281,10 @@ export default function ChapterEditor() {
                       selected ? "text-primary" : ""
                     }`}
                   >
-                    {ct.label}
+                    {t(`chapterTypes.${ct.value}.label`)}
                   </div>
                   <div className="text-xs text-muted-foreground mt-0.5">
-                    {ct.desc}
+                    {t(`chapterTypes.${ct.value}.description`)}
                   </div>
                 </div>
               </button>

--- a/frontend/src/pages/Teacher/moduleEditor/ChapterRow.tsx
+++ b/frontend/src/pages/Teacher/moduleEditor/ChapterRow.tsx
@@ -1,10 +1,11 @@
 import { Draggable } from "@hello-pangea/dnd";
 import { GripVertical, Lock, Pencil, Trash2, Unlock } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { getChapterTypeMeta } from "@/lib/chapterTypes";
+import { getChapterTypeMeta, normalizeChapterType } from "@/lib/chapterTypes";
 import type { Chapter } from "@/types";
 
 interface ChapterRowProps {
@@ -31,7 +32,8 @@ export function ChapterRow({
   onEdit,
   onDelete,
 }: ChapterRowProps) {
-  const type = chapter.chapter_type || "reading";
+  const { t } = useTranslation();
+  const type = normalizeChapterType(chapter.chapter_type);
   const badgeClass = getChapterTypeMeta(type).badgeColor;
 
   return (
@@ -60,9 +62,9 @@ export function ChapterRow({
             />
 
             <span
-              className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium shrink-0 capitalize ${badgeClass}`}
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium shrink-0 ${badgeClass}`}
             >
-              {type}
+              {t(`chapterTypes.${type}.label`)}
             </span>
 
             <Button
@@ -72,12 +74,13 @@ export function ChapterRow({
                 chapter.is_locked ? "text-warning hover:text-warning" : "text-muted-foreground"
               }`}
               onClick={onToggleLock}
-              title={chapter.is_locked ? "Unlock chapter" : "Lock chapter"}
+              title={chapter.is_locked ? t("moduleEditor.unlockChapterTooltip") : t("moduleEditor.lockChapterTooltip")}
+              aria-label={chapter.is_locked ? t("moduleEditor.unlockChapterTooltip") : t("moduleEditor.lockChapterTooltip")}
             >
               {chapter.is_locked ? (
-                <Lock className="h-3.5 w-3.5" />
+                <Lock className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
               ) : (
-                <Unlock className="h-3.5 w-3.5" />
+                <Unlock className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
               )}
             </Button>
 
@@ -86,8 +89,9 @@ export function ChapterRow({
               size="sm"
               className="shrink-0 h-8 w-8 p-0"
               onClick={onEdit}
+              aria-label={t("moduleEditor.editChapterAria", { title: chapter.title })}
             >
-              <Pencil className="h-3.5 w-3.5" />
+              <Pencil className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
             </Button>
 
             <Button
@@ -95,8 +99,9 @@ export function ChapterRow({
               size="sm"
               className="shrink-0 h-8 w-8 p-0 text-destructive hover:text-destructive"
               onClick={onDelete}
+              aria-label={t("moduleEditor.deleteChapterAria", { title: chapter.title })}
             >
-              <Trash2 className="h-3.5 w-3.5" />
+              <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
             </Button>
           </div>
         </Card>

--- a/frontend/src/pages/Teacher/progress/ProgressStats.tsx
+++ b/frontend/src/pages/Teacher/progress/ProgressStats.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next"
 import { Card, CardContent } from "@/components/ui/card"
 import { Award, TrendingUp, Users } from "lucide-react"
 
@@ -8,12 +9,13 @@ interface Props {
 }
 
 const CARDS = [
-  { key: "total", label: "Total Students", icon: Users },
-  { key: "avg", label: "Average Progress", icon: TrendingUp },
-  { key: "completion", label: "Completion Rate", icon: Award },
+  { key: "total", labelKey: "studentProgress.stats.totalStudents", icon: Users },
+  { key: "avg", labelKey: "studentProgress.stats.averageProgress", icon: TrendingUp },
+  { key: "completion", labelKey: "studentProgress.stats.completionRate", icon: Award },
 ] as const
 
 export function ProgressStats({ totalStudents, averageProgress, completionRate }: Props) {
+  const { t } = useTranslation()
   const values: Record<(typeof CARDS)[number]["key"], string> = {
     total: totalStudents.toString(),
     avg: `${averageProgress}%`,
@@ -22,15 +24,15 @@ export function ProgressStats({ totalStudents, averageProgress, completionRate }
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-      {CARDS.map(({ key, label, icon: Icon }) => (
+      {CARDS.map(({ key, labelKey, icon: Icon }) => (
         <Card key={key}>
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-muted-foreground">{label}</p>
+                <p className="text-sm text-muted-foreground">{t(labelKey)}</p>
                 <p className="text-2xl font-bold mt-1">{values[key]}</p>
               </div>
-              <Icon className="h-8 w-8 text-muted-foreground/60" />
+              <Icon className="h-6 w-6 text-muted-foreground/60" strokeWidth={1.75} aria-hidden />
             </div>
           </CardContent>
         </Card>

--- a/frontend/src/pages/Teacher/progress/StudentRow.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentRow.tsx
@@ -137,7 +137,7 @@ export function StudentRow({
           <ScoreBadge value={assignmentAvg} />
         </td>
         <td className="py-3 text-muted-foreground text-xs">
-          {relativeTime(student.last_activity)}
+          {relativeTime(student.last_activity, t)}
         </td>
       </tr>
       {isExpanded && (

--- a/frontend/src/pages/Teacher/progress/helpers.ts
+++ b/frontend/src/pages/Teacher/progress/helpers.ts
@@ -56,16 +56,25 @@ export function formatDate(d: string | null): string {
   })
 }
 
-/** "3m ago" / "5d ago" / falls back to formatDate after 7 days. */
-export function relativeTime(d: string | null): string {
-  if (!d) return "Never"
+/** Translator type matches react-i18next's ``useTranslation().t``. */
+type Translator = (key: string, options?: { count?: number }) => string
+
+/** "3m ago" / "5d ago" / falls back to formatDate after 7 days.
+ *
+ * Takes the translator as a parameter so this stays a pure function —
+ * the caller passes ``t`` from ``useTranslation()``. The i18next plural
+ * machinery handles the per-locale ``minutesAgo_one`` / ``_few`` /
+ * ``_many`` forms via the ``count`` option.
+ */
+export function relativeTime(d: string | null, t: Translator): string {
+  if (!d) return t("studentProgress.relative.never")
   const diff = Date.now() - new Date(d).getTime()
   const mins = Math.floor(diff / 60000)
-  if (mins < 60) return `${mins}m ago`
+  if (mins < 60) return t("studentProgress.relative.minutesAgo", { count: mins })
   const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h ago`
+  if (hours < 24) return t("studentProgress.relative.hoursAgo", { count: hours })
   const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}d ago`
+  if (days < 7) return t("studentProgress.relative.daysAgo", { count: days })
   return formatDate(d)
 }
 


### PR DESCRIPTION
## Summary

Frontend bilingual audit found 3 big gaps where RU users saw English (and vice versa) on high-traffic teacher / admin pages.

### 1. Chapter type labels + descriptions

\`lib/chapterTypes.ts CHAPTER_TYPE_META\` held English \`label\` + \`description\` consumed by **ChapterEditor** (type-selector cards), **ChapterTypeBadge** (everywhere), **moduleEditor/ChapterRow** (chapter row badges). Now i18n keys \`chapterTypes.{reading|quiz|exam|assignment}.{label,description}\`. \`CHAPTER_TYPE_META\` keeps icon + colour only.

### 2. Student-progress stats + relative time

\`ProgressStats\` rendered \"Total Students / Average Progress / Completion Rate\" hardcoded. \`relativeTime()\` returned \`\"Never\"\` / \`\"5m ago\"\`. Both go through i18n; \`relativeTime\` takes \`t\` as param + uses i18next plural support (\`_one\`/\`_few\`/\`_many\`/\`_other\`).

### 3. Admin role badges

\`ROLE_DISPLAY_NAMES\` held English even though \`roles.*\` keys existed. Replace with \`ROLE_I18N_KEY\` (UserRole → i18n-key string); callers run through \`t()\`. Hoist the duplicate inline copy from \`useAdminOverview\` to the shared module. \`VirtualAdminUsers\` prop renamed \`roleDisplayNames\` → \`roleI18nKey\`.

### 4. ChapterRow lock/edit/delete tooltips + aria-labels

Were hardcoded English; now \`t()\`.

## Test plan

- [x] EN + RU added together; locale parity preserved
- [x] \`keyCoverage\` static guard passes
- [x] 112 frontend tests pass
- [x] eslint + tsc clean
- [ ] CI green
- [ ] Manual: switch UI to RU → open Module Editor → all chapter badges show "Урок/Тест/Экзамен/Задание"; admin Users table shows "Студент/Преподаватель/Администратор"; StudentProgress shows "Всего студентов" etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)