### PR TITLE
db: drop stale enrollments(user_id, course_id) UNIQUE -- fix ADR-010 retake

### DIFF
--- a/supabase/migrations/20260515144600_fix_enrollment_retake_unique.sql
+++ b/supabase/migrations/20260515144600_fix_enrollment_retake_unique.sql
@@ -1,0 +1,33 @@
+-- ADR-010 (cohort_top_level, applied 2026-05-13) intended to relax the
+-- enrollments uniqueness from (user_id, course_id) -> (user_id, course_id,
+-- COALESCE(cohort_id, sentinel)) so that a student can RETAKE a course in
+-- a different cohort while keeping the original attempt's grades intact.
+--
+-- The cohort migration created the new partial-COALESCE unique index
+-- (uq_enrollment_user_course_cohort) correctly, but the DROP CONSTRAINT
+-- targeted a name that didn't exist:
+--
+--   ALTER TABLE public.enrollments DROP CONSTRAINT IF EXISTS uq_enrollment_user_course;
+--
+-- The actual constraint was named ``enrollments_user_id_course_id_key``
+-- (default Postgres name when ``UNIQUE (user_id, course_id)`` was declared
+-- on the original create table without an explicit name). The
+-- ``IF EXISTS`` clause swallowed the no-op silently and the old
+-- constraint stayed in place.
+--
+-- Effect on production today: any retake-in-different-cohort INSERT fails
+-- with ``duplicate key value violates unique constraint
+-- "enrollments_user_id_course_id_key"`` — the ADR-010 retake path is
+-- silently broken. (No real retake has been attempted yet, so no incident
+-- has been filed.)
+--
+-- Data safety: a count of (user_id, course_id) duplicate groups on
+-- 2026-05-15 returned 0 rows, so dropping the constraint cannot expose
+-- pre-existing duplicates. The new
+-- uq_enrollment_user_course_cohort index continues to enforce the
+-- intended uniqueness (with NULL cohort_id treated as a fixed sentinel
+-- via COALESCE) so accidental double-enrollment in the solo flow is
+-- still blocked.
+
+ALTER TABLE public.enrollments
+  DROP CONSTRAINT IF EXISTS enrollments_user_id_course_id_key;


### PR DESCRIPTION
## Summary

The ADR-010 cohort migration (`20260513205435_cohort_top_level.sql`) was supposed to relax enrollments uniqueness from `(user_id, course_id)` to `(user_id, course_id, COALESCE(cohort_id, sentinel))` so a student can **retake** a course in a different cohort.

The migration created the new partial-COALESCE unique index correctly, but the DROP CONSTRAINT line targeted a non-existent name:

```sql
ALTER TABLE public.enrollments DROP CONSTRAINT IF EXISTS uq_enrollment_user_course;
```

The actual constraint was named `enrollments_user_id_course_id_key` (Postgres default from the original CREATE TABLE), so `IF EXISTS` silently no-oped. The stale UNIQUE has been blocking ADR-010's retake path in prod ever since.

## What this changes

- Drops `enrollments_user_id_course_id_key` UNIQUE constraint.
- `uq_enrollment_user_course_cohort` (the partial COALESCE unique index) continues to enforce intended uniqueness, so double-enrollment in the solo flow is still blocked.
- SQLAlchemy model already declared the correct uniqueness (`uq_enrollment_user_course_cohort`) -- no model change needed.

## Data safety

`SELECT user_id, course_id, COUNT(*) FROM enrollments GROUP BY user_id, course_id HAVING COUNT(*) > 1` returned 0 rows on prod 2026-05-15. Dropping cannot expose pre-existing duplicates.

## Test plan

- [x] `apply_migration` succeeded via Supabase MCP
- [x] `python -m pytest tests/` -- 581 passed
- [x] `pg_constraint` re-queried: stale UNIQUE gone, partial COALESCE index still there
- [ ] Backend CI Postgres schema-smoke
- [ ] Manual retake-in-different-cohort once on staging (out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)