### PR TITLE
fix(certificates): allow re-request after rejection by reopening the row

### DIFF
--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -72,7 +72,16 @@ def request_certificate(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> Certificate:
-    """Request a certificate (creates a pending request)."""
+    """Request a certificate (creates a pending request).
+
+    Re-request after rejection: the cert row carries a ``(user_id,
+    course_id)`` unique constraint, so we cannot just INSERT a fresh
+    pending row when a previous request was rejected. Instead we reset
+    the rejected row back to ``pending`` (clearing approver timestamps)
+    so the student can have another go through the teacher / admin
+    workflow — matching ``reject``'s docstring promise that "a rejected
+    certificate stays rejected and the student must re-request".
+    """
     # Soft-deleted courses must not accept new certificate requests.
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
@@ -92,7 +101,18 @@ def request_certificate(
     existing = (
         db.query(Certificate).filter(Certificate.user_id == current_user.id, Certificate.course_id == course_id).first()
     )
-    if existing:
+    if existing is not None:
+        if existing.status == "rejected":
+            # Reopen the request rather than silently returning the
+            # rejected row (which previously made the "request" button a
+            # no-op for any student who had been rejected once).
+            existing.status = "pending"
+            existing.teacher_approved_at = None
+            existing.teacher_approved_by = None
+            existing.admin_approved_at = None
+            existing.admin_approved_by = None
+            db.commit()
+            db.refresh(existing)
         return existing
 
     cert = Certificate(user_id=current_user.id, course_id=course_id, status="pending")
@@ -106,7 +126,15 @@ def request_certificate(
             .filter(Certificate.user_id == current_user.id, Certificate.course_id == course_id)
             .first()
         )
-        if existing:
+        if existing is not None:
+            if existing.status == "rejected":
+                existing.status = "pending"
+                existing.teacher_approved_at = None
+                existing.teacher_approved_by = None
+                existing.admin_approved_at = None
+                existing.admin_approved_by = None
+                db.commit()
+                db.refresh(existing)
             return existing
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Certificate already requested") from exc
     db.refresh(cert)

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -234,6 +234,35 @@ class TestRequestCertificate:
         r = anon_client.post("/api/v1/certificates/course/course-1")
         assert r.status_code in (401, 403)
 
+    def test_rerequest_after_rejection_reopens_to_pending(self, student_client: TestClient, db: Session):
+        """A student must be able to ask again after a rejection.
+
+        ``reject``'s docstring promises "a rejected certificate stays
+        rejected and the student must re-request" — but the
+        ``(user_id, course_id)`` unique constraint plus the previous
+        ``if existing: return existing`` short-circuit meant a
+        re-request silently handed back the rejected row, making the
+        action a no-op. Reset to ``pending`` so the workflow restarts.
+        """
+        _seed_enrolled_course(db, progress=100)
+        rejected = _seed_certificate(db, "course-1", cert_status="rejected")
+        # Pretend a teacher had stamped approval before the admin rejected:
+        rejected.teacher_approved_at = datetime(2026, 1, 1, tzinfo=UTC)
+        rejected.teacher_approved_by = TEACHER_ID
+        db.commit()
+
+        r = student_client.post("/api/v1/certificates/course/course-1")
+        assert r.status_code == 201
+        body = r.json()
+        assert body["id"] == str(rejected.id)
+        assert body["status"] == "pending"
+        # Old approver stamps are cleared so the next teacher review
+        # starts from a clean slate.
+        assert body["teacher_approved_at"] is None
+        assert body["teacher_approved_by"] is None
+        assert body["admin_approved_at"] is None
+        assert body["admin_approved_by"] is None
+
 
 class TestGetCourseCertificate:
     """GET /api/v1/certificates/course/{course_id}"""


### PR DESCRIPTION
## Summary
- `reject`'s docstring states "a rejected certificate stays rejected and the student must re-request" — but the `(user_id, course_id)` unique constraint plus the `if existing: return existing` short-circuit in `request_certificate` meant the re-request silently handed back the rejected row. The "Request certificate" button became a no-op for any student who had been rejected once.
- When the existing row is `rejected`, reset it to `pending` and clear approver stamps. Other statuses (`pending`, `teacher_approved`, `approved`) are unchanged. The `IntegrityError` fallback for concurrent re-requests gets the same treatment.

## Test plan
- [x] Added `test_rerequest_after_rejection_reopens_to_pending` (fails before, passes after)
- [x] `python -m pytest tests/` — 603 passed
- [x] `ruff check`, `ruff format --check`, `mypy` all clean

Bug class: silent UX failure that broke a documented recovery flow. No schema change, code-level only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
