### PR TITLE
style(frontend): consolidate inline spinners onto lucide Loader2

### DIFF
--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -9,6 +9,7 @@ import {
   ListOrdered,
   Quote,
   Link2,
+  Loader2,
   Undo2,
   Redo2,
   ImageIcon,
@@ -160,7 +161,7 @@ export function EditorToolbar({
 
       <ToolbarButton onClick={onAddImage} disabled={uploading} title={t("blockEditor.toolbar.insertImage")}>
         {uploading ? (
-          <span className="inline-block h-[18px] w-[18px] animate-spin rounded-full border-2 border-current border-t-transparent" />
+          <Loader2 size={TOOLBAR_ICON_SIZE} strokeWidth={1.75} className="animate-spin" />
         ) : (
           <ImageIcon size={TOOLBAR_ICON_SIZE} strokeWidth={1.75} />
         )}

--- a/frontend/src/pages/Course/detail/MaterialsModal.tsx
+++ b/frontend/src/pages/Course/detail/MaterialsModal.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { EmptyState, Modal } from "@/components/patterns"
 import { Button } from "@/components/ui/button"
-import { Download, Paperclip } from "lucide-react"
+import { Download, Loader2, Paperclip } from "lucide-react"
 import type { CourseMaterial } from "./types"
 
 interface Props {
@@ -44,7 +44,7 @@ export function MaterialsModal({
                 onClick={() => onDownload(file.path)}
               >
                 {downloadingPath === file.path ? (
-                  <div className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  <Loader2 className="h-4 w-4 animate-spin" strokeWidth={1.75} aria-hidden />
                 ) : (
                   <Download className="h-4 w-4" strokeWidth={1.75} aria-hidden />
                 )}

--- a/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
@@ -8,6 +8,7 @@ import {
   Eye,
   EyeOff,
   Layers,
+  Loader2,
   MoreHorizontal,
   Pencil,
   Trash2,
@@ -170,7 +171,7 @@ export function CourseCard({
                 disabled={cloningId === course.id}
               >
                 {cloningId === course.id ? (
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  <Loader2 className="h-4 w-4 animate-spin" strokeWidth={1.75} aria-hidden />
                 ) : (
                   <Copy className="h-4 w-4" strokeWidth={1.75} aria-hidden />
                 )}


### PR DESCRIPTION
## Summary

Three call-sites still rolled their own CSS-only spinner via `animate-spin rounded-full border-2 border-current border-t-transparent` on a bare div / span — a relic from before the codebase standardised on `lucide-react`'s `Loader2`. Same visual outcome (rotating ring), but the inline version skips `strokeWidth={1.75}` and the `aria-hidden` discipline used by every other button in the app, so it drifts from the loading-state language elsewhere.

Swap to `Loader2 className="animate-spin"` in:

- `components/editor/EditorToolbar` — image-upload button
- `pages/Teacher/dashboard/CourseCard` — clone-course menu item
- `pages/Course/detail/MaterialsModal` — per-file download button

Each picks an existing icon size (`h-4 w-4` / 18 px) and the project-wide 1.75 stroke so the placeholder matches every other loading icon. Same dark-mode behaviour, zero behaviour change.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 112/112 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
