### PR TITLE
fix(a11y): real heading elements, search/prompt labels

### DIFF
--- a/frontend/src/components/patterns/InlineEdit.tsx
+++ b/frontend/src/components/patterns/InlineEdit.tsx
@@ -189,9 +189,16 @@ export function InlineEdit({
   const isEmpty = !value.trim()
   const displayText = isEmpty ? resolvedPlaceholder : value
 
+  // Promote the display container to a real heading element when the caller
+  // requested a heading-sized rendition. The button-as-trigger pattern stays
+  // wrapped inside, so the click/keyboard/aria-label affordance is unchanged
+  // — but assistive tech now sees an actual <h1>/<h2> in the page outline
+  // instead of a styled <span>.
+  const HeadingTag = size === "h1" ? "h1" : size === "h2" ? "h2" : "span"
+
   if (disabled) {
     return (
-      <span className={cn("inline-block w-full", className)}>
+      <HeadingTag className={cn("inline-block w-full", size !== "body" && "m-0", className)}>
         <span
           className={cn(
             "text-wrap-safe",
@@ -203,12 +210,22 @@ export function InlineEdit({
         >
           {displayText}
         </span>
-      </span>
+      </HeadingTag>
     )
   }
 
+  // For heading sizes we render a block-level <h1>/<h2> so the page outline
+  // is correct. The original body variant kept `inline-flex` so it could sit
+  // next to neighbouring text — that contract is preserved below.
   return (
-    <span className={cn("group/edit relative inline-flex w-full items-start gap-2", className)}>
+    <HeadingTag
+      className={cn(
+        size === "body"
+          ? "group/edit relative inline-flex w-full items-start gap-2"
+          : "group/edit relative flex w-full items-start gap-2 m-0",
+        className,
+      )}
+    >
       <button
         type="button"
         onClick={start}
@@ -228,6 +245,6 @@ export function InlineEdit({
           <Pencil className="h-3.5 w-3.5" strokeWidth={1.75} />
         </span>
       </span>
-    </span>
+    </HeadingTag>
   )
 }

--- a/frontend/src/components/patterns/__tests__/InlineEdit.test.tsx
+++ b/frontend/src/components/patterns/__tests__/InlineEdit.test.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react"
+import { render, screen } from "@testing-library/react"
+import { I18nextProvider } from "react-i18next"
+import { describe, expect, it, vi } from "vitest"
+import i18n from "@/i18n/config"
+import { InlineEdit } from "../InlineEdit"
+
+function TestWrapper({ children }: { children: ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+describe("InlineEdit — heading semantics", () => {
+  it('renders a real <h1> element when size="h1"', () => {
+    render(
+      <InlineEdit
+        size="h1"
+        value="Course title"
+        onSave={vi.fn()}
+        placeholder="Title"
+      />,
+      { wrapper: TestWrapper },
+    )
+    // The visible heading should be discoverable by screen readers via the
+    // heading role at the right level — not just by accessible name on a
+    // <span> styled to look like a heading.
+    expect(screen.getByRole("heading", { level: 1, name: /course title/i })).toBeInTheDocument()
+  })
+
+  it('renders a real <h2> element when size="h2"', () => {
+    render(
+      <InlineEdit
+        size="h2"
+        value="Section heading"
+        onSave={vi.fn()}
+      />,
+      { wrapper: TestWrapper },
+    )
+    expect(screen.getByRole("heading", { level: 2, name: /section heading/i })).toBeInTheDocument()
+  })
+
+  it("does NOT introduce a heading for body size", () => {
+    render(
+      <InlineEdit
+        size="body"
+        value="Some body text"
+        onSave={vi.fn()}
+      />,
+      { wrapper: TestWrapper },
+    )
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument()
+  })
+
+  it("uses a heading wrapper even when disabled (read-only)", () => {
+    render(
+      <InlineEdit
+        size="h1"
+        value="Read-only title"
+        onSave={vi.fn()}
+        disabled
+      />,
+      { wrapper: TestWrapper },
+    )
+    expect(screen.getByRole("heading", { level: 1, name: /read-only title/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -253,6 +253,9 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
                 value={promptState.value}
                 onChange={(e) => setPromptState((s) => ({ ...s, value: e.target.value }))}
                 placeholder={promptState.placeholder}
+                // Use the dialog title as the accessible name — the prompt
+                // input is the dialog's sole field, so the title IS its label.
+                aria-label={promptState.title}
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               />
               <AlertDialogFooter className="mt-4">

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -175,15 +175,18 @@ export default function ProfilePage() {
                 />
               </div>
               <div className="min-w-0 flex-1 space-y-0.5">
+                {/* The user's full name doubles as the page's h1 — every
+                    profile is "about this person", so their name is the
+                    natural document heading. Sub-cards below use CardTitle. */}
                 <InlineEdit
-                  size="h2"
+                  size="h1"
                   value={user.full_name ?? ""}
                   onSave={handleSaveName}
                   required
                   maxLength={150}
                   placeholder={t("profile.fullName")}
                   ariaLabel={t("profile.editName")}
-                  textClassName="tracking-tight"
+                  textClassName="text-xl md:text-2xl tracking-tight"
                 />
                 <CardDescription className="text-sm">{t(ROLE_I18N_KEY[user.role])}</CardDescription>
               </div>

--- a/frontend/src/pages/Teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.tsx
@@ -261,7 +261,9 @@ export default function TeacherDashboard() {
             <div className="mb-4 relative">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
               <Input
+                type="search"
                 placeholder={t("teacher.searchPlaceholder")}
+                aria-label={t("teacher.searchPlaceholder")}
                 value={searchInput}
                 onChange={(e) =>
                   setSearchInput(e.target.value.slice(0, MAX_SEARCH_LEN))


### PR DESCRIPTION
## Summary
- **InlineEdit** (`patterns/InlineEdit.tsx`) now renders a real `<h1>` / `<h2>` element when `size="h1" | "h2"`. Previously the heading text lived inside a styled `<span>` — screen readers and outline tooling saw a paragraph of text where a heading belonged. `size="body"` is unchanged (`inline-flex` `<span>`).
- **ProfilePage**: the user's full name is now the page's `<h1>` (promoted from h2). `textClassName` overrides keep the existing visual size — no design change.
- **TeacherDashboard** course-search input had only a `placeholder`. Added `aria-label` + `type="search"` so it's announced and gets the search semantic.
- **Confirm/prompt dialog** (`ui/alert-dialog.tsx`) text input had no accessible name. Wired `aria-label` to the dialog title — the input is the dialog's sole field, so the title IS its label.
- New unit tests pin the heading-level contract on InlineEdit.

## What it fixes
- Pages titled via InlineEdit (Profile, CourseEditor, ModuleEditor) now appear in the document outline. Screen-reader rotor users can jump to them.
- Form inputs without labels (TeacherDashboard search, prompt dialog input) now have an accessible name. WCAG 4.1.2 / 3.3.2.

## Test plan
- [ ] Run `npm run test:run` — 144 tests green (was 140 before this PR + 4 new InlineEdit tests).
- [ ] Open Profile page — accessible-tree / Headings rotor shows the user's name as h1.
- [ ] Open Teacher Course Editor — the title field shows as h1 in the outline.
- [ ] Open Teacher Dashboard with 4+ courses — focus the search input, screen reader reads "Search by course title" (or RU equivalent).
- [ ] Trigger any `usePrompt()` call (e.g. add link in TipTap toolbar) — input is labelled by the dialog title.
- [ ] `npm run lint` clean, `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)