### PR TITLE
obs(backend): attach stack trace when DB raises an unhandled SQLAlchemy error

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -90,7 +90,19 @@ async def integrity_error_handler(request: Request, exc: IntegrityError):
 
 @app.exception_handler(SQLAlchemyError)
 async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError):
-    logger.error("Database error on %s %s: %s", request.method, request.url.path, exc)
+    # ``exc_info=True`` so the DatadogHTTPHandler ships the full stack
+    # trace as ``error.stack``. Without it the log line only carries the
+    # exception's ``str()`` -- useful for IntegrityError where we already
+    # extracted pgcode + constraint, but useless for the general case
+    # (lock timeout, connection drop mid-statement, OperationalError)
+    # where the originating call site is what we actually need.
+    logger.error(
+        "Database error on %s %s: %s",
+        request.method,
+        request.url.path,
+        exc,
+        exc_info=True,
+    )
     return JSONResponse(
         status_code=503,
         content={"detail": "Database temporarily unavailable. Please try again."},


### PR DESCRIPTION
## Summary

- The generic `SQLAlchemyError` exception handler was logging at `ERROR` but without `exc_info=True`, so the `DatadogHTTPHandler` never received a stack trace -- only the exception's `str()`.
- For `IntegrityError` that's fine (we already extract `pgcode` + `constraint_name` -- the diagnostic fields you actually want, and the call site is obvious from the request path). For everything else `SQLAlchemyError` catches (lock timeout, `OperationalError`, connection dropped mid-statement, pool exhaustion) the originating call site IS what we need.
- The `DatadogHTTPHandler` already serialises `record.exc_info` into `error.kind` + `error.stack` (covered by `test_dd_logging.py::test_emit_includes_exc_info_when_present`); flipping `exc_info=True` here makes the trace land on every DB-error log without any handler change.

No behaviour change for callers -- still 503 with the same body.

## Test plan

- [x] `python -m pytest tests/` (607 passed)
- [x] `python -m ruff check app/main.py && python -m ruff format --check app/main.py`
- [x] `python -m mypy --config-file mypy.ini app/main.py`
- [ ] After deploy: pull a recent `service:equip-backend status:error` log line in Datadog and confirm `error.stack` is populated.

Co-authored-by: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;
