### PR TITLE
feat(frontend): EmptyState compact variant for nested containers

### DIFF
--- a/frontend/src/components/patterns/EmptyState.tsx
+++ b/frontend/src/components/patterns/EmptyState.tsx
@@ -7,9 +7,48 @@ interface EmptyStateProps {
   description?: string
   action?: ReactNode
   className?: string
+  /**
+   * `default` (the editorial dashed-border block) is what most page-level
+   * empty states use. `compact` is for nested containers (inside a Card,
+   * a Modal, or a small sidebar panel) where a second dashed border would
+   * double up and read as heavy — it drops the border/bg and reduces
+   * padding so the empty message reads as restrained inline copy.
+   */
+  variant?: "default" | "compact"
 }
 
-export function EmptyState({ icon, title, description, action, className }: EmptyStateProps) {
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+  variant = "default",
+}: EmptyStateProps) {
+  if (variant === "compact") {
+    return (
+      <div
+        className={cn(
+          "animate-fade-in flex flex-col items-center justify-center gap-2 px-4 py-6 text-center",
+          className,
+        )}
+      >
+        {icon && (
+          <span className="text-muted-foreground/80 [&_svg]:h-5 [&_svg]:w-5">
+            {icon}
+          </span>
+        )}
+        <p className="text-sm text-muted-foreground">{title}</p>
+        {description && (
+          <p className="max-w-md text-xs text-muted-foreground/80">
+            {description}
+          </p>
+        )}
+        {action && <div className="pt-1">{action}</div>}
+      </div>
+    )
+  }
+
   return (
     <div
       className={cn(

--- a/frontend/src/pages/Calendar/SelectedDayPanel.tsx
+++ b/frontend/src/pages/Calendar/SelectedDayPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { BookOpen, CalendarDays, Clock } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/patterns";
 import type { CalendarEvent } from "@/types";
 import { getEventColor } from "./constants";
 import { formatTime } from "./utils";
@@ -29,9 +30,11 @@ export function SelectedDayPanel({ selectedDay, events }: SelectedDayPanelProps)
       </CardHeader>
       <CardContent>
         {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-3 text-center">
-            {t("calendar.selectedDayEmpty")}
-          </p>
+          <EmptyState
+            variant="compact"
+            icon={<CalendarDays strokeWidth={1.75} aria-hidden />}
+            title={t("calendar.selectedDayEmpty")}
+          />
         ) : (
           <div className="space-y-2">
             {events.map((evt) => {

--- a/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
+++ b/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
@@ -2,6 +2,7 @@ import { Clock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/patterns";
 import type { CalendarEvent } from "@/types";
 import { getEventColor } from "./constants";
 import { formatShortDate, formatTime, isOverdue } from "./utils";
@@ -26,7 +27,11 @@ export function UpcomingEventsPanel({ events }: UpcomingEventsPanelProps) {
       </CardHeader>
       <CardContent>
         {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-4 text-center">{t("calendar.upcomingEmpty")}</p>
+          <EmptyState
+            variant="compact"
+            icon={<Clock strokeWidth={1.75} aria-hidden />}
+            title={t("calendar.upcomingEmpty")}
+          />
         ) : (
           <div className="space-y-2">
             {events.map((evt) => {

--- a/frontend/src/pages/Course/detail/MaterialsModal.tsx
+++ b/frontend/src/pages/Course/detail/MaterialsModal.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next"
-import { Modal } from "@/components/patterns"
+import { EmptyState, Modal } from "@/components/patterns"
 import { Button } from "@/components/ui/button"
-import { Download } from "lucide-react"
+import { Download, Paperclip } from "lucide-react"
 import type { CourseMaterial } from "./types"
 
 interface Props {
@@ -23,9 +23,11 @@ export function MaterialsModal({
   return (
     <Modal open={open} onClose={onClose} title={t("courseDetail.materialsModal.title")}>
       {materials.length === 0 ? (
-        <p className="text-sm text-muted-foreground text-center py-6">
-          {t("courseDetail.materialsModal.empty")}
-        </p>
+        <EmptyState
+          variant="compact"
+          icon={<Paperclip strokeWidth={1.75} aria-hidden />}
+          title={t("courseDetail.materialsModal.empty")}
+        />
       ) : (
         <div className="divide-y rounded-md border text-sm">
           {materials.map((file) => (

--- a/frontend/src/pages/Teacher/TeacherAnalytics.tsx
+++ b/frontend/src/pages/Teacher/TeacherAnalytics.tsx
@@ -6,7 +6,7 @@ import PageSpinner from "@/components/ui/PageSpinner"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
 import { ArrowLeft, Users, TrendingUp, Award, Calendar, BarChart3, ClipboardList, UserCheck } from "lucide-react"
-import { ErrorState, StatCard } from "@/components/patterns"
+import { EmptyState, ErrorState, StatCard } from "@/components/patterns"
 import { formatDate } from "@/i18n/format"
 
 interface AnalyticsEnrollment {
@@ -154,9 +154,11 @@ export default function TeacherAnalytics() {
         </CardHeader>
         <CardContent>
           {analytics.enrollments.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-8 text-center">
-              {t("teacherAnalytics.enrollments.emptyText")}
-            </p>
+            <EmptyState
+              variant="compact"
+              icon={<Users strokeWidth={1.75} aria-hidden />}
+              title={t("teacherAnalytics.enrollments.emptyText")}
+            />
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">

--- a/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Megaphone, Trash2 } from "lucide-react"
-import { Modal } from "@/components/patterns"
+import { EmptyState, Modal } from "@/components/patterns"
 import type { Announcement } from "@/types"
 import { formatDateTime } from "@/i18n/format"
 
@@ -56,9 +56,11 @@ export function AnnouncementsModal({
           </Button>
         </div>
         {announcements.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-4">
-            {t("teacherEditor.modals.announcements.empty")}
-          </p>
+          <EmptyState
+            variant="compact"
+            icon={<Megaphone strokeWidth={1.75} aria-hidden />}
+            title={t("teacherEditor.modals.announcements.empty")}
+          />
         ) : (
           <div className="space-y-2 max-h-60 overflow-y-auto">
             {announcements.map((a) => (

--- a/frontend/src/pages/Teacher/editor/EventsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/EventsModal.tsx
@@ -3,8 +3,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { Pencil, Save, Trash2 } from "lucide-react"
-import { Modal } from "@/components/patterns"
+import { CalendarDays, Pencil, Save, Trash2 } from "lucide-react"
+import { EmptyState, Modal } from "@/components/patterns"
 import { EventTypeBadge } from "./badges"
 import type { EventFormState } from "./types"
 import type { CourseEvent } from "@/types"
@@ -106,9 +106,11 @@ export function EventsModal({
         </div>
 
         {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-4">
-            {t("teacherEditor.modals.events.empty")}
-          </p>
+          <EmptyState
+            variant="compact"
+            icon={<CalendarDays strokeWidth={1.75} aria-hidden />}
+            title={t("teacherEditor.modals.events.empty")}
+          />
         ) : (
           <div className="space-y-2 max-h-72 overflow-y-auto">
             {events.map((event) => (

--- a/frontend/src/pages/Teacher/editor/MaterialsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/MaterialsModal.tsx
@@ -2,7 +2,7 @@ import type { Ref } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Download, Loader2, Paperclip, X } from "lucide-react"
-import { Modal } from "@/components/patterns"
+import { EmptyState, Modal } from "@/components/patterns"
 import type { MaterialFile } from "./types"
 
 interface Props {
@@ -56,9 +56,11 @@ export function MaterialsModal({
           onChange={onUploadChange}
         />
         {materials.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-6">
-            {t("teacherEditor.modals.materials.empty")}
-          </p>
+          <EmptyState
+            variant="compact"
+            icon={<Paperclip strokeWidth={1.75} aria-hidden />}
+            title={t("teacherEditor.modals.materials.empty")}
+          />
         ) : (
           <div className="space-y-2 max-h-60 overflow-y-auto">
             {materials.map((m) => (

--- a/frontend/src/pages/Teacher/gradebook/SummaryTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/SummaryTab.tsx
@@ -3,10 +3,11 @@ import { useTranslation, Trans } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { EmptyState } from "@/components/patterns"
 import {
   ChevronDown, ChevronRight,
   ArrowUp, ArrowDown, ArrowUpDown,
-  Save, Award, MessageSquare,
+  Save, Award, MessageSquare, Users,
 } from "lucide-react"
 import type {
   GradingConfig,
@@ -108,7 +109,11 @@ export function SummaryTab({
       </CardHeader>
       <CardContent>
         {studentCount === 0 ? (
-          <p className="text-sm text-muted-foreground py-8 text-center">{t("gradebook.summary.empty")}</p>
+          <EmptyState
+            variant="compact"
+            icon={<Users strokeWidth={1.75} aria-hidden />}
+            title={t("gradebook.summary.empty")}
+          />
         ) : (
           <div className="overflow-x-auto">
             <div className="grid grid-cols-[1fr_80px_80px_90px_80px_70px_70px] gap-3 px-4 py-3 border-b bg-muted/30 rounded-t-lg min-w-[700px]">


### PR DESCRIPTION
## Summary

`<EmptyState>`'s current dashed-border + 40px-icon-badge + serif
title is the right shape for page-level "no data yet" — but inside
a Card or a Modal it doubles the border and the badge reads as
heavy. We had ~14 places using an ad-hoc
`<p className="text-sm text-muted-foreground py-N text-center">{t("...empty")}</p>`
to dodge that, which gave us a parallel pattern with no icon and
inconsistent vertical padding.

This PR adds `variant="compact"` to `EmptyState` (icon + title +
optional description + optional action, no border, smaller padding)
and migrates the 8 most visible offenders. The default variant is
untouched — page-level callers keep their look.

## Sites migrated

| Path | Icon |
|---|---|
| `Calendar/UpcomingEventsPanel` | `Clock` |
| `Calendar/SelectedDayPanel` | `CalendarDays` |
| `Course/detail/MaterialsModal` | `Paperclip` |
| `Teacher/editor/EventsModal` | `CalendarDays` |
| `Teacher/editor/MaterialsModal` | `Paperclip` |
| `Teacher/editor/AnnouncementsModal` | `Megaphone` |
| `Teacher/gradebook/SummaryTab` | `Users` |
| `Teacher/TeacherAnalytics` (enrollments) | `Users` |

No new i18n keys. Titles reuse the existing `*.empty` translation
keys; description is intentionally omitted (the title alone is
enough at this density).

## Skipped (and why)

- `components/quiz/editor/QuizEditView`, `assignment/AssignmentEditor`,
  `assignment/editor/AssignmentItem`, `editor/ChapterBlockEditor`,
  `course/CourseReviews` — they use their own dashed-border boxes
  that are styled to match the surrounding editor panes. Replacing
  them adds churn without obvious win; can be a follow-up if the
  designer agrees.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 112/112 passing
- [ ] Visual: open Teacher Editor modals (events, materials,
      announcements) on an empty course; open Calendar with no
      upcoming events; open Course detail with no materials —
      confirm the empty state reads as a calm caption, not a
      framed box-inside-a-box.

Generated with [Claude Code](https://claude.com/claude-code)
