### PR TITLE
fix(cohorts): rebind orphaned enrollments on re-add / re-attach

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -282,15 +282,37 @@ def attach_course(
             Enrollment.course_id == course.id,
         )
     }
-    for user_id in all_cohort_users - already_enrolled:
-        db.add(
-            Enrollment(
-                id=f"enr-{cohort.id}-{user_id}-{course.id}",
-                user_id=user_id,
-                course_id=course.id,
-                cohort_id=cohort.id,
+    # When a course was previously attached and detached, the per-student
+    # enrollment rows survive with ``cohort_id`` nulled (see
+    # ``detach_course``). Re-attaching must rebind those orphaned rows
+    # rather than INSERT new ones — the deterministic PK
+    # ``enr-{cohort}-{user}-{course}`` would otherwise collide and the
+    # IntegrityError below would swallow the failure silently, leaving
+    # the student unattached to the freshly re-attached course.
+    missing_user_ids = all_cohort_users - already_enrolled
+    if missing_user_ids:
+        rebound = (
+            db.query(Enrollment)
+            .filter(
+                Enrollment.user_id.in_(missing_user_ids),
+                Enrollment.course_id == course.id,
+                Enrollment.cohort_id.is_(None),
             )
+            .all()
         )
+        rebound_users = set()
+        for row in rebound:
+            row.cohort_id = cohort.id
+            rebound_users.add(row.user_id)
+        for user_id in missing_user_ids - rebound_users:
+            db.add(
+                Enrollment(
+                    id=f"enr-{cohort.id}-{user_id}-{course.id}",
+                    user_id=user_id,
+                    course_id=course.id,
+                    cohort_id=cohort.id,
+                )
+            )
 
     try:
         db.commit()
@@ -431,17 +453,39 @@ def add_student(
             )
 
     course_ids = _course_ids_for_cohort(db, cohort.id)
-    for course_id in course_ids:
-        if course_id in already_enrolled_courses:
-            continue
-        db.add(
-            Enrollment(
-                id=f"enr-{cohort.id}-{user.id}-{course_id}",
-                user_id=user.id,
-                course_id=course_id,
-                cohort_id=cohort.id,
+    missing_course_ids = [cid for cid in course_ids if cid not in already_enrolled_courses]
+
+    # A student that was previously removed via ``remove_student`` has
+    # surviving enrollment rows with ``cohort_id`` nulled. Re-adding must
+    # rebind those rows rather than INSERT new ones — the deterministic
+    # PK ``enr-{cohort}-{user}-{course}`` would otherwise collide and the
+    # IntegrityError below would swallow the failure silently, returning
+    # 201 while the student stays detached from the cohort.
+    if missing_course_ids:
+        rebound = (
+            db.query(Enrollment)
+            .filter(
+                Enrollment.user_id == user.id,
+                Enrollment.course_id.in_(missing_course_ids),
+                Enrollment.cohort_id.is_(None),
             )
+            .all()
         )
+        rebound_courses = set()
+        for row in rebound:
+            row.cohort_id = cohort.id
+            rebound_courses.add(row.course_id)
+        for course_id in missing_course_ids:
+            if course_id in rebound_courses:
+                continue
+            db.add(
+                Enrollment(
+                    id=f"enr-{cohort.id}-{user.id}-{course_id}",
+                    user_id=user.id,
+                    course_id=course_id,
+                    cohort_id=cohort.id,
+                )
+            )
 
     try:
         db.commit()

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -541,6 +541,46 @@ class TestDetachCourse:
         resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort_resp.json()['id']}/courses/test-course-1")
         assert resp.status_code == 204
 
+    def test_re_attach_after_detach_rebinds_orphaned_enrollments(self, admin_client: TestClient, db: Session, student):
+        # Same silent-failure bug as TestRemoveStudent.test_re_add_…,
+        # surfacing through the course junction this time. The student
+        # must stay a cohort member (via a second course) so the
+        # auto-enroll branch fires on re-attach; otherwise re-attach has
+        # no auto-enroll target and the orphan question is moot.
+        # Before the fix, the auto-enroll INSERT collided on the
+        # deterministic PK ``enr-{cohort}-{user}-{course}`` left over from
+        # the previous attach, the IntegrityError was swallowed, and the
+        # student stayed stranded on the re-attached course.
+        _seed_course(db, course_id="course-1")
+        _seed_course(db, course_id="course-2")
+        cohort = _seed_cohort_with_course(db, course_id="course-1")
+        _attach_course_via_junction(db, cohort.id, "course-2")
+        # Student is enrolled in BOTH courses through the cohort.
+        _seed_enrollment(db, course_id="course-1", cohort_id=cohort.id)
+        _seed_enrollment(db, course_id="course-2", cohort_id=cohort.id)
+
+        # Detach course-1 → that one enrollment's cohort_id becomes NULL.
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort.id}/courses/course-1")
+        assert resp.status_code == 204
+        orphan = db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == "course-1").one()
+        assert orphan.cohort_id is None
+
+        # Re-attach course-1. The student is still a cohort member via
+        # course-2, so they're in ``all_cohort_users`` and the auto-enroll
+        # loop runs for them. Must rebind the orphan, not no-op.
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/courses", json={"course_id": "course-1"})
+        assert resp.status_code == 201
+
+        rebound = (
+            db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == "course-1").one()
+        )
+        assert rebound.cohort_id == cohort.id
+        # No duplicate row was created.
+        assert (
+            db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == "course-1").count()
+            == 1
+        )
+
 
 class TestAddStudent:
     def test_add_by_user_id_auto_enrolls_in_all_cohort_courses(self, admin_client: TestClient, db: Session, student):
@@ -597,6 +637,34 @@ class TestRemoveStudent:
         surviving = db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID).all()
         assert len(surviving) == 1
         assert surviving[0].cohort_id is None
+
+    def test_re_add_after_remove_rebinds_orphaned_enrollment(self, admin_client: TestClient, db: Session, student):
+        # Reproduces a silent-failure bug: ``add_student`` used to INSERT a
+        # row with the deterministic PK ``enr-{cohort}-{user}-{course}``,
+        # which collides with the orphaned row left behind by
+        # ``remove_student`` (the surviving row has ``cohort_id=NULL`` but
+        # the same PK). The IntegrityError was swallowed and the student
+        # was never actually re-attached to the cohort.
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        _seed_enrollment(db, course_id="test-course-1", cohort_id=cohort.id)
+
+        # Remove → row stays with cohort_id NULL.
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort.id}/students/{STUDENT_ID}")
+        assert resp.status_code == 204
+        assert (
+            db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID, Enrollment.cohort_id.is_(None)).count() == 1
+        )
+
+        # Re-add should rebind that orphaned row, not silently no-op.
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/students", json={"user_id": str(STUDENT_ID)})
+        assert resp.status_code == 201
+
+        # Exactly one enrollment, now attached to the cohort.
+        all_rows = db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID).all()
+        assert len(all_rows) == 1
+        assert all_rows[0].cohort_id == cohort.id
+        assert all_rows[0].course_id == "test-course-1"
 
 
 class TestCohortStudents:


### PR DESCRIPTION
## Summary
- Re-adding a student to a cohort after `DELETE /cohorts/{id}/students/{uid}` silently no-ops because the deterministic enrollment PK `enr-{cohort}-{user}-{course}` collides with the orphaned row left behind (cohort_id=NULL, same PK). The `IntegrityError` is swallowed and the API returns 201 while the student stays detached.
- Same shape for `POST /cohorts/{id}/courses` after a prior detach: orphaned rows block the auto-enroll INSERT.
- Fix: before INSERT, lookup `(user, course, cohort_id IS NULL)` orphans and rebind them to the current cohort. Falls back to INSERT for any user/course with no orphan.

## Test plan
- [x] New regression test `TestRemoveStudent::test_re_add_after_remove_rebinds_orphaned_enrollment` — fails before, passes after.
- [x] New regression test `TestDetachCourse::test_re_attach_after_detach_rebinds_orphaned_enrollments` — fails before, passes after.
- [x] `python -m pytest tests/` (609 pass).
- [x] `python -m ruff check .` clean.
- [x] `mypy --config-file mypy.ini` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
