### PR TITLE
docs: add OBSERVABILITY and DEPLOYMENT runbooks

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,266 @@
+# Deployment runbook
+
+How a change goes from a green PR to live on `equipbible.com` /
+`api.equipbible.com`. Companion to [`OBSERVABILITY.md`](OBSERVABILITY.md)
+(post-deploy verification) and [`SECURITY.md`](SECURITY.md).
+
+> **Note:** Section headings use Title Case and are stable -- other docs
+> may link by anchor.
+
+## What deploys when
+
+The repo has **two Vercel projects** and **one Supabase project**:
+
+| Surface | Project | Triggers | Output |
+|---|---|---|---|
+| Frontend (Vite SPA) | `equip-frontend` | Push to `main` matching `frontend/**` | `equipbible.com` + `www.equipbible.com` (apex) |
+| Backend (FastAPI on Python serverless) | `equip-backend` | Push to `main` matching `backend/**` | `api.equipbible.com` |
+| Database schema | Supabase project `Equip` | **Manual** (see below) | Postgres schema |
+
+Both Vercel projects auto-deploy from `main`. Every PR also gets a
+deploy preview. Build settings, env vars, and custom domains live in
+the Vercel project pages -- not in this repo.
+
+## Pre-deploy checks (CI must be green)
+
+`.github/workflows/backend-ci.yml`:
+
+- `ruff check .` (zero warnings)
+- `ruff format --check .`
+- `python -m py_compile` (smoke import of every module)
+- `mypy --config-file mypy.ini`
+- `pytest tests/` against in-memory SQLite (~600 tests)
+- `pip-audit` (allow-list-of-known-issues only)
+- A second job `schema-smoke-postgres` materializes the SQLAlchemy
+  models against a real Postgres service container -- catches
+  SQLite-only behaviour before it lands on the linked Supabase project.
+
+`.github/workflows/frontend-ci.yml`:
+
+- `npm ci` then `npm audit --omit=dev`
+- `eslint --max-warnings 0`
+- `tsc --noEmit` (strict)
+- `vite build`
+- `vitest run` (jsdom)
+
+CI is configured with `concurrency: cancel-in-progress` so re-pushes
+to a PR don't pile up runs.
+
+## Normal release flow
+
+Most changes need **no extra steps** -- merge to `main`, Vercel picks
+it up, both services are live in 60-120 s.
+
+1. PR opened. CI runs. Vercel posts a preview link on the PR for both
+   frontend and backend.
+2. Reviewer (or you, on a solo change) checks the preview.
+3. Merge to `main`. Vercel kicks off the production build automatically.
+4. Vercel finishes; the new commit SHA shows up at
+   `https://api.equipbible.com/` (root JSON) and in the frontend's
+   "Inspect Element → version" footer.
+
+That's it. No manual deploy step, no SSH, no `vercel --prod`.
+
+### Post-merge verification (90 seconds)
+
+After the production build finishes:
+
+1. `curl -sI https://api.equipbible.com/health` -- expect `HTTP/2 200`
+   and an `X-Request-Id` header (PR #326 onward).
+2. `curl -s https://equipbible.com/ | grep -c "<title>"` -- expect `1`.
+3. Run the [`OBSERVABILITY.md` "Check Datadog"](OBSERVABILITY.md#check-datadog----one-shot-status-snapshot)
+   PowerShell snippet. Synthetics should still be `live`; no monitors
+   firing.
+
+If any of those fail, see "Rolling back" below.
+
+## Database migrations -- the one manual step
+
+Migrations are **not auto-applied on deploy**. This is deliberate.
+The migration file is the source of truth and gets committed alongside
+the app code, but the actual `ALTER TABLE` runs against the linked
+Supabase project as a separate, human-initiated action.
+
+### Why manual
+
+- The app code never reads `supabase/migrations/*.sql` at runtime. The
+  runtime schema is whatever Supabase says it is. If the SQL file in
+  the PR is wrong, applying it on deploy could corrupt prod before
+  anyone notices.
+- A migration that does heavy work (rebuilds an index, rewrites a
+  column with a default) is best done at a chosen quiet moment, not
+  whenever the next merge-to-`main` happens.
+- Vadym wants to read the migration before it touches prod. The
+  agent-driven workflow can write the migration and queue it in a PR,
+  but applying is human-only.
+
+### How to apply
+
+After the PR is merged and CI is green:
+
+1. **Verify the migration file landed on `main`**: `git log --oneline -- supabase/migrations/`
+   should show the newest timestamp at the top.
+2. **Apply via Supabase MCP** (preferred, no CLI install needed):
+   ```
+   apply_migration(
+     name="<short_snake_case_name>",
+     query=<contents of the .sql file>
+   )
+   ```
+   The Supabase MCP server reports success / failure and writes a row
+   to `supabase_migrations.schema_migrations`.
+3. **Or apply via the Supabase CLI** (if you're at a terminal with
+   `supabase` linked to the project):
+   ```bash
+   cd supabase
+   supabase db push --linked
+   ```
+4. **Verify**: `select version from supabase_migrations.schema_migrations
+   order by version desc limit 5;` -- the new timestamp should appear.
+5. **Smoke-test the affected route** from production -- e.g. if the
+   migration added a column, hit the endpoint that reads it.
+
+### What if the migration breaks prod
+
+Migrations are append-only; do **not** edit a file that has been
+applied. To revert:
+
+1. Write a **new** migration with a fresh timestamp that undoes the
+   bad change (drop the column, restore the policy, etc.).
+2. Commit, merge, apply.
+3. Update the SQLAlchemy model so the local test suite catches the
+   revert.
+
+## Environment variables
+
+Vercel project env vars are the source of truth for production
+secrets. Local `.env` files are gitignored and never committed.
+
+### Backend (`equip-backend`)
+
+Required at boot (`Settings.load_alternative_env_vars` raises on absence):
+
+- `SUPABASE_URL` -- project URL
+- `SUPABASE_SERVICE_ROLE_KEY` (or legacy `SUPABASE_KEY`) -- server-side
+  admin client
+- `DATABASE_URL` (or `POSTGRES_URL` / `POSTGRES_PRISMA_URL`) -- pooled
+  Postgres connection
+- `JWT_SECRET_KEY` (or `SUPABASE_JWT_SECRET`) -- Supabase JWT verification
+
+Optional but production-set:
+
+- `GEMINI_API_KEY` -- enables the translation pipeline (missing → no-op)
+- `YOUVERSION_API_KEY` -- enables `/api/v1/verse-of-the-day` (missing → 404,
+  frontend hides the card)
+- `DD_API_KEY` + `DD_SITE=us5.datadoghq.com` + `DD_SERVICE=equip-backend`
+  + `DD_ENV=production` -- enables the `DatadogHTTPHandler` log shipping
+- `CORS_ORIGINS`, `CORS_ORIGIN_REGEX` -- override the defaults (rarely needed)
+
+Missing-but-required vars cause a `ValueError` at first Settings
+instantiation, which surfaces in Vercel as a 500 on the first request
+and a stack trace in the function logs. CI catches the same shape via
+the `lint-and-test` job's env defaults.
+
+### Frontend (`equip-frontend`)
+
+Build-time only (Vite inlines `VITE_*` into the bundle):
+
+- `VITE_API_URL` -- absolute URL of the backend (`https://api.equipbible.com`)
+- `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` -- Supabase client
+- `VITE_DATADOG_APPLICATION_ID`, `VITE_DATADOG_CLIENT_TOKEN`,
+  `VITE_DATADOG_ENV`, `VITE_DATADOG_SITE`, `VITE_DATADOG_SERVICE`,
+  `VITE_APP_VERSION` -- enables RUM. Missing applicationId/clientToken
+  → `initDatadogRum()` is a no-op.
+
+Build-time only on Vercel (not in the bundle):
+
+- `DATADOG_API_KEY`, `DATADOG_SITE` -- used by `scripts/upload-sourcemaps.mjs`
+  to push `.map` files to Datadog after `vite build`. Missing → build
+  still succeeds but RUM stack traces will be minified.
+
+## Vercel project settings (current)
+
+| Setting | `equip-frontend` | `equip-backend` |
+|---|---|---|
+| Framework preset | Vite | Other (custom `vercel.json`) |
+| Node version | 22.x | n/a (Python 3.12) |
+| Max function duration | n/a (static) | default (10 s on Pro plan) |
+| Function memory | n/a | default (1024 MB) |
+| Region | All edge / IAD1 | IAD1 (default Python serverless) |
+| Custom domains | `equipbible.com`, `www.equipbible.com` | `api.equipbible.com` |
+| Auto-deploy branch | `main` | `main` |
+| Log Drain | Same drain | `drn_JWO7AolUh4PEEUXB` → Datadog us5 |
+
+`backend/vercel.json` sets `maxLambdaSize: 50mb` and a single catch-all
+route to `index.py`. There are no other custom Vercel settings on the
+backend -- the FastAPI handler is the default `@vercel/python` build.
+
+`frontend/vercel.json` adds SPA fallback rewrites, the
+Supabase-storage image rewrite (`/img/<bucket>/<path>`), and the strict
+CSP header set. No custom build command -- Vercel's Vite preset runs
+`npm run build`.
+
+## Rolling back
+
+Three options, in order of preference:
+
+1. **Vercel instant rollback** (Dashboard → project → Deployments →
+   pick a known-good build → "Promote to production"). Effective
+   immediately, no rebuild. Use this for almost every "we just shipped
+   a bad change" scenario.
+2. **Revert the merge commit** on `main` (`git revert <sha>`), push, and
+   let Vercel rebuild. Slower (build time) but leaves a clean git
+   history. Use when you also need the revert recorded in source.
+3. **Roll forward with a hotfix PR.** Use when the bad code is mixed
+   with good code in the same release and only one piece needs undoing.
+
+For DB migration breakage, see "What if the migration breaks prod"
+above -- migrations roll forward, not back.
+
+## Vercel build limits we're inside today
+
+These are the Pro-plan limits (the team plan; account `arvavitcorp`,
+team `vadyms-projects-dfb6f76f`). Current usage is well below all of
+them.
+
+| Limit | Value | Where we sit |
+|---|---|---|
+| Function bundle size | 50 MB unzipped (backend `vercel.json` cap) | ~12-15 MB |
+| Function max duration | 60 s (Pro) | ≤ 30 s on Gemini translation, ≤ 1 s on normal requests |
+| Function memory | 3008 MB (Pro) | default 1024 MB |
+| Edge requests / month | 1 M (Pro) | ~hundreds |
+| Build execution / month | 6 000 min (Pro) | < 100 min |
+| Bandwidth | 1 TB (Pro) | < 1 GB |
+
+The only constraint we've actually had to plan around is the bundle
+size cap: psycopg2 + bleach + SQLAlchemy push the wheel toward 15 MB,
+so we keep `requirements.txt` lean (10 entries) and resist adding new
+deps casually.
+
+## CI / deploy environment variables to know about
+
+Set in GitHub Actions repo secrets / vars (read by `backend-ci.yml`):
+
+- `CI_SUPABASE_URL`, `CI_SUPABASE_ANON_KEY` -- placeholder by default
+- `CI_DATABASE_URL` -- placeholder by default
+- `CI_JWT_SECRET_KEY` -- placeholder by default (`ci-only-...`)
+
+These are only used by the lint-and-test job to satisfy
+`Settings.load_alternative_env_vars`. Tests then bootstrap their own
+SQLite in-memory DB via `conftest.py`. The placeholder values are safe
+to keep in source.
+
+## Known gaps / follow-ups
+
+- **No staging environment.** Vercel deploy previews substitute for one
+  -- every PR gets a `<branch>-equip-frontend-vadyms-projects-dfb6f76f.vercel.app`
+  URL that hits the same backend. For DB-affecting changes, this means
+  preview backends share the production DB. If we ever need a true
+  staging tier, the cleanest path is a separate Supabase project +
+  separate Vercel project bound to a `staging` branch.
+- **No automatic migration apply.** Documented above. Worth revisiting
+  once we have point-in-time recovery (Supabase Pro) -- the auto-apply
+  story is much less scary when a 5-minute rollback is one click.
+- **No deploy notification.** Vercel can ping a Slack channel on
+  production deploy success/failure. Equip has no shared Slack today,
+  so this is deferred until the team grows past one developer.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,215 @@
+# Observability runbook
+
+How we see what production is doing, where alerts go, and how to debug a
+prod incident. Companion to [`SECURITY.md`](SECURITY.md) (security
+posture) and [`DEPLOYMENT.md`](DEPLOYMENT.md) (release process).
+
+> **Note:** Section headings use Title Case and are stable -- other docs
+> may link by anchor.
+
+## What's wired up today
+
+Everything below is live on `equipbible.com` / `api.equipbible.com`.
+Configured 2026-05-11 to 2026-05-13. Org `arvavitcorp`, Datadog site
+`us5.datadoghq.com`.
+
+| Surface | Tool | Coverage |
+|---|---|---|
+| Frontend errors, sessions, replays, Core Web Vitals | Datadog RUM (`equip-frontend`) | 100 % session + 100 % replay sampling; React-Router integration so dashboards aggregate by route template |
+| Backend WARNING / ERROR / CRITICAL logs | `DatadogHTTPHandler` in `backend/app/core/logging.py` | Per-record HTTPS POST to Datadog intake, tagged with env / service / version / vercel_region / vercel.request_id |
+| Backend INFO logs + build logs + edge events | Vercel Log Drain `drn_JWO7AolUh4PEEUXB` | ndjson stream from Vercel → Datadog intake; covers both `equip-frontend` and `equip-backend` projects |
+| External uptime | 3 Datadog synthetic monitors (30 min cadence, 2 retries, aws:us-east-1) | `https://api.equipbible.com/health`, `https://equipbible.com/`, `https://api.equipbible.com/api/v1/courses` |
+| Transactional email delivery | Supabase Edge Function `send-email` → Resend (verified domain `equipbible.com`) | Function ships its own logs to Datadog when `DD_API_KEY` is set; one monitor on its error stream |
+
+We **do not** currently run Datadog APM (Python tracer). `ddtrace` is not
+installed in the backend. End-to-end backend traces are out of scope
+until per-request log volume proves we can afford the ingest. RUM is
+already configured to add tracing headers (`allowedTracingUrls`); the
+backend just doesn't pick them up yet.
+
+We also do not run Sentry. The Datadog Error Tracking surface on top of
+RUM (frontend) and Logs (backend) covers what Sentry would, with the
+same alert flow.
+
+## How a backend log gets to Datadog
+
+```
+FastAPI route raises / logger.warning / logger.error
+       ↓
+root logger configured in app.core.logging.setup_logging()
+       ↓                                                    ↓
+StreamHandler → stdout                          DatadogHTTPHandler.emit()
+       ↓                                                    ↓
+Vercel captures stdout                          synchronous POST with 2s timeout
+       ↓                                          to https://http-intake.logs.us5.datadoghq.com
+Vercel Log Drain drn_JWO7AolUh4PEEUXB                       ↓
+       ↓                                          Datadog index "main" (15-day retention)
+Datadog index "main"                                        ↓
+                                              tagged: env, service, version (git SHA[:7]),
+                                                      vercel_region, vercel.request_id
+```
+
+The two paths are **complementary, not duplicate**. The in-process
+handler ships only WARNING and above, with structured fields and the
+per-request `vercel.request_id` correlation key. The log drain ships
+everything Vercel sees (including INFO request lines, build failures,
+edge events, firewall events) but without the per-record tags.
+
+Both end up in the same `main` index, so a Datadog log query that
+filters by `service:equip-backend` gets both. The daily ingest cap is
+**10 000 events / day** with a warning at 80 % -- a defensive cost
+control against a logging-loop bug, not an expected ceiling.
+
+### Request correlation
+
+Every backend response carries an `X-Request-Id` header (PR #326). The
+value is `x-vercel-id` when the request came through Vercel (so it
+matches the Vercel log viewer), otherwise a UUID hex minted by the
+backend. The same value is stashed in `app.core.logging.vercel_request_id`
+and attached to every WARNING+ log shipped to Datadog as the field
+`vercel.request_id` -- so a RUM session error, a Vercel log line, and a
+Datadog log record all join on one id.
+
+To pivot from a user bug report:
+
+1. Ask them to paste the `X-Request-Id` from their network tab (or read
+   it from the RUM error context).
+2. In Datadog Logs: `service:equip-backend @vercel.request_id:<id>`.
+3. From there, click into the trace if APM is ever enabled, or jump to
+   the matching RUM session.
+
+## Monitors and where they alert
+
+All monitors notify `arvavitcorp@gmail.com`. There is no SMS / PagerDuty
+routing today -- Equip is one-developer-on-call; email and the in-app
+Datadog inbox are the routes.
+
+| ID | Type | What it fires on | Severity |
+|---|---|---|---|
+| 19728703 | Synthetics alert | Backend `/health` fails (3 retries) | crit |
+| 19728704 | Synthetics alert | Frontend `/` fails or body doesn't contain "Bible School" | crit |
+| 19728705 | Synthetics alert | Backend `/api/v1/courses` non-200 or non-JSON | crit |
+| 19728791 | RUM alert | ≥ 10 frontend errors in 10 min (warn at 5) | `priority:2` |
+| 19728792 | RUM alert | ≥ 5 rage clicks in 30 min (warn at 3) | warn |
+| 19728793 | RUM alert | avg LCP > 4 s over 15 min (warn 2.5 s). LCP is in **nanoseconds** in RUM events -- never use ms thresholds | warn |
+| 19730778 | Log alert | ≥ 5 ERROR / CRITICAL backend log lines in 10 min (warn at 2) | `priority:2` |
+| 19730779 | Log alert | ≥ 20 WARNING backend log lines in 15 min (warn at 10) -- usually IntegrityError noise | warn |
+| 19761387 | Log alert | ≥ 3 error logs from `service:send-email status:error` in 10 min (warn at 1) | `priority:2` |
+
+Dashboards:
+
+- [Equip overview (RUM)](https://app.us5.datadoghq.com/dashboard/shf-kq8-bgf) -- `shf-kq8-bgf`
+- [Equip backend (logs + synthetics)](https://app.us5.datadoghq.com/dashboard/x7b-cua-zrm) -- `x7b-cua-zrm`
+
+Both have a `$env` template variable that defaults to `production`.
+
+## How to debug a production issue
+
+### "Something is broken right now"
+
+1. **Check synthetics first.** Open the [Equip backend dashboard](https://app.us5.datadoghq.com/dashboard/x7b-cua-zrm)
+   and scan the synthetic status widgets. If any of the three is red,
+   the failure mode is one of:
+   - Backend down → check Vercel deployment status (`vercel inspect` or
+     dashboard), look at the most recent build log.
+   - Database down → query Supabase status; admin can hit
+     `GET /health/db` for a 503 / 200 confirmation.
+   - DNS / cert issue → `dig equipbible.com`, check Vercel domains page.
+
+2. **Look at error spikes.** Datadog Logs query:
+   `service:equip-backend status:error` over the last hour. A burst
+   that started "now" almost always names the cause in the first 1-2
+   stack frames (`logger.exception` writes them).
+
+3. **Pivot via request id.** If the user reported a specific failing
+   action, ask for `X-Request-Id`. Search Datadog Logs:
+   `@vercel.request_id:<id>`. You'll get every WARNING+ line emitted
+   during that request.
+
+4. **Replay the session.** In RUM, search by user email or by error
+   message; the Session Replay timeline shows clicks, scrolls, network
+   calls. Inputs are masked (`mask-user-input`) so quiz answers and
+   passwords don't leak into the recording, but the surrounding UI is
+   visible.
+
+### "I want to understand a slow page"
+
+1. RUM → Performance → filter by `@view.name:<route>`. Look at LCP, INP,
+   CLS percentiles. The monitor on LCP > 4 s fires at the dashboard
+   average; individual long-tail views can be much slower.
+2. Long-task events are tracked (`trackLongTasks: true`) -- the action
+   stream in RUM marks any > 50 ms main-thread block.
+
+### "Resend didn't send my email"
+
+1. Check monitor `19761387` ("send-email: delivery / function errors").
+2. Datadog Logs: `service:send-email status:error` -- the Edge Function
+   logs the Resend error body when a send fails.
+3. Manual check from PowerShell (see [resend-equip.md](../README.md)
+   recipe section) -- list the last 20 sends and look at `last_event`.
+
+## What's NOT wired up (known gaps)
+
+These are deliberate omissions; revisit when traffic or budget grows.
+
+- **No backend APM tracer.** `ddtrace.auto` would auto-instrument
+  FastAPI / SQLAlchemy / httpx, but on Vercel serverless there is no
+  local agent to ship traces to -- it would need an HTTPS trace
+  forwarder. Skip until log shipping proves load is fine.
+- **No SLOs.** Cheap to add once we have ~30 days of synthetic data.
+- **No Resend webhooks.** Resend supports `email.sent`, `email.delivered`,
+  `email.bounced`, `email.complained` webhooks; we're not subscribed.
+  When delivery starts mattering, wire these to a tiny Edge Function
+  that re-shapes the payload and POSTs to the Datadog HTTP logs intake.
+  (Resend cannot post directly to DD because we can't add the
+  `DD-API-KEY` header on Resend webhooks.)
+- **No `/health/ready` endpoint.** `/health` only verifies the FastAPI
+  process is up; it does not ping the DB. Vercel serverless functions
+  rarely return "warm but DB down" (the DB call is in the same cold-start
+  path), so the extra check is low-value today. `GET /health/db` exists
+  but is admin-gated. Add `/health/ready` if we ever hit a real outage
+  where the serverless function answers but DB writes are timing out.
+- **No alert routing beyond email.** All 9 monitors notify
+  `arvavitcorp@gmail.com`. Add SMS / Slack / PagerDuty if the
+  on-call rotation grows past one person.
+- **No daily Resend send-count or bounce-rate monitor.** Resend Free
+  tier is 3 000 / month; current volume is < 5. Revisit at ~1 000 /
+  month when accidental loops or compromised templates become plausible.
+
+## Recommended monitors to add (not auto-created)
+
+Per project policy, we don't auto-create Datadog monitors from agent
+sessions. The following are useful additions when Vadym wants to enable
+them manually. Each one is a one-API-call away once approved.
+
+1. **Backend P95 latency** -- alert on
+   `avg:trace.fastapi.request.duration{service:equip-backend}.percentile(95)`
+   > 1 500 ms over 15 min (warn 800 ms). Requires APM enabled first;
+   skip until then.
+2. **5xx response rate** -- log query
+   `service:equip-backend @http.status_code:[500 TO 599]`; alert at
+   ≥ 1 in 5 min. Catches issues that don't always raise an exception
+   (e.g. a misconfigured rewrite returning 503).
+3. **Datadog daily ingest** -- forecast monitor on the `main` index
+   warning at 85 % of the 10 000 / day cap, alerting at 95 %.
+   Earlier-warning version of the current Datadog-side soft limit.
+4. **Synthetic latency drift** -- on top of the existing pass/fail
+   synthetic monitors, add a warn if the median response time on
+   `/health` exceeds 2 s for 30 min. Cold-start latency creep is the
+   first visible sign of Vercel runtime regression.
+5. **Resend bounce rate** -- requires Resend webhooks (see gap above).
+   Alert at ≥ 5 % bounces over a 6 h rolling window.
+
+To enable any of these, see the `Memory/datadog-equip.md` "Check
+Datadog" PowerShell recipe and adapt the monitor JSON; do not let the
+agent create them without explicit approval.
+
+## "Check Datadog" -- one-shot status snapshot
+
+When you want a quick "is everything fine?" answer, run the recipe
+from `Memory/datadog-equip.md` (PowerShell). It prints:
+
+- Status of all 3 synthetics (`live` vs failing).
+- Any firing monitors.
+- RUM event totals for the last hour (views, errors, rage clicks).
+- A link to the Equip overview dashboard.


### PR DESCRIPTION
## Summary

Two new runbooks. No code or behaviour changes.

- **`docs/OBSERVABILITY.md`** -- what we monitor (RUM, Logs, Synthetics, send-email), how the in-process Datadog log handler and the Vercel Log Drain compose, how to debug a prod issue via the `X-Request-Id` pivot, all 9 active monitor IDs, and a list of recommended-but-not-yet-enabled monitors plus the gaps (no APM, no SLOs, no Resend webhooks).
- **`docs/DEPLOYMENT.md`** -- pre-deploy CI checklist, normal release flow (Vercel auto from `main`), explicit manual-migration runbook (Supabase MCP `apply_migration` is the preferred path; CLI `supabase db push --linked` is the alternative), rollback options, env-var inventory for both Vercel projects, current Pro-plan limits.

The migration runbook captures the "why manual" rationale explicitly: app code doesn't read migration files at runtime, heavy migrations want a chosen quiet moment, and Vadym reviews each migration before it touches prod. Auto-apply on deploy is called out as deferred-until-Supabase-Pro-PITR.

## Test plan

- [x] Cross-references between the two docs and existing `SECURITY.md` / `supabase/migrations/README.md` are valid.
- [x] All monitor IDs and dashboard hashes match `Memory/datadog-equip.md`.
- [x] All env-var names match `backend/app/core/config.py` and `frontend/src/lib/datadog.ts`.

Co-authored-by: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;
