### PR TITLE
style(frontend): polish TeacherAnalytics + Gradebook loading states

### DIFF
--- a/frontend/src/pages/Teacher/TeacherAnalytics.tsx
+++ b/frontend/src/pages/Teacher/TeacherAnalytics.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { useParams, Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
-import PageSpinner from "@/components/ui/PageSpinner"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
 import { ArrowLeft, Users, TrendingUp, Award, Calendar, BarChart3, ClipboardList, UserCheck } from "lucide-react"
@@ -79,7 +79,7 @@ export default function TeacherAnalytics() {
   }).length ?? 0
 
   if (loading) {
-    return <PageSpinner />
+    return <TeacherAnalyticsSkeleton />
   }
 
   if (!analytics) {
@@ -117,8 +117,8 @@ export default function TeacherAnalytics() {
           </Button>
         </Link>
         <div className="flex-1">
-          <h1 className="text-3xl font-serif font-bold tracking-tight flex items-center gap-2">
-            <BarChart3 className="h-7 w-7 text-primary" />
+          <h1 className="flex items-center gap-2 font-serif text-3xl font-bold tracking-tight">
+            <BarChart3 className="h-6 w-6 shrink-0 text-primary" strokeWidth={1.75} aria-hidden />
             {t("teacherAnalytics.heading")}
           </h1>
           {courseTitle && (
@@ -201,6 +201,35 @@ export default function TeacherAnalytics() {
           )}
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+/**
+ * Shimmer placeholder for the analytics page. Mirrors the real layout
+ * (back button + serif H1, four stat cards, enrolments card) so the
+ * page doesn't jump when data resolves.
+ */
+function TeacherAnalyticsSkeleton() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-5xl" aria-busy="true">
+      <div className="flex items-center gap-3 mb-8">
+        <Skeleton className="h-8 w-8 shrink-0 rounded-md" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-8 w-64 max-w-full" />
+          <Skeleton className="h-4 w-40 max-w-full" />
+        </div>
+        <Skeleton className="hidden sm:block h-9 w-32" />
+        <Skeleton className="hidden sm:block h-9 w-28" />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-md" />
+        ))}
+      </div>
+
+      <Skeleton className="h-64 rounded-md" />
     </div>
   )
 }

--- a/frontend/src/pages/Teacher/TeacherGradebook.tsx
+++ b/frontend/src/pages/Teacher/TeacherGradebook.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useParams, useSearchParams, Link } from "react-router-dom"
-import PageSpinner from "@/components/ui/PageSpinner"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
 import type { GradingConfig, GradeSummaryResponse, StudentGrade } from "@/types"
@@ -257,7 +257,7 @@ export default function TeacherGradebook() {
     )
   }, [progressData])
 
-  if (loading) return <PageSpinner />
+  if (loading) return <TeacherGradebookSkeleton />
 
   if (error) {
     return (
@@ -364,6 +364,41 @@ export default function TeacherGradebook() {
           onToggleExpand={toggleExpand}
         />
       )}
+    </div>
+  )
+}
+
+/**
+ * Shimmer placeholder for the gradebook page. Mirrors the real layout
+ * (breadcrumb, serif H1 with export button, stats row, tabs, summary
+ * card) so the page doesn't jump when data resolves.
+ */
+function TeacherGradebookSkeleton() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-7xl" aria-busy="true">
+      <div className="mb-6 flex items-center gap-2">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-4 w-4 rounded-full" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <Skeleton className="h-9 w-64 max-w-full" />
+          <Skeleton className="h-4 w-40 max-w-full" />
+        </div>
+        <Skeleton className="h-9 w-28" />
+      </div>
+
+      <div className="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-md" />
+        ))}
+      </div>
+
+      <Skeleton className="mb-6 h-10 w-72 max-w-full" />
+
+      <Skeleton className="h-96 rounded-md" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Visual polish audit on the teacher tools focus pages. Two small but
visible inconsistencies fixed:

### 1. `PageSpinner` → layout-matching `Skeleton` on the two heaviest teacher pages

`TeacherAnalytics` and `TeacherGradebook` both did
`if (loading) return <PageSpinner />` — a centred spinner with no
relationship to the page that's about to render. This PR replaces
each with a shimmering `Skeleton` that mirrors the real layout
(breadcrumb, serif H1, four-up StatCard row, body card/table). Same
direction the Teacher Dashboard already went in #247, just applied
to the next two pages in the same surface.

### 2. `TeacherAnalytics` H1 icon size

The `BarChart3` icon in the page heading was `h-7 w-7` (28px) — off
the 16/20/24 design-system grid. Every other H1 icon in the
platform (Gradebook's Award, Calendar's CalendarDays, Certificates,
StudentProgress) uses `h-6 w-6` (24px). Drop to match, and pick up
the `strokeWidth={1.75}` + `aria-hidden` + `shrink-0` that the
design rules require.

Also tightened the className token order on the H1 so it reads
`flex items-center gap-2 font-serif text-3xl font-bold tracking-tight`
exactly like TeacherGradebook's.

## Things checked but not changed

- No raw Tailwind palette colours leak in any page (`text-red-500`,
  `bg-blue-500` etc.) — already on semantic tokens.
- Spacing already on the 4px grid (the `0.5`/`1.5`/`2.5`/`3.5` Tailwind
  half-steps are 2/6/10/14px and used deliberately for chip-level
  density).
- `h-3 w-3` (12px) icons inside small status pills are intentionally
  below the 16/20/24 grid — bumping them to 16 crowds the pill.
  Left as-is.
- Profile and CourseEditor don't use `<h1>` (InlineEdit + PageHeader
  patterns); no font-serif drift to fix there.
- Profile's `if (!user) return <PageSpinner />` is a brief
  auth-context guard, not a page-data fetch — kept as the small
  spinner since a full Profile skeleton would overshoot.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 112/112
- [ ] Visual: open Teacher Analytics + Gradebook in both themes;
      confirm the skeleton echoes the real layout and the
      Analytics H1 icon aligns with the heading baseline.

Generated with [Claude Code](https://claude.com/claude-code)
