### PR TITLE
db: drop 4 truly unused indexes (modules/chapters/notifications/course_events)

### DIFF
--- a/backend/app/models/course_event.py
+++ b/backend/app/models/course_event.py
@@ -9,10 +9,12 @@ from app.core.database import Base
 
 class CourseEvent(Base):
     __tablename__ = "course_events"
-    __table_args__ = (
-        Index("ix_course_events_course_id", "course_id"),
-        Index("ix_course_events_event_date", "event_date"),
-    )
+    # event_date intentionally has no index — the calendar API loads
+    # events by course_id (covered by ix_course_events_course_id) and
+    # sorts in Python (`events.sort(key=lambda e: e.event_date)` in
+    # calendar.py). No SQL ORDER BY event_date exists, so an index
+    # there does no work.
+    __table_args__ = (Index("ix_course_events_course_id", "course_id"),)
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     course_id: Mapped[str] = mapped_column(ForeignKey("courses.id", ondelete="CASCADE"))

--- a/supabase/migrations/20260515143957_drop_truly_unused_indexes.sql
+++ b/supabase/migrations/20260515143957_drop_truly_unused_indexes.sql
@@ -1,0 +1,42 @@
+-- Drop four indexes the 2026-05-15 DB audit identified as truly unused —
+-- no current query hits them, no future query would benefit, and they
+-- aren't backing a UNIQUE constraint or a FK lookup pattern.
+--
+-- Pre-flight: each was checked against pg_stat_user_indexes (idx_scan=0
+-- since migrate-from-prior-cleanup on 2026-05-13) AND against the app
+-- query patterns under backend/app/.
+--
+-- The OTHER 27 indexes the advisor flagged stay — they back FK joins
+-- ("certs for cohort X", audit-by-user, gradebook by graded_by, etc.)
+-- or were added < 7 days ago for queries that haven't gained scan
+-- volume yet (ix_courses_status_created_at, ix_quiz_answers_attempt_question).
+
+-- 1. modules.deleted_at — partial index WHERE deleted_at IS NOT NULL.
+--    Every Module query in the app filters Module.deleted_at IS NULL
+--    (active rows). The partial points the wrong way: it indexes the
+--    trashed rows we never look up. Unused since creation.
+DROP INDEX IF EXISTS public.ix_modules_deleted_at;
+
+
+-- 2. chapters.deleted_at — same shape, same direction problem.
+--    All Chapter queries filter deleted_at IS NULL. No trash-recovery
+--    workflow currently exists.
+DROP INDEX IF EXISTS public.ix_chapters_deleted_at;
+
+
+-- 3. notifications.created_at — standalone single-column DESC index.
+--    Every notifications query in the app is user-scoped first
+--    (Notification.user_id == current_user.id) and then ordered by
+--    created_at. The composite ix_notifications_user_unread on
+--    (user_id, is_read) handles the filter; the planner does an
+--    in-memory sort over the small per-user result set. A global
+--    created_at index has no user-scoped query that could use it.
+DROP INDEX IF EXISTS public.ix_notifications_created_at;
+
+
+-- 4. course_events.event_date — never referenced in a WHERE clause.
+--    CourseEvent rows are loaded by course_id (ix_course_events_course_id
+--    covers that) and then sorted in Python via
+--    `events.sort(key=lambda e: e.event_date)` in calendar.py.
+--    No SQL ORDER BY event_date exists; index does no work.
+DROP INDEX IF EXISTS public.ix_course_events_event_date;


### PR DESCRIPTION
## Summary

Drops four indexes the 2026-05-15 DB audit flagged as unused **and** verified have no current or realistic future query support. The other 27 "unused" indexes from `get_advisors` are kept because they back FK joins, recently-added queries, or future workflows.

| Index | Why drop |
|---|---|
| `ix_modules_deleted_at` | Partial on `WHERE deleted_at IS NOT NULL`; every Module query filters `deleted_at IS NULL` (active rows). Indexes the rows we never look up. |
| `ix_chapters_deleted_at` | Same shape, same wrong direction. |
| `ix_notifications_created_at` | Standalone single-column index; notifications queries are user-scoped first via the existing `ix_notifications_user_unread` composite. |
| `ix_course_events_event_date` | Never used in a WHERE/ORDER BY in SQL; `calendar.py` sorts in Python via `events.sort(key=lambda e: e.event_date)` after loading by `course_id`. |

Model sync: `course_event.py` updated to drop the now-removed `Index("ix_course_events_event_date", ...)` and a comment explains why. The other three were never declared in models -- they lived only as DB-side indexes from old migrations.

## Test plan

- [x] Local `python -m pytest tests/` -- 581 passed
- [x] `apply_migration` succeeded via Supabase MCP
- [x] `get_advisors` (performance) re-run -- four fewer entries
- [ ] CI Postgres schema-smoke catches any SQLAlchemy model drift
- [ ] Vercel preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)