### PR TITLE
fix(i18n): preserve instant across datetime-local round-trips

### DIFF
--- a/frontend/src/i18n/__tests__/format.test.ts
+++ b/frontend/src/i18n/__tests__/format.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { isoToLocalInput, localInputToIso } from "../format"
+
+/**
+ * Regression suite for ``isoToLocalInput`` / ``localInputToIso``.
+ *
+ * The contract: the backend stores datetimes as **UTC** ISO strings,
+ * the browser ``<input type="datetime-local">`` widget reads/writes
+ * in the **local** timezone, and the round-trip helpers must preserve
+ * the instant in time across read → display → save.
+ *
+ * Pre-fix, callsites used ``iso.slice(0, 16)`` to feed the input,
+ * which silently displayed the UTC wall-clock as local — every
+ * round-trip drifted by the local UTC offset.
+ */
+describe("isoToLocalInput / localInputToIso", () => {
+  it("renders a UTC ISO in the browser's local timezone", () => {
+    // Pick an instant and confirm the rendered string matches what
+    // ``new Date(...)`` would compute for the local zone. We don't
+    // hardcode the offset because the test runs in whatever tz the
+    // CI machine is in — what matters is the helper agrees with
+    // the JS Date API the browser uses.
+    const iso = "2026-06-01T00:00:00.000Z"
+    const expected = (() => {
+      const d = new Date(iso)
+      const pad = (n: number) => n.toString().padStart(2, "0")
+      return (
+        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+        `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+      )
+    })()
+    expect(isoToLocalInput(iso)).toBe(expected)
+  })
+
+  it("returns '' for null/undefined/empty input", () => {
+    expect(isoToLocalInput(null)).toBe("")
+    expect(isoToLocalInput(undefined)).toBe("")
+    expect(isoToLocalInput("")).toBe("")
+  })
+
+  it("returns '' for an unparseable ISO string", () => {
+    expect(isoToLocalInput("not-a-date")).toBe("")
+  })
+
+  it("round-trips: ISO → local input → ISO preserves the instant", () => {
+    const original = "2026-06-01T15:30:00.000Z"
+    const local = isoToLocalInput(original)
+    const back = localInputToIso(local)
+    expect(back).not.toBeNull()
+    // datetime-local truncates to minutes, so compare at that granularity.
+    expect(new Date(back!).getTime()).toBe(new Date(original).getTime())
+  })
+
+  it("localInputToIso returns null for empty input", () => {
+    expect(localInputToIso("")).toBeNull()
+  })
+
+  it("localInputToIso returns null for unparseable input", () => {
+    expect(localInputToIso("garbage")).toBeNull()
+  })
+
+  it("localInputToIso treats input as local time (not UTC)", () => {
+    // Whatever the local timezone, a local-time string should produce
+    // an ISO whose getHours() matches the input — this is the
+    // characteristic that makes the round-trip work.
+    const local = "2026-06-01T09:15"
+    const iso = localInputToIso(local)
+    expect(iso).not.toBeNull()
+    const d = new Date(iso!)
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(5)
+    expect(d.getDate()).toBe(1)
+    expect(d.getHours()).toBe(9)
+    expect(d.getMinutes()).toBe(15)
+  })
+})

--- a/frontend/src/i18n/format.ts
+++ b/frontend/src/i18n/format.ts
@@ -106,3 +106,44 @@ export function formatDateLong(
     ...options,
   })
 }
+
+/**
+ * Convert a backend UTC ISO timestamp (or ``null``/``undefined``) into
+ * the ``YYYY-MM-DDTHH:mm`` string a ``<input type="datetime-local">``
+ * expects.
+ *
+ * The browser interprets that input value in the **local** timezone,
+ * so the obvious shortcut — ``iso.slice(0, 16)`` — silently shows the
+ * UTC wall-clock as if it were local. A user in UTC-7 looking at
+ * ``2026-06-01T00:00:00Z`` would see ``2026-06-01 00:00`` in the
+ * input, edit it (or just hit save), and have ``new Date(value)``
+ * re-encode to ``2026-06-01T07:00:00Z`` — a 7-hour drift on every
+ * round-trip.
+ *
+ * Use together with ``localInputToIso`` on save.
+ */
+export function isoToLocalInput(iso: string | null | undefined): string {
+  if (!iso) return ""
+  const d = toDate(iso)
+  if (!d) return ""
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  )
+}
+
+/**
+ * Convert the value from a ``<input type="datetime-local">`` (which
+ * the browser interprets in the local timezone) into a UTC ISO string
+ * the backend can store. Returns ``null`` for an empty input so the
+ * caller can ``PATCH`` a clear without distinguishing missing from
+ * empty.
+ *
+ * Use together with ``isoToLocalInput`` on load.
+ */
+export function localInputToIso(value: string): string | null {
+  if (!value) return null
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toISOString()
+}

--- a/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
@@ -21,7 +21,7 @@ import { ErrorState } from "@/components/patterns"
 import { cohortsService, type CohortStudent } from "@/services/cohorts"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
-import { formatDate } from "@/i18n/format"
+import { formatDate, isoToLocalInput, localInputToIso } from "@/i18n/format"
 import type { Cohort, Course } from "@/types"
 import { AttachCourseDialog } from "./AttachCourseDialog"
 import { AddStudentDialog } from "./AddStudentDialog"
@@ -466,7 +466,7 @@ interface DateFieldProps {
 }
 
 function DateField({ label, value, disabled, nullable, onSave }: DateFieldProps) {
-  const local = value ? value.slice(0, 16) : ""
+  const local = isoToLocalInput(value)
   return (
     <div className="space-y-1.5">
       <Label className="text-xs">{label}</Label>
@@ -480,7 +480,8 @@ function DateField({ label, value, disabled, nullable, onSave }: DateFieldProps)
             if (nullable) void onSave(null)
             return
           }
-          void onSave(new Date(v).toISOString())
+          const iso = localInputToIso(v)
+          if (iso) void onSave(iso)
         }}
       />
     </div>

--- a/frontend/src/pages/Admin/cohorts/CreateCohortDialog.tsx
+++ b/frontend/src/pages/Admin/cohorts/CreateCohortDialog.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { cohortsService } from "@/services/cohorts"
 import { toast } from "@/lib/toast"
+import { localInputToIso } from "@/i18n/format"
 
 interface Props {
   open: boolean
@@ -50,12 +51,18 @@ export function CreateCohortDialog({ open, onClose, onCreated }: Props) {
     if (!isValid) return
     setSaving(true)
     try {
+      const startIso = localInputToIso(start)
+      const endIso = localInputToIso(end)
+      if (!startIso || !endIso) {
+        setSaving(false)
+        return
+      }
       await cohortsService.createCohort({
         name: name.trim(),
-        start_date: new Date(start).toISOString(),
-        end_date: new Date(end).toISOString(),
-        enrollment_start: enrollStart ? new Date(enrollStart).toISOString() : null,
-        enrollment_end: enrollEnd ? new Date(enrollEnd).toISOString() : null,
+        start_date: startIso,
+        end_date: endIso,
+        enrollment_start: localInputToIso(enrollStart),
+        enrollment_end: localInputToIso(enrollEnd),
         max_students: maxStudents ? Number(maxStudents) : null,
       })
       toast({ title: t("admin.cohorts.toast.created"), variant: "success" })

--- a/frontend/src/pages/Teacher/editor/useCourseData.ts
+++ b/frontend/src/pages/Teacher/editor/useCourseData.ts
@@ -4,6 +4,7 @@ import type { DropResult } from "@hello-pangea/dnd"
 import { coursesService } from "@/services/courses"
 import { storageService } from "@/services/storage"
 import { toast } from "@/lib/toast"
+import { isoToLocalInput, localInputToIso } from "@/i18n/format"
 import type { Course } from "@/types"
 import type { useConfirm } from "@/components/ui/alert-dialog"
 
@@ -61,8 +62,8 @@ export function useCourseData(
         const data = await coursesService.getCourse(courseId)
         if (signal.cancelled) return
         setCourse(data)
-        setEnrollStart(data.enrollment_start?.slice(0, 16) ?? "")
-        setEnrollEnd(data.enrollment_end?.slice(0, 16) ?? "")
+        setEnrollStart(isoToLocalInput(data.enrollment_start))
+        setEnrollEnd(isoToLocalInput(data.enrollment_end))
       } catch {
         if (!signal.cancelled) onNotFound()
       } finally {
@@ -123,8 +124,8 @@ export function useCourseData(
     setSavingEnrollment(true)
     try {
       const payload = {
-        enrollment_start: enrollStart ? new Date(enrollStart).toISOString() : null,
-        enrollment_end: enrollEnd ? new Date(enrollEnd).toISOString() : null,
+        enrollment_start: localInputToIso(enrollStart),
+        enrollment_end: localInputToIso(enrollEnd),
       }
       await coursesService.updateCourse(courseId, payload)
       setCourse((p) => (p ? { ...p, ...payload } : p))

--- a/frontend/src/pages/Teacher/editor/useEventsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useEventsSection.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
+import { isoToLocalInput, localInputToIso } from "@/i18n/format"
 import type { CourseEvent } from "@/types"
 import type { useConfirm } from "@/components/ui/alert-dialog"
 import { EMPTY_EVENT_FORM, type EventFormState } from "./types"
@@ -60,7 +61,7 @@ export function useEventsSection(
       title: ev.title,
       description: ev.description ?? "",
       event_type: ev.event_type,
-      event_date: ev.event_date.slice(0, 16),
+      event_date: isoToLocalInput(ev.event_date),
     })
     setEditingId(ev.id)
   }, [])
@@ -68,11 +69,16 @@ export function useEventsSection(
   const save = useCallback(async () => {
     if (!courseId || !form.title.trim() || !form.event_date) return
     setSaving(true)
+    const isoDate = localInputToIso(form.event_date)
+    if (!isoDate) {
+      setSaving(false)
+      return
+    }
     const payload = {
       title: form.title.trim(),
       description: form.description.trim() || undefined,
       event_type: form.event_type,
-      event_date: new Date(form.event_date).toISOString(),
+      event_date: isoDate,
     }
     try {
       if (editingId) {

--- a/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
+++ b/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
@@ -6,6 +6,7 @@ import type { DropResult } from "@hello-pangea/dnd";
 import { coursesService } from "@/services/courses";
 import { getErrorDetail } from "@/lib/errorDetail";
 import { toast } from "@/lib/toast";
+import { isoToLocalInput, localInputToIso } from "@/i18n/format";
 import { chapterSchema, moduleSchema } from "@/lib/validations/course";
 import type { Chapter, Module } from "@/types";
 import type { useConfirm } from "@/components/ui/alert-dialog";
@@ -41,7 +42,7 @@ export function useModuleEditor(
         const data = await coursesService.getModule(courseId, moduleId);
         if (signal?.cancelled) return;
         setMod(data);
-        setModDueDate(data.due_date ? data.due_date.slice(0, 16) : "");
+        setModDueDate(isoToLocalInput(data.due_date));
       } catch {
         if (signal?.cancelled) return;
         toast({ title: t("moduleEditor.toast.moduleNotFound"), variant: "destructive" });
@@ -87,7 +88,7 @@ export function useModuleEditor(
   const saveDueDate = async (value: string) => {
     if (!courseId || !moduleId) return;
     try {
-      const due = value ? new Date(value).toISOString() : null;
+      const due = localInputToIso(value);
       await coursesService.updateModule(courseId, moduleId, { due_date: due });
       setMod((prev) => (prev ? { ...prev, due_date: due } : prev));
     } catch {


### PR DESCRIPTION
## What broke

The post-#267 UTC-everywhere contract held for displayed text but quietly broke for every `<input type="datetime-local">` we hand back to a user for editing. The reading side used `iso.slice(0, 16)` — chopping off the `Z` and handing the UTC wall-clock string to a widget that reads its value in the local zone. The writing side then `new Date(value).toISOString()`-d that local-interpreted time back to UTC.

End-to-end consequence: a user in UTC-7 viewing a cohort dated `2026-06-01T00:00:00Z` sees `2026-06-01 00:00` in the input, hits save (or just opens then closes the editor without typing anything), and the value lands in the DB as `2026-06-01T07:00:00Z`. **7-hour drift on every round-trip**, every load through the date editor.

Affected callsites:

- `useCourseData` — `enrollment_start` / `enrollment_end`
- `useEventsSection` — course event `event_date`
- `useModuleEditor` — module `due_date`
- `CohortDetailPage` — generic `DateField`
- `CreateCohortDialog` — consistency, no bug here since it's fresh-input

## How it's fixed

Two helpers in `i18n/format.ts`:

- `isoToLocalInput(iso)` — UTC ISO → `YYYY-MM-DDTHH:mm` in local time, suitable for `<input type="datetime-local">`
- `localInputToIso(value)` — that input's value back to a UTC ISO, returning `null` for empty / unparseable so callers can `PATCH` a clear without an extra ternary

Every datetime-local callsite migrated. New regression suite `i18n/__tests__/format.test.ts` pins the round-trip behaviour zone-agnostically (assertions compare against the JS Date API the browser uses, so they pass in whatever zone CI runs in).

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 119 tests passed (16 files)
- [ ] Manual: in a non-UTC timezone, open a cohort with a `start_date` set, immediately close — value should stay stable on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
