### PR TITLE
fix(i18n): audit log enums + assignment status + event type badges (pass 2)

### DIFF
--- a/frontend/src/components/assignment/editor/SubmissionGrader.tsx
+++ b/frontend/src/components/assignment/editor/SubmissionGrader.tsx
@@ -59,7 +59,7 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
           <span
             className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${STATUS_COLORS[submission.status]}`}
           >
-            {submission.status}
+            {t(`assignment.statusValue.${submission.status}`, { defaultValue: submission.status })}
           </span>
         </div>
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -157,7 +157,8 @@
     "switchToLight": "Light",
     "switchToDark": "Dark",
     "invalidInput": "Invalid input",
-    "editName": "Edit name"
+    "editName": "Edit name",
+    "avatarAlt": "{{name}} avatar"
   },
   "home": {
     "myCourses": "My Courses",
@@ -591,7 +592,13 @@
     "responsePlaceholder": "Write your assignment response here...",
     "fileLinkOptional": "File Link (optional)",
     "submitting": "Submitting...",
-    "fileLinkPlaceholder": "https://drive.google.com/..."
+    "fileLinkPlaceholder": "https://drive.google.com/...",
+    "statusValue": {
+      "pending": "Pending",
+      "submitted": "Submitted",
+      "graded": "Graded",
+      "returned": "Returned"
+    }
   },
   "certificates": {
     "dashboard": "Dashboard",
@@ -1371,7 +1378,26 @@
       "thResourceId": "Resource ID",
       "thIp": "IP",
       "errorPrefix": "Audit log error",
-      "errorTableMissing": "The audit_logs table may not exist yet. Deploy the latest migration."
+      "errorTableMissing": "The audit_logs table may not exist yet. Deploy the latest migration.",
+      "actionValue": {
+        "create": "Created",
+        "update": "Updated",
+        "delete": "Deleted",
+        "publish": "Published",
+        "enroll": "Enrolled",
+        "approve": "Approved",
+        "reject": "Rejected",
+        "grade": "Graded"
+      },
+      "resourceValue": {
+        "course": "Course",
+        "module": "Module",
+        "chapter": "Chapter",
+        "enrollment": "Enrollment",
+        "certificate": "Certificate",
+        "assignment_submission": "Assignment submission",
+        "user": "User"
+      }
     }
   },
   "roles": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -157,7 +157,8 @@
     "switchToLight": "Светлая",
     "switchToDark": "Тёмная",
     "invalidInput": "Некорректный ввод",
-    "editName": "Изменить имя"
+    "editName": "Изменить имя",
+    "avatarAlt": "Аватар {{name}}"
   },
   "home": {
     "myCourses": "Мои курсы",
@@ -609,7 +610,13 @@
     "responsePlaceholder": "Напишите ответ на задание...",
     "fileLinkOptional": "Ссылка на файл (необязательно)",
     "submitting": "Отправка...",
-    "fileLinkPlaceholder": "https://drive.google.com/..."
+    "fileLinkPlaceholder": "https://drive.google.com/...",
+    "statusValue": {
+      "pending": "Ожидает",
+      "submitted": "Сдано",
+      "graded": "Оценено",
+      "returned": "Возвращено"
+    }
   },
   "certificates": {
     "dashboard": "Главная",
@@ -1409,7 +1416,26 @@
       "thResourceId": "ID объекта",
       "thIp": "IP",
       "errorPrefix": "Ошибка журнала аудита",
-      "errorTableMissing": "Таблица audit_logs ещё не создана. Примените последнюю миграцию."
+      "errorTableMissing": "Таблица audit_logs ещё не создана. Примените последнюю миграцию.",
+      "actionValue": {
+        "create": "Создание",
+        "update": "Обновление",
+        "delete": "Удаление",
+        "publish": "Публикация",
+        "enroll": "Запись",
+        "approve": "Одобрение",
+        "reject": "Отклонение",
+        "grade": "Оценка"
+      },
+      "resourceValue": {
+        "course": "Курс",
+        "module": "Модуль",
+        "chapter": "Глава",
+        "enrollment": "Запись",
+        "certificate": "Сертификат",
+        "assignment_submission": "Сданная работа",
+        "user": "Пользователь"
+      }
     }
   },
   "roles": {

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -59,8 +59,22 @@ export function AuditLogTab({
       <Card>
         <CardContent className="p-4">
           <div className="flex flex-wrap items-end gap-3">
-            <FilterSelect label={t("admin.audit.filterAction")} value={action} onChange={onAction} options={ACTION_OPTIONS} placeholder={t("admin.audit.filterAllActions")} />
-            <FilterSelect label={t("admin.audit.filterResource")} value={resource} onChange={onResource} options={RESOURCE_OPTIONS} placeholder={t("admin.audit.filterAllResources")} />
+            <FilterSelect
+              label={t("admin.audit.filterAction")}
+              value={action}
+              onChange={onAction}
+              options={ACTION_OPTIONS}
+              optionLabel={(o) => t(`admin.audit.actionValue.${o}`)}
+              placeholder={t("admin.audit.filterAllActions")}
+            />
+            <FilterSelect
+              label={t("admin.audit.filterResource")}
+              value={resource}
+              onChange={onResource}
+              options={RESOURCE_OPTIONS}
+              optionLabel={(o) => t(`admin.audit.resourceValue.${o}`)}
+              placeholder={t("admin.audit.filterAllResources")}
+            />
             <FilterDate label={t("admin.audit.filterFrom")} value={dateFrom} onChange={onDateFrom} />
             <FilterDate label={t("admin.audit.filterTo")} value={dateTo} onChange={onDateTo} />
             <Button variant="ghost" size="sm" onClick={onReset} className="h-9">
@@ -127,10 +141,11 @@ interface FilterSelectProps {
   value: string
   onChange: (next: string) => void
   options: readonly string[]
+  optionLabel: (option: string) => string
   placeholder: string
 }
 
-function FilterSelect({ label, value, onChange, options, placeholder }: FilterSelectProps) {
+function FilterSelect({ label, value, onChange, options, optionLabel, placeholder }: FilterSelectProps) {
   return (
     <div className="space-y-1">
       <label className="text-xs font-medium text-muted-foreground">{label}</label>
@@ -142,7 +157,7 @@ function FilterSelect({ label, value, onChange, options, placeholder }: FilterSe
         <option value="">{placeholder}</option>
         {options.map((o) => (
           <option key={o} value={o}>
-            {o}
+            {optionLabel(o)}
           </option>
         ))}
       </NativeSelect>
@@ -211,10 +226,12 @@ function AuditTable({
                     ACTION_BADGE_CLASS[log.action] || "bg-muted text-muted-foreground"
                   }`}
                 >
-                  {log.action}
+                  {t(`admin.audit.actionValue.${log.action}`, { defaultValue: log.action })}
                 </span>
               </td>
-              <td className="px-6 py-3 text-muted-foreground">{log.resource_type}</td>
+              <td className="px-6 py-3 text-muted-foreground">
+                {t(`admin.audit.resourceValue.${log.resource_type}`, { defaultValue: log.resource_type })}
+              </td>
               <td
                 className="px-6 py-3 font-mono text-xs text-muted-foreground max-w-[120px] truncate"
                 title={log.resource_id}

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -143,7 +143,7 @@ export default function ProfilePage() {
                 {user.avatar_url ? (
                   <img
                     src={toProxyImage(user.avatar_url)}
-                    alt={`${user.full_name ?? "User"} avatar`}
+                    alt={t("profile.avatarAlt", { name: user.full_name ?? user.email })}
                     loading="lazy"
                     className="h-20 w-20 rounded-full border border-border object-cover ring-2 ring-background"
                   />

--- a/frontend/src/pages/Teacher/editor/badges.tsx
+++ b/frontend/src/pages/Teacher/editor/badges.tsx
@@ -20,14 +20,20 @@ const EVENT_BADGE_CLASS: Record<string, string> = {
   other: "bg-muted text-muted-foreground",
 }
 
+const KNOWN_EVENT_TYPES = new Set(["deadline", "live_session", "exam", "other"])
+
 export function EventTypeBadge({ type }: { type: string }) {
+  const { t } = useTranslation()
+  // Fall back to "other" for unknown types so we still render a sensible
+  // localized label (the i18n keys cover the four supported types).
+  const key = KNOWN_EVENT_TYPES.has(type) ? type : "other"
   return (
     <span
-      className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium capitalize ${
+      className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
         EVENT_BADGE_CLASS[type] ?? EVENT_BADGE_CLASS.other
       }`}
     >
-      {type.replace("_", " ")}
+      {t(`teacherEditor.modals.events.types.${key}`)}
     </span>
   )
 }

--- a/frontend/src/pages/Teacher/progress/ChapterBreakdownRow.tsx
+++ b/frontend/src/pages/Teacher/progress/ChapterBreakdownRow.tsx
@@ -107,7 +107,7 @@ export function ChapterBreakdownRow({
             {assignment.title}:{" "}
             {assignment.grade !== null
               ? `${assignment.grade}/${assignment.max_score}`
-              : assignment.status}
+              : t(`assignment.statusValue.${assignment.status}`, { defaultValue: assignment.status })}
           </span>
         </div>
       )}


### PR DESCRIPTION
## Summary

Frontend bilingual audit pass 2 — closes the remaining visible-to-the-user gaps where raw English / Russian enum values leak through.

### 1. Admin audit log
Action / resource dropdowns AND table cells rendered the raw API enum literally (\`create\`, \`assignment_submission\`). Now uses \`admin.audit.actionValue.*\` / \`resourceValue.*\` keys; \`FilterSelect\` takes an \`optionLabel\` callback. \`defaultValue\` fallback covers any future enum.

### 2. Event type badges
\`EventTypeBadge\` rendered \`type.replace("_", " ")\` (raw English). \`teacherEditor.modals.events.types.*\` keys already existed but were unused.

### 3. Assignment submission status
\`SubmissionGrader\` (teacher grading) and \`ChapterBreakdownRow\` (student progress detail) rendered \`submission.status\` raw. Added \`assignment.statusValue.*\` keys.

### 4. Profile avatar alt
Used \`\${user.full_name ?? \"User\"} avatar\` literal. Now \`profile.avatarAlt\` with name interpolation.

## Test plan

- [x] EN + RU added together; locale parity
- [x] keyCoverage guard passes
- [x] 112 frontend tests
- [x] eslint + tsc clean
- [ ] CI green
- [ ] Manual: RU UI → admin audit log shows "Создание / Курс / Сданная работа"; teacher events modal shows "Дедлайн / Прямая сессия"; submission status shows "Сдано / Оценено / Возвращено"

🤖 Generated with [Claude Code](https://claude.com/claude-code)