### PR TITLE
style(frontend): map arbitrary text sizes to the design-system scale

### DIFF
--- a/frontend/src/components/announcements/CourseAnnouncements.tsx
+++ b/frontend/src/components/announcements/CourseAnnouncements.tsx
@@ -35,7 +35,7 @@ export default function CourseAnnouncements({ courseId }: Props) {
           <div className="min-w-0 flex-1 text-wrap-safe">
             <h4 className="text-sm font-medium">{a.title}</h4>
             <p className="mt-1 text-xs text-muted-foreground whitespace-pre-line">{a.content}</p>
-            <time className="mt-1 block text-[10px] text-muted-foreground/60">
+            <time className="mt-1 block text-xs text-muted-foreground/60">
               {formatDate(a.created_at)}
             </time>
           </div>

--- a/frontend/src/pages/Calendar/MonthGrid.tsx
+++ b/frontend/src/pages/Calendar/MonthGrid.tsx
@@ -74,7 +74,7 @@ export function MonthGrid({
           {DAY_NAMES.map((d) => (
             <div
               key={d}
-              className="text-center text-[10px] font-medium text-muted-foreground uppercase tracking-wider py-1"
+              className="text-center text-xs font-medium text-muted-foreground uppercase tracking-wider py-1"
             >
               {d}
             </div>
@@ -115,7 +115,7 @@ export function MonthGrid({
                       return (
                         <span
                           key={evt.id}
-                          className={`block w-full rounded px-1 py-0.5 text-[9px] leading-tight truncate ${color.bg} ${color.text}`}
+                          className={`block w-full rounded px-1 py-0.5 text-xs leading-tight truncate ${color.bg} ${color.text}`}
                           title={evt.title}
                         >
                           {evt.title}
@@ -123,7 +123,7 @@ export function MonthGrid({
                       );
                     })}
                     {dayEvents.length > 3 && (
-                      <span className="text-[9px] text-muted-foreground pl-1">
+                      <span className="text-xs text-muted-foreground pl-1">
                         {t("calendar.moreEvents", { count: dayEvents.length - 3 })}
                       </span>
                     )}
@@ -134,7 +134,7 @@ export function MonthGrid({
           })}
         </div>
 
-        <div className="flex flex-wrap items-center gap-3 mt-3 text-[10px]">
+        <div className="flex flex-wrap items-center gap-3 mt-3 text-xs">
           {Object.entries(EVENT_COLORS).map(([type, color]) => (
             <span key={type} className="flex items-center gap-1">
               <span className={`w-2 h-2 rounded-full ${color.dot}`} />

--- a/frontend/src/pages/Calendar/SelectedDayPanel.tsx
+++ b/frontend/src/pages/Calendar/SelectedDayPanel.tsx
@@ -49,7 +49,7 @@ export function SelectedDayPanel({ selectedDay, events }: SelectedDayPanelProps)
                     <span className={`mt-1 w-2 h-2 rounded-full shrink-0 ${color.dot}`} />
                     <div className="flex-1 min-w-0">
                       <p className={`text-sm font-medium ${color.text}`}>{evt.title}</p>
-                      <div className="flex items-center gap-2 mt-0.5 text-[10px] text-muted-foreground">
+                      <div className="flex items-center gap-2 mt-0.5 text-xs text-muted-foreground">
                         <span className="flex items-center gap-0.5">
                           <Clock className="h-2.5 w-2.5" strokeWidth={1.75} />
                           {formatTime(evt.event_date)}
@@ -59,14 +59,14 @@ export function SelectedDayPanel({ selectedDay, events }: SelectedDayPanelProps)
                       {evt.course_title && (
                         <Link
                           to={`/courses/${evt.course_id}`}
-                          className="flex items-center gap-1 mt-1 text-[10px] text-primary hover:underline"
+                          className="flex items-center gap-1 mt-1 text-xs text-primary hover:underline"
                         >
                           <BookOpen className="h-2.5 w-2.5" strokeWidth={1.75} />
                           {evt.course_title}
                         </Link>
                       )}
                       {evt.description && (
-                        <p className="text-[10px] text-muted-foreground mt-1 line-clamp-2">
+                        <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
                           {evt.description}
                         </p>
                       )}

--- a/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
+++ b/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
@@ -55,7 +55,7 @@ export function UpcomingEventsPanel({ events }: UpcomingEventsPanelProps) {
                     >
                       {evt.title}
                     </p>
-                    <div className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
+                    <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
                       <span>{formatShortDate(evt.event_date)}</span>
                       <span>{formatTime(evt.event_date)}</span>
                       {overdue && (
@@ -63,7 +63,7 @@ export function UpcomingEventsPanel({ events }: UpcomingEventsPanelProps) {
                       )}
                     </div>
                     {evt.course_title && (
-                      <p className="text-[10px] text-muted-foreground/70 truncate mt-0.5">
+                      <p className="text-xs text-muted-foreground/70 truncate mt-0.5">
                         {evt.course_title}
                       </p>
                     )}

--- a/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
@@ -73,7 +73,7 @@ export function AnnouncementsModal({
                       {a.content}
                     </p>
                   )}
-                  <time className="text-[10px] text-muted-foreground/60 mt-1 block">
+                  <time className="mt-1 block text-xs text-muted-foreground/60">
                     {formatDateTime(a.created_at)}
                   </time>
                 </div>

--- a/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
@@ -162,7 +162,7 @@ function GradeTableHead({
           >
             <div className="flex flex-col items-center gap-0.5">
               <span className="text-muted-foreground">{chapterTypeIcon(ch.chapter_type)}</span>
-              <span className="truncate max-w-[52px] text-[10px]">{ch.title}</span>
+              <span className="truncate max-w-[52px] text-xs">{ch.title}</span>
             </div>
           </th>
         ))}
@@ -218,7 +218,7 @@ function GradeTableRow({
               <p className="truncate text-xs font-semibold max-w-[140px]">
                 {student.full_name || student.email}
               </p>
-              <p className="truncate text-[10px] text-muted-foreground max-w-[140px]">
+              <p className="truncate text-xs text-muted-foreground max-w-[140px]">
                 {student.email}
               </p>
             </div>
@@ -236,10 +236,10 @@ function GradeTableRow({
         <td className="border-b px-2 py-2 text-center">
           <div className="flex flex-col items-center">
             <span className="font-semibold text-sm">{earned}</span>
-            <span className="text-[10px] text-muted-foreground">/{total}</span>
+            <span className="text-xs text-muted-foreground">/{total}</span>
             {manualGrade?.grade && (
               <span
-                className={`mt-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-bold ${letterColor(
+                className={`mt-0.5 rounded-full px-1.5 py-0.5 text-xs font-bold ${letterColor(
                   manualGrade.grade,
                 )}`}
               >
@@ -325,7 +325,7 @@ function ChapterCell({ chapter }: { chapter: ChapterInfo | undefined }) {
           }`}
         >
           <span className="font-semibold">{pct}%</span>
-          <span className="text-[10px] opacity-70">
+          <span className="text-xs opacity-70">
             {chapter.quiz_result.score}/{chapter.quiz_result.max_score}
           </span>
         </div>
@@ -348,7 +348,7 @@ function ChapterCell({ chapter }: { chapter: ChapterInfo | undefined }) {
           {graded ? (
             <>
               <span className="font-semibold">{chapter.assignment_result.grade}pt</span>
-              <span className="text-[10px] opacity-70">{t("gradebook.table.cellGraded")}</span>
+              <span className="text-xs opacity-70">{t("gradebook.table.cellGraded")}</span>
             </>
           ) : (
             <span>{t("gradebook.table.cellSubmitted")}</span>
@@ -360,7 +360,7 @@ function ChapterCell({ chapter }: { chapter: ChapterInfo | undefined }) {
   }
 
   return (
-    <div className="flex items-center justify-center h-9 rounded bg-muted/20 text-muted-foreground/30 text-[10px]">
+    <div className="flex items-center justify-center h-9 rounded bg-muted/20 text-muted-foreground/30 text-xs">
       —
     </div>
   )
@@ -420,38 +420,38 @@ function GradeTableLegend() {
   return (
     <div className="mt-4 flex flex-wrap gap-4 border-t pt-4 text-xs text-muted-foreground">
       <div className="flex items-center gap-1.5">
-        <div className="flex h-4 w-4 items-center justify-center rounded border border-success/30 bg-success/10">
-          <CheckCircle2 className="h-2.5 w-2.5 text-success" strokeWidth={1.75} />
+        <div className="flex h-5 w-5 items-center justify-center rounded border border-success/30 bg-success/10">
+          <CheckCircle2 className="h-3 w-3 text-success" strokeWidth={1.75} />
         </div>
         {t("gradebook.table.legend.completed")}
       </div>
       <div className="flex items-center gap-1.5">
-        <div className="flex h-4 w-6 items-center justify-center rounded border border-success/30 bg-success/10 text-[9px] font-semibold text-success">
+        <div className="flex h-5 w-9 items-center justify-center rounded border border-success/30 bg-success/10 text-xs font-semibold text-success">
           85%
         </div>
         {t("gradebook.table.legend.quizPassed")}
       </div>
       <div className="flex items-center gap-1.5">
-        <div className="flex h-4 w-6 items-center justify-center rounded border border-destructive/30 bg-destructive/10 text-[9px] font-semibold text-destructive">
+        <div className="flex h-5 w-9 items-center justify-center rounded border border-destructive/30 bg-destructive/10 text-xs font-semibold text-destructive">
           40%
         </div>
         {t("gradebook.table.legend.quizFailed")}
       </div>
       <div className="flex items-center gap-1.5">
-        <div className="flex h-4 w-10 items-center justify-center rounded border border-info/30 bg-info/10 text-[9px] font-semibold text-info">
+        <div className="flex h-5 items-center justify-center rounded border border-info/30 bg-info/10 px-1.5 text-xs font-semibold text-info">
           {t("gradebook.table.cellGraded")}
         </div>
         {t("gradebook.table.legend.assignmentGraded")}
       </div>
       <div className="flex items-center gap-1.5">
-        <div className="flex h-4 w-14 items-center justify-center rounded border border-warning/30 bg-warning/10 text-[9px] text-warning">
+        <div className="flex h-5 items-center justify-center rounded border border-warning/30 bg-warning/10 px-1.5 text-xs text-warning">
           {t("gradebook.table.cellSubmitted")}
         </div>
         {t("gradebook.table.legend.assignmentSubmitted")}
       </div>
       <div className="flex items-center gap-1.5">
-        <div className="flex h-4 w-4 items-center justify-center rounded border bg-muted/30">
-          <Circle className="h-2.5 w-2.5 text-muted-foreground/40" strokeWidth={1.75} />
+        <div className="flex h-5 w-5 items-center justify-center rounded border bg-muted/30">
+          <Circle className="h-3 w-3 text-muted-foreground/40" strokeWidth={1.75} />
         </div>
         {t("gradebook.table.legend.notSubmitted")}
       </div>


### PR DESCRIPTION
## Summary

`DESIGN.md` bans arbitrary pixel text sizes (`text-[Npx]`) and pins the scale at `32 / 24 / 18 / 16 / 14 / 13` px. A handful of dense surfaces were still using `text-[9px]` / `text-[10px]` / `text-[11px]`. The design-audit follow-ups flagged three areas explicitly:

- `AnnouncementsModal` (and its sibling `CourseAnnouncements`)
- Several Calendar files (`MonthGrid`, `SelectedDayPanel`, `UpcomingEventsPanel`)
- `GradeTableTab`

All mapped to `text-xs` (12 px) — the closest legal token.

One small follow-on: the gradebook **legend** swatches were sized assuming 9 px content ("85%", "Graded", "Submitted"). At `text-xs` the labels overflowed. Bumped the swatch height from `h-4` to `h-5` and switched the variable-text swatches to `px-1.5` so they breathe naturally at the design-system size.

Out of scope (still violating; saved for a future sweep): `BlockRow`, `ChapterBreakdownRow`, `NotificationItem`, `RegisterForm`, `CourseReadinessCard`, `ChapterTypeBadge`, `CertificatesPage`, `ModuleList`, `VerseOfTheDayCard`. Those weren't flagged and several sit on the HomePage which is locked at baseline.

## Test plan

- [x] `npm run lint` clean (zero warnings)
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 112/112 pass
- [x] Visual check (mentally) of legend at `text-xs` — `85%` / `40%` fit in `w-9 h-5`; `Graded` / `Submitted` shrink-to-fit via `px-1.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
