### PR TITLE
design(a11y): consistent focus-visible rings across primitives

### DIFF
--- a/frontend/src/components/patterns/InlineEdit.tsx
+++ b/frontend/src/components/patterns/InlineEdit.tsx
@@ -135,7 +135,7 @@ export function InlineEdit({
       disabled: saving,
       "aria-label": ariaLabel,
       className: cn(
-        "w-full rounded-md border border-input bg-background px-2 py-1 outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "w-full rounded-md border border-input bg-background px-2 py-1 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         sizeClasses[size],
         textClassName,
       ),
@@ -163,7 +163,7 @@ export function InlineEdit({
             <>
               <button
                 type="button"
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => void commit()}
                 aria-label={t("inlineEdit.save")}
@@ -172,7 +172,7 @@ export function InlineEdit({
               </button>
               <button
                 type="button"
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={cancel}
                 aria-label={t("inlineEdit.cancel")}
@@ -214,7 +214,7 @@ export function InlineEdit({
         onClick={start}
         aria-label={ariaLabel ?? t("inlineEdit.editAria", { what: resolvedPlaceholder.toLowerCase() })}
         className={cn(
-          "flex-1 min-w-0 cursor-text rounded-md px-2 py-1 text-left transition-colors text-wrap-safe hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "flex-1 min-w-0 cursor-text rounded-md px-2 py-1 text-left transition-colors text-wrap-safe hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           multiline && "whitespace-pre-line",
           sizeClasses[size],
           isEmpty && "text-muted-foreground italic",

--- a/frontend/src/components/patterns/InlineEditCover.tsx
+++ b/frontend/src/components/patterns/InlineEditCover.tsx
@@ -116,7 +116,7 @@ export function InlineEditCover({
           type="button"
           onClick={() => inputRef.current?.click()}
           disabled={disabled || busy}
-          className="group flex h-full w-full flex-col items-center justify-center gap-2 text-muted-foreground transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="group flex h-full w-full flex-col items-center justify-center gap-2 text-muted-foreground transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           {busy ? (
             <Loader2 className="h-6 w-6 animate-spin" strokeWidth={1.75} />
@@ -144,7 +144,7 @@ export function InlineEditCover({
                 type="button"
                 onClick={() => inputRef.current?.click()}
                 disabled={busy}
-                className="inline-flex items-center gap-1.5 rounded-md bg-background/90 px-2.5 py-1 text-xs font-medium text-foreground shadow-sm ring-1 ring-border hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="inline-flex items-center gap-1.5 rounded-md bg-background/90 px-2.5 py-1 text-xs font-medium text-foreground shadow-sm ring-1 ring-border hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               >
                 {busy ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.75} />
@@ -158,7 +158,7 @@ export function InlineEditCover({
                   type="button"
                   onClick={remove}
                   disabled={busy}
-                  className="inline-flex items-center gap-1.5 rounded-md bg-background/90 px-2.5 py-1 text-xs font-medium text-foreground shadow-sm ring-1 ring-border hover:bg-destructive hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="inline-flex items-center gap-1.5 rounded-md bg-background/90 px-2.5 py-1 text-xs font-medium text-foreground shadow-sm ring-1 ring-border hover:bg-destructive hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
                   <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />
                   {t("inlineEdit.cover.remove")}

--- a/frontend/src/components/patterns/PageHeader.tsx
+++ b/frontend/src/components/patterns/PageHeader.tsx
@@ -29,7 +29,7 @@ export function PageHeader({
       {backTo && (
         <Link
           to={backTo}
-          className="-mx-2 inline-flex min-h-[44px] items-center gap-1 px-2 text-xs text-muted-foreground hover:text-foreground sm:mx-0 sm:min-h-0 sm:px-0"
+          className="-mx-2 inline-flex min-h-[44px] items-center gap-1 rounded-md px-2 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:mx-0 sm:min-h-0 sm:px-0"
         >
           <ChevronLeft className="h-3.5 w-3.5" strokeWidth={1.75} />
           {backLabel}

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -253,7 +253,7 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
                 value={promptState.value}
                 onChange={(e) => setPromptState((s) => ({ ...s, value: e.target.value }))}
                 placeholder={promptState.placeholder}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               />
               <AlertDialogFooter className="mt-4">
                 <AlertDialogCancel type="button" onClick={() => handlePromptDone(null)}>

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
   {
     variants: {
       variant: {

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
           <X className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
           <span className="sr-only">{t("common.close")}</span>
         </DialogPrimitive.Close>

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -58,7 +58,7 @@ const SheetContent = React.forwardRef<
       <SheetOverlay />
       <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
         {children}
-        <SheetPrimitive.Close className="absolute right-3 top-3 rounded-md p-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+        <SheetPrimitive.Close className="absolute right-3 top-3 rounded-md p-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
           <X className="h-4 w-4" strokeWidth={1.75} aria-hidden />
           <span className="sr-only">{t("common.close")}</span>
         </SheetPrimitive.Close>


### PR DESCRIPTION
## Summary

Audit of keyboard-focus across primitives + patterns turned up seven small inconsistencies. Each is invisible alone; together they make keyboard navigation feel uneven — some elements ring on mouse-click (the classic `focus:` artifact) and others don't ring at all on Tab.

- **Badge / Dialog close / Sheet close**: `focus:` → `focus-visible:` so the ring only appears on keyboard focus, not after a mouse click. Matches every other primitive in the codebase.
- **AlertDialog prompt input**: was missing `focus-visible:ring-offset-2` so the ring sat flush against the input border. Now matches the rest of the inputs.
- **InlineEdit save / cancel icon buttons**: had **no focus state at all**. Now ring on Tab, transition-colors on hover.
- **InlineEdit edit-trigger button**: missing the ring-offset-2 step that every other primitive uses; the ring touched the text. Fixed.
- **InlineEdit editing input**: had `outline-none` unconditionally instead of `focus-visible:outline-none`. Same visual result with focus, but consistent with the rest of the system.
- **InlineEditCover** (replace / remove / empty-state buttons): all three were missing `focus-visible:ring-offset-2`. Fixed.
- **PageHeader back link**: no focus state at all. Now ring on Tab with a rounded hit area + transition-colors.

No visual regression on mouse interaction. Keyboard users get a ring on every actionable surface, with consistent offset spacing.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 125/125 pass
- [ ] Tab through the app on a sample page (home + a course detail + admin) and confirm every visible interactive element rings.
