### PR TITLE
design: quiz taker polish

### DIFF
--- a/frontend/src/components/quiz/QuizTaker.tsx
+++ b/frontend/src/components/quiz/QuizTaker.tsx
@@ -131,8 +131,20 @@ export default function QuizTaker({ chapterId, quizId, onSubmitted }: QuizTakerP
     setResult(null)
   }
 
+  const answeredCount = sortedQuestions.reduce((count, q) => {
+    const a = answers[q.id]
+    if (!a) return count
+    if (q.question_type === "short_answer" || q.question_type === "essay") {
+      return a.text_answer?.trim() ? count + 1 : count
+    }
+    return a.selected_option_id ? count + 1 : count
+  }, 0)
+  const answerProgress = sortedQuestions.length
+    ? Math.round((answeredCount / sortedQuestions.length) * 100)
+    : 0
+
   return (
-    <div className="border rounded-lg bg-card mt-6">
+    <div className="mt-6 rounded-lg border border-border bg-card">
       <QuizHeader
         quiz={quiz}
         questionCount={sortedQuestions.length}
@@ -159,7 +171,21 @@ export default function QuizTaker({ chapterId, quizId, onSubmitted }: QuizTakerP
           )}
         </>
       ) : (
-        <div className="p-5 space-y-6">
+        <div className="space-y-6 p-5">
+          {!attemptsReached && (
+            <div className="flex items-center gap-3" aria-hidden>
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground tabular-nums">
+                {t("quiz.progressEyebrow", { current: answeredCount, total: sortedQuestions.length })}
+              </p>
+              <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
+                  style={{ width: `${answerProgress}%` }}
+                />
+              </div>
+            </div>
+          )}
+
           {attemptsReached && (
             <div className="rounded-md border border-border border-l-stripe border-l-warning bg-warning/10 px-3 py-2 text-xs text-foreground">
               {t("quiz.maxAttemptsReached", { type: t(assessmentTypeKey).toLowerCase() })}
@@ -198,7 +224,7 @@ export default function QuizTaker({ chapterId, quizId, onSubmitted }: QuizTakerP
             )}
           </Button>
           {!allAnswered && !attemptsReached && (
-            <p className="text-xs text-muted-foreground text-center">
+            <p className="text-center text-xs text-muted-foreground">
               {t("quiz.answerAll")}
             </p>
           )}

--- a/frontend/src/components/quiz/taker/EssayAnswer.tsx
+++ b/frontend/src/components/quiz/taker/EssayAnswer.tsx
@@ -12,7 +12,7 @@ export function EssayAnswer({ value, minWords, onChange }: Props) {
   const words = value.trim() ? value.trim().split(/\s+/).filter(Boolean).length : 0
   const minReached = !minWords || words >= minWords
   return (
-    <div className="ml-8 space-y-1.5">
+    <div className="ml-9 space-y-1.5">
       <Textarea
         fieldSize="default"
         value={value}

--- a/frontend/src/components/quiz/taker/QuestionPrompt.tsx
+++ b/frontend/src/components/quiz/taker/QuestionPrompt.tsx
@@ -20,29 +20,32 @@ export function QuestionPrompt({ question, index, answer, onAnswer }: Props) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-start gap-2">
-        <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+      <div className="flex items-start gap-3">
+        <span
+          aria-hidden
+          className="mt-0.5 inline-flex h-6 min-w-[1.5rem] shrink-0 items-center justify-center rounded-md border border-border bg-muted/60 px-1.5 text-xs font-medium tabular-nums text-muted-foreground"
+        >
           {index + 1}
         </span>
         <div className="min-w-0 flex-1 text-wrap-safe">
-          <p className="text-sm font-medium whitespace-pre-line">
+          <p className="text-sm font-medium leading-relaxed whitespace-pre-line">
             {question.question_text}
           </p>
-          <span className="text-xs text-muted-foreground">
+          <span className="mt-1 inline-block text-xs text-muted-foreground tabular-nums">
             {t("quiz.questionPoints", { count: question.points })}
           </span>
         </div>
       </div>
 
       {question.question_type === "multiple_choice" && (
-        <div className="ml-8 space-y-2">
+        <div className="ml-9 space-y-2">
           {sortedOptions.map((opt) => (
             <label
               key={opt.id}
-              className={`flex items-center gap-3 px-3 py-2.5 rounded-md border cursor-pointer transition-colors ${
+              className={`flex cursor-pointer items-center gap-3 rounded-md border px-3 py-2.5 transition-colors ${
                 answer?.selected_option_id === opt.id
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:bg-muted/50"
+                  ? "border-primary/60 bg-primary/5 ring-1 ring-primary/30"
+                  : "border-border hover:bg-muted/40"
               }`}
             >
               <input
@@ -52,23 +55,23 @@ export function QuestionPrompt({ question, index, answer, onAnswer }: Props) {
                 onChange={() => onAnswer({ selected_option_id: opt.id })}
                 className="accent-primary"
               />
-              <span className="text-sm">{opt.option_text}</span>
+              <span className="text-sm text-wrap-safe">{opt.option_text}</span>
             </label>
           ))}
         </div>
       )}
 
       {question.question_type === "true_false" && (
-        <div className="ml-8 flex gap-3">
+        <div className="ml-9 grid grid-cols-2 gap-2">
           {sortedOptions.map((opt) => (
             <button
               key={opt.id}
               type="button"
               onClick={() => onAnswer({ selected_option_id: opt.id })}
-              className={`flex-1 py-2.5 rounded-md border text-sm font-medium transition-colors ${
+              className={`rounded-md border px-3 py-2.5 text-sm font-medium transition-colors ${
                 answer?.selected_option_id === opt.id
-                  ? "border-primary bg-primary/10 text-primary"
-                  : "border-border hover:bg-muted/50"
+                  ? "border-primary/60 bg-primary/10 text-primary ring-1 ring-primary/30"
+                  : "border-border hover:bg-muted/40"
               }`}
             >
               {getTrueFalseLabel(opt.option_text, t)}
@@ -78,7 +81,7 @@ export function QuestionPrompt({ question, index, answer, onAnswer }: Props) {
       )}
 
       {question.question_type === "short_answer" && (
-        <div className="ml-8">
+        <div className="ml-9">
           <Textarea
             fieldSize="default"
             value={answer?.text_answer ?? ""}

--- a/frontend/src/components/quiz/taker/QuizHeader.tsx
+++ b/frontend/src/components/quiz/taker/QuizHeader.tsx
@@ -1,4 +1,4 @@
-import { ClipboardList } from "lucide-react"
+import { GraduationCap, HelpCircle } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import type { Quiz } from "@/types"
 
@@ -21,25 +21,30 @@ export function QuizHeader({
 }: Props) {
   const { t } = useTranslation()
   const totalMaxScore = autoMaxScore + manualMaxScore
+  const isExam = quiz.quiz_type === "exam"
+  const TypeIcon = isExam ? GraduationCap : HelpCircle
+  const typeLabel = isExam ? t("quiz.exam") : t("quiz.quiz")
   const questionsLabel = t("quiz.nQuestions", { count: questionCount })
   const pointsLabel = t("quiz.nPoints", { count: totalMaxScore })
 
   return (
-    <div className="p-5 border-b">
-      <div className="flex items-center gap-2 mb-1">
-        <ClipboardList className="h-5 w-5 shrink-0 text-muted-foreground" strokeWidth={1.75} />
-        <h3 className="min-w-0 flex-1 text-base font-semibold text-wrap-safe">
-          {quiz.title}
-        </h3>
-      </div>
+    <div className="border-b border-border px-5 py-5">
+      <p className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <TypeIcon className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+        {typeLabel}
+      </p>
+      <h3 className="font-serif text-lg font-semibold tracking-tight text-wrap-safe">
+        {quiz.title}
+      </h3>
       {quiz.description && (
-        <p className="ml-7 text-sm text-muted-foreground text-wrap-safe whitespace-pre-line">
+        <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground text-wrap-safe whitespace-pre-line">
           {quiz.description}
         </p>
       )}
-      <div className="flex items-center gap-4 ml-7 mt-2 text-xs text-muted-foreground flex-wrap">
-        <span>{questionsLabel}</span>
-        <span>
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        <span className="tabular-nums">{questionsLabel}</span>
+        <span aria-hidden className="text-muted-foreground/40">·</span>
+        <span className="tabular-nums">
           {pointsLabel}
           {manualMaxScore > 0 && autoMaxScore > 0 && (
             <>
@@ -48,9 +53,13 @@ export function QuizHeader({
             </>
           )}
         </span>
-        <span>{t("quiz.passingShort", { score: quiz.passing_score })}</span>
+        <span aria-hidden className="text-muted-foreground/40">·</span>
+        <span className="tabular-nums">{t("quiz.passingShort", { score: quiz.passing_score })}</span>
         {maxAttempts !== null && (
-          <span>{t("quiz.attemptsShort", { used: attemptsUsed, max: maxAttempts })}</span>
+          <>
+            <span aria-hidden className="text-muted-foreground/40">·</span>
+            <span className="tabular-nums">{t("quiz.attemptsShort", { used: attemptsUsed, max: maxAttempts })}</span>
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/quiz/taker/ResultsView.tsx
+++ b/frontend/src/components/quiz/taker/ResultsView.tsx
@@ -38,9 +38,9 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
             : "border-l-stripe border-l-destructive"
         }
       >
-        <CardContent className="py-6 text-center">
+        <CardContent className="py-7 text-center">
           {prefersReducedMotion ? (
-            <ResultIcon className={`mx-auto mb-3 h-10 w-10 ${iconColor}`} />
+            <ResultIcon className={`mx-auto mb-3 h-10 w-10 ${iconColor}`} strokeWidth={1.75} aria-hidden />
           ) : (
             <motion.div
               className="mx-auto mb-3 w-fit"
@@ -48,20 +48,21 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
               animate={{ scale: 1, opacity: 1 }}
               transition={{ type: "spring", stiffness: 320, damping: 18, delay: 0.05 }}
             >
-              <ResultIcon className={`h-10 w-10 ${iconColor}`} />
+              <ResultIcon className={`h-10 w-10 ${iconColor}`} strokeWidth={1.75} aria-hidden />
             </motion.div>
           )}
-          <h3 className="text-lg font-bold mb-1">
+          <p className={`mb-2 text-xs font-medium uppercase tracking-[0.18em] ${result.passed ? "text-success" : "text-destructive"}`}>
             {result.passed ? t("quiz.passedTitle") : t("quiz.notPassedTitle")}
-          </h3>
-          <p className="text-2xl font-bold mb-1">
-            {result.score ?? 0}/{result.max_score ?? 0}
           </p>
-          <p className="text-sm text-muted-foreground">
+          <p className="font-serif text-3xl font-semibold tabular-nums tracking-tight">
+            {result.score ?? 0}
+            <span className="text-muted-foreground/60"> / {result.max_score ?? 0}</span>
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground tabular-nums">
             {t("quiz.passingScoreLine", { percent: scorePercent, passing: quiz.passing_score })}
           </p>
           {hasOpenEnded && (
-            <p className="mt-2 text-xs text-warning">
+            <p className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-warning/30 bg-warning/10 px-2.5 py-1 text-xs font-medium text-warning">
               {t("quiz.pendingTeacherReview")}
             </p>
           )}
@@ -69,7 +70,9 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
       </Card>
 
       <div className="space-y-4">
-        <h4 className="text-sm font-semibold">{t("quiz.reviewAnswers")}</h4>
+        <h4 className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          {t("quiz.reviewAnswers")}
+        </h4>
         <StaggerChildren className="space-y-4">
           {questions.map((q, idx) => {
           const userAnswer = answers[q.id]
@@ -100,11 +103,14 @@ export function ResultsView({ result, quiz, questions, answers }: Props) {
                     : "border-destructive/30 bg-destructive/5"
               }`}
             >
-              <div className="flex items-start gap-2 mb-2">
-                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">
+              <div className="flex items-start gap-3 mb-2">
+                <span
+                  aria-hidden
+                  className="inline-flex h-5 min-w-[1.25rem] shrink-0 items-center justify-center rounded border border-border bg-background px-1 text-xs font-medium tabular-nums text-muted-foreground"
+                >
                   {idx + 1}
                 </span>
-                <p className="min-w-0 flex-1 text-sm font-medium text-wrap-safe whitespace-pre-line">
+                <p className="min-w-0 flex-1 text-sm font-medium leading-relaxed text-wrap-safe whitespace-pre-line">
                   {q.question_text}
                 </p>
                 {isCorrect !== null && (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -351,6 +351,7 @@
     "submitQuiz": "Submit Quiz",
     "submitExam": "Submit Exam",
     "answerAll": "Answer all questions to submit",
+    "progressEyebrow": "{{current}} / {{total}} answered",
     "passedTitle": "You Passed!",
     "notPassedTitle": "Not Quite",
     "passingScoreLine": "{{percent}}% — Passing score: {{passing}}%",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -359,6 +359,7 @@
     "submitQuiz": "Отправить тест",
     "submitExam": "Отправить экзамен",
     "answerAll": "Ответьте на все вопросы, чтобы отправить",
+    "progressEyebrow": "{{current}} / {{total}} отвечено",
     "passedTitle": "Зачёт!",
     "notPassedTitle": "Почти",
     "passingScoreLine": "{{percent}}% — проходной балл: {{passing}}%",


### PR DESCRIPTION
## Summary

The quiz taker is where students prove they actually learned something — it should feel like a real assessment, not a generic form.

- **QuizHeader** picks up the editorial eyebrow (Exam/Quiz with icon), promotes the title to `font-serif tracking-tight`, and switches metadata to `·`-separated tokens.
- **QuizTaker** grows a subtle answered-so-far progress strip ("3 / 10 answered") above the question stack so students see how far they've come without a separate progress page.
- **QuestionPrompt** swaps the round primary-tinted "1" bubble for a quieter bordered numeral. Selected radio / true-false get a 1 px primary ring on top of the existing tint so the chosen state reads as deliberate.
- **ResultsView** turns the centred result card into something more ceremonial: the score becomes the largest element, the passed/failed label is an eyebrow, "pending teacher review" gets a real pill.
- **Review answers** heading becomes an editorial eyebrow; question-number bubbles in the review match the prompt style.

No new motion or library — existing `StaggerChildren` + result-icon spring stay.

## Test plan

- [x] `npm run lint` — 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 125 passed (incl. existing QuizTaker test)
- [x] `node scripts/i18n-check.mjs` — locales in parity
- [ ] Manual: take an MCQ quiz, T/F, short answer, essay in both light/dark + EN/RU; verify progress strip, results hero, and review section render
