### PR TITLE
fix(announcements): treat soft-deleted course as not-found when creating

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -139,7 +139,12 @@ def create_announcement(
     frontend's DOMPurify.
     """
     if data.course_id:
-        course = db.query(Course).filter(Course.id == data.course_id).first()
+        # Course must be alive — a teacher who's already trashed the
+        # course shouldn't be able to push an announcement that fans out
+        # notifications to every enrolled student via
+        # ``create_notifications_bulk`` below, pointing at content that
+        # no longer exists in the catalog.
+        course = db.query(Course).filter(Course.id == data.course_id, Course.deleted_at.is_(None)).first()
         if not course:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -1159,6 +1159,29 @@ class TestCreateAnnouncement:
         )
         assert resp.status_code == 404
 
+    def test_create_for_soft_deleted_course_returns_404(self, client: TestClient, db: Session):
+        """A teacher who's already trashed a course cannot post an
+        announcement to it. The course is gone from every catalog
+        surface, but enrollments persist (so a fan-out would still hit
+        every student) and the announcement would link to content the
+        student can no longer reach. Treat the trashed course as
+        not-found, matching every other ``Course.deleted_at IS NULL``
+        gate elsewhere in the API.
+        """
+        course = _create_course_via_api(client)
+        # Soft-delete the course directly so we don't depend on the
+        # delete-course endpoint's exact response shape.
+        row = db.query(Course).filter(Course.id == course["id"]).first()
+        assert row is not None
+        row.deleted_at = NOW
+        db.commit()
+
+        resp = client.post(
+            ANNOUNCEMENT_PREFIX,
+            json=_announcement_payload(course_id=course["id"]),
+        )
+        assert resp.status_code == 404
+
     def test_create_missing_title_returns_422(self, client: TestClient):
         resp = client.post(
             ANNOUNCEMENT_PREFIX,


### PR DESCRIPTION
## Summary
- A teacher who soft-deleted a course could still POST `/api/v1/announcements` for it. The announcement would fan out a notification to every enrolled student, linking back to `/courses/{course_id}` which the student can no longer reach.
- Filter on `Course.deleted_at IS NULL` so a trashed course is treated as not-found. Matches the same gate used by every other course-touching endpoint (cert request, prereq, calendar, etc.).

## Test plan
- [x] Added `test_create_for_soft_deleted_course_returns_404` (fails before, passes after)
- [x] `python -m pytest tests/` — 603 passed
- [x] `ruff check`, `ruff format --check`, `mypy` all clean

Bug class: soft-delete leak with notification fan-out. Severity: low/medium — requires a teacher to act on their own trashed course; net effect is spurious notifications and dead links.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
