### PR TITLE
design: migrate remaining border-l-[3px] to .border-l-stripe

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,7 +64,7 @@ function Gate({ mode, children }: { mode: RouteMode; children: React.ReactNode }
 function PendingTeacherBanner() {
   const { t } = useTranslation()
   return (
-    <div className="border-b border-border border-l-[3px] border-l-warning bg-warning/10">
+    <div className="border-b border-border border-l-stripe border-l-warning bg-warning/10">
       <div className="container mx-auto px-4 py-3 text-center">
         <p className="text-sm text-foreground">
           {t("pendingTeacher.banner")}{" "}

--- a/frontend/src/components/announcements/CourseAnnouncements.tsx
+++ b/frontend/src/components/announcements/CourseAnnouncements.tsx
@@ -30,7 +30,7 @@ export default function CourseAnnouncements({ courseId }: Props) {
   return (
     <div className="space-y-3 mb-6">
       {announcements.map((a) => (
-        <div key={a.id} className="flex gap-3 rounded-md border border-border border-l-[3px] border-l-info bg-info/5 p-4">
+        <div key={a.id} className="flex gap-3 rounded-md border border-border border-l-stripe border-l-info bg-info/5 p-4">
           <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-info" strokeWidth={1.75} />
           <div className="min-w-0 flex-1 text-wrap-safe">
             <h4 className="text-sm font-medium">{a.title}</h4>

--- a/frontend/src/components/course/CertificateCard.tsx
+++ b/frontend/src/components/course/CertificateCard.tsx
@@ -83,7 +83,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
 
   if (!certificate) {
     return (
-      <Card className="border-dashed border-l-[3px] border-l-accent">
+      <Card className="border-dashed border-l-stripe border-l-accent">
         <CardContent className="py-6">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-muted">
@@ -109,7 +109,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
 
   if (certificate.status === "pending") {
     return (
-      <Card className="border-l-[3px] border-l-warning">
+      <Card className="border-l-stripe border-l-warning">
         <CardContent className="py-6">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-warning/10">
@@ -129,7 +129,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
 
   if (certificate.status === "teacher_approved") {
     return (
-      <Card className="border-l-[3px] border-l-info">
+      <Card className="border-l-stripe border-l-info">
         <CardContent className="py-6">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-info/10">
@@ -149,7 +149,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
 
   if (certificate.status === "approved") {
     return (
-      <Card className="border-l-[3px] border-l-accent">
+      <Card className="border-l-stripe border-l-accent">
         <CardContent className="space-y-5 py-6">
           <div className="flex items-start gap-4">
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-accent/15">
@@ -255,7 +255,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
 
   if (certificate.status === "rejected") {
     return (
-      <Card className="border-l-[3px] border-l-destructive">
+      <Card className="border-l-stripe border-l-destructive">
         <CardContent className="py-6">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-destructive/10">

--- a/frontend/src/components/quiz/QuizTaker.tsx
+++ b/frontend/src/components/quiz/QuizTaker.tsx
@@ -161,7 +161,7 @@ export default function QuizTaker({ chapterId, quizId, onSubmitted }: QuizTakerP
       ) : (
         <div className="p-5 space-y-6">
           {attemptsReached && (
-            <div className="rounded-md border border-border border-l-[3px] border-l-warning bg-warning/10 px-3 py-2 text-xs text-foreground">
+            <div className="rounded-md border border-border border-l-stripe border-l-warning bg-warning/10 px-3 py-2 text-xs text-foreground">
               {t("quiz.maxAttemptsReached", { type: t(assessmentTypeKey).toLowerCase() })}
             </div>
           )}

--- a/frontend/src/components/quiz/taker/ResultsView.tsx
+++ b/frontend/src/components/quiz/taker/ResultsView.tsx
@@ -34,8 +34,8 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
       <Card
         className={
           result.passed
-            ? "border-l-[3px] border-l-success"
-            : "border-l-[3px] border-l-destructive"
+            ? "border-l-stripe border-l-success"
+            : "border-l-stripe border-l-destructive"
         }
       >
         <CardContent className="py-6 text-center">

--- a/frontend/src/pages/Auth/register/SuccessView.tsx
+++ b/frontend/src/pages/Auth/register/SuccessView.tsx
@@ -53,7 +53,7 @@ export function SuccessView({ email, isTeacher }: Props) {
               {t("authRegister.success.clickLinkToActivate")}
             </p>
             {isTeacher && (
-              <div className="mt-4 rounded-md border border-border border-l-[3px] border-l-warning bg-warning/5 p-3">
+              <div className="mt-4 rounded-md border border-border border-l-stripe border-l-warning bg-warning/5 p-3">
                 <p className="text-sm leading-relaxed text-foreground">
                   {t("authRegister.success.teacherApprovalBanner")}
                 </p>

--- a/frontend/src/pages/Certificates/CertificatesPage.tsx
+++ b/frontend/src/pages/Certificates/CertificatesPage.tsx
@@ -87,7 +87,7 @@ export default function CertificatesPage() {
           {certificates.map((cert) => (
             <Card
               key={cert.id}
-              className="group relative overflow-hidden border-l-[3px] border-l-accent transition-colors hover:border-primary/40"
+              className="group relative overflow-hidden border-l-stripe border-l-accent transition-colors hover:border-primary/40"
             >
               <CardContent className="pb-5 pt-6">
                 <div className="mb-4 flex items-start justify-between">

--- a/frontend/src/pages/Course/ModuleView.tsx
+++ b/frontend/src/pages/Course/ModuleView.tsx
@@ -130,9 +130,9 @@ export default function ModuleView() {
         return (
           <div className={`mb-4 flex items-center gap-2 rounded-md border px-3 py-2 ${
             isOverdue
-              ? "border-l-[3px] border-l-destructive border-border bg-destructive/5"
+              ? "border-l-stripe border-l-destructive border-border bg-destructive/5"
               : isUpcoming
-                ? "border-l-[3px] border-l-warning border-border bg-warning/10"
+                ? "border-l-stripe border-l-warning border-border bg-warning/10"
                 : "border-border bg-muted/50"
           }`}>
             {isOverdue ? (
@@ -156,7 +156,7 @@ export default function ModuleView() {
       })()}
 
       {allComplete && (
-        <div className="mb-4 flex items-center gap-2 rounded-md border border-border border-l-[3px] border-l-success bg-success/10 px-3 py-2">
+        <div className="mb-4 flex items-center gap-2 rounded-md border border-border border-l-stripe border-l-success bg-success/10 px-3 py-2">
           <CheckCircle className="h-4 w-4 shrink-0 text-success" strokeWidth={1.75} />
           <span className="text-sm font-medium text-success">{t("module.moduleComplete")}</span>
         </div>

--- a/frontend/src/pages/Course/detail/UpcomingEvents.tsx
+++ b/frontend/src/pages/Course/detail/UpcomingEvents.tsx
@@ -37,7 +37,7 @@ export function UpcomingEvents({ events }: Props) {
               key={evt.id}
               className={`flex items-center gap-2 px-3 py-2 rounded-md border text-sm ${
                 overdue
-                  ? "border-l-[3px] border-l-destructive border-border bg-destructive/5"
+                  ? "border-l-stripe border-l-destructive border-border bg-destructive/5"
                   : "border-border hover:bg-muted/50"
               }`}
             >

--- a/frontend/src/pages/Teacher/gradebook/SummaryTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/SummaryTab.tsx
@@ -283,7 +283,7 @@ function StudentSummaryRow({
           </div>
 
           {hasDifferentManual && (
-            <div className="rounded border border-border border-l-[3px] border-l-warning bg-warning/10 px-3 py-2 text-xs text-foreground">
+            <div className="rounded border border-border border-l-stripe border-l-warning bg-warning/10 px-3 py-2 text-xs text-foreground">
               <Trans
                 i18nKey="gradebook.summary.manualDiffers"
                 values={{


### PR DESCRIPTION
## Summary
- Migrates the remaining ten `border-l-[3px]` call sites to the `.border-l-stripe` utility introduced in #277. Now every accent stripe in the app uses a single utility for the 3px width.
- Touched: `App.tsx` (pending-teacher banner), `CourseAnnouncements`, `ModuleView` (overdue/upcoming/complete), `UpcomingEvents`, `SummaryTab`, `CertificatesPage`, `CertificateCard` (5 status variants), `QuizTaker`, `SuccessView`, `ResultsView`.
- HomePage is intentionally left untouched (locked).

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run`
- [ ] Visually confirm pending-teacher banner, overdue module callouts, certificate cards, quiz results all still render with the same 3px stripe in both themes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
