### PR TITLE
docs(contributing): branch naming, PowerShell, bilingual, enum mirror

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,10 +112,16 @@ supabase/
 
 ## Development workflow
 
-1. **Create a branch** off `main`:
+1. **Create a branch** off `main`. The branch name should mirror the commit
+   type so the intent is visible in the branch list:
    ```bash
-   git checkout -b feat/my-feature
+   git checkout -b feat/quiz-extra-attempts
+   git checkout -b fix/audit-invalid-uuid
+   git checkout -b docs/readme-refresh
+   git checkout -b refactor/role-const
    ```
+   Common prefixes: `feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `test/`,
+   `design/` (UI-only polish). Use `kebab-case` for the rest.
 2. **Make your changes** — keep each PR focused on a single concern.
 3. **Run linters and tests locally** before pushing:
    ```bash
@@ -124,6 +130,7 @@ supabase/
 
    # Frontend
    cd frontend && npm run lint && npx tsc --noEmit && npm run test:run
+   cd frontend && npm run i18n:check    # locale parity (see "Bilingual workflow")
    ```
 4. **Push** and open a pull request against `main`.
 
@@ -145,9 +152,31 @@ Optional longer body explaining *why*, not *what*.
 | `chore`    | Maintenance, deps, CI config |
 | `refactor` | Code change that neither fixes a bug nor adds a feature |
 | `test`     | Adding or updating tests |
+| `style`    | UI / design polish (CSS, animation, micro-interactions) |
 
 **Scope** is optional but encouraged: `feat(quiz)`, `fix(auth)`,
-`chore(ci)`, `docs(readme)`.
+`chore(ci)`, `docs(readme)`, `style(frontend)`.
+
+### Multi-line commit messages on Windows / PowerShell
+
+`git commit -m "..."` only accepts a single quoted line on PowerShell, and
+PowerShell does not support bash heredocs. For commits with a body, write
+the message to a file and pass it with `-F`:
+
+```powershell
+@'
+feat(quiz): allow teacher-gifted extra attempts
+
+A student who runs out of attempts can be granted more without
+resetting the whole `attempts_used` counter. Implemented as a new
+`quiz_extra_attempts` row keyed on (quiz_id, user_id).
+'@ | Set-Content .commit-msg.tmp -Encoding utf8
+git commit -F .commit-msg.tmp
+Remove-Item .commit-msg.tmp
+```
+
+`.commit-msg.tmp` and `.tmp-commit-msg.txt` are gitignored exactly so you
+can do this without staging the scratch file by accident.
 
 ## Pull request process
 
@@ -196,25 +225,74 @@ the [ROADMAP](ROADMAP.md) for bigger-picture direction.
 - Code, comments, commit messages, and docs are in **English**.
 - The application UI is **bilingual** RU↔EN with the design language
   targeting Russian-speaking Bible schools first. Every user-facing
-  string goes through `t(...)` — see `.cursor/rules/frontend-react.mdc`.
+  string goes through `t(...)`. See [the bilingual workflow](docs/I18N.md)
+  for the full pattern (locale bundles, plural categories, the parity
+  guard, and how to add a key for a DB-persisted enum value).
 - No Docker — the project intentionally avoids container-based
   workflows today. A potential self-hosted installer (which may use
   Docker Compose) is on the long-term roadmap; if/when that lands the
   rule changes only for that path. Until then: deploy via Vercel,
   develop natively.
 
+### Bilingual workflow (UI strings)
+
+Short version:
+
+- All user-facing strings come from `frontend/src/i18n/locales/{en,ru}.json`.
+- Never hand-edit only one of the two files — they must stay in parity.
+  `npm run i18n:check` (and a stricter `keyCoverage` Vitest test) enforces
+  this in CI.
+- Russian uses the four plural categories `_one`, `_few`, `_many`, `_other`.
+  English uses `_one` and `_other`. i18next picks the right form at
+  runtime based on the count argument.
+
+See [`docs/I18N.md`](docs/I18N.md) for the full guide — including how to
+add a translation key for a Postgres-persisted enum value (course status,
+quiz question type, certificate status, etc.) so the same string can map
+to a DB row.
+
+### Backend ↔ Frontend ↔ Database: the four-way enum mirror
+
+Every persisted enum value (role, course status, quiz question type,
+certificate status, audit action, …) is declared in **four** places that
+must stay in lockstep:
+
+1. **Postgres `CHECK` constraint** on the column — the runtime guard.
+2. **Pydantic `Literal[...]`** in `backend/app/schemas/` — the API
+   contract (and what FastAPI's OpenAPI export advertises).
+3. **TypeScript union type** in `frontend/src/types/` — what the client
+   knows about.
+4. **TypeScript `const` object** in `frontend/src/types/` (e.g. `ROLES`,
+   `STATUSES`) — the no-typo accessor every callsite uses.
+
+When you add or change a value, change all four. The pattern is
+documented at the `ROLES` const in `frontend/src/types/index.ts`. A typo
+in `"adimn"` is caught by TypeScript when you use `ROLES.ADMIN`; the
+bare string would silently fail the role check.
+
 ### Conventions library
 
-The canonical conventions live under [`.cursor/rules/*.mdc`](.cursor/rules/).
-These files are written for the Cursor editor's AI features but they're
-plain Markdown — read them in any editor:
+Tracked-in-git references that every contributor reads:
 
-- `project-overview.mdc` — stack, scale targets, established patterns
-- `backend-python.mdc` — FastAPI / SQLAlchemy / Pydantic conventions
-- `frontend-react.mdc` — design system, one-per-job library policy
-- `supabase-migrations.mdc` — append-only migration workflow
-- `git-ci.mdc` — Conventional Commits + CI matrix
-- `agent-autonomy.mdc` — testing expectations before declaring done
+- [`docs/DESIGN.md`](docs/DESIGN.md) — design system: aesthetic, tokens,
+  typography, spacing, motion, icons, banned patterns, the
+  four-check rule for adding a library.
+- [`docs/COMPONENTS.md`](docs/COMPONENTS.md) — the patterns library
+  (`<Badge>`, `<StatCard>`, `<EmptyState>`, `<ErrorState>`,
+  `<InlineEdit>`, `<PageHeader>`, `<Modal>`) and when to reach for each.
+- [`docs/I18N.md`](docs/I18N.md) — bilingual workflow, plural categories,
+  parity guard, how to add a key for a DB-persisted enum value.
+- [`docs/UI-DECISIONS.md`](docs/UI-DECISIONS.md) — log of frozen UI
+  decisions (don't re-litigate without sign-off).
+- [`docs/adr/`](docs/adr/) — Architecture Decision Records for
+  cross-module choices.
+- [`supabase/migrations/README.md`](supabase/migrations/README.md) —
+  append-only migration workflow.
+
+> If you have Cursor installed locally, a `.cursor/rules/` directory of
+> editor-targeted rules can give the AI assistant the same conventions
+> in a more concise form. That directory is gitignored (each contributor
+> maintains their own); the tracked docs above are the source of truth.
 
 ## Getting help
 


### PR DESCRIPTION
## Summary

Four onboarding gaps in `CONTRIBUTING.md` that a new contributor previously had to discover by reading commits and tripping over CI:

- **Branch naming convention** with concrete prefixes (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `test/`, `design/`) and examples that match the existing branch list. Adds `style` to the Conventional Commit type table since it's used for design polish.
- **PowerShell `-F <file>` caveat** for multi-line commit bodies. Windows contributors couldn't do Conventional Commits with a body because PowerShell has no heredoc. Documents the `Set-Content` + `git commit -F` workflow this repo already uses and references the gitignored `.commit-msg.tmp` / `.tmp-commit-msg.txt` filenames.
- **Bilingual workflow** — short version inline (locale parity, plural categories, `npm run i18n:check`) with a pointer to the full `docs/I18N.md` (landing in `docs/i18n-workflow`).
- **Four-way enum mirror** (Postgres CHECK ↔ Pydantic `Literal` ↔ TS union ↔ TS `const`) with `ROLES` as the worked example. This is the single most common "why does prod reject my request" trap.

### Also

Replaces the "Conventions library" pointer to `.cursor/rules/*.mdc` — that directory is gitignored (one rule set per contributor; the `.gitignore` comment notes the decision was reverted in 2026-04). The references were broken for anyone cloning fresh. Replaced with a tracked-in-git index covering `docs/DESIGN.md`, `docs/COMPONENTS.md`, `docs/I18N.md`, `docs/UI-DECISIONS.md`, ADRs, and the supabase migration guide. The Cursor-rules path is preserved as an opt-in note for users who have the editor.

## Type of change

- [x] Documentation

## Test plan

- [x] `npm run lint` passes (no-op for `.md` changes).
- [x] Cross-doc links resolve (verified by hand — `docs/I18N.md` and `docs/COMPONENTS.md` are companion PRs).
- [ ] No code changes — no functional tests needed.
