### PR TITLE
design(a11y): announce loading states to screen readers

### DIFF
--- a/frontend/src/components/ui/PageSpinner.tsx
+++ b/frontend/src/components/ui/PageSpinner.tsx
@@ -5,19 +5,37 @@ interface PageSpinnerProps {
    *  - `section`: in-card/in-section loader, smaller spinner and padding
    *  - `inline`: bare spinner (no wrapper) for one-off layouts */
   variant?: "page" | "screen" | "section" | "inline"
-  /** Optional helper label shown under the spinner (screen variant only). */
+  /** Optional helper label shown under the spinner (screen variant only).
+   *  Also used as the accessible name announced to screen readers — when
+   *  `label` is omitted we still announce a generic "Loading" so AT users
+   *  know a fetch is in progress instead of meeting an empty region. */
   label?: string
 }
 
 // One shared spinner used everywhere we'd previously hand-rolled
 // `animate-spin rounded-full border-* border-primary border-t-transparent`.
 // Consolidating means theme tweaks (color, size) only need to land in one file.
+//
+// `role="status"` + `aria-live="polite"` lets screen readers announce
+// the load state without interrupting whatever the user was doing. The
+// rotating ring itself is decorative — meaning lives in the label, which
+// is always available to AT (via `aria-label`) even when it's not shown.
 export default function PageSpinner({ variant = "page", label }: PageSpinnerProps) {
+  const accessibleLabel = label ?? "Loading"
+
   if (variant === "screen") {
     return (
       <div className="flex items-center justify-center min-h-screen bg-background">
-        <div className="flex flex-col items-center gap-4">
-          <div className="h-10 w-10 animate-spin rounded-full border-[3px] border-primary border-t-transparent" />
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label={accessibleLabel}
+          className="flex flex-col items-center gap-4"
+        >
+          <div
+            aria-hidden="true"
+            className="h-10 w-10 animate-spin rounded-full border-[3px] border-primary border-t-transparent"
+          />
           {label && <span className="text-sm text-muted-foreground">{label}</span>}
         </div>
       </div>
@@ -26,21 +44,44 @@ export default function PageSpinner({ variant = "page", label }: PageSpinnerProp
 
   if (variant === "section") {
     return (
-      <div className="flex justify-center py-8">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label={accessibleLabel}
+        className="flex justify-center py-8"
+      >
+        <div
+          aria-hidden="true"
+          className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent"
+        />
       </div>
     )
   }
 
   if (variant === "inline") {
+    // The `inline` variant ships as a bare ring so callers can compose it
+    // anywhere they need a spinner. The wrapping context (button, row,
+    // modal) is responsible for any announcement — here we just mark the
+    // glyph decorative.
     return (
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      <div
+        aria-hidden="true"
+        className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"
+      />
     )
   }
 
   return (
-    <div className="flex justify-center py-20">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={accessibleLabel}
+      className="flex justify-center py-20"
+    >
+      <div
+        aria-hidden="true"
+        className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"
+      />
     </div>
   )
 }

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,8 +1,19 @@
 import { cn } from "@/lib/utils"
 
+/**
+ * Decorative loading placeholder. Hidden from assistive tech by default —
+ * the shape is purely visual, and announcing it would just say "blank
+ * blank blank" while the real content streams in. The surrounding region
+ * (page, card, etc.) is responsible for its own `aria-busy` if AT users
+ * should be told a load is in progress.
+ *
+ * `aria-hidden` is set on the wrapper, but callers can override via the
+ * standard HTML attribute if they want their skeleton announced.
+ */
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
+      aria-hidden="true"
       className={cn("skeleton-shimmer", className)}
       {...props}
     />


### PR DESCRIPTION
## Summary

Two loading primitives were completely silent to assistive tech.

### `PageSpinner`

The rotating ring is decorative; the actual "loading is in progress" signal lived only in the visual. Screen reader users hit an empty region with no indication anything was happening.

- `role="status"` + `aria-live="polite"` on the announcing wrapper, so loading is communicated without interrupting the user (polite, not assertive).
- `aria-label` (defaulting to `"Loading"`, overridable via the existing `label` prop) gives the announcement a name.
- `aria-hidden="true"` on the rotating ring itself — it's pure visual noise; meaning lives in the label.
- The `inline` variant stays bare (just `aria-hidden`) — callers like buttons and rows are responsible for their own announcement, matching that variant's documented intent.

### `Skeleton`

Decorative loading placeholder. Marked `aria-hidden="true"` so AT skips it (saying "blank blank blank" while content streams in is not useful). The surrounding region (page / card / list) is responsible for its own `aria-busy` if AT users should be told. Callers can override via the standard HTML attribute if they have a different intent.

No visual or JS change. Just attributes the screen reader needed and didn't have.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 125/125 pass
- [ ] VoiceOver / NVDA check: navigate to a route that uses `<PageSpinner>` as a Suspense fallback; confirm "Loading" is announced once and not repeatedly.
- [ ] Confirm Skeleton-bearing routes (admin tables, course lists) no longer announce empty regions when AT is on.
