### PR TITLE
feat(frontend): sticky unsaved-changes save bar on ChapterEditor

### DIFF
--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -310,18 +310,62 @@ export default function ChapterEditor() {
         </CardContent>
       </Card>
 
-      {/* Save button */}
+      {/* Inline save button (always visible). When the chapter is dirty,
+          a sticky reminder also appears at the bottom of the viewport. */}
       <div className="flex items-center gap-3">
         <Button onClick={save} disabled={saving}>
           {saving ? (
-            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" strokeWidth={1.75} aria-hidden />
           ) : (
-            <Save className="h-4 w-4 mr-2" />
+            <Save className="h-4 w-4 mr-2" strokeWidth={1.75} aria-hidden />
           )}
           {saving ? t("chapterEditor.saving") : t("chapterEditor.save")}
         </Button>
         <span className="text-xs text-muted-foreground">{t("chapterEditor.saveHint")}</span>
       </div>
+
+      {/* Sticky save bar — only renders while there are unsaved changes.
+          The pulsing warning dot is the visual cue for "unsaved"; the
+          accompanying text reuses the existing `saveHint` ("Ctrl+S to
+          save") string so we don't introduce a new i18n key from this
+          PR. TODO i18n: a future bilingual pass can swap the dot's
+          aria-label and add an explicit `chapterEditor.unsavedChanges`
+          status string. */}
+      {isDirty && (
+        <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-4 sm:pb-6">
+          <Card
+            role="status"
+            aria-live="polite"
+            className="pointer-events-auto animate-fade-in w-full max-w-2xl bg-card/95 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-card/85"
+          >
+            <CardContent className="flex items-center gap-3 px-4 py-3">
+              <span
+                className="relative flex h-2 w-2 shrink-0"
+                aria-hidden
+              >
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-warning/60" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-warning" />
+              </span>
+              <span className="flex-1 text-xs text-muted-foreground sm:text-sm">
+                {t("chapterEditor.saveHint")}
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                onClick={save}
+                disabled={saving}
+              >
+                {saving ? (
+                  <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" strokeWidth={1.75} aria-hidden />
+                ) : (
+                  <Save className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.75} aria-hidden />
+                )}
+                {saving ? t("chapterEditor.saving") : t("chapterEditor.save")}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

When a teacher edits a chapter the Save button lived inline at the
bottom of the page. Once the rich-text editor scrolled past it, the
only signal that there were unsaved changes was the browser's
`beforeunload` prompt — surprising, easy to lose work to.

This PR adds a small Card-shaped sticky bar pinned to the bottom of
the viewport that renders ONLY while `isDirty === true`:

- pulsing warning dot — visual "unsaved" signal
- existing `chapterEditor.saveHint` ("Ctrl+S to save") as the caption
- compact Save button (same `save()` handler as the inline one)
- `role="status"` + `aria-live="polite"` so AT announces it on appear
- dark-mode safe — semantic tokens only (`bg-card`, `bg-warning`,
  `text-muted-foreground`, `text-foreground`, `border-border`)
- backdrop-blur with `supports-[backdrop-filter]` fallback
- wrapper is `pointer-events-none` so it doesn't block clicks
  outside the bar

The inline Save button is preserved — the sticky bar is purely
additive. The existing Ctrl+S handler is unaffected.

## i18n note

The bar deliberately doesn't introduce a new `chapterEditor.unsavedChanges`
string — the pulsing warning dot carries the "unsaved" meaning
visually, and the saveHint caption is already bilingual. A future
bilingual pass can swap the caption for an explicit
"Unsaved changes" string. Left a TODO at the call site.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 112/112 (i18n key-coverage included)
- [ ] Visual: edit a chapter (e.g. change the title), confirm the
      bar fades in at bottom-center, dot pulses, Save button works,
      bar disappears after save settles
- [ ] Dark theme parity
- [ ] Mobile width (sm:) — bar still readable, padding scales

Generated with [Claude Code](https://claude.com/claude-code)
