### PR TITLE
fix(a11y): dropdown ARIA, scroll-to-top focus, banner live region

### DIFF
--- a/frontend/src/components/announcements/AnnouncementBanner.tsx
+++ b/frontend/src/components/announcements/AnnouncementBanner.tsx
@@ -42,7 +42,11 @@ export default function AnnouncementBanner() {
   if (!announcement || announcement.id === dismissedId) return null
 
   return (
-    <div className="border-b border-border bg-muted/40">
+    // role="status" surfaces the banner to AT as a polite live region — the
+    // banner mounts mid-session whenever the user finishes loading or a new
+    // announcement is published, and a screen-reader user shouldn't have to
+    // re-Tab past the page just to discover it.
+    <div role="status" aria-live="polite" className="border-b border-border bg-muted/40">
       <div className="container mx-auto flex items-center gap-3 px-4 py-2.5">
         <Megaphone className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
         <div className="min-w-0 flex-1 text-wrap-safe">
@@ -56,8 +60,9 @@ export default function AnnouncementBanner() {
           )}
         </div>
         <button
+          type="button"
           onClick={() => setDismissedId(announcement.id)}
-          className="rounded p-1 text-muted-foreground hover:bg-muted"
+          className="rounded p-1 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           aria-label={t("common.dismissAnnouncement")}
         >
           <X className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />

--- a/frontend/src/components/editor/CalloutDropdown.tsx
+++ b/frontend/src/components/editor/CalloutDropdown.tsx
@@ -48,8 +48,15 @@ export function CalloutDropdown({
         setOpen(false);
       }
     };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
   }, [open]);
 
   const insertCallout = (variant: CalloutVariant) => {
@@ -70,39 +77,48 @@ export function CalloutDropdown({
         type="button"
         onClick={() => setOpen((v) => !v)}
         title={t("blockEditor.callout.trigger")}
+        aria-label={t("blockEditor.callout.trigger")}
+        aria-haspopup="menu"
+        aria-expanded={open}
         className={cn(
-          "flex items-center gap-0.5 rounded p-1.5 transition-colors",
+          "flex items-center gap-0.5 rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           isActive
             ? "bg-primary/15 text-primary"
             : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
         )}
       >
-        <Info size={iconSize} strokeWidth={1.75} />
-        <ChevronDown size={12} strokeWidth={1.75} />
+        <Info size={iconSize} strokeWidth={1.75} aria-hidden="true" />
+        <ChevronDown size={12} strokeWidth={1.75} aria-hidden="true" />
       </button>
       {open && (
-        <div className="absolute left-0 top-full z-20 mt-1 w-52 rounded-md border bg-background py-1 shadow-lg">
+        <div
+          role="menu"
+          aria-label={t("blockEditor.callout.trigger")}
+          className="absolute left-0 top-full z-20 mt-1 w-52 rounded-md border bg-background py-1 shadow-lg"
+        >
           {CALLOUT_VARIANTS.map((v) => {
             const Icon = v.icon;
             return (
               <button
                 key={v.value}
                 type="button"
+                role="menuitem"
                 onClick={() => insertCallout(v.value)}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
               >
-                <Icon size={16} className={v.color} />
+                <Icon size={16} className={v.color} aria-hidden="true" />
                 {t(`blockEditor.callout.${v.value}`)}
               </button>
             );
           })}
           {isActive && (
             <>
-              <div className="my-1 border-t" />
+              <div className="my-1 border-t" role="separator" />
               <button
                 type="button"
+                role="menuitem"
                 onClick={removeCallout}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-muted transition-colors text-left"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
               >
                 {t("blockEditor.callout.remove")}
               </button>

--- a/frontend/src/components/layout/ScrollToTop.tsx
+++ b/frontend/src/components/layout/ScrollToTop.tsx
@@ -27,14 +27,21 @@ export default function ScrollToTop() {
 
   return (
     <button
+      type="button"
       onClick={scrollToTop}
       aria-label={t("common.scrollToTop")}
+      // When the button is hidden (page near the top), hide it from AT and
+      // pull it out of the tab order so keyboard users don't land on an
+      // invisible target. The opacity-only fade animation is preserved.
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
       className={`
         fixed bottom-6 right-6 z-50
         flex items-center justify-center
         w-12 h-12 rounded-full
         bg-primary text-primary-foreground
         hover:bg-primary/90
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
         transition-opacity duration-300
         ${
           visible
@@ -43,7 +50,7 @@ export default function ScrollToTop() {
         }
       `}
     >
-      <ChevronUp className="h-5 w-5" strokeWidth={1.75} />
+      <ChevronUp className="h-5 w-5" strokeWidth={1.75} aria-hidden="true" />
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Three small a11y wiring fixes around the edges of the app.

- **CalloutDropdown** (TipTap toolbar): trigger now has `aria-label`, `aria-haspopup="menu"`, `aria-expanded`; the menu container is `role="menu"` with `role="menuitem"` items and a `role="separator"`. Decorative icons are `aria-hidden`. Escape closes the menu (was click-outside-only).
- **ScrollToTop**: was always in the DOM at opacity 0 when the page was near the top — keyboard users could Tab onto an invisible target. Now `aria-hidden` and `tabIndex={-1}` until `visible`; also adds the missing `type="button"` and a focus ring.
- **AnnouncementBanner**: wraps in `role="status" aria-live="polite"` so screen-reader users hear a banner that mounts mid-session. Dismiss button gets `type="button"` + focus ring.

## What it fixes
- Editor users dropping into a callout menu via keyboard get the standard menu semantics + Escape contract.
- ScrollToTop no longer traps Tab on invisible targets.
- Mid-session site-wide announcements are actually surfaced to screen-reader users.

## Test plan
- [ ] In a chapter editor, focus the callout-button in the toolbar with Tab. Activate. Verify `aria-expanded="true"`. Press Escape — menu closes.
- [ ] On any long page, scroll to top. Tab through interactive elements. Verify the scroll-to-top button is NOT in the tab order (it's hidden). Scroll down past 300px. Tab — the button is reachable.
- [ ] If an admin publishes a site-wide announcement while a user has a page open, screen reader should politely announce the banner title.
- [ ] `npm run lint` clean, `npx tsc --noEmit` clean, `npm run test:run` green (140 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)