### PR TITLE
fix(quizzes): stop losing 0-point/no-comment essay grades from the pending queue

### DIFF
--- a/backend/app/api/v1/quizzes/grading.py
+++ b/backend/app/api/v1/quizzes/grading.py
@@ -1,5 +1,6 @@
 """Teacher grading of open-ended quiz answers (and their pending queue)."""
 
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import Depends, HTTPException, Query, status
@@ -56,10 +57,12 @@ def list_pending_answers(
         .order_by(QuizAttempt.completed_at.desc(), QuizQuestion.order_index.asc())
     )
     if not include_graded:
-        query = query.filter(
-            QuizAnswer.grader_comment.is_(None),
-            QuizAnswer.points_earned == 0,
-        )
+        # ``graded_at IS NULL`` is the authoritative "still pending"
+        # signal. The previous heuristic ``(grader_comment IS NULL AND
+        # points_earned == 0)`` silently kept rows in the queue when a
+        # teacher legitimately graded an open-ended answer as 0 with no
+        # comment — the row would re-appear on every page reload.
+        query = query.filter(QuizAnswer.graded_at.is_(None))
 
     results: list[PendingAnswerInfo] = []
     for answer, question, attempt, student in query.all():
@@ -141,6 +144,9 @@ def grade_answer(
         answer.is_correct = False
     else:
         answer.is_correct = None
+    # Stamping ``graded_at`` is the one signal the pending-answer queue
+    # consults. Re-grading the same row simply refreshes the timestamp.
+    answer.graded_at = datetime.now(UTC)
 
     quiz_service.recompute_attempt_grade(db, attempt, quiz)
     db.commit()

--- a/backend/app/models/quiz.py
+++ b/backend/app/models/quiz.py
@@ -116,5 +116,14 @@ class QuizAnswer(Base):
     # Teacher feedback for manually-graded answers; null until a teacher
     # actually grades it (see PATCH /quizzes/answers/{id}).
     grader_comment: Mapped[str | None] = mapped_column(Text)
+    # When this answer was last graded. ``NULL`` means "still pending a
+    # teacher's manual review" — used by the pending-answer queue to
+    # distinguish unmodified open-ended answers from ones a teacher
+    # legitimately scored at 0 with no comment (see migration
+    # 20260515153526_quiz_answers_graded_at.sql). Auto-graded answer
+    # types (multiple_choice / true_false) are stamped at submit time
+    # because they're scored deterministically; only open-ended answers
+    # ever have ``graded_at IS NULL`` in steady state.
+    graded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     attempt: Mapped["QuizAttempt"] = relationship(back_populates="answers")

--- a/backend/app/services/quiz_service.py
+++ b/backend/app/services/quiz_service.py
@@ -111,6 +111,7 @@ def persist_answers(
     total_score = 0
     answer_results: list[QuizAnswerResult] = []
     answered: set[Any] = set()
+    now = datetime.now(UTC)
 
     for ans in submitted:
         question = questions_map.get(ans.question_id)
@@ -122,6 +123,13 @@ def persist_answers(
         answered.add(question.id)
         is_correct, points_earned = grade_auto_answer(question, ans.selected_option_id, options_by_id)
         total_score += points_earned
+        # Auto-gradable answers are scored deterministically right now,
+        # so they get ``graded_at`` stamped at submit. Open-ended
+        # answers (essay / short_answer) keep ``graded_at = NULL`` until
+        # a teacher hits PATCH /quizzes/answers/{id} — the pending
+        # queue uses that NULL as its single source of truth for "this
+        # answer still needs a human".
+        auto_graded_at = now if question.question_type in AUTO_GRADED_QUESTION_TYPES else None
 
         # Pre-generate the PK so we can build QuizAnswerResult without
         # round-tripping a flush per row. The caller (`submit_quiz`)
@@ -136,6 +144,7 @@ def persist_answers(
                 text_answer=ans.text_answer,
                 is_correct=is_correct,
                 points_earned=points_earned,
+                graded_at=auto_graded_at,
             )
         )
         answer_results.append(
@@ -157,6 +166,11 @@ def persist_answers(
         if q.id in answered:
             continue
         skip_id = uuid.uuid4()
+        # Auto-gradable skips are final at 0. Open-ended skips have no
+        # ``text_answer`` so they never enter the pending queue (the
+        # query requires ``text_answer IS NOT NULL``), but stamping
+        # ``graded_at`` for them too keeps ``graded_at IS NULL`` strictly
+        # equivalent to "an essay/short_answer with text awaiting review".
         db.add(
             QuizAnswer(
                 id=skip_id,
@@ -166,6 +180,7 @@ def persist_answers(
                 text_answer=None,
                 is_correct=False,
                 points_earned=0,
+                graded_at=now,
             )
         )
         answer_results.append(

--- a/backend/tests/test_quizzes_and_blocks.py
+++ b/backend/tests/test_quizzes_and_blocks.py
@@ -1239,6 +1239,43 @@ def test_grade_essay_answer_recomputes_passed(client: TestClient, student, db: S
     assert graded_list[0]["points_earned"] == 18
 
 
+def test_grade_zero_with_no_comment_clears_pending_queue(client: TestClient, student, db: Session):
+    """A 0-point grade with no comment must still drop out of the pending queue.
+
+    Regression for the bug where the pending-answers filter used
+    ``(grader_comment IS NULL AND points_earned == 0)`` as its
+    "still pending" heuristic — that's exactly what a "graded as 0 with
+    no feedback" row also looks like, so the row would silently reappear
+    on every reload and the teacher could never actually mark a poor
+    essay as zero without inventing a comment.
+    """
+    _seed_course_with_enrollment(db)
+    quiz, _essay, _attempt, essay_answer = _seed_submitted_essay_attempt(db)
+
+    # Pre-state: row visible in the pending queue.
+    pending = client.get(f"/api/v1/quizzes/{quiz.id}/pending-answers").json()
+    assert len(pending) == 1
+    assert pending[0]["answer_id"] == str(essay_answer.id)
+
+    # Grade with the exact ambiguous combo: 0 points, no comment.
+    resp = client.patch(
+        f"/api/v1/quizzes/answers/{essay_answer.id}",
+        json={"points_earned": 0},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Post-state: row is no longer pending.
+    pending_after = client.get(f"/api/v1/quizzes/{quiz.id}/pending-answers").json()
+    assert pending_after == []
+
+    # And it does show up when the teacher asks for graded rows too.
+    graded = client.get(f"/api/v1/quizzes/{quiz.id}/pending-answers?include_graded=true").json()
+    assert len(graded) == 1
+    assert graded[0]["answer_id"] == str(essay_answer.id)
+    assert graded[0]["points_earned"] == 0
+    assert graded[0]["grader_comment"] is None
+
+
 def test_grade_answer_rejects_points_above_cap(client: TestClient, student, db: Session):
     _seed_course_with_enrollment(db)
     _quiz, _essay, _attempt, essay_answer = _seed_submitted_essay_attempt(db)

--- a/supabase/migrations/20260515153526_quiz_answers_graded_at.sql
+++ b/supabase/migrations/20260515153526_quiz_answers_graded_at.sql
@@ -1,0 +1,54 @@
+-- Add an explicit ``graded_at`` timestamp to ``quiz_answers`` so the
+-- teacher-pending grading queue stops relying on a fragile
+-- ``(grader_comment IS NULL AND points_earned = 0)`` heuristic.
+--
+-- Why this exists
+-- ---------------
+-- Open-ended answers (``essay`` / ``short_answer``) are submitted with
+-- ``points_earned = 0`` + ``grader_comment IS NULL`` and stay that way
+-- until a teacher hits PATCH /api/v1/quizzes/answers/{id}. The pending
+-- queue at GET /quizzes/{id}/pending-answers filtered on those two
+-- columns to spot un-graded rows. That works for the common case
+-- ("teacher awarded N>0 points" or "teacher left a comment") but
+-- silently breaks when a teacher legitimately grades an answer as
+-- 0 points with no feedback — the row stays in the queue forever and
+-- next page-load shows it back as if untouched.
+--
+-- ``graded_at`` is the unambiguous "this has been touched by a grader"
+-- signal. Backend now treats ``graded_at IS NOT NULL`` as the
+-- source of truth for "this open-ended answer was graded".
+--
+-- Backfill semantics
+-- ------------------
+-- 1. Auto-graded answers (multiple_choice / true_false) are scored
+--    deterministically at submit time — they have no "pending" state.
+--    Stamp them with NOW() so the column reads as "graded".
+-- 2. Open-ended answers (essay / short_answer) keep ``graded_at`` NULL
+--    when their state still looks pending (the old heuristic), and
+--    get NOW() when anything suggests a teacher already acted (any
+--    points awarded, or a comment was left). This preserves the
+--    behaviour callers see today: nothing newly appears in or vanishes
+--    from the queue on deploy.
+
+ALTER TABLE public.quiz_answers
+  ADD COLUMN IF NOT EXISTS graded_at timestamptz;
+
+-- Auto-graded answers: always stamp (they were "graded" at submit).
+UPDATE public.quiz_answers AS qa
+  SET graded_at = NOW()
+  WHERE graded_at IS NULL
+    AND EXISTS (
+      SELECT 1 FROM public.quiz_questions q
+      WHERE q.id = qa.question_id
+        AND q.question_type IN ('multiple_choice', 'true_false')
+    );
+
+-- Open-ended answers: stamp only the ones the old heuristic already
+-- treated as "graded" (any points or any comment present).
+UPDATE public.quiz_answers
+  SET graded_at = NOW()
+  WHERE graded_at IS NULL
+    AND (grader_comment IS NOT NULL OR points_earned <> 0);
+
+CREATE INDEX IF NOT EXISTS ix_quiz_answers_graded_at
+  ON public.quiz_answers (graded_at);


### PR DESCRIPTION
## Summary
- Teacher PATCHes `/api/v1/quizzes/answers/{id}` with `points_earned=0` and no `grader_comment` → row stays "pending" forever in the queue and re-appears on every reload. The filter `(grader_comment IS NULL AND points_earned == 0)` was indistinguishable from the freshly-submitted state.
- Adds `quiz_answers.graded_at` and switches the pending filter to `graded_at IS NULL` so the signal is unambiguous. Submit-time auto-grading (multiple_choice / true_false) stamps it immediately; `grade_answer` stamps it when a human grader acts.
- Migration backfills existing rows using the old heuristic so deploy is a no-op for callers.

## Test plan
- [x] Added `test_grade_zero_with_no_comment_clears_pending_queue` (fails before, passes after)
- [x] `python -m pytest tests/` — 593 passed
- [x] `ruff check`, `ruff format --check`, `mypy` all clean

Bug class: silent data-loss in teacher UX (the action ran, but the worklist didn't update). No security impact; one schema migration, additive only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
