### PR TITLE
docs(i18n): bilingual workflow guide

### DIFF
--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -1,0 +1,221 @@
+# Bilingual workflow (RU ↔ EN)
+
+Equip is bilingual by default. Every user-facing string in the UI exists
+in both Russian and English, and every teacher-authored field (course,
+module, chapter, quiz, assignment, announcement, cohort, event, …) is
+auto-translated to the other locale by the backend pipeline. This
+document covers the **UI side** — the `react-i18next` workflow that
+contributors interact with day-to-day. The backend translation pipeline
+is described in the `Unreleased` section of [CHANGELOG.md](../CHANGELOG.md);
+the registry lives in `backend/app/services/translation/registry.py`.
+
+## How locale resolution works
+
+[`frontend/src/i18n/config.ts`](../frontend/src/i18n/config.ts) is the
+single bootstrap. Resolution order:
+
+1. The explicit setting on the authenticated profile (`user.preferred_locale`)
+   once `LocaleSync` mounts.
+2. The persisted choice in `localStorage` (key `equip:locale`).
+3. `navigator.language`.
+4. Hard-coded fallback `ru` — the project was launched in Russian and
+   every existing course is authored in it.
+
+The active locale also gets mirrored onto `<html lang>` so screen
+readers, browser translation toolbars, and CSS `:lang(...)` selectors
+all line up.
+
+## Where the strings live
+
+```
+frontend/src/i18n/
+  config.ts              i18next bootstrap (resolution order, plurals, dev guard)
+  format.ts              locale-aware date / number helpers
+  useLocaleSync.ts       writes auth-profile locale back into i18next
+  locales/
+    en.json              English bundle  (~1200 keys)
+    ru.json              Russian bundle  (~1250 keys — extra keys are RU-only plural variants)
+  __tests__/
+    keyCoverage.test.ts  every literal t("...") in the tree must resolve in BOTH bundles
+```
+
+Each bundle is a single nested JSON object. Dot-separated keys like
+`certificate.status.approved` map onto `{ certificate: { status: { approved: "…" } } }`.
+Keep namespaces shallow — at most three levels deep — and group by
+**feature**, not by component file.
+
+## The three guards (parity is enforced, not aspirational)
+
+Bilingual drift would be invisible until a user hit the page in the
+non-default locale and saw the raw key (or worse, a fallback string).
+Three layers prevent that:
+
+1. **CI parity script** —
+   [`frontend/scripts/i18n-check.mjs`](../frontend/scripts/i18n-check.mjs)
+   (`npm run i18n:check`). Flattens both bundles to dot-paths and fails
+   if any EN key is missing from RU (or vice versa, accounting for the
+   RU-only `_few` / `_many` plural suffixes). Run locally before pushing.
+2. **`missingKeyHandler` in `config.ts`** — throws in `test` mode,
+   logs an error in `development`. A test rendering a component whose
+   `t("foo.bar")` doesn't resolve fails immediately rather than
+   pass with the raw key as the fallback.
+3. **`keyCoverage` Vitest test** —
+   [`frontend/src/i18n/__tests__/keyCoverage.test.ts`](../frontend/src/i18n/__tests__/keyCoverage.test.ts).
+   Scans every `.ts` / `.tsx` file in `src/` for literal `t("…")` calls
+   and asserts that each key (or one of its plural variants) exists in
+   both bundles. Catches keys added in source without a corresponding
+   JSON entry, even if no other test happens to render the component.
+
+If any of these fails, fix the JSON — don't silence the guard.
+
+## Plural categories
+
+Russian has three plural categories that English doesn't:
+
+| Suffix    | EN   | RU   | Example range |
+|-----------|------|------|---------------|
+| `_one`    | yes  | yes  | 1, 21, 31, … (Russian uses it for "ends in 1 except 11"). |
+| `_few`    | no   | yes  | 2-4, 22-24, … ("ends in 2-4 except 12-14"). |
+| `_many`   | no   | yes  | 0, 5-20, 25-30, … ("everything else", including zero). |
+| `_other`  | yes  | yes  | "the rest" — for English, anything ≠ 1. |
+
+i18next resolves the base key at render time from `count`. From a
+caller's perspective, you just write the base key:
+
+```tsx
+t("quiz.nQuestions", { count: questions.length })
+```
+
+In `en.json`:
+
+```jsonc
+{
+  "quiz": {
+    "nQuestions_one":   "{{count}} question",
+    "nQuestions_other": "{{count}} questions"
+  }
+}
+```
+
+In `ru.json`:
+
+```jsonc
+{
+  "quiz": {
+    "nQuestions_one":  "{{count}} вопрос",
+    "nQuestions_few":  "{{count}} вопроса",
+    "nQuestions_many": "{{count}} вопросов"
+  }
+}
+```
+
+The CI parity check knows that `_few` / `_many` are RU-only and won't
+flag them as missing on the EN side, as long as the base key has a
+plural form (`_one` or `_other`) on the EN side.
+
+## Adding a new translation key
+
+1. Decide the dot-path. Group by feature
+   (`certificate.status.approved`), not by file (`CertificatePage.title`).
+2. Add it to **both** `en.json` and `ru.json`. The CI parity guard will
+   block a one-sided edit.
+3. If the value depends on a count, use a plural — add `_one` / `_other`
+   on the EN side and `_one` / `_few` / `_many` on the RU side.
+4. Call `t("your.key")` from the component. Do **not** concatenate
+   strings to build a key dynamically (`t(\`prefix.${variant}\`)`) — the
+   `keyCoverage` static check can't verify dynamic keys and they're a
+   maintenance trap. If you have a finite set of variants, write a
+   `switch` or lookup table that returns the literal key.
+
+### Adding a key for a DB-persisted enum value
+
+When the enum lives in Postgres (course status, quiz type, certificate
+status, audit-log action, etc.), the same value appears in four places
+that have to stay in sync — see [CONTRIBUTING.md → "Four-way enum mirror"](../CONTRIBUTING.md#backend--frontend--database-the-four-way-enum-mirror).
+For the **i18n side**, the convention is:
+
+```
+{
+  "<entity>": {
+    "<field>": {
+      "<value>": "Human-readable label"
+    }
+  }
+}
+```
+
+Real examples:
+
+- `certificate.status.pending` / `certificate.status.approved` / `certificate.status.rejected`
+- `course.status.draft` / `course.status.published`
+- `audit.action.user.role_changed` / `audit.action.course.published`
+
+The TS `const` (e.g. `STATUSES.APPROVED`) is what your component
+reaches for; the bare `"approved"` string is what comes back from the
+API. Resist the temptation to write
+`t(\`certificate.status.\${status}\`)` — a template literal makes the
+key invisible to the `keyCoverage` static check, so a missing JSON
+entry won't fail at PR time. **Use a lookup table instead:**
+
+```tsx
+import { CERTIFICATE_STATUSES, type CertificateStatus } from "@/types"
+
+const CERTIFICATE_STATUS_LABEL_KEY: Record<CertificateStatus, string> = {
+  pending: "certificate.status.pending",
+  teacher_approved: "certificate.status.teacherApproved",
+  approved: "certificate.status.approved",
+  rejected: "certificate.status.rejected",
+}
+
+<Badge variant="successSubtle">
+  {t(CERTIFICATE_STATUS_LABEL_KEY[cert.status])}
+</Badge>
+```
+
+That way the `t()` call site stays a string literal that the
+`keyCoverage` test can see, and adding a new enum value forces you to
+update the Record (TypeScript will fail if you miss one).
+
+## Editing the JSON bundles safely
+
+The locale files are large (1200+ keys each). Hand-editing them in a
+text editor is error-prone — you can easily duplicate a key, break the
+JSON, or leave the bundles out of parity.
+
+Safe-edit recipe:
+
+- **Add or rename** — open both files in the same editor session, do
+  the edit twice in parallel, then run `npm run i18n:check` before
+  staging. The script's `--json` mode is parseable if you want to wire
+  it into a custom workflow.
+- **Bulk renames** — use a Node script (or Python's `json.load` /
+  `json.dump` with `ensure_ascii=False` and `indent=2`) rather than
+  sed/awk. JSON is too easy to corrupt with regex.
+- **Reordering** — keep both files in the same key order if you can,
+  but i18next doesn't care about order. The parity script doesn't
+  either. Don't reorder just to "tidy up" inside an unrelated PR —
+  it makes the diff unreadable.
+
+If you find yourself touching more than ~20 keys in one PR, split it
+into a refactor PR (the renames) and a feature PR (the new strings).
+
+## Locale-aware formatting
+
+For dates and numbers, use the helpers in
+[`frontend/src/i18n/format.ts`](../frontend/src/i18n/format.ts) rather
+than `Date.prototype.toLocaleString` directly. They thread the active
+i18next locale through to `Intl` and apply the project's date format
+conventions.
+
+## When to NOT use `t()`
+
+- **Brand name.** "Equip" is latin even in the Russian UI. Hard-code it.
+- **Email addresses, URLs, raw IDs.** They don't translate.
+- **Code blocks in user-authored content.** Teachers' rich-text content
+  goes through the backend translation pipeline (Gemini + canonical
+  Bible substitution), not through `t()`.
+
+If you're tempted to skip `t()` for "this is a developer-facing thing
+nobody will see in Russian," reconsider — the admin panel is in scope.
+Internal-only utilities (CLI scripts, migration files) are the only
+real exception.


### PR DESCRIPTION
## Summary

New `docs/I18N.md` — the bilingual workflow that a translator, new contributor, or AI agent can read before their first PR to avoid breaking bundle parity. Before this, the workflow was scattered across `config.ts`, `keyCoverage.test.ts`, and `i18n-check.mjs`; you had to read all three to piece it together.

Covers:

- **Locale resolution order** — auth profile → localStorage (`equip:locale`) → `navigator.language` → `ru` fallback.
- **Bundle layout and key conventions** — feature-grouped dot-paths, three-level cap.
- **The three parity guards** — `npm run i18n:check` (CI), `missingKeyHandler` (throws in test mode), `keyCoverage.test.ts` (scans every `t("…")` literal in source).
- **Plural categories** — EN `_one`/`_other` vs RU `_one`/`_few`/`_many`, with `quiz.nQuestions` as a worked example pulled from the live bundles.
- **Adding a new key** — including the don't-use-template-literals rule because the static `keyCoverage` scan can't see them.
- **DB-persisted enum values** — the `Record<EnumType, "literal.key">` lookup pattern that keeps both the TS exhaustiveness check and the `keyCoverage` check happy. Real `certificate.status.*` example.
- **Safe-edit recipe** for the 1200+-key bundles (parallel edit, no sed, run `i18n:check`).
- **Locale-aware formatting** pointer to `i18n/format.ts`.
- **When NOT to use `t()`** — brand "Equip" stays latin in RU, URLs, raw IDs, teacher-authored content (handled by Gemini pipeline).

Forward-referenced from the README (`docs/readme-refresh`) and CONTRIBUTING (`docs/contributing-guide`).

## Type of change

- [x] Documentation

## Test plan

- [x] `npm run lint` passes.
- [x] `npm run test:run` passes (112/112).
- [x] `npm run i18n:check` passes (en: 1214, ru: 1252, both in parity).
- [x] Examples match live bundle contents (`quiz.nQuestions_*` verified in `en.json:355-356` and `ru.json:361-363`).
- [ ] No code changes — no functional tests needed.
