### PR TITLE
sec(rls): lock email + created_at on profiles self-update

### DIFF
--- a/backend/tests/test_profiles_self_update_policy.py
+++ b/backend/tests/test_profiles_self_update_policy.py
@@ -1,0 +1,63 @@
+"""Regression tests for the ``profiles_update_own_safe_fields`` RLS policy.
+
+These tests parse the migration SQL and confirm that the WITH CHECK
+clause pins every identity column a user could otherwise spoof
+(``role``, ``email``, ``id``, ``created_at``). They never touch a real
+database — SQLite (our test DB) cannot enforce RLS, so a text-level
+check is the most reliable signal that a future migration relaxing
+this policy will get caught in CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "supabase" / "migrations"
+
+
+def _profiles_lock_sql() -> str:
+    matches = sorted(MIGRATIONS_DIR.glob("*_profiles_lock_email_self_update.sql"))
+    assert matches, "profiles_lock_email_self_update migration not found"
+    return matches[-1].read_text(encoding="utf-8")
+
+
+def test_old_permissive_policy_is_dropped() -> None:
+    """The previous ``profiles_update_own_no_role`` policy pinned
+    only ``role`` and left ``email`` writable. It must be explicitly
+    dropped before the safer policy is created."""
+    sql = _profiles_lock_sql()
+    assert "DROP POLICY IF EXISTS profiles_update_own_no_role ON public.profiles" in sql, (
+        "Migration must drop the old profiles_update_own_no_role policy before creating the replacement."
+    )
+
+
+def test_with_check_pins_email() -> None:
+    """A user must not be able to PATCH profiles.email to spoof
+    another identity (the column is read in analytics/grades/progress
+    surfaces that teachers trust)."""
+    sql = _profiles_lock_sql()
+    # The pin pattern reads the column from the current row and
+    # compares it against the new value in the same statement.
+    assert "email = (" in sql, (
+        "WITH CHECK must compare email against the current row to prevent client-side email spoofing."
+    )
+    assert "FROM public.profiles p WHERE p.id = (SELECT auth.uid())" in sql, (
+        "Pin comparisons must read the canonical row by auth.uid()."
+    )
+
+
+def test_with_check_pins_role() -> None:
+    """Role pin must survive the policy rewrite — otherwise we
+    re-open the privilege-escalation hole this policy historically
+    closed."""
+    sql = _profiles_lock_sql()
+    assert "role = (" in sql, "WITH CHECK must compare role against the current row to prevent self-promotion."
+
+
+def test_with_check_pins_created_at() -> None:
+    """created_at is part of the audit/identity surface (e.g. admin
+    'user list' shows account age). Must not be client-mutable."""
+    sql = _profiles_lock_sql()
+    assert "created_at IS NOT DISTINCT FROM" in sql, (
+        "WITH CHECK must pin created_at using IS NOT DISTINCT FROM (handles the NULL-on-NULL case correctly)."
+    )

--- a/supabase/migrations/20260515185101_profiles_lock_email_self_update.sql
+++ b/supabase/migrations/20260515185101_profiles_lock_email_self_update.sql
@@ -1,0 +1,69 @@
+-- Supabase migration: profiles_lock_email_self_update
+-- Version: 20260515184958
+--
+-- MEDIUM severity: profile-row spoofing for social engineering.
+--
+-- The existing ``profiles_update_own_no_role`` policy correctly prevents
+-- role escalation but its WITH CHECK only protects ``role``. A user
+-- could PATCH ``profiles.email`` (or ``created_at``) via PostgREST to
+-- any value:
+--
+--   await supabase.from('profiles')
+--     .update({ email: 'admin@equipbible.com' })
+--     .eq('id', myId);
+--
+-- ``profiles.email`` is a synced copy of ``auth.users.email`` (the
+-- canonical column for auth). The JWT ``sub`` claim is still the
+-- user's real UUID, so this isn't a session-takeover -- but
+-- ``profiles.email`` IS the column the backend reads when surfacing
+-- the user's identity in:
+--   * analytics.py L65-66       (course-level student roster)
+--   * grades.py L112            (StudentCalculatedGrade.student_email)
+--   * student_progress_service  (teacher's "see all students" view)
+--
+-- A student spoofing their email to ``admin@equipbible.com`` then
+-- showing up in a teacher's grade roster is a clean social-engineering
+-- vector ("I'm the admin, please regrade this"). And teachers tend to
+-- trust the email column more than the UUID.
+--
+-- Fix: replace the existing UPDATE policy with one whose WITH CHECK
+-- also pins ``email``, ``id``, and ``created_at`` to their current
+-- values. Only ``full_name``, ``avatar_url``, ``preferred_locale``,
+-- ``updated_at`` remain client-mutable (matching the
+-- ``usersService.updateProfile`` frontend contract). ``role`` stays
+-- pinned via the existing subquery -- carried verbatim.
+--
+-- There is currently no SPA flow that changes a user's email
+-- (``services/auth.ts`` only calls ``supabase.auth.updateUser`` with
+-- ``{ password }``), and no trigger that mirrors ``auth.users.email``
+-- changes back into ``profiles.email`` -- so locking the column is
+-- not a UX regression. If we add an email-change flow later, the
+-- right shape is a server-mediated POST (which runs as ``postgres``
+-- and bypasses RLS) or a new auth-users-on-update trigger.
+
+DROP POLICY IF EXISTS profiles_update_own_no_role ON public.profiles;
+
+CREATE POLICY profiles_update_own_safe_fields ON public.profiles
+  FOR UPDATE
+  TO authenticated
+  USING (
+    (SELECT auth.uid()) = id
+  )
+  WITH CHECK (
+    (SELECT auth.uid()) = id
+    -- role: must match the current row (no escalation)
+    AND role = (
+      SELECT p.role FROM public.profiles p WHERE p.id = (SELECT auth.uid())
+    )
+    -- email: must match the current row (no spoofing)
+    AND email = (
+      SELECT p.email FROM public.profiles p WHERE p.id = (SELECT auth.uid())
+    )
+    -- created_at: immutable
+    AND created_at IS NOT DISTINCT FROM (
+      SELECT p.created_at FROM public.profiles p WHERE p.id = (SELECT auth.uid())
+    )
+  );
+
+COMMENT ON POLICY profiles_update_own_safe_fields ON public.profiles IS
+  'Self-update is allowed only on full_name / avatar_url / preferred_locale / updated_at. role / email / id / created_at are pinned to current values so PostgREST clients cannot spoof identity columns. Trigger-sync from auth.users runs as postgres and bypasses this policy.';


### PR DESCRIPTION
## Severity: MEDIUM — identity spoofing for social engineering

**Note: the migration is already applied to production** (Supabase MCP `apply_migration`). The committed file `20260515185101_profiles_lock_email_self_update.sql` matches the version in `supabase_migrations.schema_migrations`.

## What was broken

The pre-existing `profiles_update_own_no_role` policy pinned only the `role` column in its `WITH CHECK`:

```sql
-- old:
WITH CHECK (
  (SELECT auth.uid()) = id
  AND role = (SELECT p.role FROM profiles p WHERE p.id = (SELECT auth.uid()))
)
```

`email`, `created_at`, and `id` were not pinned. A user could PATCH their own `profiles.email` directly via PostgREST:

```js
await supabase.from('profiles')
  .update({ email: 'admin@equipbible.com' })
  .eq('id', myId);
```

This isn't a session takeover — the JWT `sub` claim is still the user's real UUID, so `get_current_user` still resolves them correctly. But `profiles.email` IS the column the backend reads when surfacing identity in teacher-facing surfaces:

| Surface | Code |
|---|---|
| Course-level student roster | `analytics.py:65-66` |
| Calculated grade (CSV + UI) | `grades.py:112` (`student_email`) |
| "All students" view | `student_progress_service.py:358-359` |

A student spoofing their email to `admin@equipbible.com`, then showing up in a teacher's grade roster, is a clean social-engineering vector ("I'm an admin — please regrade this"). Teachers tend to trust the email column more than a raw UUID.

## What changed

Replace the policy with `profiles_update_own_safe_fields`. The new `WITH CHECK` pins all the identity columns:

```sql
WITH CHECK (
  (SELECT auth.uid()) = id
  AND role       = (SELECT p.role       FROM profiles p WHERE p.id = (SELECT auth.uid()))
  AND email      = (SELECT p.email      FROM profiles p WHERE p.id = (SELECT auth.uid()))
  AND created_at IS NOT DISTINCT FROM
                    (SELECT p.created_at FROM profiles p WHERE p.id = (SELECT auth.uid()))
)
```

Only `full_name`, `avatar_url`, `preferred_locale`, and `updated_at` remain client-mutable — which matches the `usersService.updateProfile` frontend contract (typed as `{ full_name?: string; avatar_url?: string }`) exactly.

`id` is implicitly pinned by the `auth.uid() = id` predicate combined with the row-by-id PK; renaming `id` would change which row the predicate applies to, so it cannot survive.

## Why this is safe to ship

- **No SPA email-change flow exists.** `frontend/src/services/auth.ts` calls `supabase.auth.updateUser({ password })` only — never `{ email }`. There is no other code path that PATCHes `profiles.email`.
- **No `auth.users` → `profiles` email-sync trigger.** Only the INSERT-time `handle_new_user` trigger runs; subsequent `auth.users.email` changes don't propagate today, so `profiles.email` was already stale-by-design for any user who changed their Supabase auth email.
- **`role` pinning is preserved verbatim** from the old policy, so the role-escalation guard the original policy provided is intact.
- If an email-change flow is added later, the right shape is a server-mediated POST (FastAPI connects as `postgres`, bypasses RLS) or a new `auth.users` ON UPDATE trigger — not relaxing this policy.

## Regression test

`backend/tests/test_profiles_self_update_policy.py` parses the migration SQL and asserts:
1. The old `profiles_update_own_no_role` policy is explicitly dropped.
2. The new policy pins `email` against the current row.
3. It still pins `role` (the original guard).
4. It pins `created_at` using `IS NOT DISTINCT FROM` (handles NULLs correctly).

Text-level so it catches a future migration that loosens this even though SQLite can't enforce RLS.

## Test plan

- [x] `python -m pytest tests/test_profiles_self_update_policy.py -v` — 4/4 pass.
- [x] `python -m pytest tests/` — 585/585 pass.
- [x] `ruff check`, `ruff format --check`, `mypy` clean on touched files.
- [x] Live DB: `pg_policies` query confirms `profiles_update_own_safe_fields` is in place with the new WITH CHECK; old policy is gone.
- [ ] Manual smoke test: open profile editor in the SPA, change display name, save. Should still work (only `full_name` mutated; `email` pin not triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
