### PR TITLE
design: skeletons for three full-page spinners

### DIFF
--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { NativeSelect } from "@/components/ui/native-select"
-import PageSpinner from "@/components/ui/PageSpinner"
+import { Skeleton } from "@/components/ui/skeleton"
 import { cohortsService } from "@/services/cohorts"
 import { formatDate } from "@/i18n/format"
 import type { Cohort } from "@/types"
@@ -92,7 +92,7 @@ export function CohortsTab() {
       </CardHeader>
       <CardContent>
         {loading ? (
-          <PageSpinner />
+          <CohortsTableSkeleton />
         ) : error ? (
           <div className="py-10 text-center">
             <p className="text-sm text-destructive">{error}</p>
@@ -226,6 +226,45 @@ function EmptyCohorts({ hasQuery, onCreate }: { hasQuery: boolean; onCreate: () 
           {t("admin.cohorts.createButton")}
         </Button>
       )}
+    </div>
+  )
+}
+
+/**
+ * Cohort list loading placeholder. Mirrors the table on desktop and the
+ * stacked card list on mobile so the layout doesn't snap when data arrives.
+ */
+function CohortsTableSkeleton() {
+  return (
+    <div aria-busy="true">
+      {/* Mobile stack */}
+      <div className="space-y-2 sm:hidden">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-md border border-border bg-card p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            <div className="mt-3 flex items-center gap-4">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* Desktop table */}
+      <div className="hidden overflow-x-auto -mx-6 sm:block">
+        {Array.from({ length: 6 }).map((_, row) => (
+          <div key={row} className="px-6 py-3 border-b flex items-center gap-4">
+            {Array.from({ length: 5 }).map((_, col) => (
+              <Skeleton key={col} className="h-4 flex-1" />
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input"
 import { NativeSelect } from "@/components/ui/native-select"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import PageSpinner from "@/components/ui/PageSpinner"
+import { Skeleton } from "@/components/ui/skeleton"
 import { FileText, ChevronLeft, ChevronRight } from "lucide-react"
 import type { AuditLogEntry } from "@/types"
 import {
@@ -97,7 +97,7 @@ export function AuditLogTab({
         </CardHeader>
         <CardContent>
           {loading ? (
-            <PageSpinner />
+            <AuditTableSkeleton />
           ) : logs.length === 0 ? (
             <div className="flex flex-col items-center py-16 text-center">
               <FileText className="mb-3 h-12 w-12 text-muted-foreground/40" strokeWidth={1.75} aria-hidden />
@@ -251,6 +251,30 @@ function AuditTable({
           ))}
         </tbody>
       </table>
+    </div>
+  )
+}
+
+/**
+ * Audit-table loading placeholder. Renders 8 ghost rows in the table layout
+ * so column widths don't snap when real data arrives. Calling 8 because that's
+ * the default page size for the audit log.
+ */
+function AuditTableSkeleton() {
+  return (
+    <div className="-mx-6 overflow-x-auto" aria-busy="true">
+      <div className="px-6 py-3 border-b flex gap-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-3 flex-1" />
+        ))}
+      </div>
+      {Array.from({ length: 8 }).map((_, row) => (
+        <div key={row} className="px-6 py-3 border-b flex gap-4 items-center">
+          {Array.from({ length: 5 }).map((_, col) => (
+            <Skeleton key={col} className="h-4 flex-1" />
+          ))}
+        </div>
+      ))}
     </div>
   )
 }

--- a/frontend/src/pages/Certificates/CertificatesPage.tsx
+++ b/frontend/src/pages/Certificates/CertificatesPage.tsx
@@ -7,7 +7,7 @@ import { coursesService } from "@/services/courses"
 import type { Certificate, Enrollment } from "@/types"
 import { toast } from "@/lib/toast"
 import { Award, ArrowLeft, ScrollText } from "lucide-react"
-import PageSpinner from "@/components/ui/PageSpinner"
+import { Skeleton } from "@/components/ui/skeleton"
 import { formatDateLong } from "@/i18n/format"
 
 export default function CertificatesPage() {
@@ -48,7 +48,7 @@ export default function CertificatesPage() {
   }
 
   if (loading) {
-    return <PageSpinner />
+    return <CertificatesPageSkeleton />
   }
 
   return (
@@ -134,6 +134,37 @@ export default function CertificatesPage() {
           ))}
         </div>
       )}
+    </div>
+  )
+}
+
+/**
+ * Loading placeholder. Mirrors the final layout (back-button, page header,
+ * 1×3 grid of certificate cards) so the page doesn't reflow on data arrival.
+ */
+function CertificatesPageSkeleton() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-5xl" aria-busy="true">
+      <Skeleton className="mb-6 h-7 w-32" />
+      <div className="mb-8 flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-md" />
+        <Skeleton className="h-8 w-56" />
+      </div>
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardContent className="pb-5 pt-6">
+              <div className="mb-4 flex items-start justify-between">
+                <Skeleton className="h-11 w-11 rounded-md" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+              <Skeleton className="mb-3 h-5 w-3/4" />
+              <Skeleton className="mb-2 h-3 w-1/2" />
+              <Skeleton className="h-3 w-2/3" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- DESIGN.md says: every data view shows a skeleton matching the final layout; `<PageSpinner>` is only for the case a skeleton is impossible. Three pages with known layouts still flashed a centered spinner and then snapped to a fully-rendered grid / table.
- Replace each with a shape-matching skeleton so the page never reflows on data arrival.

Skeletons added:

| Page | Shape mirrored |
| --- | --- |
| `CertificatesPage` | Back-button + heading + 1×3 grid of certificate cards |
| `AuditLogTab` | 5-column header strip + 8 ghost rows (default page size) |
| `CohortsTab` | Mobile stack of cards (`<sm`) + desktop table (`≥sm`), both shapes |

Each skeleton lives next to its consumer (page-local, like `CourseCardSkeleton`). No shared helpers, no behaviour change.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 112/112 pass
- [ ] Visually confirm no layout snap on each page in throttled DevTools

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
