### PR TITLE
docs(readme): refresh stale test count, add documentation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ cd frontend && npm run dev                      # http://localhost:5173
 ### 4. Run tests
 
 ```bash
-cd backend  && python -m pytest tests/    # 396+ tests (SQLite in-memory)
+cd backend  && python -m pytest tests/    # 540+ tests (SQLite in-memory)
 cd frontend && npm run test:run           # Vitest + jsdom
+cd frontend && npm run i18n:check         # bilingual locale parity (en.json ↔ ru.json)
 ```
 
 ---
@@ -195,6 +196,18 @@ this platform:
   is driven by real ministry needs.
 
 ---
+
+## Documentation
+
+| Audience | Document |
+|----------|----------|
+| Contributors | [CONTRIBUTING.md](CONTRIBUTING.md) — setup, workflow, conventions |
+| Designers / UI work | [docs/DESIGN.md](docs/DESIGN.md) — aesthetic, tokens, motion, banned patterns |
+| Component reuse | [docs/COMPONENTS.md](docs/COMPONENTS.md) — the patterns library (`<Badge>`, `<StatCard>`, `<EmptyState>`, …) |
+| Translators / i18n work | [docs/I18N.md](docs/I18N.md) — bilingual workflow, locale files, key parity |
+| Architecture | [docs/adr/](docs/adr/) — Architecture Decision Records |
+| Cross-cutting UI calls | [docs/UI-DECISIONS.md](docs/UI-DECISIONS.md) — frozen UI decisions log |
+| Security disclosure | [SECURITY.md](SECURITY.md) |
 
 ## Community
 


### PR DESCRIPTION
## Summary

Two small, docs-only README updates:

- **Stale test count fixed.** README claimed `396+ tests`; the suite is now 540+ (matches what `CONTRIBUTING.md` already says).
- **`npm run i18n:check` added to the onboarding test commands** so contributors discover the bilingual locale-parity guard up front rather than first encountering it in CI.
- **New "Documentation" section** maps audiences (contributors, designers, translators, architects) to the right doc so newcomers don't have to grep for filenames. Forward-references `docs/COMPONENTS.md` and `docs/I18N.md`, which are landing in companion PRs (`docs/components-pattern-library`, `docs/i18n-workflow`).

## Type of change

- [x] Documentation

## Test plan

- [x] `npm run lint` passes (no-op for `.md` changes — sanity).
- [x] Markdown renders correctly (table, links, code blocks).
- [ ] No code changes — no functional tests needed.
