### PR TITLE
style(frontend): refine ChapterEditor type selector cards

### DIFF
--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -263,10 +263,12 @@ export default function ChapterEditor() {
             return (
               <button
                 key={ct.value}
+                type="button"
                 onClick={() => setChapterType(ct.value)}
-                className={`flex items-start gap-3 rounded-lg border-2 p-4 text-left transition-all ${
+                aria-pressed={selected}
+                className={`flex items-start gap-3 rounded-md border p-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                   selected
-                    ? "border-primary bg-primary/5 shadow-sm"
+                    ? "border-primary bg-primary/[0.04] ring-1 ring-primary/40"
                     : "border-border hover:border-primary/30 hover:bg-muted/40"
                 }`}
               >
@@ -274,6 +276,8 @@ export default function ChapterEditor() {
                   className={`h-5 w-5 mt-0.5 shrink-0 ${
                     selected ? "text-primary" : "text-muted-foreground"
                   }`}
+                  strokeWidth={1.75}
+                  aria-hidden
                 />
                 <div>
                   <div


### PR DESCRIPTION
## Summary

Refine the chapter-type picker cards on `ChapterEditor`:

- `border-2 rounded-lg shadow-sm` → `border rounded-md` with a `ring-1 ring-primary/40` halo on the selected card. Matches the lighter idiom used elsewhere (selectable filters, segmented controls).
- Add `aria-pressed` so screen readers announce the selected card.
- Add `focus-visible:ring-2 ring-ring ring-offset-2` for keyboard navigation.
- Icons get `strokeWidth={1.75}` + `aria-hidden` to match the rest of the editor's icon style.
- `transition-all` → `transition-colors` (no shadow to animate any more).

Single file, six-line diff.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 112/112 passing
- [ ] Manual: open a chapter in the editor — pick each of the four chapter types; selected card reads as primary tint + halo; keyboard focus ring works; EN + RU + dark + light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
