### PR TITLE
style(frontend): unify page H1 typography with font-serif

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -48,7 +48,7 @@ export default function AdminDashboard() {
         <div className="p-2 rounded-lg bg-primary/10">
           <Shield className="h-6 w-6 text-primary" />
         </div>
-        <h1 className="text-3xl font-bold tracking-tight">{t("admin.title")}</h1>
+        <h1 className="text-3xl font-serif font-bold tracking-tight">{t("admin.title")}</h1>
       </div>
 
       <AdminTabs active={tab} onChange={setTab} />

--- a/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
@@ -199,7 +199,7 @@ export default function CohortDetailPage() {
       <div className="flex items-start justify-between gap-4 flex-wrap mb-8">
         <div>
           <div className="flex items-center gap-3 mb-2">
-            <h1 className="text-3xl font-bold tracking-tight">{cohort.name}</h1>
+            <h1 className="text-3xl font-serif font-bold tracking-tight">{cohort.name}</h1>
             <Badge variant={STATUS_BADGE[cohort.status]} className="capitalize">
               {t(`admin.cohorts.status${capitalize(cohort.status)}`)}
             </Badge>

--- a/frontend/src/pages/Teacher/StudentProgress.tsx
+++ b/frontend/src/pages/Teacher/StudentProgress.tsx
@@ -194,7 +194,7 @@ export default function StudentProgress() {
 
       <div className="flex items-center gap-3 mb-8">
         <div className="flex-1">
-          <h1 className="text-3xl font-bold tracking-tight">{t("studentProgress.heading")}</h1>
+          <h1 className="text-3xl font-serif font-bold tracking-tight">{t("studentProgress.heading")}</h1>
           <p className="text-muted-foreground mt-1">{data.course_title}</p>
         </div>
         <div className="flex items-center gap-2">

--- a/frontend/src/pages/Teacher/TeacherAnalytics.tsx
+++ b/frontend/src/pages/Teacher/TeacherAnalytics.tsx
@@ -117,7 +117,7 @@ export default function TeacherAnalytics() {
           </Button>
         </Link>
         <div className="flex-1">
-          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+          <h1 className="text-3xl font-serif font-bold tracking-tight flex items-center gap-2">
             <BarChart3 className="h-7 w-7 text-primary" />
             {t("teacherAnalytics.heading")}
           </h1>

--- a/frontend/src/pages/Teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.tsx
@@ -214,7 +214,7 @@ export default function TeacherDashboard() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-5xl">
       <div className="flex items-center justify-between mb-8">
-        <h1 className="text-3xl font-bold tracking-tight">{t("teacher.dashboardTitle")}</h1>
+        <h1 className="text-3xl font-serif font-bold tracking-tight">{t("teacher.dashboardTitle")}</h1>
         <Button onClick={() => setShowCreate(!showCreate)} size="sm">
           <Plus className="h-4 w-4 mr-1.5" />
           {t("teacher.newCourse")}


### PR DESCRIPTION
## Summary

- Add `font-serif` to the H1 on Teacher Dashboard, Teacher Analytics, Student Progress, Admin Dashboard, and Cohort Detail.
- Aligns them with the editorial-serif identity already used on HomePage, Profile, CourseEditor, and Gradebook — pages now read as one product instead of "polished landing + utilitarian inner pages."
- Single-class change per file; zero behavior delta.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 112/112 passing
- [ ] Manual: render each of the 5 pages, EN + RU, light + dark — H1 reads in serif and the rest of the page is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
