### PR TITLE
refactor(frontend): consolidate inline status pills onto Badge

### DIFF
--- a/frontend/src/components/assignment/editor/SubmissionGrader.tsx
+++ b/frontend/src/components/assignment/editor/SubmissionGrader.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
 import { FileText, Loader2, MessageSquare, Save, Star, User } from "lucide-react"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
@@ -16,10 +17,12 @@ interface Props {
   onUpdate: (updated: AssignmentSubmission) => void
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  submitted: "bg-info/15 text-info",
-  graded: "bg-success/15 text-success",
-  returned: "bg-warning/15 text-warning",
+type StatusVariant = "infoSubtle" | "successSubtle" | "warningSubtle" | "muted"
+
+const STATUS_VARIANT: Record<string, StatusVariant> = {
+  submitted: "infoSubtle",
+  graded: "successSubtle",
+  returned: "warningSubtle",
 }
 
 export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
@@ -56,11 +59,11 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
               {submission.student_id.slice(0, 8)}...
             </span>
           </div>
-          <span
-            className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${STATUS_COLORS[submission.status]}`}
-          >
-            {t(`assignment.statusValue.${submission.status}`, { defaultValue: submission.status })}
-          </span>
+          <Badge variant={STATUS_VARIANT[submission.status] ?? "muted"}>
+            {t(`assignment.statusValue.${submission.status}`, {
+              defaultValue: submission.status,
+            })}
+          </Badge>
         </div>
 
         {submission.content && (

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -23,6 +23,12 @@ const badgeVariants = cva(
           "border-transparent bg-muted text-muted-foreground hover:bg-muted/80",
         accent:
           "border-transparent bg-accent text-accent-foreground hover:bg-accent/80",
+        successSubtle: "border-transparent bg-success/15 text-success",
+        warningSubtle: "border-transparent bg-warning/15 text-warning",
+        infoSubtle: "border-transparent bg-info/15 text-info",
+        destructiveSubtle:
+          "border-transparent bg-destructive/15 text-destructive",
+        primarySubtle: "border-transparent bg-primary/15 text-primary",
       },
     },
     defaultVariants: { variant: "default" },

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -3,13 +3,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { NativeSelect } from "@/components/ui/native-select"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import PageSpinner from "@/components/ui/PageSpinner"
 import { FileText, ChevronLeft, ChevronRight } from "lucide-react"
 import type { AuditLogEntry } from "@/types"
 import {
   ACTION_OPTIONS,
   RESOURCE_OPTIONS,
-  ACTION_BADGE_CLASS,
+  ACTION_BADGE_VARIANT,
 } from "./constants"
 import { formatDateTime } from "@/i18n/format"
 
@@ -221,13 +222,11 @@ function AuditTable({
                   : "—"}
               </td>
               <td className="px-6 py-3">
-                <span
-                  className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${
-                    ACTION_BADGE_CLASS[log.action] || "bg-muted text-muted-foreground"
-                  }`}
-                >
-                  {t(`admin.audit.actionValue.${log.action}`, { defaultValue: log.action })}
-                </span>
+                <Badge variant={ACTION_BADGE_VARIANT[log.action] ?? "muted"}>
+                  {t(`admin.audit.actionValue.${log.action}`, {
+                    defaultValue: log.action,
+                  })}
+                </Badge>
               </td>
               <td className="px-6 py-3 text-muted-foreground">
                 {t(`admin.audit.resourceValue.${log.resource_type}`, { defaultValue: log.resource_type })}

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -26,16 +26,23 @@ export const RESOURCE_OPTIONS = [
 
 export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
 
-/** Background/foreground pair used in audit-log action pills. */
-export const ACTION_BADGE_CLASS: Record<string, string> = {
-  create: "bg-success/15 text-success",
-  update: "bg-info/15 text-info",
-  delete: "bg-destructive/15 text-destructive",
-  publish: "bg-primary/15 text-primary",
-  enroll: "bg-info/15 text-info",
-  approve: "bg-success/15 text-success",
-  reject: "bg-destructive/15 text-destructive",
-  grade: "bg-warning/15 text-warning",
+/** Maps each audit-log action to a `<Badge>` variant. */
+export const ACTION_BADGE_VARIANT: Record<
+  string,
+  | "successSubtle"
+  | "infoSubtle"
+  | "destructiveSubtle"
+  | "primarySubtle"
+  | "warningSubtle"
+> = {
+  create: "successSubtle",
+  update: "infoSubtle",
+  delete: "destructiveSubtle",
+  publish: "primarySubtle",
+  enroll: "infoSubtle",
+  approve: "successSubtle",
+  reject: "destructiveSubtle",
+  grade: "warningSubtle",
 }
 
 /** Maps each role to its i18n key. Use with ``useTranslation().t`` to

--- a/frontend/src/pages/Teacher/editor/badges.tsx
+++ b/frontend/src/pages/Teacher/editor/badges.tsx
@@ -13,11 +13,17 @@ export function EnrollmentStatusBadge({ start, end }: { start: string; end: stri
   return <Badge variant="success">{t("teacherEditor.badges.open")}</Badge>
 }
 
-const EVENT_BADGE_CLASS: Record<string, string> = {
-  deadline: "bg-destructive/15 text-destructive",
-  live_session: "bg-info/15 text-info",
-  exam: "bg-warning/15 text-warning",
-  other: "bg-muted text-muted-foreground",
+type EventVariant =
+  | "destructiveSubtle"
+  | "infoSubtle"
+  | "warningSubtle"
+  | "muted"
+
+const EVENT_BADGE_VARIANT: Record<string, EventVariant> = {
+  deadline: "destructiveSubtle",
+  live_session: "infoSubtle",
+  exam: "warningSubtle",
+  other: "muted",
 }
 
 const KNOWN_EVENT_TYPES = new Set(["deadline", "live_session", "exam", "other"])
@@ -28,13 +34,9 @@ export function EventTypeBadge({ type }: { type: string }) {
   // localized label (the i18n keys cover the four supported types).
   const key = KNOWN_EVENT_TYPES.has(type) ? type : "other"
   return (
-    <span
-      className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
-        EVENT_BADGE_CLASS[type] ?? EVENT_BADGE_CLASS.other
-      }`}
-    >
+    <Badge variant={EVENT_BADGE_VARIANT[type] ?? "muted"}>
       {t(`teacherEditor.modals.events.types.${key}`)}
-    </span>
+    </Badge>
   )
 }
 


### PR DESCRIPTION
## Summary

- Add five `subtle` variants to `<Badge>`: `successSubtle`, `warningSubtle`, `infoSubtle`, `destructiveSubtle`, `primarySubtle`. They preserve the muted tinted-pill look (`bg-foo/15 text-foo`) while inheriting `<Badge>`'s padding / focus ring / rounded corners.
- Replace three hand-rolled `<span>` pills with `<Badge>` calls:
  - `AuditLogTab` action cell
  - `SubmissionGrader` submission status
  - `EventTypeBadge` (teacher editor)
- Net: every status pill across the admin tools and teacher editor is now one component with one styling source. Net diff is small (+55 / −38) but eliminates three local `XXX_BADGE_CLASS` maps.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 112/112 passing
- [ ] Manual: `/admin?tab=audit` action pills (EN + RU), assignment grader status pill, teacher editor events tab — colors unchanged but typography/padding tightened to match other badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
