### PR TITLE
style(frontend): introduce .border-l-stripe utility for accent stripes

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -318,6 +318,14 @@
     overflow-wrap: anywhere;
     word-break: normal;
   }
+  /* Accent stripe — a 3 px left border used as an editorial marker on
+     status cards and rows (pending items, errors, warnings). Replaces
+     the `border-l-[3px]` arbitrary value that was sprinkled across the
+     codebase; pair with `border-l-{semantic-color}` to set the hue.
+     Width-only utility so the color stays a separate concern. */
+  .border-l-stripe {
+    border-left-width: 3px;
+  }
 }
 
 @layer components {

--- a/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
@@ -26,7 +26,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
   if (certs.length === 0) return null
 
   return (
-    <Card className="mb-8 border-l-[3px] border-l-primary">
+    <Card className="mb-8 border-l-stripe border-l-primary">
       <CardHeader>
         <CardTitle className="text-xl flex items-center gap-2">
           <Award className="h-5 w-5 text-primary" strokeWidth={1.75} aria-hidden />
@@ -41,7 +41,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
           {certs.map((cert) => (
             <div
               key={cert.id}
-              className="flex items-center justify-between rounded-md border border-l-[3px] border-l-primary/60 bg-primary/5 p-4"
+              className="flex items-center justify-between rounded-md border border-l-stripe border-l-primary/60 bg-primary/5 p-4"
             >
               <div className="min-w-0">
                 <p className="font-medium truncate">{cert.student_name || t("admin.pendingCerts.studentFallback")}</p>

--- a/frontend/src/pages/Admin/dashboard/PendingTeachersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingTeachersCard.tsx
@@ -20,7 +20,7 @@ export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: 
   if (pending.length === 0) return null
 
   return (
-    <Card className="mb-8 border-l-[3px] border-l-warning">
+    <Card className="mb-8 border-l-stripe border-l-warning">
       <CardHeader>
         <CardTitle className="text-xl flex items-center gap-2">
           <Clock className="h-5 w-5 text-warning" strokeWidth={1.75} aria-hidden />
@@ -35,7 +35,7 @@ export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: 
           {pending.map((u) => (
             <div
               key={u.id}
-              className="flex items-center justify-between rounded-md border border-l-[3px] border-l-warning/60 bg-warning/5 p-4"
+              className="flex items-center justify-between rounded-md border border-l-stripe border-l-warning/60 bg-warning/5 p-4"
             >
               <div className="flex items-center gap-3 min-w-0">
                 {u.avatar_url ? (

--- a/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
@@ -17,7 +17,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
   const { t } = useTranslation()
   if (certs.length === 0) return null
   return (
-    <Card className="mb-8 border-l-[3px] border-l-warning">
+    <Card className="mb-8 border-l-stripe border-l-warning">
       <CardHeader>
         <CardTitle className="text-xl flex items-center gap-2">
           <Award className="h-5 w-5 text-warning" strokeWidth={1.75} />
@@ -32,7 +32,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
           {certs.map((cert) => (
             <div
               key={cert.id}
-              className="flex items-center justify-between rounded-md border border-l-[3px] border-l-warning/60 bg-warning/5 p-4"
+              className="flex items-center justify-between rounded-md border border-l-stripe border-l-warning/60 bg-warning/5 p-4"
             >
               <div className="min-w-0">
                 <p className="font-medium truncate">


### PR DESCRIPTION
## Summary

Several status cards use `border-l-[3px]` (an arbitrary Tailwind value) for a 3 px editorial left stripe — the audit flagged this and asked for either a custom utility or an editorial accept. Going with the utility route, scoped narrowly.

- Added `.border-l-stripe { border-left-width: 3px; }` in `index.css` `@layer utilities`. Width-only — color stays as `border-l-{semantic}`.
- Migrated the three flagged surfaces:
  - `Admin/dashboard/PendingTeachersCard` (Card chrome + each row)
  - `Admin/dashboard/PendingCertsCard` (Card chrome + each row)
  - `Teacher/dashboard/PendingCertsCard` (Card chrome + each row)

The same `border-l-[3px]` pattern still lives in `App.tsx`, `Course/ModuleView`, `CertificateCard`, `ResultsView`, `QuizTaker`, etc. — out of scope here. Those can migrate opportunistically; the utility is in place when they touch.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 112/112 pass
- [x] `npm run build` succeeds, `border-l-stripe { border-left-width: 3px }` lands in the production CSS bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
