### PR TITLE
mobile: admin tables — card view for users + cohorts

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1399,6 +1399,8 @@
       "thResource": "Resource",
       "thResourceId": "Resource ID",
       "thIp": "IP",
+      "prevPageAria": "Previous page",
+      "nextPageAria": "Next page",
       "errorPrefix": "Audit log error",
       "errorTableMissing": "The audit_logs table may not exist yet. Deploy the latest migration.",
       "actionValue": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1437,6 +1437,8 @@
       "thResource": "Объект",
       "thResourceId": "ID объекта",
       "thIp": "IP",
+      "prevPageAria": "Предыдущая страница",
+      "nextPageAria": "Следующая страница",
       "errorPrefix": "Ошибка журнала аудита",
       "errorTableMissing": "Таблица audit_logs ещё не создана. Примените последнюю миграцию.",
       "actionValue": {

--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -43,12 +43,12 @@ export default function AdminDashboard() {
   }
 
   return (
-    <div className="animate-fade-in container mx-auto px-4 py-8 max-w-6xl">
-      <div className="flex items-center gap-3 mb-6">
-        <div className="p-2 rounded-lg bg-primary/10">
+    <div className="animate-fade-in container mx-auto max-w-6xl px-4 py-6 sm:py-8">
+      <div className="mb-6 flex items-center gap-3">
+        <div className="rounded-lg bg-primary/10 p-2">
           <Shield className="h-6 w-6 text-primary" strokeWidth={1.75} />
         </div>
-        <h1 className="text-3xl font-serif font-bold tracking-tight">{t("admin.title")}</h1>
+        <h1 className="font-serif text-2xl font-bold tracking-tight sm:text-3xl">{t("admin.title")}</h1>
       </div>
 
       <AdminTabs active={tab} onChange={setTab} />

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -56,9 +56,9 @@ export function CohortsTab() {
 
   return (
     <Card>
-      <CardHeader className="flex-row items-center justify-between gap-4 space-y-0 flex-wrap">
+      <CardHeader className="flex-col items-stretch gap-3 space-y-0 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-4">
         <CardTitle className="text-xl">{t("admin.cohorts.title")}</CardTitle>
-        <div className="flex items-center gap-3 flex-wrap">
+        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
           <NativeSelect
             fieldSize="sm"
             value={statusFilter}
@@ -84,7 +84,7 @@ export function CohortsTab() {
               className="pl-9"
             />
           </div>
-          <Button size="sm" onClick={() => setCreateOpen(true)}>
+          <Button size="sm" onClick={() => setCreateOpen(true)} className="h-11 sm:h-9">
             <Plus className="h-4 w-4 mr-1.5" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.createButton")}
           </Button>
@@ -103,58 +103,96 @@ export function CohortsTab() {
         ) : filtered.length === 0 ? (
           <EmptyCohorts hasQuery={Boolean(search)} onCreate={() => setCreateOpen(true)} />
         ) : (
-          <div className="overflow-x-auto -mx-6">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-left">
-                  <th className="px-6 py-3 font-medium text-muted-foreground">
-                    {t("admin.cohorts.thName")}
-                  </th>
-                  <th className="px-6 py-3 font-medium text-muted-foreground">
-                    {t("admin.cohorts.thStatus")}
-                  </th>
-                  <th className="px-6 py-3 font-medium text-muted-foreground">
-                    {t("admin.cohorts.thDates")}
-                  </th>
-                  <th className="px-6 py-3 font-medium text-muted-foreground">
-                    {t("admin.cohorts.thCourses")}
-                  </th>
-                  <th className="px-6 py-3 font-medium text-muted-foreground">
-                    {t("admin.cohorts.thStudents")}
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {filtered.map((c) => (
-                  <tr key={c.id} className="hover:bg-muted/50 transition-colors">
-                    <td className="px-6 py-3">
-                      <Link
-                        to={`/admin/cohorts/${c.id}`}
-                        className="font-medium hover:text-primary"
-                      >
-                        {c.name}
-                      </Link>
-                    </td>
-                    <td className="px-6 py-3">
-                      <Badge variant={STATUS_BADGE[c.status]} className="capitalize">
-                        {t(`admin.cohorts.status${capitalize(c.status)}`)}
-                      </Badge>
-                    </td>
-                    <td className="px-6 py-3 text-muted-foreground">
-                      {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
-                    </td>
-                    <td className="px-6 py-3 text-muted-foreground">
-                      {c.course_ids.length}
-                    </td>
-                    <td className="px-6 py-3 text-muted-foreground">
-                      {c.student_count}
-                      {c.max_students ? ` / ${c.max_students}` : ""}
-                    </td>
+          <>
+            {/* Mobile: stack of cards. Each card is the full row, link-wrapped. */}
+            <div className="space-y-2 sm:hidden">
+              {filtered.map((c) => (
+                <Link
+                  key={c.id}
+                  to={`/admin/cohorts/${c.id}`}
+                  className="block rounded-md border border-border bg-card p-3 transition-colors hover:border-primary/30 hover:bg-muted/40"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-foreground">{c.name}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
+                      </p>
+                    </div>
+                    <Badge variant={STATUS_BADGE[c.status]} className="shrink-0 capitalize">
+                      {t(`admin.cohorts.status${capitalize(c.status)}`)}
+                    </Badge>
+                  </div>
+                  <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+                    <span>
+                      {t("admin.cohorts.thCourses")}: <span className="text-foreground">{c.course_ids.length}</span>
+                    </span>
+                    <span>
+                      {t("admin.cohorts.thStudents")}:{" "}
+                      <span className="text-foreground">
+                        {c.student_count}
+                        {c.max_students ? ` / ${c.max_students}` : ""}
+                      </span>
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+
+            {/* Desktop: classic table */}
+            <div className="hidden overflow-x-auto -mx-6 sm:block">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left">
+                    <th className="px-6 py-3 font-medium text-muted-foreground">
+                      {t("admin.cohorts.thName")}
+                    </th>
+                    <th className="px-6 py-3 font-medium text-muted-foreground">
+                      {t("admin.cohorts.thStatus")}
+                    </th>
+                    <th className="px-6 py-3 font-medium text-muted-foreground">
+                      {t("admin.cohorts.thDates")}
+                    </th>
+                    <th className="px-6 py-3 font-medium text-muted-foreground">
+                      {t("admin.cohorts.thCourses")}
+                    </th>
+                    <th className="px-6 py-3 font-medium text-muted-foreground">
+                      {t("admin.cohorts.thStudents")}
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody className="divide-y">
+                  {filtered.map((c) => (
+                    <tr key={c.id} className="hover:bg-muted/50 transition-colors">
+                      <td className="px-6 py-3">
+                        <Link
+                          to={`/admin/cohorts/${c.id}`}
+                          className="font-medium hover:text-primary"
+                        >
+                          {c.name}
+                        </Link>
+                      </td>
+                      <td className="px-6 py-3">
+                        <Badge variant={STATUS_BADGE[c.status]} className="capitalize">
+                          {t(`admin.cohorts.status${capitalize(c.status)}`)}
+                        </Badge>
+                      </td>
+                      <td className="px-6 py-3 text-muted-foreground">
+                        {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
+                      </td>
+                      <td className="px-6 py-3 text-muted-foreground">
+                        {c.course_ids.length}
+                      </td>
+                      <td className="px-6 py-3 text-muted-foreground">
+                        {c.student_count}
+                        {c.max_students ? ` / ${c.max_students}` : ""}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
       </CardContent>
 

--- a/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
+++ b/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
@@ -11,7 +11,7 @@ interface Props {
 export function AdminTabs({ active, onChange }: Props) {
   const { t } = useTranslation()
   return (
-    <div className="flex gap-1 mb-8 border-b">
+    <div className="mb-6 flex gap-1 border-b sm:mb-8">
       <TabButton
         active={active === "overview"}
         onClick={() => onChange("overview")}
@@ -45,7 +45,7 @@ function TabButton({ active, onClick, icon, label }: TabButtonProps) {
   return (
     <button
       onClick={onClick}
-      className={`px-4 py-2.5 text-sm font-medium transition-colors relative ${
+      className={`relative min-h-[44px] px-3 py-2.5 text-sm font-medium transition-colors sm:min-h-0 sm:px-4 ${
         active ? "text-primary" : "text-muted-foreground hover:text-foreground"
       }`}
     >

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -59,7 +59,7 @@ export function AuditLogTab({
     <div className="space-y-6">
       <Card>
         <CardContent className="p-4">
-          <div className="flex flex-wrap items-end gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:flex sm:flex-wrap sm:items-end">
             <FilterSelect
               label={t("admin.audit.filterAction")}
               value={action}
@@ -78,7 +78,7 @@ export function AuditLogTab({
             />
             <FilterDate label={t("admin.audit.filterFrom")} value={dateFrom} onChange={onDateFrom} />
             <FilterDate label={t("admin.audit.filterTo")} value={dateTo} onChange={onDateTo} />
-            <Button variant="ghost" size="sm" onClick={onReset} className="h-9">
+            <Button variant="ghost" size="sm" onClick={onReset} className="h-11 sm:h-9">
               {t("admin.audit.filterClear")}
             </Button>
           </div>
@@ -116,6 +116,8 @@ export function AuditLogTab({
                     size="sm"
                     disabled={page <= 1}
                     onClick={() => onPageChange(page - 1)}
+                    className="h-11 w-11 p-0 sm:h-9 sm:w-9"
+                    aria-label={t("admin.audit.prevPageAria", { defaultValue: "Previous page" })}
                   >
                     <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
                   </Button>
@@ -124,6 +126,8 @@ export function AuditLogTab({
                     size="sm"
                     disabled={page >= totalPages}
                     onClick={() => onPageChange(page + 1)}
+                    className="h-11 w-11 p-0 sm:h-9 sm:w-9"
+                    aria-label={t("admin.audit.nextPageAria", { defaultValue: "Next page" })}
                   >
                     <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
                   </Button>
@@ -154,6 +158,7 @@ function FilterSelect({ label, value, onChange, options, optionLabel, placeholde
         fieldSize="md"
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        className="w-full sm:w-auto"
       >
         <option value="">{placeholder}</option>
         {options.map((o) => (
@@ -183,7 +188,7 @@ function FilterDate({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         fieldSize="md"
-        className="w-40"
+        className="w-full sm:w-40"
       />
     </div>
   )

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -73,12 +73,13 @@ export function UsersCard({
         <CardTitle className="text-xl">{t("admin.users.title")}</CardTitle>
         <div className="flex items-center gap-3 flex-wrap">
           {selectedIds.size > 0 && (
-            <div className="flex items-center gap-2 bg-primary/5 border border-primary/20 rounded-lg px-3 py-1.5">
+            <div className="flex w-full flex-wrap items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-1.5 sm:w-auto">
               <span className="text-xs font-medium">{t("admin.users.selected", { count: selectedIds.size })}</span>
               <NativeSelect
-                fieldSize="xs"
+                fieldSize="sm"
                 value={bulkRole}
                 onChange={(e) => onBulkRoleChange(e.target.value as UserRole)}
+                className="w-auto"
               >
                 <option value="student">{t("roles.student")}</option>
                 <option value="pending_teacher">{t("roles.pendingTeacher")}</option>
@@ -87,7 +88,7 @@ export function UsersCard({
               </NativeSelect>
               <Button
                 size="sm"
-                className="h-7 text-xs"
+                className="h-9 text-xs sm:h-7"
                 onClick={onApplyBulkRole}
                 disabled={bulkUpdating}
               >
@@ -96,7 +97,7 @@ export function UsersCard({
               <Button
                 size="sm"
                 variant="ghost"
-                className="h-7 text-xs"
+                className="h-9 text-xs sm:h-7"
                 onClick={onClearSelection}
               >
                 {t("admin.users.bulkClear")}
@@ -206,29 +207,23 @@ function UsersTable({
     filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
 
   return (
-    <div className="overflow-x-auto -mx-6">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b text-left">
-            <th className="px-3 py-3 w-10">
-              <input
-                type="checkbox"
-                checked={allFilteredSelected}
-                onChange={onToggleSelectAll}
-                className="h-4 w-4 rounded border-input"
-                aria-label={t("admin.users.selectAllAria")}
-              />
-            </th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thName")}</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thEmail")}</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thRole")}</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thJoined")}</th>
-            <th className="px-6 py-3 w-10" aria-label={t("admin.users.thActions")} />
-          </tr>
-        </thead>
-        <tbody className="divide-y">
+    <>
+      {/* Mobile: stacked card list — the table doesn't fit a phone. Same
+          data, same controls, larger tap targets. */}
+      <div className="-mx-3 space-y-2 sm:hidden">
+        <label className="mx-3 flex min-h-[44px] items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={allFilteredSelected}
+            onChange={onToggleSelectAll}
+            className="h-4 w-4 rounded border-input"
+            aria-label={t("admin.users.selectAllAria")}
+          />
+          <span>{t("admin.users.selectAllN", { count: filtered.length })}</span>
+        </label>
+        <div className="mx-3 space-y-2">
           {filtered.map((u) => (
-            <UserRow
+            <UserCard
               key={u.id}
               user={u}
               selected={selectedIds.has(u.id)}
@@ -239,8 +234,115 @@ function UsersTable({
               onDeleteUser={onDeleteUser}
             />
           ))}
-        </tbody>
-      </table>
+        </div>
+      </div>
+
+      {/* Desktop: classic semantic table */}
+      <div className="hidden overflow-x-auto -mx-6 sm:block">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left">
+              <th className="px-3 py-3 w-10">
+                <input
+                  type="checkbox"
+                  checked={allFilteredSelected}
+                  onChange={onToggleSelectAll}
+                  className="h-4 w-4 rounded border-input"
+                  aria-label={t("admin.users.selectAllAria")}
+                />
+              </th>
+              <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thName")}</th>
+              <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thEmail")}</th>
+              <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thRole")}</th>
+              <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thJoined")}</th>
+              <th className="px-6 py-3 w-10" aria-label={t("admin.users.thActions")} />
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {filtered.map((u) => (
+              <UserRow
+                key={u.id}
+                user={u}
+                selected={selectedIds.has(u.id)}
+                updating={updatingId === u.id}
+                isSelf={u.id === currentUserId}
+                onToggleSelect={onToggleSelect}
+                onRoleChange={onRoleChange}
+                onDeleteUser={onDeleteUser}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  )
+}
+
+function UserCard({
+  user,
+  selected,
+  updating,
+  isSelf,
+  onToggleSelect,
+  onRoleChange,
+  onDeleteUser,
+}: UserRowProps) {
+  const { t } = useTranslation()
+  const displayName = user.full_name || user.email
+  return (
+    <div
+      className={`rounded-md border border-border bg-card p-3 transition-colors ${
+        selected ? "border-primary/40 bg-primary/[0.03]" : ""
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={() => onToggleSelect(user.id)}
+          className="mt-1.5 h-4 w-4 shrink-0 rounded border-input"
+          aria-label={t("admin.users.selectAriaPrefix", { name: displayName })}
+        />
+        {user.avatar_url ? (
+          <img
+            src={toProxyImage(user.avatar_url)}
+            alt={t("admin.users.avatarAltPrefix", { name: user.full_name ?? user.email })}
+            className="h-10 w-10 shrink-0 rounded-full object-cover"
+          />
+        ) : (
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground">
+            {(user.full_name?.[0] ?? user.email[0] ?? "?").toUpperCase()}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">
+            {user.full_name || t("admin.users.missingName")}
+          </p>
+          <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {formatDate(user.created_at)}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-11 w-11 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+          disabled={updating || isSelf}
+          onClick={() => onDeleteUser(user)}
+          aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
+          title={isSelf ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
+        >
+          <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+        </Button>
+      </div>
+      <div className="mt-3 pl-7">
+        <RoleSelector
+          role={user.role}
+          disabled={updating || isSelf}
+          onChange={(next) => onRoleChange(user.id, next)}
+          ariaLabel={t("admin.users.changeRoleAria", { name: displayName })}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Admin dashboard tables — the last desktop-first surface — swap to per-row card stacks below `sm`, table stays for `sm+`.

### UsersCard
- Mobile: stack of user cards (avatar, name, email, joined date, role selector, delete). Same data, 44 px tap targets.
- Virtual list (50+ users) stays as-is — that path is the allowed horizontal-scroll exception per spec.
- Bulk-action toolbar wraps full-width on mobile with `h-9` buttons.

### CohortsTab
- Mobile renders cards (name, status badge, date range, course/student counts) linking into the detail page.
- Header toolbar stacks status select + search + Create on mobile.

### AuditLogTab
- Table keeps horizontal scroll (explicitly allowed by spec).
- Filter row stacks into a 1-column grid on mobile so the four filters get full-width inputs.
- "Clear filters" bumps to `h-11` on mobile.
- Pagination prev/next become 44×44 hit targets with new aria-labels (`admin.audit.prevPageAria` / `nextPageAria`) added to both `en` and `ru`. `npm run i18n:check` green.

### AdminDashboard shell
- `py-6` on mobile, `py-8` `sm+`; title `text-2xl` mobile, `text-3xl` `sm+`.
- `AdminTabs` get `min-h-[44px]` on mobile; narrower horizontal padding on mobile so all three tabs fit a 375 px row.

## Test plan
- [x] `npm run lint` zero warnings
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` all 112 tests green (incl. keyCoverage)
- [x] `npm run i18n:check` parity green
- [ ] Open /admin at 375 / 390 / 414 — verify Users cards, Cohorts cards, Audit filters stack
- [ ] Verify `sm+` table view returns intact on desktop

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
