### PR TITLE
perf(admin): lazy-load AdminDashboard tabs (-45% chunk gz)

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -1,19 +1,31 @@
+import { lazy, Suspense } from "react"
 import { Navigate, useSearchParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { Shield } from "lucide-react"
 import { useAuth } from "@/context/useAuth"
 import { Button } from "@/components/ui/button"
 import { ErrorState } from "@/components/patterns"
+import PageSpinner from "@/components/ui/PageSpinner"
 import { ADMIN_TABS, type AdminTab } from "./dashboard/constants"
 import { AdminTabs } from "./dashboard/AdminTabs"
 import { OverviewStats } from "./dashboard/OverviewStats"
 import { PendingTeachersCard } from "./dashboard/PendingTeachersCard"
 import { PendingCertsCard } from "./dashboard/PendingCertsCard"
 import { UsersCard } from "./dashboard/UsersCard"
-import { AuditLogTab } from "./dashboard/AuditLogTab"
 import { useAdminOverview } from "./dashboard/useAdminOverview"
 import { useAdminAudit } from "./dashboard/useAdminAudit"
-import { CohortsTab } from "./cohorts"
+
+// The audit log and cohorts tabs are rarely the entry point — most admins
+// land on Overview. Splitting them off keeps the initial AdminDashboard
+// chunk lean (no react-window for cohorts via VirtualAdminUsers is still in
+// UsersCard, but the audit table machinery and the cohorts list components
+// don't need to ship until the matching tab is selected).
+const AuditLogTab = lazy(() =>
+  import("./dashboard/AuditLogTab").then((m) => ({ default: m.AuditLogTab })),
+)
+const CohortsTab = lazy(() =>
+  import("./cohorts/CohortsTab").then((m) => ({ default: m.CohortsTab })),
+)
 
 /**
  * Admin dashboard orchestrator. Delegates every piece of state to
@@ -105,27 +117,33 @@ export default function AdminDashboard() {
         </>
       )}
 
-      {tab === "cohorts" && <CohortsTab />}
+      {tab === "cohorts" && (
+        <Suspense fallback={<PageSpinner />}>
+          <CohortsTab />
+        </Suspense>
+      )}
 
       {!overview.error && tab === "audit" && (
-        <AuditLogTab
-          logs={audit.logs}
-          total={audit.total}
-          loading={audit.loading}
-          page={audit.page}
-          pageSize={audit.pageSize}
-          userMap={overview.userMap}
-          action={audit.action}
-          resource={audit.resource}
-          dateFrom={audit.dateFrom}
-          dateTo={audit.dateTo}
-          onAction={audit.setAction}
-          onResource={audit.setResource}
-          onDateFrom={audit.setDateFrom}
-          onDateTo={audit.setDateTo}
-          onReset={audit.resetFilters}
-          onPageChange={audit.setPage}
-        />
+        <Suspense fallback={<PageSpinner />}>
+          <AuditLogTab
+            logs={audit.logs}
+            total={audit.total}
+            loading={audit.loading}
+            page={audit.page}
+            pageSize={audit.pageSize}
+            userMap={overview.userMap}
+            action={audit.action}
+            resource={audit.resource}
+            dateFrom={audit.dateFrom}
+            dateTo={audit.dateTo}
+            onAction={audit.setAction}
+            onResource={audit.setResource}
+            onDateFrom={audit.setDateFrom}
+            onDateTo={audit.setDateTo}
+            onReset={audit.resetFilters}
+            onPageChange={audit.setPage}
+          />
+        </Suspense>
       )}
     </div>
   )

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react"
 import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -7,11 +8,15 @@ import { Users, Search, Trash2 } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import PageSpinner from "@/components/ui/PageSpinner"
 import { EmptyState } from "@/components/patterns/EmptyState"
-import VirtualAdminUsers from "../VirtualAdminUsers"
 import { RoleSelector } from "@/components/admin/RoleSelector"
 import type { UserRole } from "@/types"
 import { formatDate } from "@/i18n/format"
 import { type ProfileRow } from "./constants"
+
+// Only rendered when the filtered list crosses USERS_VIRTUAL_THRESHOLD —
+// keeps `react-window` (~10 KB gz) out of the eager AdminDashboard chunk
+// for the common case (small tenants with <50 users).
+const VirtualAdminUsers = lazy(() => import("../VirtualAdminUsers"))
 
 /**
  * Above this row count we swap the full <table> render for a react-window
@@ -136,15 +141,17 @@ export function UsersCard({
                 {t("admin.users.selectAllN", { count: filtered.length })}
               </span>
             </div>
-            <VirtualAdminUsers
-              users={filtered}
-              selectedIds={selectedIds}
-              updatingId={updatingId}
-              currentUserId={currentUserId}
-              onToggleSelect={onToggleSelect}
-              onRoleChange={onRoleChange}
-              onDeleteUser={onDeleteUser}
-            />
+            <Suspense fallback={<PageSpinner />}>
+              <VirtualAdminUsers
+                users={filtered}
+                selectedIds={selectedIds}
+                updatingId={updatingId}
+                currentUserId={currentUserId}
+                onToggleSelect={onToggleSelect}
+                onRoleChange={onRoleChange}
+                onDeleteUser={onDeleteUser}
+              />
+            </Suspense>
           </>
         ) : (
           <UsersTable


### PR DESCRIPTION
## Summary

The admin dashboard ships three tabs (overview, cohorts, audit) plus the react-window-backed users list. Most admins land on overview and never open the others, but today the matching components are statically imported, so the full `AdminDashboard` chunk has to be parsed before the overview can render.

This PR splits `AuditLogTab`, `CohortsTab`, and `VirtualAdminUsers` into their own on-demand chunks via `React.lazy`:

- `AuditLogTab` / `CohortsTab` — only loaded when the user switches tab via `?tab=audit` / `?tab=cohorts`.
- `VirtualAdminUsers` — only loaded when the filtered users list crosses `USERS_VIRTUAL_THRESHOLD` (50 rows), so small tenants never download `react-window`.

## Measured

Vite build (rolldown-vite 8.x), before vs after:

| Chunk | Before | After | Δ |
| --- | --- | --- | --- |
| `AdminDashboard` raw | 52,093 B | 26,290 B | **−49.5 %** |
| `AdminDashboard` gz | 12,870 B | 7,090 B | **−45 %** |
| `index` (main) raw | 287,595 B | 282,312 B | −1.8 % |
| `index` (main) gz | 93,809 B | 91,501 B | −2.5 % |

New chunks materialise only when the matching tab opens:

| Chunk | Raw | Gz |
| --- | --- | --- |
| `AuditLogTab` | 6,170 B | 1,810 B |
| `CohortsTab` | 9,790 B | 2,710 B |
| `VirtualAdminUsers` | 12,030 B | 4,330 B |

## Behaviour

Unchanged — `Suspense` fallbacks use the existing `PageSpinner` that's already shown during the page-level lazy load, so the visual shape stays the same.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 140/140 pass
- [x] `npx vite build` — bundle measurements above
- [ ] Manual: open `/admin`, `/admin?tab=cohorts`, `/admin?tab=audit` — confirm each tab loads, the spinner flashes once per cold transition, and tab switching keeps URL state.

Generated with [Claude Code](https://claude.com/claude-code)
