### PR TITLE
fix(i18n): Profile role label uses ROLE_I18N_KEY, helper moved to lib/

### DIFF
--- a/frontend/src/lib/roles.ts
+++ b/frontend/src/lib/roles.ts
@@ -1,0 +1,33 @@
+import type { UserRole } from "@/types"
+
+/**
+ * Single source of truth for mapping a ``UserRole`` enum value (which
+ * mirrors Pydantic / Postgres ``CHECK`` constraint) to its i18n key.
+ *
+ * The camelCase keys (``pendingTeacher``) are i18next conventions; the
+ * snake_case role values (``pending_teacher``) mirror the API contract.
+ * The bridge lives here so every component that needs to render a role
+ * — Profile, Admin dashboard, virtualised admin table, useAdminOverview
+ * — uses the same lookup instead of re-deriving it.
+ */
+export const ROLE_I18N_KEY: Record<UserRole, string> = {
+  student: "roles.student",
+  pending_teacher: "roles.pendingTeacher",
+  teacher: "roles.teacher",
+  admin: "roles.admin",
+}
+
+/**
+ * Maps each role to its ``<Badge>`` colour variant. Kept next to the
+ * i18n map because both are display-time concerns; the same Profile +
+ * Admin surfaces use both together.
+ */
+export const ROLE_BADGE_VARIANT: Record<
+  UserRole,
+  "destructiveSubtle" | "primarySubtle" | "warningSubtle" | "infoSubtle"
+> = {
+  admin: "destructiveSubtle",
+  teacher: "primarySubtle",
+  pending_teacher: "warningSubtle",
+  student: "infoSubtle",
+}

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -1,5 +1,9 @@
 import type { UserRole } from "@/types"
 
+// Re-export from the shared location so Profile + other surfaces can
+// use the same role i18n mapping without depending on Admin pages.
+export { ROLE_I18N_KEY, ROLE_BADGE_VARIANT } from "@/lib/roles"
+
 export type AdminTab = "overview" | "cohorts" | "audit"
 export const ADMIN_TABS: readonly AdminTab[] = ["overview", "cohorts", "audit"]
 
@@ -43,33 +47,6 @@ export const ACTION_BADGE_VARIANT: Record<
   approve: "successSubtle",
   reject: "destructiveSubtle",
   grade: "warningSubtle",
-}
-
-/** Maps each role to its i18n key. Use with ``useTranslation().t`` to
- * render localized role labels — never hardcode the English values.
- *
- * The camelCase keys (``pendingTeacher``) are i18next conventions; the
- * snake_case role values (``pending_teacher``) mirror the Pydantic /
- * Postgres CHECK constraint. The mapping lives here so the bridge is
- * a single source of truth instead of being re-derived in every
- * component that needs to render a role.
- */
-export const ROLE_I18N_KEY: Record<UserRole, string> = {
-  student: "roles.student",
-  pending_teacher: "roles.pendingTeacher",
-  teacher: "roles.teacher",
-  admin: "roles.admin",
-}
-
-/** Maps each role to its `<Badge>` variant. */
-export const ROLE_BADGE_VARIANT: Record<
-  UserRole,
-  "destructiveSubtle" | "primarySubtle" | "warningSubtle" | "infoSubtle"
-> = {
-  admin: "destructiveSubtle",
-  teacher: "primarySubtle",
-  pending_teacher: "warningSubtle",
-  student: "infoSubtle",
 }
 
 export interface ProfileRow {

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -14,6 +14,7 @@ import { storageService } from "@/services/storage"
 import { coursesService } from "@/services/courses"
 import { makeProfileSchema } from "@/lib/validations/course"
 import { toProxyImage } from "@/lib/images"
+import { ROLE_I18N_KEY } from "@/lib/roles"
 import { formatDate } from "@/i18n/format"
 import { toast } from "@/lib/toast"
 import {
@@ -184,7 +185,7 @@ export default function ProfilePage() {
                   ariaLabel={t("profile.editName")}
                   textClassName="tracking-tight"
                 />
-                <CardDescription className="text-sm capitalize">{user.role}</CardDescription>
+                <CardDescription className="text-sm">{t(ROLE_I18N_KEY[user.role])}</CardDescription>
               </div>
             </div>
           </CardHeader>
@@ -252,7 +253,7 @@ export default function ProfilePage() {
                 <Shield className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
                 <div>
                   <dt className="text-xs text-muted-foreground">{t("profile.role")}</dt>
-                  <dd className="text-sm font-medium capitalize">{user.role}</dd>
+                  <dd className="text-sm font-medium">{t(ROLE_I18N_KEY[user.role])}</dd>
                 </div>
               </div>
               {user.created_at && (


### PR DESCRIPTION
## Summary

Profile page rendered `{user.role}` raw in two places (name subtitle + Account Details "Role" row) with `capitalize` CSS — RU users saw `Student`, EN users saw `pending_teacher` with the underscore visible.

- New `lib/roles.ts` holds `ROLE_I18N_KEY` + `ROLE_BADGE_VARIANT` — single source of truth for role display, no layering violation for non-Admin pages.
- Re-exported from old `Admin/dashboard/constants.ts` so all 4 existing callsites (`UsersCard`, `VirtualAdminUsers`, `useAdminOverview`) keep working — zero churn.
- Profile uses `t(ROLE_I18N_KEY[user.role])` in both spots; `capitalize` class dropped (translated strings come out already-cased).

No new i18n keys needed — `roles.*` already existed in both locales.

## Test plan

- [x] `keyCoverage` guard test passes
- [x] Full vitest run — 112/112 green
- [x] `eslint --max-warnings 0` clean
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
