### PR TITLE
mobile: make ChapterView nav and back-links thumb-friendly

### DIFF
--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -116,15 +116,15 @@ function FileBlockLink({
       type="button"
       onClick={handleClick}
       disabled={opening}
-      className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-muted/50 disabled:opacity-60"
+      className="inline-flex min-h-[44px] items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-muted/50 disabled:opacity-60 sm:min-h-0"
     >
       {opening ? (
         <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" strokeWidth={1.75} aria-hidden />
       ) : (
         <File className="h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden />
       )}
-      <span>{label}</span>
-      <Download className="h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+      <span className="break-all">{label}</span>
+      <Download className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
     </button>
   )
 }
@@ -191,51 +191,57 @@ function ChapterNav({
   const { t } = useTranslation()
   const navigate = useNavigate()
 
+  const navBtn = "h-11 gap-2 sm:h-10"
+  const prevLabel = t("chapter.prevChapter")
+  const nextLabel = t("chapter.nextChapter")
+
   return (
-    <div className="mt-8 pt-6 border-t flex items-center justify-between">
+    <div className="mt-8 flex items-center justify-between gap-2 border-t pt-6">
       {prevChapter ? (
         <PressFeedback>
           <Button
             variant="outline"
             onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}/chapters/${prevChapter.id}`)}
-            className="gap-2"
+            className={navBtn}
+            aria-label={prevLabel}
           >
             <ArrowLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-            {t("chapter.prevChapter")}
+            <span className="hidden sm:inline">{prevLabel}</span>
           </Button>
         </PressFeedback>
       ) : (
-        <Button variant="outline" disabled className="gap-2">
+        <Button variant="outline" disabled className={navBtn} aria-label={prevLabel}>
           <ArrowLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          {t("chapter.prevChapter")}
+          <span className="hidden sm:inline">{prevLabel}</span>
         </Button>
       )}
 
-      <span className="text-xs text-muted-foreground">
+      <span className="text-xs font-medium tabular-nums text-muted-foreground">
         {currentIdx + 1}/{total}
       </span>
 
       {nextChapter ? (
         isNextLocked ? (
-          <Button variant="outline" disabled className="gap-2">
+          <Button variant="outline" disabled className={navBtn} aria-label={nextLabel}>
             <Lock className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-            {t("chapter.nextChapter")}
+            <span className="hidden sm:inline">{nextLabel}</span>
           </Button>
         ) : (
           <PressFeedback>
             <Button
               variant="outline"
               onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}/chapters/${nextChapter.id}`)}
-              className="gap-2"
+              className={navBtn}
+              aria-label={nextLabel}
             >
-              {t("chapter.nextChapter")}
+              <span className="hidden sm:inline">{nextLabel}</span>
               <ArrowRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
             </Button>
           </PressFeedback>
         )
       ) : (
-        <Button variant="outline" disabled className="gap-2">
-          {t("chapter.nextChapter")}
+        <Button variant="outline" disabled className={navBtn} aria-label={nextLabel}>
+          <span className="hidden sm:inline">{nextLabel}</span>
           <ArrowRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
         </Button>
       )}
@@ -381,8 +387,8 @@ export default function ChapterView() {
   if (locked) {
     return (
       <div className="container mx-auto px-4 py-6 max-w-3xl">
-        <Link to={`/courses/${courseId}/modules/${moduleId}`}>
-          <Button variant="ghost" size="sm" className="mb-4 h-8 text-xs">
+        <Link to={`/courses/${courseId}/modules/${moduleId}`} className="-mx-2 mb-4 inline-flex">
+          <Button variant="ghost" size="sm" className="h-11 text-xs sm:h-8">
             <ArrowLeft className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("course.backToModule")}
           </Button>
@@ -406,8 +412,8 @@ export default function ChapterView() {
 
   return (
     <div className="container mx-auto px-4 py-6 max-w-3xl">
-      <Link to={`/courses/${courseId}/modules/${moduleId}`}>
-        <Button variant="ghost" size="sm" className="mb-6 h-8 text-xs">
+      <Link to={`/courses/${courseId}/modules/${moduleId}`} className="-mx-2 mb-6 inline-flex">
+        <Button variant="ghost" size="sm" className="h-11 text-xs sm:h-8">
           <ArrowLeft className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
           {t("course.backToModule")}
         </Button>

--- a/frontend/src/pages/Course/detail/EnrolledHeader.tsx
+++ b/frontend/src/pages/Course/detail/EnrolledHeader.tsx
@@ -29,8 +29,8 @@ export function EnrolledHeader({
   const { t } = useTranslation()
   return (
     <>
-      <Link to="/">
-        <Button variant="ghost" size="sm" className="mb-4 h-8 text-xs">
+      <Link to="/" className="-mx-2 mb-4 inline-flex">
+        <Button variant="ghost" size="sm" className="h-11 text-xs sm:h-8">
           <ArrowLeft className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
           {t("courseDetail.allCourses")}
         </Button>

--- a/frontend/src/pages/Course/detail/ModuleList.tsx
+++ b/frontend/src/pages/Course/detail/ModuleList.tsx
@@ -128,8 +128,11 @@ function ModuleRow({
             </span>
           </CardTitle>
           {!isLocked && (
-            <Link to={`/courses/${courseId}/modules/${module.id}`}>
-              <Button variant="ghost" size="sm" className="h-7 text-xs shrink-0">
+            <Link
+              to={`/courses/${courseId}/modules/${module.id}`}
+              className="-my-2 inline-flex shrink-0 sm:my-0"
+            >
+              <Button variant="ghost" size="sm" className="h-11 text-xs sm:h-7">
                 {t("courseDetail.openModule")}
                 <ArrowRight className="ml-1 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
               </Button>
@@ -158,7 +161,7 @@ function ModuleRow({
           const overdue = dueDate < now && !allComplete
           return (
             <div
-              className={`ml-8 mt-1 flex items-center gap-1 text-[11px] ${
+              className={`ml-8 mt-1 flex items-center gap-1 text-xs ${
                 overdue ? "text-destructive" : "text-muted-foreground"
               }`}
             >


### PR DESCRIPTION
## Summary
- `ChapterNav` (Previous / counter / Next): on mobile the localised labels hide so the two outlined buttons + counter fit a 375 px row without wrapping. Buttons keep their full `aria-label` so screen readers still announce them. Height bumps `h-10 -> h-11` on mobile to clear the HIG 44 px hit area, stays `h-10` on `sm+`.
- Back-links ("All courses", "Back to module") were `h-8` ghost buttons (32 px). Now wrapped in inline-flex links that give the visible button `h-11` on mobile, preserve `h-8` on `sm+`, with `-mx-2` to absorb the extra height without shifting layout.
- `FileBlockLink` download buttons enforce `min-h-[44px]` on mobile and let the filename wrap (`break-all`) instead of stretching the row.
- `ModuleList`: replaces `text-[11px]` arbitrary px with `text-xs`; "Open module" button grows `h-7 -> h-11` on mobile, stays `h-7` on `sm+`.

## Test plan
- [x] `npm run lint` zero warnings
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` all 112 tests green
- [ ] Walk a chapter at 375 / 390 / 414 — tap Prev/Next, confirm fits and lands; tap "Back to module", confirm comfortable; download a file from a file block, confirm full filename wraps inside the chip
- [ ] Verify `sm+` desktop is visually unchanged (labels back, h-10 back, h-8 back-links back)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
