### PR TITLE
ux(teacher): consistent breadcrumbs on Analytics + Gradebook

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -733,7 +733,10 @@
     "courseFallback": "Course",
     "loadFailed": "Failed to load analytics",
     "backToCourses": "Back to courses",
-    "backToDashboard": "Back to dashboard",
+    "breadcrumb": {
+      "myCourses": "My Courses",
+      "courseFallback": "Course"
+    },
     "heading": "Course Analytics",
     "studentProgress": "Student Progress",
     "gradebook": "Gradebook",
@@ -1131,6 +1134,7 @@
     "tableTab": "Grade Table",
     "failedLoad": "Failed to load gradebook. Please try again.",
     "breadcrumbCourses": "My Courses",
+    "breadcrumbCourseFallback": "Course",
     "pageHeading": "Gradebook",
     "exportCsv": "Export CSV",
     "exporting": "Exporting...",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -757,7 +757,10 @@
     "courseFallback": "Курс",
     "loadFailed": "Не удалось загрузить аналитику",
     "backToCourses": "К моим курсам",
-    "backToDashboard": "К панели",
+    "breadcrumb": {
+      "myCourses": "Мои курсы",
+      "courseFallback": "Курс"
+    },
     "heading": "Аналитика курса",
     "studentProgress": "Прогресс студентов",
     "gradebook": "Журнал оценок",
@@ -1167,6 +1170,7 @@
     "tableTab": "Таблица оценок",
     "failedLoad": "Не удалось загрузить журнал. Попробуйте снова.",
     "breadcrumbCourses": "Мои курсы",
+    "breadcrumbCourseFallback": "Курс",
     "pageHeading": "Журнал оценок",
     "exportCsv": "Экспорт CSV",
     "exporting": "Экспорт…",

--- a/frontend/src/pages/Teacher/TeacherAnalytics.tsx
+++ b/frontend/src/pages/Teacher/TeacherAnalytics.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
-import { ArrowLeft, Users, TrendingUp, Award, Calendar, BarChart3, ClipboardList, UserCheck } from "lucide-react"
+import { ArrowLeft, Users, TrendingUp, Award, Calendar, BarChart3, ChevronRight, ClipboardList, UserCheck } from "lucide-react"
 import { EmptyState, ErrorState, StatCard } from "@/components/patterns"
 import { formatDate } from "@/i18n/format"
 
@@ -110,12 +110,22 @@ export default function TeacherAnalytics() {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-5xl">
-      <div className="flex items-center gap-3 mb-8">
-        <Link to="/teacher">
-          <Button variant="ghost" size="icon" className="shrink-0" aria-label={t("teacherAnalytics.backToDashboard")}>
-            <ArrowLeft className="h-4 w-4" strokeWidth={1.75} />
-          </Button>
+      <div className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
+        <Link to="/teacher" className="hover:text-foreground transition-colors">
+          {t("teacherAnalytics.breadcrumb.myCourses")}
         </Link>
+        <ChevronRight className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+        <Link
+          to={`/teacher/courses/${courseId}`}
+          className="hover:text-foreground transition-colors truncate"
+        >
+          {courseTitle || t("teacherAnalytics.breadcrumb.courseFallback")}
+        </Link>
+        <ChevronRight className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+        <span className="text-foreground font-medium">{t("teacherAnalytics.heading")}</span>
+      </div>
+
+      <div className="flex items-center gap-3 mb-8">
         <div className="flex-1">
           <h1 className="flex items-center gap-2 font-serif text-3xl font-bold tracking-tight">
             <BarChart3 className="h-6 w-6 shrink-0 text-primary" strokeWidth={1.75} aria-hidden />

--- a/frontend/src/pages/Teacher/TeacherGradebook.tsx
+++ b/frontend/src/pages/Teacher/TeacherGradebook.tsx
@@ -293,6 +293,13 @@ export default function TeacherGradebook() {
           {t("gradebook.breadcrumbCourses")}
         </Link>
         <ChevronRight className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} aria-hidden />
+        <Link
+          to={`/teacher/courses/${courseId}`}
+          className="hover:text-foreground transition-colors truncate"
+        >
+          {courseTitle || t("gradebook.breadcrumbCourseFallback")}
+        </Link>
+        <ChevronRight className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.75} aria-hidden />
         <span className="text-foreground font-medium">{t("gradebook.pageHeading")}</span>
       </div>
 


### PR DESCRIPTION
## What
Three teacher pages live under `/teacher/courses/:courseId/...` and are course-scoped:
- `/teacher/courses/:courseId/progress` (StudentProgress)
- `/teacher/courses/:courseId/analytics` (TeacherAnalytics)
- `/teacher/courses/:courseId/gradebook` (TeacherGradebook)

Their logical parent is the course editor at `/teacher/courses/:courseId`, not the teacher home `/teacher`. **StudentProgress** already used a proper 3-step breadcrumb. The other two skipped the course editor in their navigation:

| Page | Before |
|---|---|
| StudentProgress | `My Courses › Course Title › Student Progress` ✓ |
| TeacherAnalytics | `[← icon-only back to "dashboard"]` — went to `/teacher`, skipped course editor |
| TeacherGradebook | `My Courses › Gradebook` — skipped the course editor middle step |

## Before / After

**TeacherAnalytics** — before: tiny icon arrow back to `/teacher`.
After: `My Courses › Bible 101 › Course Analytics` — text breadcrumb that matches StudentProgress visually and lets the user step back into the course editor in one click.

**TeacherGradebook** — before: `My Courses › Gradebook`.
After: `My Courses › Bible 101 › Gradebook` — inserts the course editor as the middle step. Same 3-segment shape as StudentProgress.

## Why this PR
Part of the logic-audit pass. Three sibling pages that share a URL parent and serve the same teacher → course context should navigate the same way. Otherwise the user can't intuit where the back button will take them: `StudentProgress` lands in the course editor, but `Analytics` and `Gradebook` skip past it and dump them on the courses list. That inconsistency is the bug.

## Change set
- `frontend/src/pages/Teacher/TeacherAnalytics.tsx` — replace icon back button with 3-step text breadcrumb mirroring StudentProgress.
- `frontend/src/pages/Teacher/TeacherGradebook.tsx` — insert the course-editor middle breadcrumb segment.
- `frontend/src/i18n/locales/{en,ru}.json` —
  - new keys `teacherAnalytics.breadcrumb.{myCourses,courseFallback}`,
  - new key `gradebook.breadcrumbCourseFallback`,
  - removed dead key `teacherAnalytics.backToDashboard` (verified no callers).

## Test plan
- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run test:run` — 112/112 pass.
- [ ] Manual: visit `/teacher/courses/:id/analytics` and `/teacher/courses/:id/gradebook`; confirm breadcrumbs match StudentProgress and each link goes to the right place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
