### PR TITLE
refactor(frontend): admin user role pills onto Badge

### DIFF
--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -2,10 +2,12 @@ import { List, type RowComponentProps } from "react-window"
 import { useTranslation } from "react-i18next"
 import { Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { NativeSelect } from "@/components/ui/native-select"
 import { toProxyImage } from "@/lib/images"
 import type { UserRole } from "@/types"
 import { formatDate } from "@/i18n/format"
+import { ROLE_BADGE_VARIANT, ROLE_I18N_KEY } from "./dashboard/constants"
 
 interface ProfileRow {
   id: string
@@ -21,8 +23,6 @@ interface VirtualAdminUsersProps {
   selectedIds: Set<string>
   updatingId: string | null
   currentUserId: string | undefined
-  roleBadgeClass: Record<string, string>
-  roleI18nKey: Record<string, string>
   onToggleSelect: (id: string) => void
   onRoleChange: (userId: string, role: UserRole) => void
   onDeleteUser: (user: ProfileRow) => void
@@ -39,8 +39,6 @@ function UserRow({
   selectedIds,
   updatingId,
   currentUserId,
-  roleBadgeClass,
-  roleI18nKey,
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
@@ -86,11 +84,9 @@ function UserRow({
         {u.email}
       </div>
       <div role="cell" className="px-3 flex items-center gap-2">
-        <span
-          className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${roleBadgeClass[u.role] ?? ""}`}
-        >
-          {t(roleI18nKey[u.role] ?? "")}
-        </span>
+        <Badge variant={ROLE_BADGE_VARIANT[u.role]}>
+          {t(ROLE_I18N_KEY[u.role])}
+        </Badge>
         <NativeSelect
           fieldSize="sm"
           value={u.role}
@@ -128,8 +124,6 @@ export default function VirtualAdminUsers({
   selectedIds,
   updatingId,
   currentUserId,
-  roleBadgeClass,
-  roleI18nKey,
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
@@ -161,8 +155,6 @@ export default function VirtualAdminUsers({
           selectedIds,
           updatingId,
           currentUserId,
-          roleBadgeClass,
-          roleI18nKey,
           onToggleSelect,
           onRoleChange,
           onDeleteUser,

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { NativeSelect } from "@/components/ui/native-select"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Users, Search, Trash2 } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import PageSpinner from "@/components/ui/PageSpinner"
@@ -11,7 +12,7 @@ import type { UserRole } from "@/types"
 import { formatDate } from "@/i18n/format"
 import {
   type ProfileRow,
-  ROLE_BADGE_CLASS,
+  ROLE_BADGE_VARIANT,
   ROLE_I18N_KEY,
 } from "./constants"
 
@@ -142,8 +143,6 @@ export function UsersCard({
               selectedIds={selectedIds}
               updatingId={updatingId}
               currentUserId={currentUserId}
-              roleBadgeClass={ROLE_BADGE_CLASS}
-              roleI18nKey={ROLE_I18N_KEY}
               onToggleSelect={onToggleSelect}
               onRoleChange={onRoleChange}
               onDeleteUser={onDeleteUser}
@@ -305,11 +304,9 @@ function UserRow({
       <td className="px-6 py-3 text-muted-foreground">{user.email}</td>
       <td className="px-6 py-3">
         <div className="flex items-center gap-2">
-          <span
-            className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${ROLE_BADGE_CLASS[user.role]}`}
-          >
+          <Badge variant={ROLE_BADGE_VARIANT[user.role]}>
             {t(ROLE_I18N_KEY[user.role])}
-          </span>
+          </Badge>
           <NativeSelect
             fieldSize="sm"
             value={user.role}

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -61,12 +61,15 @@ export const ROLE_I18N_KEY: Record<UserRole, string> = {
   admin: "roles.admin",
 }
 
-/** Role-pill color classes. */
-export const ROLE_BADGE_CLASS: Record<UserRole, string> = {
-  admin: "bg-destructive/15 text-destructive",
-  teacher: "bg-primary/15 text-primary",
-  pending_teacher: "bg-warning/15 text-warning",
-  student: "bg-info/15 text-info",
+/** Maps each role to its `<Badge>` variant. */
+export const ROLE_BADGE_VARIANT: Record<
+  UserRole,
+  "destructiveSubtle" | "primarySubtle" | "warningSubtle" | "infoSubtle"
+> = {
+  admin: "destructiveSubtle",
+  teacher: "primarySubtle",
+  pending_teacher: "warningSubtle",
+  student: "infoSubtle",
 }
 
 export interface ProfileRow {


### PR DESCRIPTION
## Summary

- Replace the inline `<span>` role pill in `UsersCard` (small table) and `VirtualAdminUsers` (react-window row) with `<Badge>`.
- `ROLE_BADGE_CLASS` (raw class strings) → `ROLE_BADGE_VARIANT` (typed Badge variants — using the `subtle` variants added in the prior PR).
- Drop the `roleBadgeClass` / `roleI18nKey` props from `VirtualAdminUsers`; both renderers now read straight from `./dashboard/constants`.

(This PR was originally #250 stacked on the subtle-badge PR; that one merged into `main` and auto-closed the stacked PR. Same diff, re-targeted at `main`.)

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 112/112 passing
- [ ] Manual: `/admin` users tab with <50 users (small table) and >50 users (react-window) — role pills render in both; EN + RU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
