### PR TITLE
db: fix chapters.chapter_type default drift (content -> reading)

### DIFF
--- a/backend/app/models/course.py
+++ b/backend/app/models/course.py
@@ -175,7 +175,7 @@ class Chapter(Base):
     module_id: Mapped[str] = mapped_column(ForeignKey("modules.id"))
     title: Mapped[str] = mapped_column()
     order_index: Mapped[int] = mapped_column(default=0)
-    chapter_type: Mapped[str] = mapped_column(default="reading")
+    chapter_type: Mapped[str] = mapped_column(default="reading", server_default="reading")
     requires_completion: Mapped[bool] = mapped_column(default=False)
     is_locked: Mapped[bool] = mapped_column(default=False)
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/supabase/migrations/20260515144737_fix_chapter_type_default.sql
+++ b/supabase/migrations/20260515144737_fix_chapter_type_default.sql
@@ -1,0 +1,24 @@
+-- Repair a schema-drift bug surfaced by the 2026-05-15 DB audit.
+--
+-- chapters.chapter_type has DEFAULT 'content' but the CHECK constraint
+-- (chapters_chapter_type_check, last edited in
+-- 20260422234516_drop_legacy_chapter_course_columns.sql) only allows
+-- ('reading', 'quiz', 'exam', 'assignment'). That migration tightened
+-- the CHECK to match CHAPTER_TYPES in backend/app/schemas/course.py
+-- but forgot to update the column default.
+--
+-- Effect: any INSERT INTO public.chapters that omits chapter_type
+-- relies on the 'content' default, which then violates the CHECK. The
+-- failure has been latent because the SQLAlchemy Chapter model passes
+-- chapter_type='reading' explicitly via its Python-side default, so
+-- the bad default is never exercised through the app. A raw INSERT
+-- (psql, MCP, future script) would fail with:
+--     ERROR: new row for relation "chapters" violates check constraint
+--            "chapters_chapter_type_check"
+--
+-- Data is already clean: pre-flight on 2026-05-15 returned only
+-- 'reading' (21), 'quiz' (5), 'exam' (1) for existing rows. No
+-- 'content' values exist.
+
+ALTER TABLE public.chapters
+  ALTER COLUMN chapter_type SET DEFAULT 'reading';


### PR DESCRIPTION
## Summary

`chapters.chapter_type` has DEFAULT `'content'` left over from the original create-table, but the CHECK constraint was tightened in [`20260422234516_drop_legacy_chapter_course_columns`](https://github.com/ArVaViT/equip/blob/main/supabase/migrations/20260422234516_drop_legacy_chapter_course_columns.sql) to only allow `('reading', 'quiz', 'exam', 'assignment')`. The two have been inconsistent ever since.

```
DEFAULT  = 'content'        <- column default
CHECK    IN ('reading',     <- constraint
            'quiz',
            'exam',
            'assignment')
```

The bug is latent because the SQLAlchemy `Chapter` model passes `chapter_type='reading'` via its Python default, so the DB default is never reached through the app. But any raw INSERT (psql, Supabase MCP, future script, manual data load) that omits `chapter_type` would fail with `chapters_chapter_type_check` violation.

## What this changes

- DB: `ALTER COLUMN chapter_type SET DEFAULT 'reading'`.
- Model: adds matching `server_default="reading"` so SQLite tests and real Postgres agree.

## Data safety

`SELECT chapter_type, COUNT(*) FROM chapters GROUP BY chapter_type` returned `reading=21, quiz=5, exam=1` -- zero legacy `'content'` rows.

## Test plan

- [x] `apply_migration` succeeded via Supabase MCP
- [x] `information_schema.columns` re-queried: default is now `'reading'::character varying`
- [x] `python -m pytest tests/` -- 581 passed
- [ ] Backend CI Postgres schema-smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)