### PR TITLE
feat(a11y): skip-to-content link and main landmark

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -119,10 +119,19 @@ function AppRoutes() {
 
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">
+      {/* Skip link — hidden until focused via Tab. First focusable element on
+          every authenticated page so keyboard / screen-reader users can jump
+          past the persistent Header + banners straight to page content. */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        {t("common.skipToContent")}
+      </a>
       <Header />
       {user?.role === ROLES.PENDING_TEACHER && <PendingTeacherBanner />}
       <AnnouncementBanner />
-      <main className="flex-1">
+      <main id="main-content" tabIndex={-1} className="flex-1 focus:outline-none">
         <ErrorBoundary>
           <Suspense fallback={<PageSpinner />}>
             <Routes>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -11,6 +11,7 @@
     "register": "Register",
     "close": "Close",
     "scrollToTop": "Scroll to top",
+    "skipToContent": "Skip to main content",
     "dismissAnnouncement": "Dismiss announcement"
   },
   "inlineEdit": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -11,6 +11,7 @@
     "register": "Регистрация",
     "close": "Закрыть",
     "scrollToTop": "Наверх",
+    "skipToContent": "Перейти к содержимому",
     "dismissAnnouncement": "Закрыть объявление"
   },
   "inlineEdit": {


### PR DESCRIPTION
## Summary
- Every authenticated page now renders a visually-hidden skip link as the **first focusable element**. Pressing Tab reveals it; activating it jumps focus to `<main id="main-content">`, bypassing Header + banners.
- `<main>` gains `id="main-content" tabIndex={-1}` so the anchor lands focus on the region itself (and screen readers announce "main").
- Auth pages already render their own minimal `AuthLayout` so no skip link is added there.
- Bilingual: `common.skipToContent` added in `en.json` + `ru.json`.

## What it fixes
- Keyboard users no longer have to Tab through the sticky Header, NotificationBell, AnnouncementBanner, etc. on every navigation.
- Screen-reader users get a labelled landmark target.

## Test plan
- [ ] Load any authenticated page (e.g. `/`, `/profile`, `/teacher`). Press Tab once — the skip link should appear at the top-left.
- [ ] Press Enter — focus should jump into `<main>`, page should scroll if needed.
- [ ] Visually check the link is hidden when not focused.
- [ ] Confirm RU locale shows "Перейти к содержимому".
- [ ] `npm run lint` clean, `npx tsc --noEmit` clean, `npm run test:run` green (140 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)