### PR TITLE
design(motion): centralize editorial easing + duration tokens

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -8,8 +8,7 @@ import type { Course } from "@/types"
 import { BookOpen, ArrowRight } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import { formatDate } from "@/i18n/format"
-
-const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
+import { EDITORIAL_EASE } from "@/lib/motion"
 
 interface CourseCardProps {
   course: Course

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ import { ROLES } from "@/types"
 import { User as UserIcon, Menu } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import { cn } from "@/lib/utils"
+import { EDITORIAL_EASE } from "@/lib/motion"
 import { Tooltip, TooltipContent,TooltipTrigger } from "@/components/ui/tooltip"
 
 const UNDERLINE_LAYOUT_ID = "header-active-underline"
@@ -62,7 +63,7 @@ function HeaderNavLink({
           <motion.span
             layoutId={UNDERLINE_LAYOUT_ID}
             className="pointer-events-none absolute inset-x-3 bottom-0 h-0.5 rounded-sm bg-primary"
-            transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
+            transition={{ duration: 0.32, ease: EDITORIAL_EASE }}
             aria-hidden
           />
         ))}

--- a/frontend/src/components/motion/FadeIn.tsx
+++ b/frontend/src/components/motion/FadeIn.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react"
 import { motion, useReducedMotion } from "motion/react"
+import { EDITORIAL_EASE, MOTION_DURATION } from "@/lib/motion"
 
 type FadeInProps = {
   children: ReactNode
@@ -9,12 +10,10 @@ type FadeInProps = {
   className?: string
 }
 
-const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
-
 export function FadeIn({
   children,
   delay = 0,
-  duration = 0.48,
+  duration = MOTION_DURATION.entrance,
   y = 8,
   className,
 }: FadeInProps) {

--- a/frontend/src/components/motion/HoverLift.tsx
+++ b/frontend/src/components/motion/HoverLift.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react"
 import { motion, useReducedMotion } from "motion/react"
+import { EDITORIAL_EASE, MOTION_DURATION } from "@/lib/motion"
 
 type HoverLiftProps = {
   children: ReactNode
@@ -7,8 +8,6 @@ type HoverLiftProps = {
   lift?: number
   press?: number
 }
-
-const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
 
 export function HoverLift({
   children,
@@ -27,7 +26,7 @@ export function HoverLift({
       className={className}
       whileHover={{ y: -lift }}
       whileTap={press ? { y: press } : undefined}
-      transition={{ duration: 0.28, ease: EDITORIAL_EASE }}
+      transition={{ duration: MOTION_DURATION.base, ease: EDITORIAL_EASE }}
     >
       {children}
     </motion.div>

--- a/frontend/src/components/motion/PageTransition.tsx
+++ b/frontend/src/components/motion/PageTransition.tsx
@@ -1,12 +1,11 @@
 import { type ReactNode } from "react"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
+import { EDITORIAL_EASE, MOTION_DURATION } from "@/lib/motion"
 
 type PageTransitionProps = {
   routeKey: string
   children: ReactNode
 }
-
-const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
 
 export function PageTransition({ routeKey, children }: PageTransitionProps) {
   const prefersReducedMotion = useReducedMotion()
@@ -22,7 +21,7 @@ export function PageTransition({ routeKey, children }: PageTransitionProps) {
         initial={{ opacity: 0, y: 6 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -4 }}
-        transition={{ duration: 0.28, ease: EDITORIAL_EASE }}
+        transition={{ duration: MOTION_DURATION.base, ease: EDITORIAL_EASE }}
       >
         {children}
       </motion.div>

--- a/frontend/src/components/motion/PressFeedback.tsx
+++ b/frontend/src/components/motion/PressFeedback.tsx
@@ -1,13 +1,12 @@
 import { type ReactNode } from "react"
 import { motion, useReducedMotion } from "motion/react"
+import { EDITORIAL_EASE, MOTION_DURATION } from "@/lib/motion"
 
 type PressFeedbackProps = {
   children: ReactNode
   className?: string
   scale?: number
 }
-
-const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
 
 export function PressFeedback({
   children,
@@ -24,7 +23,7 @@ export function PressFeedback({
     <motion.div
       className={className}
       whileTap={{ scale }}
-      transition={{ duration: 0.12, ease: EDITORIAL_EASE }}
+      transition={{ duration: MOTION_DURATION.instant, ease: EDITORIAL_EASE }}
     >
       {children}
     </motion.div>

--- a/frontend/src/components/motion/Reveal.tsx
+++ b/frontend/src/components/motion/Reveal.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react"
 import { motion, useReducedMotion } from "motion/react"
+import { EDITORIAL_EASE, MOTION_DURATION } from "@/lib/motion"
 
 type RevealProps = {
   children: ReactNode
@@ -8,8 +9,6 @@ type RevealProps = {
   once?: boolean
   amount?: number
 }
-
-const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
 
 export function Reveal({
   children,
@@ -30,7 +29,7 @@ export function Reveal({
       initial={{ opacity: 0, y }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once, amount }}
-      transition={{ duration: 0.55, ease: EDITORIAL_EASE }}
+      transition={{ duration: MOTION_DURATION.slow, ease: EDITORIAL_EASE }}
     >
       {children}
     </motion.div>

--- a/frontend/src/components/motion/StaggerChildren.tsx
+++ b/frontend/src/components/motion/StaggerChildren.tsx
@@ -1,5 +1,6 @@
 import { Children, type ReactNode } from "react"
 import { motion, useReducedMotion } from "motion/react"
+import { EDITORIAL_EASE, MOTION_DURATION } from "@/lib/motion"
 
 type StaggerChildrenProps = {
   children: ReactNode
@@ -9,12 +10,10 @@ type StaggerChildrenProps = {
   className?: string
 }
 
-const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
-
 export function StaggerChildren({
   children,
   stagger = 0.045,
-  duration = 0.48,
+  duration = MOTION_DURATION.entrance,
   y = 8,
   className,
 }: StaggerChildrenProps) {

--- a/frontend/src/lib/motion.ts
+++ b/frontend/src/lib/motion.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared motion tokens — single source of truth for animation timing and easing
+ * across the app. Keeps editorial feel consistent everywhere: page transitions,
+ * card hovers, fade-ins, reveal scrolls, hero blocks all use the same curve.
+ *
+ * Why a constant, not a Tailwind utility:
+ * - `framer-motion`/`motion` `transition.ease` accepts a cubic-bezier tuple,
+ *   not a CSS string. Tailwind's `ease-editorial` covers the CSS side; this
+ *   covers the JS side. Both encode the same curve so a hover-in-CSS and a
+ *   layout-shift-in-JS feel like one system.
+ *
+ * Curve: `[0.22, 1, 0.36, 1]` — "easeOutQuint"-ish. Quick start, gentle settle.
+ * Reads as confident, never bouncy. Matches the print-leaning visual language.
+ */
+export const EDITORIAL_EASE = [0.22, 1, 0.36, 1] as const
+
+/**
+ * Standard durations (seconds — `motion` defaults to seconds, not ms).
+ * Use these instead of inline literals so timing reads as a system, not noise.
+ *
+ * - `instant`  — color/state changes that should feel immediate (0.12s)
+ * - `fast`     — small affordances: press, hover-color, focus ring (0.2s)
+ * - `base`     — most state changes (0.28s) — this is the default
+ * - `entrance` — list/card initial reveals (0.48s)
+ * - `slow`     — hero/large-block reveals (0.55s)
+ */
+export const MOTION_DURATION = {
+  instant: 0.12,
+  fast: 0.2,
+  base: 0.28,
+  entrance: 0.48,
+  slow: 0.55,
+} as const


### PR DESCRIPTION
## Summary

Until now seven motion primitives plus `CourseCard` and `Header` each redefined `EDITORIAL_EASE = [0.22, 1, 0.36, 1]` locally. That's the same curve duplicated nine times — easy for it to drift, hard to audit. This hoists it into `@/lib/motion` alongside a small `MOTION_DURATION` scale so durations also read as a system instead of literal seconds sprinkled across the codebase.

- New `frontend/src/lib/motion.ts` exports `EDITORIAL_EASE` + `MOTION_DURATION` (`instant`, `fast`, `base`, `entrance`, `slow`).
- All seven motion primitives (`FadeIn`, `StaggerChildren`, `HoverLift`, `PressFeedback`, `Reveal`, `PageTransition`) plus `CourseCard` and `Header` now import the constant instead of redeclaring it.
- No behavior changes — same curve, same durations.

Why care: the next motion edit becomes honest. Change one constant and the whole app responds; today you have to grep nine files.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 125/125 pass (including the 11 motion-primitive tests)

Touches no pages, no business logic, no public APIs.
