### PR TITLE
design: compact variant for four nested empty states

### DIFF
--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { NativeSelect } from "@/components/ui/native-select"
 import PageSpinner from "@/components/ui/PageSpinner"
+import { EmptyState } from "@/components/patterns/EmptyState"
 import { cohortsService } from "@/services/cohorts"
 import { formatDate } from "@/i18n/format"
 import type { Cohort } from "@/types"
@@ -215,17 +216,18 @@ function capitalize(s: string): string {
 function EmptyCohorts({ hasQuery, onCreate }: { hasQuery: boolean; onCreate: () => void }) {
   const { t } = useTranslation()
   return (
-    <div className="flex flex-col items-center py-16 text-center">
-      <GraduationCap className="h-12 w-12 text-muted-foreground/40 mb-3" strokeWidth={1.5} aria-hidden />
-      <p className="text-muted-foreground mb-4">
-        {hasQuery ? t("admin.cohorts.emptyNoMatch") : t("admin.cohorts.emptyNoCohorts")}
-      </p>
-      {!hasQuery && (
-        <Button size="sm" onClick={onCreate}>
-          <Plus className="h-4 w-4 mr-1.5" strokeWidth={1.75} aria-hidden />
-          {t("admin.cohorts.createButton")}
-        </Button>
-      )}
-    </div>
+    <EmptyState
+      variant="compact"
+      icon={<GraduationCap strokeWidth={1.75} aria-hidden />}
+      title={hasQuery ? t("admin.cohorts.emptyNoMatch") : t("admin.cohorts.emptyNoCohorts")}
+      action={
+        !hasQuery ? (
+          <Button size="sm" onClick={onCreate}>
+            <Plus className="h-4 w-4 mr-1.5" strokeWidth={1.75} aria-hidden />
+            {t("admin.cohorts.createButton")}
+          </Button>
+        ) : undefined
+      }
+    />
   )
 }

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -5,6 +5,7 @@ import { NativeSelect } from "@/components/ui/native-select"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import PageSpinner from "@/components/ui/PageSpinner"
+import { EmptyState } from "@/components/patterns/EmptyState"
 import { FileText, ChevronLeft, ChevronRight } from "lucide-react"
 import type { AuditLogEntry } from "@/types"
 import {
@@ -99,10 +100,11 @@ export function AuditLogTab({
           {loading ? (
             <PageSpinner />
           ) : logs.length === 0 ? (
-            <div className="flex flex-col items-center py-16 text-center">
-              <FileText className="mb-3 h-12 w-12 text-muted-foreground/40" strokeWidth={1.75} aria-hidden />
-              <p className="text-muted-foreground">{t("admin.audit.empty")}</p>
-            </div>
+            <EmptyState
+              variant="compact"
+              icon={<FileText strokeWidth={1.75} aria-hidden />}
+              title={t("admin.audit.empty")}
+            />
           ) : (
             <>
               <AuditTable logs={logs} userMap={userMap} />

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Users, Search, Trash2 } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import PageSpinner from "@/components/ui/PageSpinner"
+import { EmptyState } from "@/components/patterns/EmptyState"
 import VirtualAdminUsers from "../VirtualAdminUsers"
 import { RoleSelector } from "@/components/admin/RoleSelector"
 import type { UserRole } from "@/types"
@@ -170,14 +171,13 @@ export function UsersCard({
 function EmptyUsers({ hasQuery }: { hasQuery: boolean }) {
   const { t } = useTranslation()
   return (
-    <div className="flex flex-col items-center py-16 text-center">
-      <Users className="h-12 w-12 text-muted-foreground/40 mb-3" strokeWidth={1.75} />
-      <p className="text-muted-foreground">
-        {hasQuery
-          ? t("admin.users.emptyNoMatch")
-          : t("admin.users.emptyNoUsers")}
-      </p>
-    </div>
+    <EmptyState
+      variant="compact"
+      icon={<Users strokeWidth={1.75} aria-hidden />}
+      title={
+        hasQuery ? t("admin.users.emptyNoMatch") : t("admin.users.emptyNoUsers")
+      }
+    />
   )
 }
 

--- a/frontend/src/pages/Teacher/progress/StudentTable.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentTable.tsx
@@ -7,6 +7,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Users } from "lucide-react"
+import { EmptyState as DesignEmptyState } from "@/components/patterns/EmptyState"
 import { StudentRow } from "./StudentRow"
 import {
   assignmentAvg,
@@ -120,14 +121,15 @@ export function StudentTable({
 function EmptyState({ hasSearch }: { hasSearch: boolean }) {
   const { t } = useTranslation()
   return (
-    <div className="text-center py-12 text-muted-foreground">
-      <Users className="h-10 w-10 mx-auto mb-3 opacity-30" strokeWidth={1.75} />
-      <p className="text-sm">
-        {hasSearch
+    <DesignEmptyState
+      variant="compact"
+      icon={<Users strokeWidth={1.75} aria-hidden />}
+      title={
+        hasSearch
           ? t("studentProgress.table.emptyNoMatch")
-          : t("studentProgress.table.emptyNoStudents")}
-      </p>
-    </div>
+          : t("studentProgress.table.emptyNoStudents")
+      }
+    />
   )
 }
 


### PR DESCRIPTION
## Summary
- Four "empty" states sat inside an existing `<CardContent>`, hand-rolled as `<div className="flex flex-col items-center py-16 text-center">` with a faint icon + muted line. Inside an already-bordered Card this read as a page-shaped block 12rem tall.
- Migrate each to `<EmptyState variant="compact">` so vertical rhythm matches the other compact empties (Calendar's `SelectedDayPanel`, `UpcomingEventsPanel`, the editor modals).

Touched:
- `StudentTable` (Teacher progress)
- `UsersCard` (Admin users)
- `CohortsTab` (Admin cohorts)
- `AuditLogTab` (Admin audit)

## What stays as the default variant
The dashed-box default is the right call for **page-level** empties that fill the content area when there's literally nothing to show — `EmptyCoursesCard`, `ModuleEditor` no-chapters, `ModulesList` no-modules. Those are editorial moments, not nested-in-a-Card.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 112/112 pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
