### PR TITLE
fix(i18n): translate notification 'x ago' timestamps

### DIFF
--- a/frontend/src/components/layout/notifications/NotificationItem.tsx
+++ b/frontend/src/components/layout/notifications/NotificationItem.tsx
@@ -58,7 +58,7 @@ export function NotificationItem({ notification, onActivate, onDelete }: Props) 
             {notification.message}
           </p>
           <p className="mt-1 text-[11px] text-muted-foreground/70">
-            {timeAgo(notification.created_at)}
+            {timeAgo(notification.created_at, t)}
           </p>
         </div>
       </button>

--- a/frontend/src/components/layout/notifications/__tests__/timeAgo.test.ts
+++ b/frontend/src/components/layout/notifications/__tests__/timeAgo.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { timeAgo } from "../notificationMeta"
+
+/**
+ * Regression suite for the notification bell's relative-time helper.
+ *
+ * Pre-fix the function hardcoded English strings (``just now`` /
+ * ``5m ago`` / ``2d ago``) in a bilingual product, leaving the
+ * Russian side broken. It now takes the translator from
+ * ``useTranslation().t`` and renders keys under
+ * ``notifications.timeAgo.*``.
+ *
+ * Tests use a fake translator so they don't have to wire up i18next.
+ */
+describe("timeAgo", () => {
+  // Capture (key, count) calls so we can assert the right bucket
+  // was reached and the right count was passed for pluralization.
+  const fakeT = vi.fn(
+    (key: string, options?: { count?: number }) =>
+      options?.count !== undefined ? `${key}:${options.count}` : key,
+  )
+
+  beforeEach(() => {
+    fakeT.mockClear()
+  })
+
+  it("'just now' for sub-minute diffs", () => {
+    const recent = new Date(Date.now() - 30_000).toISOString()
+    expect(timeAgo(recent, fakeT)).toBe("notifications.timeAgo.justNow")
+  })
+
+  it("minutesAgo with count for sub-hour diffs", () => {
+    const fiveMin = new Date(Date.now() - 5 * 60_000).toISOString()
+    expect(timeAgo(fiveMin, fakeT)).toBe("notifications.timeAgo.minutesAgo:5")
+  })
+
+  it("hoursAgo with count for sub-day diffs", () => {
+    const threeHr = new Date(Date.now() - 3 * 60 * 60_000).toISOString()
+    expect(timeAgo(threeHr, fakeT)).toBe("notifications.timeAgo.hoursAgo:3")
+  })
+
+  it("daysAgo with count for sub-week diffs", () => {
+    const twoDay = new Date(Date.now() - 2 * 24 * 60 * 60_000).toISOString()
+    expect(timeAgo(twoDay, fakeT)).toBe("notifications.timeAgo.daysAgo:2")
+  })
+
+  it("falls back to YYYY-MM-DD past 7 days", () => {
+    const old = new Date("2026-01-15T10:00:00Z").toISOString()
+    // 2026-01-15 in browser local — the helper uses formatDate which
+    // is local-zone canonical, so we recompute the same way.
+    const d = new Date(old)
+    const expected =
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+    expect(timeAgo(old, fakeT)).toBe(expected)
+  })
+
+  it("returns em-dash for unparseable input", () => {
+    expect(timeAgo("not-a-date", fakeT)).toBe("—")
+  })
+})

--- a/frontend/src/components/layout/notifications/notificationMeta.ts
+++ b/frontend/src/components/layout/notifications/notificationMeta.ts
@@ -36,19 +36,34 @@ export const NOTIFICATION_COLORS: Record<NotificationType, string> = {
   enrollment_confirmed: "text-success",
 }
 
-/** Compact "x minutes ago" formatter used by the dropdown list. */
-export function timeAgo(dateStr: string): string {
+/** Translator type matches react-i18next's ``useTranslation().t``. */
+type Translator = (key: string, options?: { count?: number }) => string
+
+/**
+ * Compact "x minutes ago" formatter used by the dropdown list.
+ *
+ * Takes the translator as a parameter so this stays a pure function
+ * — the caller passes ``t`` from ``useTranslation()``. i18next's
+ * plural machinery picks the right ``_one`` / ``_few`` / ``_many`` /
+ * ``_other`` form per locale via the ``count`` option, which is
+ * essential for the Russian side (``5 минут`` vs ``2 минуты`` vs ``1
+ * минуту``). Strings live under ``notifications.timeAgo.*``.
+ *
+ * Days ≥ 7 falls through to the canonical ``formatDate`` (locale-
+ * neutral ``YYYY-MM-DD``).
+ */
+export function timeAgo(dateStr: string, t: Translator): string {
   const parsed = new Date(dateStr).getTime()
   if (Number.isNaN(parsed)) return "—"
   const now = Date.now()
   const diff = now - parsed
   const seconds = Math.floor(diff / 1000)
-  if (seconds < 60) return "just now"
+  if (seconds < 60) return t("notifications.timeAgo.justNow")
   const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
+  if (minutes < 60) return t("notifications.timeAgo.minutesAgo", { count: minutes })
   const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
+  if (hours < 24) return t("notifications.timeAgo.hoursAgo", { count: hours })
   const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}d ago`
+  if (days < 7) return t("notifications.timeAgo.daysAgo", { count: days })
   return formatDate(dateStr)
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -65,7 +65,16 @@
     "tryAgain": "Try again",
     "loadMore": "Load more",
     "loadingMore": "Loading...",
-    "deleteAriaLabel": "Delete notification"
+    "deleteAriaLabel": "Delete notification",
+    "timeAgo": {
+      "justNow": "just now",
+      "minutesAgo_one": "{{count}}m ago",
+      "minutesAgo_other": "{{count}}m ago",
+      "hoursAgo_one": "{{count}}h ago",
+      "hoursAgo_other": "{{count}}h ago",
+      "daysAgo_one": "{{count}}d ago",
+      "daysAgo_other": "{{count}}d ago"
+    }
   },
   "language": {
     "label": "Language",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -65,7 +65,22 @@
     "tryAgain": "Повторить",
     "loadMore": "Ещё",
     "loadingMore": "Загрузка...",
-    "deleteAriaLabel": "Удалить уведомление"
+    "deleteAriaLabel": "Удалить уведомление",
+    "timeAgo": {
+      "justNow": "только что",
+      "minutesAgo_one": "{{count}} мин назад",
+      "minutesAgo_few": "{{count}} мин назад",
+      "minutesAgo_many": "{{count}} мин назад",
+      "minutesAgo_other": "{{count}} мин назад",
+      "hoursAgo_one": "{{count}} ч назад",
+      "hoursAgo_few": "{{count}} ч назад",
+      "hoursAgo_many": "{{count}} ч назад",
+      "hoursAgo_other": "{{count}} ч назад",
+      "daysAgo_one": "{{count}} д назад",
+      "daysAgo_few": "{{count}} д назад",
+      "daysAgo_many": "{{count}} д назад",
+      "daysAgo_other": "{{count}} д назад"
+    }
   },
   "language": {
     "label": "Язык",


### PR DESCRIPTION
## What broke

The bell-dropdown's `timeAgo()` helper hardcoded the English strings `just now` / `5m ago` / `2d ago` in a bilingual product. The rest of the dropdown (title, "mark all read", empty state, delete tooltip) was already translated, so the relative timestamp was the one English fragment a Russian user saw in their otherwise-Russian UI.

## How it's fixed

Mirrors the shape `relativeTime()` in `pages/Teacher/progress/helpers.ts` has used since the studentProgress work landed: take `t` as a parameter so the function stays pure, render keys under `notifications.timeAgo.*`. The Russian side ships all four i18next plural forms (`_one` / `_few` / `_many` / `_other`) even though the noninflected `мин` / `ч` / `д` doesn't strictly need them — matches the precedent so the bundle stays predictable for future translators.

New strings:

- `notifications.timeAgo.justNow`
- `notifications.timeAgo.minutesAgo_{one,few,many,other}`
- `notifications.timeAgo.hoursAgo_{one,few,many,other}`
- `notifications.timeAgo.daysAgo_{one,few,many,other}`

Regression suite (`__tests__/timeAgo.test.ts`) pins each bucket via a fake translator — no i18next wiring needed.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 118 tests passed
- [x] `npm run i18n:check` — bundles in parity (1264 EN / 1312 RU keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
