### PR TITLE
sec(csp): add Content-Security-Policy-Report-Only to vercel.json

### DIFF
--- a/frontend/src/__tests__/vercelCsp.test.ts
+++ b/frontend/src/__tests__/vercelCsp.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression tests for the Content-Security-Policy-Report-Only header
+ * served by `frontend/vercel.json`.
+ *
+ * The CSP is enforced at the CDN edge, so it has no JavaScript surface
+ * we can poke at runtime -- the most reliable contract is a string-shape
+ * check against `vercel.json` itself. These tests catch:
+ *
+ *   - someone dropping a connect-src origin (Datadog, Supabase, the API)
+ *     which would silently start dropping telemetry in real browsers,
+ *   - someone deleting the policy entirely (which would silently stop
+ *     surfacing violations in the console), or
+ *   - someone "promoting" Report-Only to enforcing CSP without updating
+ *     the directive list to cover every legitimate origin (a 100%
+ *     CSP-block of the live site is exactly what the report-only stage
+ *     is supposed to prevent).
+ *
+ * If you legitimately need to remove or rename a directive, update the
+ * EXPECTED_TOKENS table below in the same PR -- the test exists to make
+ * those changes deliberate.
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+interface VercelHeader {
+  key: string
+  value: string
+}
+interface VercelHeaderRule {
+  source: string
+  headers: VercelHeader[]
+}
+interface VercelConfig {
+  headers?: VercelHeaderRule[]
+}
+
+function readVercelJson(): VercelConfig {
+  const root = path.resolve(__dirname, "..", "..")
+  const raw = fs.readFileSync(path.join(root, "vercel.json"), "utf8")
+  return JSON.parse(raw) as VercelConfig
+}
+
+function findCspReportOnly(): string {
+  const cfg = readVercelJson()
+  const headers = cfg.headers ?? []
+  for (const rule of headers) {
+    if (rule.source !== "/(.*)") continue
+    for (const h of rule.headers) {
+      if (h.key === "Content-Security-Policy-Report-Only") return h.value
+    }
+  }
+  throw new Error("Content-Security-Policy-Report-Only header not found in vercel.json")
+}
+
+// Each entry: a directive token that MUST appear verbatim in the policy.
+// Pick literals that are load-bearing and would not survive a sloppy edit.
+const REQUIRED_TOKENS: ReadonlyArray<string> = [
+  // Default fallback locked down to same-origin.
+  "default-src 'self'",
+  // Scripts only from same-origin -- no inline, no eval.
+  "script-src 'self'",
+  // Datadog RUM intake (us5 and any region; the SDK builds the host
+  // dynamically). Anchored to a wildcard subdomain to avoid having to
+  // chase each region rename.
+  "https://*.datadoghq.com",
+  "https://*.browser-intake-datadoghq.com",
+  // Supabase project endpoint (auth + REST + realtime websocket).
+  "https://rrisqutxlkamwfhcashl.supabase.co",
+  "wss://rrisqutxlkamwfhcashl.supabase.co",
+  // Backend API.
+  "https://api.equipbible.com",
+  // YouTube embeds -- the only iframe origin we whitelist on the SPA.
+  "https://www.youtube.com",
+  "https://www.youtube-nocookie.com",
+  // Clickjacking + base-tag injection guards.
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  // Form-submit hijack guard.
+  "form-action 'self'",
+  // Flash / Java / ActiveX -- always off.
+  "object-src 'none'",
+]
+
+describe("CSP Report-Only header in vercel.json", () => {
+  it("contains every required directive token", () => {
+    const csp = findCspReportOnly()
+    const missing = REQUIRED_TOKENS.filter((t) => !csp.includes(t))
+    expect(missing).toEqual([])
+  })
+
+  it("ships as Report-Only, not enforcing", () => {
+    // Belt-and-suspenders: the first pass intentionally ships in
+    // report-only mode so we surface violations without breaking the
+    // live site. Promoting to enforcing CSP is a deliberate later step
+    // that needs its own PR and its own review.
+    const cfg = readVercelJson()
+    const rule = cfg.headers?.find((r) => r.source === "/(.*)")
+    expect(rule).toBeDefined()
+    const enforcing = rule!.headers.find((h) => h.key === "Content-Security-Policy")
+    expect(enforcing).toBeUndefined()
+  })
+
+  it("does not whitelist 'unsafe-eval' anywhere", () => {
+    // 'unsafe-eval' lets a string be turned back into executable code
+    // (eval / new Function / setTimeout("...")). Letting it in
+    // un-defeats the whole script-src protection. None of our deps
+    // currently need it -- if a future dep does, this test forces a
+    // conscious decision rather than a silent regression.
+    const csp = findCspReportOnly()
+    expect(csp).not.toMatch(/['"]?unsafe-eval['"]?/)
+  })
+
+  it("does not whitelist a wildcard host for scripts", () => {
+    const csp = findCspReportOnly()
+    // Pull just the script-src section so we don't trip on
+    // unrelated wildcards in connect-src.
+    const match = csp.match(/script-src[^;]*/)
+    expect(match).not.toBeNull()
+    expect(match![0]).not.toContain("*")
+  })
+})

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -20,6 +20,10 @@
         {
           "key": "Strict-Transport-Security",
           "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "Content-Security-Policy-Report-Only",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://rrisqutxlkamwfhcashl.supabase.co; font-src 'self' data:; connect-src 'self' https://api.equipbible.com https://rrisqutxlkamwfhcashl.supabase.co wss://rrisqutxlkamwfhcashl.supabase.co https://*.datadoghq.com https://*.browser-intake-datadoghq.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; worker-src 'self' blob:"
         }
       ]
     }


### PR DESCRIPTION
## Summary

`vercel.json` already shipped HSTS, X-Frame-Options, Referrer-Policy, and Permissions-Policy, but no CSP. This PR adds **`Content-Security-Policy-Report-Only`** -- one release in report-only mode so any false positives surface in the browser console (and Datadog RUM) without breaking the live site, then a follow-up PR can promote it to enforcing.

CSP is the single biggest XSS defence-in-depth: if a future sanitizer bug lets an inline script land in the DOM, the browser refuses to execute it and reports the violation.

## Inventory of external origins

Found by greping `services/`, `lib/`, `index.html`, `package.json`:

| Directive | Allowed origins | Why |
|---|---|---|
| `connect-src` | `'self'`, `https://api.equipbible.com`, `https://rrisqutxlkamwfhcashl.supabase.co`, `wss://rrisqutxlkamwfhcashl.supabase.co`, `https://*.datadoghq.com`, `https://*.browser-intake-datadoghq.com` | API, Supabase REST/Auth/Realtime, Datadog RUM + Session Replay |
| `img-src` | `'self'`, `data:`, `blob:`, `https://rrisqutxlkamwfhcashl.supabase.co` | App icons + Supabase storage |
| `frame-src` | `'self'`, `https://www.youtube.com`, `https://www.youtube-nocookie.com` | Video block embeds (only iframe origins we whitelist anywhere in `sanitize.ts`) |
| `script-src` | `'self'` | Vite-hashed chunks only; no inline, no eval, no wildcard |
| `style-src` | `'self'`, `'unsafe-inline'` | Radix / Motion / react-window emit inline `style=` props -- documented tradeoff in the commit message |
| `frame-ancestors`, `base-uri`, `form-action`, `object-src`, `worker-src` | locked-down values | Clickjacking, base-tag injection, form hijack, Flash/Java, worker exfil |

Notable absences (verified by grep):

- No external font loaders (we use `@fontsource-variable/*`)
- No Sentry, no Vercel Analytics, no Google Tag Manager
- No inline `<script>` in `dist/index.html` (Vite emits external chunks)
- No `'unsafe-eval'` needed by any current dep (verified -- @datadog/browser-rum has no `new Function`/`eval(`)

## What's NOT in this PR

- **Promotion to enforcing CSP**. Deliberately deferred -- ship report-only first, watch a week of real traffic, fix any blocked-resource reports, then enforce.
- **A `report-uri` endpoint**. Vercel doesn't host one. Violations surface in the browser console + Datadog RUM error events for now. A `/api/v1/csp-report` endpoint can be added later.

## Test plan

- [x] `npx vitest run src/__tests__/vercelCsp.test.ts` -- 4 new tests pass.
- [x] `npm run test:run` -- 18 files / 129 tests passed.
- [x] `npm run lint` -- 0 warnings.
- [x] `npx tsc --noEmit` -- clean.
- [ ] Vercel preview from this branch loads in the browser and the Network tab shows no blocked resources (Report-Only mode -- verification only, not a blocker).

Severity: **medium** (defence-in-depth; XSS sanitizer is the primary control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
