### PR TITLE
mobile: tighten HomePage spacing and bump small text

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -92,7 +92,7 @@ function CourseCard({ course, style }: CourseCardProps) {
           {course.title}
         </CardTitle>
         {course.description && (
-          <CardDescription className="line-clamp-2 text-xs leading-relaxed text-wrap-safe">
+          <CardDescription className="line-clamp-2 text-sm leading-relaxed text-wrap-safe sm:text-xs">
             {course.description}
           </CardDescription>
         )}

--- a/frontend/src/components/home/VerseOfTheDayCard.tsx
+++ b/frontend/src/components/home/VerseOfTheDayCard.tsx
@@ -66,7 +66,7 @@ export function VerseOfTheDayCard() {
             />
           </div>
           <div className="min-w-0">
-            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
               {t("home.votd.eyebrow")}
             </p>
             <h2
@@ -89,15 +89,15 @@ export function VerseOfTheDayCard() {
           </div>
         ) : (
           <figure className="space-y-4">
-            <blockquote className="font-serif text-base leading-relaxed text-foreground sm:text-[17px]">
+            <blockquote className="font-serif text-base leading-relaxed text-foreground sm:text-lg">
               &ldquo;{verse.text}&rdquo;
             </blockquote>
-            <figcaption className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs">
+            <figcaption className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm text-muted-foreground sm:text-xs">
               <cite className="not-italic font-medium text-foreground">
                 {verse.reference}
               </cite>
-              <span className="text-muted-foreground">·</span>
-              <span className="text-muted-foreground">{verse.version}</span>
+              <span aria-hidden>·</span>
+              <span>{verse.version}</span>
             </figcaption>
           </figure>
         )}

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -228,7 +228,7 @@ export default function HomePage() {
   }, [query, reloadKey, t])
 
   return (
-    <div className="container mx-auto px-4 py-10">
+    <div className="container mx-auto px-4 py-6 sm:py-10">
       {user && (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,1fr)]">
           {/* My Courses on the left (wide) sits next to the Verse of the
@@ -239,7 +239,7 @@ export default function HomePage() {
         </div>
       )}
 
-      <section className="relative mb-14 md:mb-20" aria-labelledby="home-catalog-heading">
+      <section className="relative mb-10 md:mb-20" aria-labelledby="home-catalog-heading">
         <div className="pointer-events-none absolute left-1/2 top-0 -z-0 h-[min(22rem,55vw)] w-[min(120vw,44rem)] -translate-x-1/2 md:h-[26rem] md:w-[52rem]">
           <div className="bg-home-hero-glow h-full w-full blur-3xl" aria-hidden />
         </div>
@@ -275,12 +275,12 @@ export default function HomePage() {
       </section>
 
       {!user && (
-        <div className="mb-8 flex items-center justify-center gap-2 rounded-md border border-border border-l-[3px] border-l-info bg-info/5 px-4 py-3">
-          <LogIn className="h-4 w-4 text-info" strokeWidth={1.75} aria-hidden="true" />
+        <div className="mb-8 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 rounded-md border border-border border-l-[3px] border-l-info bg-info/5 px-4 py-3 text-center sm:text-left">
+          <LogIn className="h-4 w-4 shrink-0 text-info" strokeWidth={1.75} aria-hidden="true" />
           <p className="text-sm text-foreground">
             <Link
               to="/login"
-              className="font-medium underline underline-offset-2 hover:no-underline"
+              className="-my-2 inline-flex min-h-[44px] items-center font-medium underline underline-offset-2 hover:no-underline sm:my-0 sm:min-h-0"
             >
               {t("home.signInLink")}
             </Link>{" "}
@@ -290,7 +290,7 @@ export default function HomePage() {
       )}
 
       {loading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-7">
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-7 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => <CourseCardSkeleton key={i} />)}
         </div>
       ) : error ? (
@@ -311,7 +311,7 @@ export default function HomePage() {
           className="border-none bg-transparent py-20"
         />
       ) : (
-        <div className="stagger-fade-in grid grid-cols-1 gap-7 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="stagger-fade-in grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-7 lg:grid-cols-3">
           {courses.map((course, index) => (
             <CourseCard
               key={course.id}


### PR DESCRIPTION
## Summary
- HomePage container uses `py-6` on mobile (40% less vertical padding than desktop) and the catalog grid drops to `gap-5` on a single column so cards feel like a connected list instead of floating tiles. Desktop (`sm+`) keeps the airy spacing.
- Catalog hero margin tightens (`mb-14 -> mb-10` on mobile) so the search input sits closer to the headline without scrolling.
- "Sign in to enroll" alert wraps cleanly on narrow screens; the sign-in link sits in a 44 px tap area on mobile, inline on `sm+`.
- `CourseCard` description: `text-sm` on mobile (full-width single column), `text-xs` on `sm+` where the card narrows in the 2/3-column grid.
- `VerseOfTheDayCard`: replaces `text-[11px]` / `text-[17px]` arbitrary px values with semantic sizes (`text-xs`, `sm:text-lg`). Mobile reference/version line bumps to `text-sm` for readability.

## Test plan
- [x] `npm run lint` zero warnings
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` all 112 tests green
- [ ] Walk dashboard at 375 / 390 / 414 — confirm My Courses + Verse stack cleanly, course cards fit, search input no zoom on focus
- [ ] Verify desktop `lg+` two-column layout (3fr/1fr) unchanged

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
