### PR TITLE
style(frontend): tasteful glass on notification popover and dialog dim

### DIFF
--- a/frontend/src/components/layout/notifications/NotificationPanel.tsx
+++ b/frontend/src/components/layout/notifications/NotificationPanel.tsx
@@ -54,10 +54,15 @@ export const NotificationPanel = forwardRef<HTMLDivElement, Props>(
         role="region"
         aria-label={t("notifications.panelAriaLabel")}
         className={cn(
-          "absolute top-full z-50 mt-2 overflow-hidden rounded-lg border border-border bg-background shadow-lg",
+          "absolute top-full z-50 mt-2 overflow-hidden rounded-lg border border-border shadow-lg",
+          // Glass effect on the desktop popover only: when the notification
+          // dropdown floats over a busy course/admin page, the frosted layer
+          // separates it from the content underneath without using a hard
+          // shadow alone. Stays solid on the mobile sheet variant — the
+          // sheet already has its own backdrop, doubling up reads as noise.
           isSheet
-            ? "left-0 right-0 z-[60] w-full max-w-none"
-            : "right-0 w-80 sm:w-96",
+            ? "left-0 right-0 z-[60] w-full max-w-none bg-background"
+            : "right-0 w-80 sm:w-96 bg-background/85 backdrop-blur-md supports-[backdrop-filter]:bg-background/75",
         )}
       >
         <div className="flex items-center justify-between border-b border-border px-4 py-3">

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -13,7 +13,12 @@ const AlertDialogOverlay = React.forwardRef<
   <AlertDialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/70 backdrop-blur-[1px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      // Frosted glass dim: softer than the previous near-black wash, paired
+      // with a real `backdrop-blur-md` so the page behind reads as context
+      // (not just darkness). The fallback `bg-black/60` keeps the contrast
+      // budget when backdrop-filter is unsupported; under `supports`, the
+      // dim drops to `/45` since the blur does the layering work.
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-md supports-[backdrop-filter]:bg-black/45 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary

Two surfaces get a tasteful glass accent — one editorial moment each, no piling on gradients or shadows on top of blur.

1. **Notification popover (desktop only)** — when the dropdown floats over a busy course or admin page, the panel is now frosted: `bg-background/85` fallback, `bg-background/75 backdrop-blur-md` where supported. The mobile sheet variant stays solid (`bg-background`) — the sheet's own backdrop already does the layering work and doubling up reads as noise.

2. **AlertDialog overlay** — was a near-flat `bg-black/70 backdrop-blur-[1px]` (decorative blur). Now a real glass dim: `bg-black/60` fallback, `bg-black/45 backdrop-blur-md` where supported. The blur picks up the layering work the heavier dim used to overcompensate for, so the page behind reads as context rather than darkness.

Both use the `supports-[backdrop-filter]:` Tailwind variant for a graceful non-blur fallback. Stays on semantic tokens (`background`, `black`) so the existing dark-mode HSLs flow through automatically — no separate dark-mode rules needed.

Surfaces considered but **left alone** to avoid overkill:
- Site header / `AuthLayout` mobile bar — already correctly frosted, no change needed.
- ChapterEditor sticky save bar — already has `backdrop-blur supports-[backdrop-filter]:bg-card/85`, hand-tuned by the original author.
- VerseOfTheDayCard — sits on the locked HomePage.
- Sheet overlay — uses a different dim model (`bg-black/40 backdrop-blur-[2px]`) and the sheet content itself slides in, so the dim isn't carrying the same weight as the dialog overlay.

## Test plan

- [x] `npm run lint` clean (zero warnings)
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 112/112 pass
- [x] `npm run build` succeeds
- [ ] Visual: open a confirm dialog on a course page → softer blurred dim, page outline visible behind
- [ ] Visual: open the bell over a course → notification panel frosted, content readable
- [ ] Visual: dark mode — overlay and panel still legible, no contrast regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
