### PR TITLE
design: finish the text-[Npx] sweep + document eyebrow

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -47,6 +47,12 @@ One scale, one serif, one sans.
 - **Sans (`Inter`):** everything else.
 - **Scale:** `32 / 24 / 18 / 16 / 14 / 13` px. No `text-[Npx]` arbitrary values.
 - **Weights:** 400 body, 500 UI, 600 emphasis, 700 display. No 800/900.
+- **Editorial eyebrow:** the tiny uppercase label that sits above a heading
+  (e.g. VerseOfTheDayCard, CourseReadinessCard) is `text-xs font-medium
+  uppercase tracking-[0.18em] text-muted-foreground`. The wide tracking is
+  load-bearing — that's what makes it read as an eyebrow rather than a
+  shrunk body line. Inline is fine; only worth extracting a component if it
+  appears more than ~4 times.
 
 ## Spacing, radius, elevation
 

--- a/frontend/src/components/course/ChapterTypeBadge.tsx
+++ b/frontend/src/components/course/ChapterTypeBadge.tsx
@@ -13,7 +13,7 @@ export default function ChapterTypeBadge({ type, size = "md" }: Props) {
   const Icon = meta.icon
   const sizing =
     size === "sm"
-      ? "gap-1 px-2 py-0.5 text-[10px]"
+      ? "gap-1 px-2 py-0.5 text-xs"
       : "gap-1.5 px-3 py-1 text-xs"
   const iconSize = size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5"
   return (

--- a/frontend/src/components/editor/blocks/BlockRow.tsx
+++ b/frontend/src/components/editor/blocks/BlockRow.tsx
@@ -79,7 +79,7 @@ export function BlockRow({
         )}
         <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         <span className="text-sm font-medium flex-1">{label}</span>
-        <span className="text-[10px] text-muted-foreground">#{index + 1}</span>
+        <span className="text-xs text-muted-foreground">#{index + 1}</span>
         <Button
           variant="ghost"
           size="sm"

--- a/frontend/src/components/layout/notifications/NotificationItem.tsx
+++ b/frontend/src/components/layout/notifications/NotificationItem.tsx
@@ -57,7 +57,7 @@ export function NotificationItem({ notification, onActivate, onDelete }: Props) 
           <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
             {notification.message}
           </p>
-          <p className="mt-1 text-[11px] text-muted-foreground/70">
+          <p className="mt-1 text-xs text-muted-foreground/70">
             {timeAgo(notification.created_at)}
           </p>
         </div>

--- a/frontend/src/pages/Certificates/CertificatesPage.tsx
+++ b/frontend/src/pages/Certificates/CertificatesPage.tsx
@@ -94,7 +94,7 @@ export default function CertificatesPage() {
                   <div className="flex h-11 w-11 items-center justify-center rounded-md bg-muted">
                     <Award className="h-5 w-5 text-muted-foreground" strokeWidth={1.75} />
                   </div>
-                  <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground/70">
+                  <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground/70">
                     {t("certificates.badge")}
                   </span>
                 </div>

--- a/frontend/src/pages/Teacher/editor/CourseReadinessCard.tsx
+++ b/frontend/src/pages/Teacher/editor/CourseReadinessCard.tsx
@@ -119,7 +119,7 @@ export function CourseReadinessCard({ report, loading, onFix }: Props) {
           prefersReducedMotion={Boolean(prefersReducedMotion)}
         />
         <div className="min-w-0 flex-1">
-          <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
             {t("courseReadiness.title")}
           </p>
           <p className="mt-0.5 font-serif text-base font-semibold tracking-tight text-foreground">

--- a/frontend/src/pages/Teacher/progress/ChapterBreakdownRow.tsx
+++ b/frontend/src/pages/Teacher/progress/ChapterBreakdownRow.tsx
@@ -78,7 +78,7 @@ export function ChapterBreakdownRow({
             <Button
               variant="ghost"
               size="sm"
-              className="h-6 px-1.5 text-[10px] text-muted-foreground hover:text-foreground"
+              className="h-6 px-1.5 text-xs text-muted-foreground hover:text-foreground"
               disabled={grantingQuizId === quiz.quiz_id}
               onClick={(e) => {
                 e.stopPropagation()


### PR DESCRIPTION
## Summary
- Finishes the `text-[Npx]` cleanup that #276 deferred — `BlockRow`, `ChapterBreakdownRow`, `NotificationItem`, `CourseReadinessCard`, `ChapterTypeBadge`, `CertificatesPage`. After this, zero `text-[\d+px]` matches in `frontend/src`.
- All six were mapped to `text-xs` (12 px), the closest legal token on the design-system scale `32/24/18/16/14/13`.
- The editorial **eyebrow** pattern is now documented in `DESIGN.md`: `text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground`. The two existing call sites (`VerseOfTheDayCard`, `CourseReadinessCard`) were lightly off — one used `text-xs`, the other `text-[11px]`. Standardising on `text-xs` and writing down that the wide tracking is load-bearing so future agents don't flatten it back to body type.

## Why this matters
With the codebase clean, the `text-[Npx]` ban can finally be ESLint-enforced (next pass — out of scope here).

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 112/112 pass
- [x] No `text-[\d+px]` left in `frontend/src` (grep verified)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
