### PR TITLE
refactor(frontend): name the cache TTLs

### DIFF
--- a/frontend/src/lib/cache.ts
+++ b/frontend/src/lib/cache.ts
@@ -1,6 +1,22 @@
 const DEFAULT_TTL = 5 * 60 * 1000
 const MAX_ENTRIES = 200
 
+/**
+ * Named TTLs used by service caches. Picking from this menu keeps the
+ * meaning of each value visible at the call site — "this list mutates
+ * fast, hold it briefly" beats `30 * 1000`. Values are in milliseconds.
+ */
+export const CACHE_TTL = {
+  /** Fast-moving data (live analytics, in-flight student progress). */
+  THIRTY_SECONDS: 30 * 1000,
+  /** Default for per-user lists that change after writes (enrollments, grades, calendar). */
+  ONE_MINUTE: 60 * 1000,
+  /** Reference data that updates occasionally (announcements, course lists, cohorts). */
+  TWO_MINUTES: 2 * 60 * 1000,
+  /** Stable detail views (course detail, module detail). */
+  THREE_MINUTES: 3 * 60 * 1000,
+} as const
+
 interface CacheEntry<T = unknown> {
   value: T
   expiresAt: number

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet } from "@/lib/cache"
+import { cacheGet, cacheSet, CACHE_TTL } from "@/lib/cache"
 
 interface CourseAnalyticsEnrollment {
   enrollment_id: string
@@ -25,7 +25,7 @@ export const analyticsService = {
     const cached = cacheGet<CourseAnalytics>(key)
     if (cached) return cached
     const response = await api.get<CourseAnalytics>(`/analytics/course/${courseId}`)
-    cacheSet(key, response.data, 30 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.THIRTY_SECONDS)
     return response.data
   },
 }

--- a/frontend/src/services/announcements.ts
+++ b/frontend/src/services/announcements.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { Announcement } from "@/types"
 
 export const announcementsService = {
@@ -9,7 +9,7 @@ export const announcementsService = {
     if (cached) return cached
     const params = courseId ? { course_id: courseId } : undefined
     const response = await api.get<Announcement[]>("/announcements", { params })
-    cacheSet(key, response.data, 2 * 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.TWO_MINUTES)
     return response.data
   },
 

--- a/frontend/src/services/blocks.ts
+++ b/frontend/src/services/blocks.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { ChapterBlock, BlockType } from "@/types"
 
 type ChapterBlockCreateData = {
@@ -23,7 +23,7 @@ export const blocksService = {
     const cached = cacheGet<ChapterBlock[]>(key)
     if (cached) return cached
     const response = await api.get<ChapterBlock[]>(`/blocks/chapter/${chapterId}`)
-    cacheSet(key, response.data, 2 * 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.TWO_MINUTES)
     return response.data
   },
 

--- a/frontend/src/services/calendar.ts
+++ b/frontend/src/services/calendar.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { CalendarEvent, CourseEvent } from "@/types"
 
 export const calendarService = {
@@ -9,7 +9,7 @@ export const calendarService = {
     if (cached) return cached
     const params = courseId ? { course_id: courseId } : undefined
     const response = await api.get<CalendarEvent[]>("/calendar/events", { params })
-    cacheSet(key, response.data, 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.ONE_MINUTE)
     return response.data
   },
 
@@ -18,7 +18,7 @@ export const calendarService = {
     const cached = cacheGet<CourseEvent[]>(key)
     if (cached) return cached
     const response = await api.get<CourseEvent[]>(`/courses/${courseId}/events`)
-    cacheSet(key, response.data, 2 * 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.TWO_MINUTES)
     return response.data
   },
 

--- a/frontend/src/services/cohorts.ts
+++ b/frontend/src/services/cohorts.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { Cohort } from "@/types"
 
 export interface CohortStudent {
@@ -53,7 +53,7 @@ export const cohortsService = {
     const cached = cacheGet<Cohort[]>(key)
     if (cached) return cached
     const response = await api.get<Cohort[]>(`/cohorts/course/${courseId}`)
-    cacheSet(key, response.data, 2 * 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.TWO_MINUTES)
     return response.data
   },
 

--- a/frontend/src/services/courses.ts
+++ b/frontend/src/services/courses.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { Course, Module, Chapter } from "@/types"
 
 import { adminUsersService } from "./adminUsers"
@@ -36,7 +36,7 @@ const courseCrud = {
     if (cached) return cached
     const params = search ? { search } : undefined
     const response = await api.get<Course[]>("/courses", { params })
-    cacheSet(key, response.data, 2 * 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.TWO_MINUTES)
     return response.data
   },
 
@@ -45,7 +45,7 @@ const courseCrud = {
     const cached = cacheGet<Course>(key)
     if (cached) return cached
     const response = await api.get<Course>(`/courses/${id}`)
-    cacheSet(key, response.data, 3 * 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.THREE_MINUTES)
     return response.data
   },
 
@@ -54,7 +54,7 @@ const courseCrud = {
     const cached = cacheGet<Course[]>(key)
     if (cached) return cached
     const response = await api.get<Course[]>("/courses/my")
-    cacheSet(key, response.data, 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.ONE_MINUTE)
     return response.data
   },
 
@@ -126,7 +126,7 @@ const courseCrud = {
     const cached = cacheGet<Module>(key)
     if (cached) return cached
     const response = await api.get<Module>(`/courses/${courseId}/modules/${moduleId}`)
-    cacheSet(key, response.data, 3 * 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.THREE_MINUTES)
     return response.data
   },
 

--- a/frontend/src/services/enrollments.ts
+++ b/frontend/src/services/enrollments.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { Enrollment } from "@/types"
 
 export const enrollmentsService = {
@@ -23,7 +23,7 @@ export const enrollmentsService = {
     const cached = cacheGet<Enrollment[]>(key)
     if (cached) return cached
     const response = await api.get<Enrollment[]>("/users/me/courses")
-    cacheSet(key, response.data, 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.ONE_MINUTE)
     return response.data
   },
 
@@ -36,7 +36,7 @@ export const enrollmentsService = {
     const response = await api.get<{ enrolled: boolean; enrollment: Enrollment | null }>(
       `/courses/${courseId}/enrollment-status`,
     )
-    cacheSet(key, response.data, 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.ONE_MINUTE)
     return response.data
   },
 }

--- a/frontend/src/services/grades.ts
+++ b/frontend/src/services/grades.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { GradingConfig, GradeSummaryResponse, StudentGrade } from "@/types"
 
 export const gradesService = {
@@ -8,7 +8,7 @@ export const gradesService = {
     const cached = cacheGet<StudentGrade[]>(key)
     if (cached) return cached
     const response = await api.get<StudentGrade[]>(`/grades/course/${courseId}`)
-    cacheSet(key, response.data, 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.ONE_MINUTE)
     return response.data
   },
 
@@ -32,7 +32,7 @@ export const gradesService = {
     const cached = cacheGet<StudentGrade[]>(key)
     if (cached) return cached
     const response = await api.get<StudentGrade[]>("/grades/my")
-    cacheSet(key, response.data, 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.ONE_MINUTE)
     return response.data
   },
 
@@ -51,7 +51,7 @@ export const gradesService = {
     const response = await api.get<GradeSummaryResponse>(
       `/grades/course/${courseId}/summary`,
     )
-    cacheSet(key, response.data, 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.ONE_MINUTE)
     return response.data
   },
 

--- a/frontend/src/services/progress.ts
+++ b/frontend/src/services/progress.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { StudentProgressResponse } from "@/types"
 
 export const progressService = {
@@ -20,7 +20,7 @@ export const progressService = {
     const cached = cacheGet<string[]>(key)
     if (cached) return cached
     const response = await api.get<string[]>(`/progress/course/${courseId}/my-progress`)
-    cacheSet(key, response.data, 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.ONE_MINUTE)
     return response.data
   },
 
@@ -31,7 +31,7 @@ export const progressService = {
     const response = await api.get<StudentProgressResponse>(
       `/progress/course/${courseId}/students`,
     )
-    cacheSet(key, response.data, 30 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.THIRTY_SECONDS)
     return response.data
   },
 }

--- a/frontend/src/services/reviews.ts
+++ b/frontend/src/services/reviews.ts
@@ -1,5 +1,5 @@
 import api from "./api"
-import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix } from "@/lib/cache"
+import { cacheGet, cacheSet, cacheInvalidate, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
 import type { CourseReview } from "@/types"
 
 export const reviewsService = {
@@ -8,7 +8,7 @@ export const reviewsService = {
     const cached = cacheGet<CourseReview[]>(key)
     if (cached) return cached
     const response = await api.get<CourseReview[]>(`/reviews/course/${courseId}`)
-    cacheSet(key, response.data, 2 * 60 * 1000)
+    cacheSet(key, response.data, CACHE_TTL.TWO_MINUTES)
     return response.data
   },
 


### PR DESCRIPTION
## Summary

- Adds a `CACHE_TTL` const map to `lib/cache.ts` with four named values: `THIRTY_SECONDS`, `ONE_MINUTE`, `TWO_MINUTES`, `THREE_MINUTES`.
- Replaces magic-number TTLs (`30 * 1000`, `60 * 1000`, `2 * 60 * 1000`, `3 * 60 * 1000`) across ten service files. Each call site now reads as "this list is fresh for ONE_MINUTE" instead of "60 * 1000 — go think about what that means."
- The two `quizzes.ts` call sites are intentionally left untouched; another agent has the quiz services.
- Behavior is identical: the new constants resolve to the same millisecond literals at compile time.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (max-warnings 0)
- [x] `npm run test:run` — 17 files / 125 tests pass
- [ ] CI green
