### PR TITLE
ux(profile): drop duplicate role row from Account Details

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -149,7 +149,6 @@
     "viewAllCertificates": "View all certificates",
     "accountDetails": "Account Details",
     "memberSince": "Member since",
-    "role": "Role",
     "preferences": "Preferences",
     "theme": "Theme",
     "themeDark": "Dark mode",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -149,7 +149,6 @@
     "viewAllCertificates": "Все сертификаты",
     "accountDetails": "Сведения об аккаунте",
     "memberSince": "С нами с",
-    "role": "Роль",
     "preferences": "Настройки",
     "theme": "Тема",
     "themeDark": "Тёмная тема",

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -18,7 +18,7 @@ import { ROLE_I18N_KEY } from "@/lib/roles"
 import { formatDateLong } from "@/i18n/format"
 import { toast } from "@/lib/toast"
 import {
-  User as UserIcon, Mail, Shield, Calendar, Camera, Globe,
+  User as UserIcon, Mail, Calendar, Camera, Globe,
   Loader2, Award, BookOpen, ArrowRight, LogOut, Moon, Sun,
 } from "lucide-react"
 
@@ -247,13 +247,6 @@ export default function ProfilePage() {
                 <div className="min-w-0">
                   <dt className="text-xs text-muted-foreground">{t("auth.email")}</dt>
                   <dd className="text-sm font-medium">{user.email}</dd>
-                </div>
-              </div>
-              <div className="flex items-start gap-3 px-4 py-3">
-                <Shield className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
-                <div>
-                  <dt className="text-xs text-muted-foreground">{t("profile.role")}</dt>
-                  <dd className="text-sm font-medium">{t(ROLE_I18N_KEY[user.role])}</dd>
                 </div>
               </div>
               {user.created_at && (


### PR DESCRIPTION
## What
The Profile page rendered the user's role in two places on the same screen:

1. The top "identity" card — directly under the user's name, next to the avatar (a `CardDescription`).
2. The "Account Details" card — as a Shield-icon row in the dl/dt/dd list, alongside email and member-since.

Same fact, twice, no extra context the second time around.

## Before / After

**Before** (signed-in user with role "Teacher"):
```
┌─────────────────────────────────────────┐
│ [avatar]   Vadym Arnaut                 │
│            Teacher                ← role│
└─────────────────────────────────────────┘
…
┌─ Account Details ───────────────────────┐
│ ✉ Email      vadym@example.com          │
│ 🛡 Role      Teacher              ← role│  ← duplicate
│ 📅 Member    May 14, 2026                │
└─────────────────────────────────────────┘
```

**After**:
```
┌─────────────────────────────────────────┐
│ [avatar]   Vadym Arnaut                 │
│            Teacher                ← role│
└─────────────────────────────────────────┘
…
┌─ Account Details ───────────────────────┐
│ ✉ Email      vadym@example.com          │
│ 📅 Member    May 14, 2026                │
└─────────────────────────────────────────┘
```

## Why this PR
Part of the logic-audit pass — finding pairs that say the same thing in two places. The role placement in the header card (next to the name) is the right home: it's the user's "who am I in this system" identity, and the eye is already there reading the name. The Account Details row was redundant; nothing else on the page referred back to it.

The card keeps **Email** and **Member-since**, the two facts that aren't surfaced anywhere else on the page.

## Change set
- `frontend/src/pages/Profile/ProfilePage.tsx` — remove the role row, drop the now-unused `Shield` icon import.
- `frontend/src/i18n/locales/{en,ru}.json` — drop the now-dead `profile.role` key.

## Test plan
- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run test:run` — 112/112 pass.
- [ ] Manual: visit `/profile`, confirm role still appears under the name and no longer in Account Details. Confirm Account Details renders Email + Member Since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
