### PR TITLE
design(ui): press feedback on menu items + smooth card border transitions

### DIFF
--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -8,7 +8,12 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-md border border-border bg-card text-card-foreground shadow-none",
+      // `transition-[border-color,background-color]` (not just `transition-colors`)
+      // keeps the hover handoff smooth on cards that change border tint on hover
+      // — multiple call sites use `hover:border-primary/25..40`. Without this the
+      // border jumps; with it, the hue settles over ~200ms, which reads as the
+      // card "noticing" the cursor instead of toggling.
+      "rounded-md border border-border bg-card text-card-foreground shadow-none transition-[border-color,background-color] duration-200 ease-editorial",
       className
     )}
     {...props}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -33,10 +33,14 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0",
+      // `focus:` (not `focus-visible:`) is intentional — Radix moves visual
+      // focus to whichever item is hovered or arrow-keyed onto, so the bg
+      // tracks both mouse and keyboard. `active:` adds a quick press tint
+      // for tactile feedback on touch and mouse-down.
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground active:bg-accent/80 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0",
       inset && "pl-8",
       destructive &&
-        "text-destructive focus:bg-destructive focus:text-destructive-foreground",
+        "text-destructive focus:bg-destructive focus:text-destructive-foreground active:bg-destructive/85",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary

Two small "felt off" microinteraction fixes:

1. **DropdownMenuItem** — adds `active:bg-accent/80` (destructive variant gets `active:bg-destructive/85`). Radix already does focus tracking, but there was no tactile press feedback. On touch the menu reacted only on lift; now it confirms the press in flight.

2. **Card primitive** — adds `transition-[border-color,background-color] duration-200 ease-editorial` as the default. Multiple call sites animate `hover:border-primary/25..40` but the base `Card` had no transition, so the border colour was popping instead of settling. This is the missing piece that ties all the existing `hover:border-*` intents into one consistent system.

200ms is short enough to feel responsive but long enough to read as intentional. The `ease-editorial` curve matches every other JS-driven motion in the codebase (which is now a shared constant per #302).

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 125/125 pass
- [ ] Visual check: open Profile dropdown, hover then click each item; press feels right.
- [ ] Visual check: hover over a CourseCard; border colour fades in, not jumps.
