### PR TITLE
refactor(admin): role badge IS the role selector

### DIFF
--- a/frontend/src/components/admin/RoleSelector.tsx
+++ b/frontend/src/components/admin/RoleSelector.tsx
@@ -1,0 +1,94 @@
+import { useTranslation } from "react-i18next"
+import { Check, ChevronDown } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import { ROLE_BADGE_VARIANT, ROLE_I18N_KEY } from "@/lib/roles"
+import type { UserRole } from "@/types"
+
+interface Props {
+  role: UserRole
+  disabled?: boolean
+  onChange: (next: UserRole) => void
+  /** Optional label for assistive tech, e.g. "Change role for John Doe". */
+  ariaLabel?: string
+}
+
+const ROLE_ORDER: UserRole[] = ["student", "pending_teacher", "teacher", "admin"]
+
+/**
+ * The role badge IS the role picker — no separate select alongside.
+ *
+ * Replaces the previous ``<Badge /> + <NativeSelect />`` pair that
+ * showed the current role twice (once as a coloured pill, once as the
+ * selected option in the dropdown). One affordance, one place to
+ * click. Keyboard works: ``Enter`` / ``Space`` opens the menu, arrows
+ * navigate, ``Esc`` closes.
+ *
+ * When ``disabled`` is true (e.g. the actor is editing their own row)
+ * the badge renders flat without the dropdown chevron, signalling
+ * read-only without changing the layout of surrounding cells.
+ */
+export function RoleSelector({ role, disabled = false, onChange, ariaLabel }: Props) {
+  const { t } = useTranslation()
+
+  const badge = (
+    <Badge
+      variant={ROLE_BADGE_VARIANT[role]}
+      className={cn(
+        "gap-1.5 select-none",
+        disabled && "cursor-default",
+        !disabled &&
+          "cursor-pointer transition-shadow hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      )}
+    >
+      {t(ROLE_I18N_KEY[role])}
+      {!disabled && <ChevronDown className="h-3 w-3 opacity-70" strokeWidth={1.75} aria-hidden />}
+    </Badge>
+  )
+
+  if (disabled) {
+    return badge
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild aria-label={ariaLabel}>
+        <button
+          type="button"
+          className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          {badge}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[12rem]">
+        {ROLE_ORDER.map((value) => {
+          const selected = value === role
+          return (
+            <DropdownMenuItem
+              key={value}
+              onSelect={() => {
+                if (!selected) onChange(value)
+              }}
+              className={cn(
+                "justify-between",
+                selected && "font-medium text-foreground",
+              )}
+            >
+              <span>{t(ROLE_I18N_KEY[value])}</span>
+              {selected && (
+                <Check className="h-3.5 w-3.5 text-primary" strokeWidth={1.75} aria-hidden />
+              )}
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1318,7 +1318,8 @@
       "emptyNoMatch": "No users match your search",
       "emptyNoUsers": "No users found",
       "showing": "Showing {{shown}} of {{total}} users",
-      "missingName": "—"
+      "missingName": "—",
+      "changeRoleAria": "Change role for {{name}}"
     },
     "pendingTeachers": {
       "title": "Pending Teacher Approvals",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1356,7 +1356,8 @@
       "emptyNoMatch": "Нет пользователей по запросу",
       "emptyNoUsers": "Пользователи не найдены",
       "showing": "Показано {{shown}} из {{total}} пользователей",
-      "missingName": "—"
+      "missingName": "—",
+      "changeRoleAria": "Изменить роль для {{name}}"
     },
     "pendingTeachers": {
       "title": "Заявки преподавателей",

--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -2,12 +2,10 @@ import { List, type RowComponentProps } from "react-window"
 import { useTranslation } from "react-i18next"
 import { Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { NativeSelect } from "@/components/ui/native-select"
+import { RoleSelector } from "@/components/admin/RoleSelector"
 import { toProxyImage } from "@/lib/images"
 import type { UserRole } from "@/types"
 import { formatDate } from "@/i18n/format"
-import { ROLE_BADGE_VARIANT, ROLE_I18N_KEY } from "./dashboard/constants"
 
 interface ProfileRow {
   id: string
@@ -84,20 +82,12 @@ function UserRow({
         {u.email}
       </div>
       <div role="cell" className="px-3 flex items-center gap-2">
-        <Badge variant={ROLE_BADGE_VARIANT[u.role]}>
-          {t(ROLE_I18N_KEY[u.role])}
-        </Badge>
-        <NativeSelect
-          fieldSize="sm"
-          value={u.role}
+        <RoleSelector
+          role={u.role}
           disabled={updatingId === u.id || u.id === currentUserId}
-          onChange={(e) => onRoleChange(u.id, e.target.value as UserRole)}
-        >
-          <option value="student">{t("roles.student")}</option>
-          <option value="pending_teacher">{t("roles.pendingTeacher")}</option>
-          <option value="teacher">{t("roles.teacher")}</option>
-          <option value="admin">{t("roles.admin")}</option>
-        </NativeSelect>
+          onChange={(next) => onRoleChange(u.id, next)}
+          ariaLabel={t("admin.users.changeRoleAria", { name: displayName })}
+        />
       </div>
       <div role="cell" className="px-3 text-muted-foreground">
         {formatDate(u.created_at)}

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -3,18 +3,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { NativeSelect } from "@/components/ui/native-select"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { Users, Search, Trash2 } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import PageSpinner from "@/components/ui/PageSpinner"
 import VirtualAdminUsers from "../VirtualAdminUsers"
+import { RoleSelector } from "@/components/admin/RoleSelector"
 import type { UserRole } from "@/types"
 import { formatDate } from "@/i18n/format"
-import {
-  type ProfileRow,
-  ROLE_BADGE_VARIANT,
-  ROLE_I18N_KEY,
-} from "./constants"
+import { type ProfileRow } from "./constants"
 
 /**
  * Above this row count we swap the full <table> render for a react-window
@@ -303,22 +299,12 @@ function UserRow({
       </td>
       <td className="px-6 py-3 text-muted-foreground">{user.email}</td>
       <td className="px-6 py-3">
-        <div className="flex items-center gap-2">
-          <Badge variant={ROLE_BADGE_VARIANT[user.role]}>
-            {t(ROLE_I18N_KEY[user.role])}
-          </Badge>
-          <NativeSelect
-            fieldSize="sm"
-            value={user.role}
-            disabled={updating || isSelf}
-            onChange={(e) => onRoleChange(user.id, e.target.value as UserRole)}
-          >
-            <option value="student">{t("roles.student")}</option>
-            <option value="pending_teacher">{t("roles.pendingTeacher")}</option>
-            <option value="teacher">{t("roles.teacher")}</option>
-            <option value="admin">{t("roles.admin")}</option>
-          </NativeSelect>
-        </div>
+        <RoleSelector
+          role={user.role}
+          disabled={updating || isSelf}
+          onChange={(next) => onRoleChange(user.id, next)}
+          ariaLabel={t("admin.users.changeRoleAria", { name: displayName })}
+        />
       </td>
       <td className="px-6 py-3 text-muted-foreground">
         {formatDate(user.created_at)}


### PR DESCRIPTION
## Summary

Fixes a specific UX papercut Vadym flagged: the admin Users table showed each user's role **twice** — once as a coloured `<Badge>` and again as the selected option of an adjacent `<NativeSelect>`. Two controls for one value.

Collapsed to a single `<RoleSelector>` (new component under `components/admin/`):

- Click the badge itself → Radix `DropdownMenu` with the four role options + a check mark next to the current one.
- Keyboard: `Enter`/`Space` opens, arrows navigate, `Esc` closes. Focus ring on the badge button.
- `aria-label` interpolates the user's name (`"Change role for John Doe"`).
- Disabled (actor's own row): renders flat without the chevron — clear read-only signal without breaking column alignment.

Replaces the pair in both the small-table renderer (`UsersCard.UserRow`) and the react-window virtualised list (`VirtualAdminUsers`).

## Companion design audit

Vadym noted "many similar errors everywhere — work on design and CSS overall". An Opus design-audit agent is running in parallel to find and fix the same kind of pattern across Admin / Teacher / Course Editor / Forms.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 112/112 passing
- [ ] Manual: open `/admin` users table → click any badge → menu opens; pick a role → it changes; tab into the badge → focus ring; try on own row → flat badge, no dropdown. EN + RU; light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
