### PR TITLE
sec(rate-limit): cover certificates/verify and verse-of-the-day

### DIFF
--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -40,8 +40,29 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.core.http import get_client_ip
 
+# Per-endpoint overrides. Resolution is a longest-prefix-style ``startswith``
+# (see ``_resolve_limit``), so any sub-route inherits the bucket of the closest
+# matching prefix. Pick conservative ceilings for unauthenticated routes and
+# anything that can be enumerated or that fans out to a paid upstream API.
+#
+# Limits in (max_calls, window_seconds) per client IP per bucket.
 ENDPOINT_LIMITS: dict[str, tuple[int, int]] = {
+    # Authenticated identity probe. Tight to keep token-brute attempts pricy.
+    # Frontend hits this once per page load + on auth state change, so 10/min
+    # is comfortably above legitimate usage.
     "/api/v1/auth/": (10, 60),
+    # Unauthenticated certificate-number lookup. Each call enumerates one
+    # value; cap at 30/min/IP so the verify page stays usable for the
+    # legitimate share-your-credential flow while making bulk enumeration
+    # impractical. Certificate numbers are random UUIDs already, so the cap
+    # is defence-in-depth, not the primary control.
+    "/api/v1/certificates/verify/": (30, 60),
+    # Verse-of-the-day proxies through an upstream Bible API on cache miss.
+    # The route is unauthenticated so it shows up on the marketing page in
+    # the future; 60/min/IP is well above the once-per-page-load real use
+    # case and prevents trivial cost-amplification attacks against the
+    # upstream quota.
+    "/api/v1/verse-of-the-day": (60, 60),
 }
 
 MAX_BUCKETS = 10_000

--- a/backend/tests/test_rate_limit_coverage.py
+++ b/backend/tests/test_rate_limit_coverage.py
@@ -1,0 +1,89 @@
+"""Regression tests for per-endpoint rate-limit coverage.
+
+The in-memory ``RateLimitMiddleware`` carries a small ``ENDPOINT_LIMITS``
+table that overrides the global 100/60s default for sensitive routes.
+These tests assert that the table stays populated for the
+high-abuse-surface endpoints we care about and that ``_resolve_limit``
+actually picks the override (not the global default) when a request
+to one of them lands.
+
+Why this matters: ``ENDPOINT_LIMITS`` is a plain dict, so a future
+edit could silently drop an entry without breaking anything else.
+Catching a regression at the dict level is cheap; catching it after
+a credential-stuffing burst against ``/auth/me`` or a brute-force
+enumeration of ``/certificates/verify/`` is not.
+
+These tests inspect the middleware directly and do not depend on the
+``autouse=True`` rate-limiter reset fixture, so they are immune to
+the bucket bleed that would otherwise make ``429`` assertions flaky.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.middleware.rate_limit import ENDPOINT_LIMITS, RateLimitMiddleware
+
+# Each entry is (route_path, expected_max_calls, expected_window_seconds).
+# Pick representative sub-paths under each prefix so the ``startswith``
+# resolution is exercised the way real traffic hits it.
+EXPECTED_OVERRIDES: tuple[tuple[str, int, int], ...] = (
+    ("/api/v1/auth/me", 10, 60),
+    ("/api/v1/certificates/verify/abc-123", 30, 60),
+    ("/api/v1/verse-of-the-day", 60, 60),
+)
+
+
+@pytest.mark.parametrize("path, expected_calls, expected_window", EXPECTED_OVERRIDES)
+def test_endpoint_resolves_to_per_route_override(path: str, expected_calls: int, expected_window: int) -> None:
+    """Each sensitive endpoint must resolve to its tighter override,
+    not the global 100/60s default.
+    """
+    mw = RateLimitMiddleware(app=None, calls=100, window=60)
+    calls, window = mw._resolve_limit(path)
+    assert (calls, window) == (expected_calls, expected_window), (
+        f"{path} resolved to ({calls}, {window}); expected ({expected_calls}, {expected_window}). "
+        "Did someone drop the per-route override from ENDPOINT_LIMITS?"
+    )
+
+
+def test_default_route_keeps_global_limit() -> None:
+    """A route with no matching prefix must fall through to the global
+    default. This guards against an accidental wildcard entry being
+    added to ENDPOINT_LIMITS that would tighten everything.
+    """
+    mw = RateLimitMiddleware(app=None, calls=100, window=60)
+    calls, window = mw._resolve_limit("/api/v1/courses")
+    assert (calls, window) == (100, 60)
+
+
+def test_sensitive_prefixes_are_all_present() -> None:
+    """Belt-and-suspenders: assert by literal prefix that the table
+    still contains every override we depend on. Catches the case where
+    someone renames the key (e.g. trailing slash drift) and breaks the
+    ``startswith`` match without the parametrized test above noticing.
+    """
+    required_prefixes = (
+        "/api/v1/auth/",
+        "/api/v1/certificates/verify/",
+        "/api/v1/verse-of-the-day",
+    )
+    missing = [p for p in required_prefixes if p not in ENDPOINT_LIMITS]
+    assert not missing, f"ENDPOINT_LIMITS lost coverage for: {missing}"
+
+
+def test_overrides_are_tighter_than_global_default() -> None:
+    """An override that's looser than the global default is almost
+    certainly a typo and would silently make a sensitive endpoint
+    cheaper to abuse, not more expensive.
+    """
+    global_calls, global_window = 100, 60
+    for prefix, (calls, window) in ENDPOINT_LIMITS.items():
+        # Per-window rate: calls/window. Compare to the global.
+        rate = calls / window
+        global_rate = global_calls / global_window
+        assert rate <= global_rate, (
+            f"Override for {prefix!r} allows {rate:.2f} req/s, which is looser "
+            f"than the global {global_rate:.2f} req/s. Either tighten it or "
+            f"remove the entry."
+        )


### PR DESCRIPTION
## Summary

`ENDPOINT_LIMITS` in `app/middleware/rate_limit.py` previously covered only `/api/v1/auth/`. This PR extends per-route coverage to two public, unauthenticated routes that are higher-abuse-surface than the global 100/60s default reflects:

- `/api/v1/certificates/verify/{number}` -> **30/60s**. Cuts the cost of bulk enumeration of certificate numbers. UUID-shaped numbers already make brute force infeasible; this is defence-in-depth.
- `/api/v1/verse-of-the-day` -> **60/60s**. Caps cost amplification against the upstream Bible API on cache misses. Real-world usage is once per page load, so 60/min is comfortably above legitimate traffic.

Both ceilings are tighter than the global default, so nothing regresses for normal traffic. The previous agent's note in `rate_limit.py` about Vercel WAF being the recommended hard limit still stands -- this commit closes the per-instance gap.

Severity: **medium** (per-instance defence-in-depth on a public surface; Vercel WAF is the primary control).

## Test plan

- [x] `pytest tests/test_rate_limit_coverage.py` -- 6 new tests pass (parametrized override resolution + structural assertions).
- [x] `pytest tests/` -- 598 passed.
- [x] `ruff check app/middleware/rate_limit.py tests/test_rate_limit_coverage.py` -- clean.
- [x] `mypy` on touched files -- no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
