### PR TITLE
fix(certificates): block self-approval at both teacher and admin steps

### DIFF
--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -91,6 +91,23 @@ def _assert_status(cert: Certificate, expected: str | tuple[str, ...]) -> None:
         )
 
 
+def _assert_not_self_approval(cert: Certificate, approver: User) -> None:
+    """Refuse approval / issuance when the approver is the certificate recipient.
+
+    A teacher who owns a course satisfies ``assert_course_owner``, and an
+    admin satisfies ``require_admin`` — but neither check stops them from
+    being the *student* whose certificate is being signed off. That path
+    would let a course owner enroll in their own course, request a cert,
+    and self-sign it; or an admin to issue their own cert with no second
+    pair of eyes. Both undermine the two-stage approval design.
+    """
+    if str(cert.user_id) == str(approver.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot approve or issue your own certificate",
+        )
+
+
 def _status_error_message(cert: Certificate, allowed: tuple[str, ...]) -> str:
     if allowed == ("pending",):
         return f"Certificate is not pending (current status: {cert.status})"
@@ -102,6 +119,7 @@ def _status_error_message(cert: Certificate, allowed: tuple[str, ...]) -> str:
 def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request) -> Certificate:
     cert = _load_cert_or_404(db, cert_id, for_update=True)
     _assert_status(cert, "pending")
+    _assert_not_self_approval(cert, teacher)
 
     ownership_detail = "You can only approve certificates for your own courses"
     course = _load_active_course_or_403(db, cert.course_id, ownership_detail=ownership_detail)
@@ -128,6 +146,7 @@ def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request)
 def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> Certificate:
     cert = _load_cert_or_404(db, cert_id, for_update=True)
     _assert_status(cert, "teacher_approved")
+    _assert_not_self_approval(cert, admin)
 
     cert.status = "approved"
     cert.certificate_number = generate_certificate_number()

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -361,6 +361,33 @@ class TestTeacherApproveCertificate:
         r = student_client.put(f"/api/v1/certificates/{cert.id}/teacher-approve")
         assert r.status_code == 403
 
+    def test_self_approval_forbidden(self, client: TestClient, db: Session):
+        """A teacher cannot teacher-approve a certificate issued to themselves.
+
+        Regression: ``assert_course_owner`` passes when the teacher owns the
+        course, and nothing else stopped the same teacher from being both
+        approver and recipient. That collapses the two-stage approval
+        check into a single self-signed action.
+        """
+        _seed_course(db)  # course-1 owned by TEACHER_ID
+        # Enroll TEACHER_ID in their own course as a "student".
+        db.add(
+            Enrollment(
+                id="enroll-self",
+                user_id=TEACHER_ID,
+                course_id="course-1",
+                progress=100,
+            )
+        )
+        cert = Certificate(user_id=TEACHER_ID, course_id="course-1", status="pending")
+        db.add(cert)
+        db.commit()
+        db.refresh(cert)
+
+        r = client.put(f"/api/v1/certificates/{cert.id}/teacher-approve")
+        assert r.status_code == 403
+        assert "own" in r.json()["detail"].lower()
+
 
 class TestAdminApproveCertificate:
     """PUT /api/v1/certificates/{cert_id}/admin-approve"""
@@ -394,6 +421,36 @@ class TestAdminApproveCertificate:
         _make_admin(db)
         r = client.put(f"/api/v1/certificates/{uuid.uuid4()}/admin-approve")
         assert r.status_code == 404
+
+    def test_admin_self_approval_forbidden(self, client: TestClient, db: Session):
+        """Admin cannot issue a certificate where they are the recipient.
+
+        Regression: ``require_admin`` only checks the role, not whether
+        the admin is the certificate's user. Without this guard a single
+        admin account could complete the entire approve → issue path.
+        """
+        _make_admin(db)
+        _seed_course(db)  # course-1 owned by TEACHER_ID == the admin
+        db.add(
+            Enrollment(
+                id="enroll-self-admin",
+                user_id=TEACHER_ID,
+                course_id="course-1",
+                progress=100,
+            )
+        )
+        cert = Certificate(
+            user_id=TEACHER_ID,
+            course_id="course-1",
+            status="teacher_approved",
+        )
+        db.add(cert)
+        db.commit()
+        db.refresh(cert)
+
+        r = client.put(f"/api/v1/certificates/{cert.id}/admin-approve")
+        assert r.status_code == 403
+        assert "own" in r.json()["detail"].lower()
 
 
 class TestRejectCertificate:


### PR DESCRIPTION
## Summary
- The two-stage cert-approval design (`pending` → `teacher_approved` → `approved`) only checked role + course ownership at each step. Nothing stopped the approver from also being the certificate's recipient, so a course owner who self-enrolls could teacher-approve their own request, and an admin could admin-approve a cert issued to themselves — collapsing the two-sign-off design into a single self-signed act.
- Adds `_assert_not_self_approval(cert, approver)` and calls it from both `teacher_approve` and `admin_approve`. Returns 403 with `"You cannot approve or issue your own certificate"`. `reject` is unchanged: rejecting your own request is harmless self-service.

## Test plan
- [x] Added `test_self_approval_forbidden` and `test_admin_self_approval_forbidden` — both fail before, pass after
- [x] `python -m pytest tests/` — 594 passed
- [x] `ruff check`, `ruff format --check`, `mypy` all clean

Bug class: integrity hole in the approval workflow. Code-level fix only; no schema or data migration. Severity: medium — exploit requires being a teacher / admin to begin with, but the fix is cheap and the design intent is unambiguous.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
