### PR TITLE
obs(backend): always emit X-Request-Id and stash a fallback id locally

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import uuid
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -108,15 +109,24 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
-    # Vercel attaches a unique id to every inbound request on the
-    # ``x-vercel-id`` header. Stashing it in a contextvar lets the
-    # DatadogHTTPHandler tag every WARNING+ log emitted during this
-    # request with the same id, so a RUM session error and the backend
-    # log line that produced it can be correlated by Vercel request id.
-    token = vercel_request_id.set(request.headers.get("x-vercel-id"))
+    # Per-request correlation id. In production Vercel attaches its own
+    # unique id on the ``x-vercel-id`` header; we reuse it so a RUM
+    # session error and the backend log line that produced it can be
+    # joined by the same value already visible in the Vercel log viewer.
+    # Outside Vercel (local dev, self-host) we mint a UUID so the field
+    # is always populated and the contract is consistent everywhere.
+    # Stashing it in a contextvar lets the DatadogHTTPHandler tag every
+    # WARNING+ log emitted during this request with the same id.
+    request_id = request.headers.get("x-vercel-id") or uuid.uuid4().hex
+    token = vercel_request_id.set(request_id)
     try:
         start = time.time()
         response = await call_next(request)
+        # Surface the id back to the caller (and to RUM) so a user
+        # reporting a bug can quote it and we can pivot from a single
+        # browser session straight to the backend log line. The header
+        # is already listed in ``expose_headers`` on the CORS config.
+        response.headers["X-Request-Id"] = request_id
         duration = round((time.time() - start) * 1000, 1)
         logger.info(
             "%s %s %s %sms",

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -31,3 +31,28 @@ def test_health_returns_ok():
         resp = tc.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
+
+
+def test_response_includes_x_request_id_header():
+    """Every response must carry an ``X-Request-Id`` header so a user
+    reporting a bug can quote it and we can pivot from a single browser
+    session straight to the backend log line. Outside Vercel (here in
+    the test client) the middleware mints a UUID hex so the field is
+    always populated."""
+    with TestClient(app) as tc:
+        resp = tc.get("/health")
+    assert resp.status_code == 200
+    request_id = resp.headers.get("X-Request-Id")
+    assert request_id, "X-Request-Id must be set on every response"
+    # UUID hex (32 hex chars) when generated locally; Vercel ids look
+    # like ``iad1::abc123`` so we only sanity-check non-emptiness here.
+    assert len(request_id) >= 16
+
+
+def test_response_echoes_vercel_request_id_when_present():
+    """When Vercel forwards ``x-vercel-id`` we surface it verbatim
+    instead of minting our own, so the value matches what the Vercel
+    log viewer already shows for the same request."""
+    with TestClient(app) as tc:
+        resp = tc.get("/health", headers={"x-vercel-id": "iad1::test-abc-123"})
+    assert resp.headers.get("X-Request-Id") == "iad1::test-abc-123"


### PR DESCRIPTION
## Summary

- `CORSMiddleware.expose_headers` already advertised `X-Request-Id` but the middleware never set it -- callers (and RUM session errors) had no id to quote when reporting bugs.
- `log_requests` now reuses `x-vercel-id` when present (so the value matches the Vercel log viewer) and mints a UUID hex otherwise, then echoes it back on the response and stashes it in the contextvar that `DatadogHTTPHandler` reads.
- Two new tests cover both the local-mint and the Vercel-passthrough paths.

## Test plan

- [x] `cd backend && python -m pytest tests/` (609 passed)
- [x] `python -m ruff check . && python -m ruff format --check app/main.py tests/test_health.py`
- [x] `python -m mypy --config-file mypy.ini app/main.py`
- [ ] After deploy: hit `api.equipbible.com/health` and confirm the response carries `X-Request-Id`; confirm Datadog WARNING+ records get `vercel.request_id` even when `x-vercel-id` is absent (e.g. from synthetics or curl).

Co-authored-by: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;
