### PR TITLE
test(frontend): RoleSelector, CourseReadinessCard, hook + lib coverage

### DIFF
--- a/frontend/src/components/admin/__tests__/RoleSelector.test.tsx
+++ b/frontend/src/components/admin/__tests__/RoleSelector.test.tsx
@@ -1,0 +1,128 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { I18nextProvider } from "react-i18next"
+import { describe, it, expect, vi } from "vitest"
+
+import i18n from "@/i18n/config"
+import { RoleSelector } from "@/components/admin/RoleSelector"
+
+/**
+ * The role badge IS the role picker. ``RoleSelector`` rolls four
+ * affordances into one Radix ``DropdownMenu`` + ``Badge`` pair, so
+ * the observable contract is:
+ *
+ *   1. The current role's i18n label is always visible (badge text).
+ *   2. ``disabled`` collapses the affordance to a read-only badge —
+ *      no dropdown trigger, no chevron.
+ *   3. Opening the menu reveals all four roles in canonical order:
+ *      student → pending_teacher → teacher → admin.
+ *   4. Picking a different role fires ``onChange(nextRole)``.
+ *   5. Picking the already-selected role does NOT fire ``onChange``
+ *      (matches the ``if (!selected) onChange(value)`` guard).
+ *   6. The ``ariaLabel`` prop wires through to the trigger so AT can
+ *      announce the user the action targets.
+ *
+ * Tests deliberately don't reach into Radix internals — the menu's
+ * positioning, focus management, and keyboard handling are owned by
+ * Radix and have their own coverage.
+ */
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+const renderOpts = { wrapper: Wrapper }
+
+describe("RoleSelector", () => {
+  it("renders the current role's localized label", async () => {
+    render(<RoleSelector role="teacher" onChange={vi.fn()} />, renderOpts)
+    // ``Teacher`` for EN; the i18n config falls back to EN when RU is
+    // missing, so this is locale-independent in this test setup.
+    await i18n.changeLanguage("en")
+    expect(screen.getByText("Teacher")).toBeInTheDocument()
+  })
+
+  it("renders a chevron + clickable trigger when not disabled", () => {
+    render(<RoleSelector role="student" onChange={vi.fn()} />, renderOpts)
+    // Trigger is the <button> wrapping the badge.
+    expect(screen.getByRole("button")).toBeInTheDocument()
+  })
+
+  it("renders no trigger when disabled (read-only badge)", () => {
+    render(
+      <RoleSelector role="admin" disabled={true} onChange={vi.fn()} />,
+      renderOpts,
+    )
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("propagates ariaLabel to the trigger", () => {
+    render(
+      <RoleSelector
+        role="student"
+        onChange={vi.fn()}
+        ariaLabel="Change role for Jane Doe"
+      />,
+      renderOpts,
+    )
+    expect(
+      screen.getByRole("button", { name: "Change role for Jane Doe" }),
+    ).toBeInTheDocument()
+  })
+
+  it("opens the menu showing all four roles in canonical order", async () => {
+    const user = userEvent.setup()
+    await i18n.changeLanguage("en")
+    render(<RoleSelector role="student" onChange={vi.fn()} />, renderOpts)
+
+    await user.click(screen.getByRole("button"))
+
+    const items = await screen.findAllByRole("menuitem")
+    expect(items.map((i) => i.textContent?.trim())).toEqual([
+      "Student",
+      "Pending Teacher",
+      "Teacher",
+      "Admin",
+    ])
+  })
+
+  it("fires onChange when a different role is picked", async () => {
+    const user = userEvent.setup()
+    await i18n.changeLanguage("en")
+    const onChange = vi.fn()
+    render(<RoleSelector role="student" onChange={onChange} />, renderOpts)
+
+    await user.click(screen.getByRole("button"))
+    const teacherItem = await screen.findByRole("menuitem", { name: "Teacher" })
+    await user.click(teacherItem)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith("teacher")
+  })
+
+  it("does NOT fire onChange when the current role is picked", async () => {
+    const user = userEvent.setup()
+    await i18n.changeLanguage("en")
+    const onChange = vi.fn()
+    render(<RoleSelector role="teacher" onChange={onChange} />, renderOpts)
+
+    await user.click(screen.getByRole("button"))
+    const teacherItem = await screen.findByRole("menuitem", { name: "Teacher" })
+    await user.click(teacherItem)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("renders the localized label under RU as well as EN", async () => {
+    await i18n.changeLanguage("ru")
+    render(<RoleSelector role="pending_teacher" onChange={vi.fn()} />, renderOpts)
+    // The RU label is "Преподаватель на проверке" / "Ожидающий…" —
+    // we don't pin the exact string (translation may evolve), just
+    // assert it's NOT the English one and is non-empty.
+    const buttons = screen.queryAllByRole("button")
+    const text = buttons[0]?.textContent ?? ""
+    expect(text).not.toMatch(/Pending Teacher/i)
+    expect(text.trim().length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/lib/__tests__/motion.test.ts
+++ b/frontend/src/lib/__tests__/motion.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+
+import { EDITORIAL_EASE, MOTION_DURATION } from "@/lib/motion"
+
+/**
+ * Shared motion tokens are imported across page transitions, card
+ * hovers, fade-ins, reveal scrolls — anywhere the JS side of motion
+ * needs to match the CSS ``ease-editorial`` curve. The values are
+ * load-bearing for visual consistency, so a typo / accidental rename
+ * would scatter the look-and-feel without triggering any lint or type
+ * error.
+ *
+ * Tests pin the shape and values so a refactor that, say, drops a
+ * duration tier or changes the curve coefficients shows up
+ * immediately in CI.
+ */
+
+describe("EDITORIAL_EASE", () => {
+  it("is the canonical 'easeOutQuint'-ish cubic-bezier", () => {
+    expect(Array.from(EDITORIAL_EASE)).toEqual([0.22, 1, 0.36, 1])
+  })
+
+  it("matches the cubic-bezier(4-tuple) shape framer/motion expects", () => {
+    expect(EDITORIAL_EASE.length).toBe(4)
+    for (const n of EDITORIAL_EASE) {
+      expect(typeof n).toBe("number")
+      expect(Number.isFinite(n)).toBe(true)
+    }
+  })
+
+  it("starts and ends inside the [0, 1] cubic-bezier control range", () => {
+    // The X coordinates of a cubic-bezier ease MUST be in [0, 1] for
+    // CSS / framer-motion compatibility — otherwise the timing
+    // function is invalid. Y can exceed (overshoot / undershoot) but
+    // this curve doesn't.
+    expect(EDITORIAL_EASE[0]).toBeGreaterThanOrEqual(0)
+    expect(EDITORIAL_EASE[0]).toBeLessThanOrEqual(1)
+    expect(EDITORIAL_EASE[2]).toBeGreaterThanOrEqual(0)
+    expect(EDITORIAL_EASE[2]).toBeLessThanOrEqual(1)
+  })
+})
+
+describe("MOTION_DURATION", () => {
+  it("exposes the five canonical tiers", () => {
+    expect(Object.keys(MOTION_DURATION).sort()).toEqual(
+      ["base", "entrance", "fast", "instant", "slow"].sort(),
+    )
+  })
+
+  it("is in seconds (matches motion library default unit), not milliseconds", () => {
+    // Every tier should be < 1s — anything in the ms range would
+    // surface as 10+ seconds of motion in the actual library, which
+    // would be wildly wrong.
+    for (const value of Object.values(MOTION_DURATION)) {
+      expect(value).toBeGreaterThan(0)
+      expect(value).toBeLessThan(1)
+    }
+  })
+
+  it("tiers ascend in duration (instant < fast < base < entrance < slow)", () => {
+    expect(MOTION_DURATION.instant).toBeLessThan(MOTION_DURATION.fast)
+    expect(MOTION_DURATION.fast).toBeLessThan(MOTION_DURATION.base)
+    expect(MOTION_DURATION.base).toBeLessThan(MOTION_DURATION.entrance)
+    expect(MOTION_DURATION.entrance).toBeLessThan(MOTION_DURATION.slow)
+  })
+
+  it("locks in the exact values (regression guard)", () => {
+    expect(MOTION_DURATION).toEqual({
+      instant: 0.12,
+      fast: 0.2,
+      base: 0.28,
+      entrance: 0.48,
+      slow: 0.55,
+    })
+  })
+})

--- a/frontend/src/lib/__tests__/roles.test.ts
+++ b/frontend/src/lib/__tests__/roles.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+
+import { ROLE_BADGE_VARIANT, ROLE_I18N_KEY } from "@/lib/roles"
+
+/**
+ * ``lib/roles.ts`` is the single source of truth that maps a
+ * ``UserRole`` enum value (which mirrors the Pydantic Literal /
+ * Postgres CHECK constraint on ``profiles.role``) to its i18n key and
+ * its Badge variant. The Profile, Admin dashboard, virtualised admin
+ * table, and ``useAdminOverview`` all read these maps — so a
+ * mismatch silently de-syncs the entire role-display surface.
+ *
+ * Tests:
+ *   1. Every backend role has an i18n key.
+ *   2. The i18n keys live under the ``roles.*`` namespace (matches
+ *      ``i18n/locales/{en,ru}.json``).
+ *   3. Every backend role has a Badge variant.
+ *   4. Variant assignments match the design contract: admin =
+ *      destructive (most authority), teacher = primary, pending =
+ *      warning (action needed), student = info (default state).
+ *
+ * If a new role lands in ``UserRole`` and these maps don't get
+ * updated, TypeScript will reject the missing key in the
+ * ``Record<UserRole, …>`` type — these runtime tests catch the
+ * complementary case where the *value* is wrong.
+ */
+
+const ALL_ROLES = ["student", "pending_teacher", "teacher", "admin"] as const
+
+describe("ROLE_I18N_KEY", () => {
+  it("covers every UserRole", () => {
+    for (const r of ALL_ROLES) {
+      expect(ROLE_I18N_KEY[r]).toBeDefined()
+    }
+  })
+
+  it("keys all live under the roles.* namespace", () => {
+    for (const r of ALL_ROLES) {
+      expect(ROLE_I18N_KEY[r].startsWith("roles.")).toBe(true)
+    }
+  })
+
+  it("uses camelCase for the i18n suffix (matches i18next conventions)", () => {
+    // snake_case role value → camelCase i18n suffix
+    expect(ROLE_I18N_KEY.pending_teacher).toBe("roles.pendingTeacher")
+  })
+
+  it("locks in the exact mapping (regression guard against silent rename)", () => {
+    expect(ROLE_I18N_KEY).toEqual({
+      student: "roles.student",
+      pending_teacher: "roles.pendingTeacher",
+      teacher: "roles.teacher",
+      admin: "roles.admin",
+    })
+  })
+})
+
+describe("ROLE_BADGE_VARIANT", () => {
+  it("covers every UserRole", () => {
+    for (const r of ALL_ROLES) {
+      expect(ROLE_BADGE_VARIANT[r]).toBeDefined()
+    }
+  })
+
+  it("matches the design contract for tone-by-authority", () => {
+    // Admin should read as "most authority / destructive-tone weight"
+    expect(ROLE_BADGE_VARIANT.admin).toBe("destructiveSubtle")
+    // Teacher is the platform's primary brand role
+    expect(ROLE_BADGE_VARIANT.teacher).toBe("primarySubtle")
+    // Pending teacher needs admin attention → warning tone
+    expect(ROLE_BADGE_VARIANT.pending_teacher).toBe("warningSubtle")
+    // Student is the default state → info tone
+    expect(ROLE_BADGE_VARIANT.student).toBe("infoSubtle")
+  })
+
+  it("every variant uses the *Subtle suffix (matches the Badge design tier)", () => {
+    for (const r of ALL_ROLES) {
+      expect(ROLE_BADGE_VARIANT[r]).toMatch(/Subtle$/)
+    }
+  })
+})

--- a/frontend/src/pages/Teacher/editor/__tests__/CourseReadinessCard.test.tsx
+++ b/frontend/src/pages/Teacher/editor/__tests__/CourseReadinessCard.test.tsx
@@ -1,0 +1,276 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { I18nextProvider } from "react-i18next"
+import { describe, it, expect, vi } from "vitest"
+
+import i18n from "@/i18n/config"
+import type {
+  ReadinessAction,
+  ReadinessCheck,
+  ReadinessReport,
+} from "@/services/courseReadiness"
+import { CourseReadinessCard } from "@/pages/Teacher/editor/CourseReadinessCard"
+
+/**
+ * Component tests for ``CourseReadinessCard``. The card is the only
+ * surface the editor reads readiness through, so its observable
+ * contract is:
+ *
+ *   1. ``loading=true`` → render the skeleton (a11y-busy=true).
+ *   2. ``report=null`` → render nothing (silently hide on backend blip).
+ *   3. ``report`` provided → render the score, the summary line, and
+ *      — once expanded — the failing checks grouped by severity, with
+ *      a Fix button on those that carry an ``action``.
+ *   4. Tone follows severity precedence: critical wins over
+ *      recommended wins over success.
+ *   5. ``onFix`` fires with the check's action when the Fix button is
+ *      clicked.
+ */
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+const renderOpts = { wrapper: Wrapper }
+
+function makeCheck(over: Partial<ReadinessCheck> = {}): ReadinessCheck {
+  return {
+    id: over.id ?? "courseReadiness.checks.hasDescription",
+    severity: over.severity ?? "critical",
+    passed: over.passed ?? false,
+    message_key: over.message_key ?? "courseReadiness.checks.hasDescription",
+    subject: over.subject ?? null,
+    action: over.action ?? null,
+  }
+}
+
+function makeReport(over: Partial<ReadinessReport> = {}): ReadinessReport {
+  return {
+    course_id: over.course_id ?? "c-1",
+    total: over.total ?? 5,
+    passing: over.passing ?? 4,
+    critical_failing: over.critical_failing ?? 0,
+    score: over.score ?? 80,
+    checks: over.checks ?? [],
+  }
+}
+
+describe("CourseReadinessCard", () => {
+  it("renders the skeleton when loading", () => {
+    const { container } = render(
+      <CourseReadinessCard report={null} loading={true} />,
+      renderOpts,
+    )
+    const section = container.querySelector('[aria-busy="true"]')
+    expect(section).not.toBeNull()
+  })
+
+  it("renders nothing when report is null and not loading", () => {
+    const { container } = render(
+      <CourseReadinessCard report={null} loading={false} />,
+      renderOpts,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders the all-passed message when every check is green", () => {
+    const report = makeReport({
+      passing: 5,
+      total: 5,
+      critical_failing: 0,
+      score: 100,
+      checks: [makeCheck({ passed: true, severity: "polish" })],
+    })
+    render(<CourseReadinessCard report={report} loading={false} />, renderOpts)
+    expect(
+      screen.getByText(/your course is ready to publish/i),
+    ).toBeInTheDocument()
+  })
+
+  it("renders the failing-summary line and critical count when applicable", () => {
+    const report = makeReport({
+      passing: 3,
+      total: 5,
+      critical_failing: 2,
+      score: 60,
+      checks: [
+        makeCheck({ id: "a", severity: "critical", passed: false }),
+        makeCheck({ id: "b", severity: "critical", passed: false }),
+        makeCheck({ id: "c", severity: "recommended", passed: true }),
+      ],
+    })
+    render(<CourseReadinessCard report={report} loading={false} />, renderOpts)
+    // Summary uses i18n interpolation; assert against the numeric
+    // substrings the translation guarantees.
+    expect(screen.getByText(/3.*5/)).toBeInTheDocument()
+    // Critical-count line.
+    expect(screen.getByText(/2.*critical/i)).toBeInTheDocument()
+  })
+
+  it("starts collapsed and expands when the header is clicked", async () => {
+    const user = userEvent.setup()
+    const report = makeReport({
+      checks: [
+        makeCheck({
+          id: "open-1",
+          severity: "critical",
+          passed: false,
+          message_key: "courseReadiness.checks.hasDescription",
+        }),
+      ],
+    })
+    render(<CourseReadinessCard report={report} loading={false} />, renderOpts)
+
+    // Collapsed: the check's message must not be in the DOM yet.
+    expect(
+      screen.queryByText(/has a description for the catalog/i),
+    ).not.toBeInTheDocument()
+
+    const header = screen.getByRole("button", { expanded: false })
+    await user.click(header)
+
+    // Expanded: the check appears.
+    expect(
+      screen.getByText(/has a description for the catalog/i),
+    ).toBeInTheDocument()
+  })
+
+  it("groups checks by severity in the canonical order", async () => {
+    const user = userEvent.setup()
+    const report = makeReport({
+      checks: [
+        makeCheck({
+          id: "polish-1",
+          severity: "polish",
+          message_key: "courseReadiness.checks.hasMultipleModules",
+        }),
+        makeCheck({
+          id: "crit-1",
+          severity: "critical",
+          message_key: "courseReadiness.checks.hasDescription",
+        }),
+        makeCheck({
+          id: "rec-1",
+          severity: "recommended",
+          message_key: "courseReadiness.checks.hasEnrollmentWindow",
+        }),
+      ],
+    })
+    render(<CourseReadinessCard report={report} loading={false} />, renderOpts)
+    await user.click(screen.getByRole("button", { expanded: false }))
+
+    // Header order: critical → recommended → polish.
+    const headers = screen.getAllByRole("heading", { level: 3 })
+    expect(headers.map((h) => h.textContent?.toLowerCase())).toEqual([
+      "critical",
+      "recommended",
+      "polish",
+    ])
+  })
+
+  it("calls onFix with the check's action when Fix is clicked", async () => {
+    const user = userEvent.setup()
+    const onFix = vi.fn()
+    const action: ReadinessAction = {
+      type: "set_description",
+      params: { course_id: "c-1" },
+    }
+    const check = makeCheck({
+      id: "fixable",
+      severity: "critical",
+      passed: false,
+      action,
+      message_key: "courseReadiness.checks.hasDescription",
+    })
+    const report = makeReport({ checks: [check] })
+    render(
+      <CourseReadinessCard report={report} loading={false} onFix={onFix} />,
+      renderOpts,
+    )
+
+    await user.click(screen.getByRole("button", { expanded: false }))
+    const fixButton = screen.getByRole("button", { name: /fix/i })
+    await user.click(fixButton)
+
+    expect(onFix).toHaveBeenCalledTimes(1)
+    expect(onFix).toHaveBeenCalledWith(action, check)
+  })
+
+  it("does NOT render a Fix button for passing checks", async () => {
+    const user = userEvent.setup()
+    const onFix = vi.fn()
+    const action: ReadinessAction = {
+      type: "set_description",
+      params: { course_id: "c-1" },
+    }
+    const report = makeReport({
+      checks: [
+        makeCheck({
+          id: "done",
+          severity: "critical",
+          passed: true,
+          action,
+          message_key: "courseReadiness.checks.hasDescription",
+        }),
+      ],
+    })
+    render(
+      <CourseReadinessCard report={report} loading={false} onFix={onFix} />,
+      renderOpts,
+    )
+    await user.click(screen.getByRole("button", { expanded: false }))
+
+    expect(screen.queryByRole("button", { name: /fix/i })).toBeNull()
+  })
+
+  it("does NOT render a Fix button when the check has no action even if failing", async () => {
+    const user = userEvent.setup()
+    const onFix = vi.fn()
+    const report = makeReport({
+      checks: [
+        makeCheck({
+          id: "no-action",
+          severity: "critical",
+          passed: false,
+          action: null,
+          message_key: "courseReadiness.checks.hasDescription",
+        }),
+      ],
+    })
+    render(
+      <CourseReadinessCard report={report} loading={false} onFix={onFix} />,
+      renderOpts,
+    )
+    await user.click(screen.getByRole("button", { expanded: false }))
+
+    expect(screen.queryByRole("button", { name: /fix/i })).toBeNull()
+  })
+
+  it("interpolates the subject title into the check message", async () => {
+    const user = userEvent.setup()
+    const report = makeReport({
+      checks: [
+        makeCheck({
+          id: "with-subject",
+          severity: "critical",
+          passed: false,
+          subject: { type: "module", id: "m-1", title: "Genesis Overview" },
+          message_key: "courseReadiness.checks.moduleHasChapters",
+        }),
+      ],
+    })
+    render(<CourseReadinessCard report={report} loading={false} />, renderOpts)
+    await user.click(screen.getByRole("button", { expanded: false }))
+
+    // The "moduleHasChapters" key contains "{{title}}" which the
+    // component interpolates from check.subject.title.
+    expect(screen.getByText(/Genesis Overview/)).toBeInTheDocument()
+  })
+
+  it("displays the numeric score in the ring", () => {
+    const report = makeReport({ score: 73, passing: 4, total: 5 })
+    render(<CourseReadinessCard report={report} loading={false} />, renderOpts)
+    expect(screen.getByText("73")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/Teacher/editor/__tests__/useCourseReadiness.test.ts
+++ b/frontend/src/pages/Teacher/editor/__tests__/useCourseReadiness.test.ts
@@ -1,0 +1,147 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// ``services/api`` (transitively imported by ``services/courseReadiness``)
+// reads ``VITE_SUPABASE_URL`` / ``VITE_SUPABASE_ANON_KEY`` at module load
+// to spin up the supabase client. Mock the supabase module before any
+// other import so this test never depends on the real env vars. The
+// auth surface only needs to expose the calls api.ts attaches at boot.
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      refreshSession: vi.fn(),
+      signOut: vi.fn(),
+      onAuthStateChange: vi
+        .fn()
+        .mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+    },
+  },
+}))
+
+import { useCourseReadiness } from "@/pages/Teacher/editor/useCourseReadiness"
+import { courseReadinessService } from "@/services/courseReadiness"
+
+/**
+ * The course editor renders the readiness card by piping
+ * ``useCourseReadiness(courseId)`` straight into ``CourseReadinessCard``,
+ * so the hook's three observable behaviours — initial fetch, refresh,
+ * and silent-failure-on-error — are the entire contract the rest of
+ * the editor relies on.
+ */
+describe("useCourseReadiness", () => {
+  const report = {
+    course_id: "c-1",
+    total: 5,
+    passing: 4,
+    critical_failing: 0,
+    score: 80,
+    checks: [],
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns null/loading until the fetch resolves, then surfaces the report", async () => {
+    const get = vi
+      .spyOn(courseReadinessService, "get")
+      .mockResolvedValue(report)
+
+    const { result } = renderHook(() => useCourseReadiness("c-1"))
+
+    expect(result.current.loading).toBe(true)
+    expect(result.current.report).toBeNull()
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(get).toHaveBeenCalledWith("c-1")
+    expect(result.current.report).toEqual(report)
+  })
+
+  it("does not fetch when courseId is undefined", async () => {
+    const get = vi
+      .spyOn(courseReadinessService, "get")
+      .mockResolvedValue(report)
+
+    const { result } = renderHook(() => useCourseReadiness(undefined))
+
+    // Give the effect a tick to settle.
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(get).not.toHaveBeenCalled()
+    // ``load`` early-returns without flipping ``loading`` back to false
+    // — the editor only renders the card once a courseId is in hand.
+    expect(result.current.loading).toBe(true)
+    expect(result.current.report).toBeNull()
+  })
+
+  it("re-fetches when courseId changes", async () => {
+    const get = vi
+      .spyOn(courseReadinessService, "get")
+      .mockImplementation(async (id: string) => ({ ...report, course_id: id }))
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useCourseReadiness(id),
+      { initialProps: { id: "c-1" } },
+    )
+
+    await waitFor(() => expect(result.current.report?.course_id).toBe("c-1"))
+    expect(get).toHaveBeenCalledTimes(1)
+
+    rerender({ id: "c-2" })
+
+    await waitFor(() => expect(result.current.report?.course_id).toBe("c-2"))
+    expect(get).toHaveBeenLastCalledWith("c-2")
+  })
+
+  it("silently swallows fetch errors and surfaces report=null", async () => {
+    // Per the docstring: "the card hides itself when ``report === null``
+    // — a transient backend blip shouldn't break the editor."
+    vi.spyOn(courseReadinessService, "get").mockRejectedValue(new Error("backend down"))
+
+    const { result } = renderHook(() => useCourseReadiness("c-1"))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.report).toBeNull()
+  })
+
+  it("refresh() re-runs the fetch with the same id", async () => {
+    let attempt = 0
+    const get = vi
+      .spyOn(courseReadinessService, "get")
+      .mockImplementation(async () => {
+        attempt += 1
+        return { ...report, passing: attempt }
+      })
+
+    const { result } = renderHook(() => useCourseReadiness("c-1"))
+
+    await waitFor(() => expect(result.current.report?.passing).toBe(1))
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(result.current.report?.passing).toBe(2)
+  })
+
+  it("refresh() after a previous error recovers and shows the new report", async () => {
+    const get = vi.spyOn(courseReadinessService, "get")
+    get.mockRejectedValueOnce(new Error("transient"))
+    get.mockResolvedValueOnce(report)
+
+    const { result } = renderHook(() => useCourseReadiness("c-1"))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.report).toBeNull()
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(result.current.report).toEqual(report)
+  })
+})


### PR DESCRIPTION
## Summary

Five new test files close the biggest frontend coverage holes flagged
in the audit — the teacher-editor readiness flow, the admin role
picker, and two design-system constants modules with zero existing
coverage.

- **`useCourseReadiness` hook** — initial fetch, courseId=undefined
  skip, id-change refetch, silent error swallow, refresh()
  roundtrip, recovery-after-error.
- **`CourseReadinessCard` component** — loading skeleton, null-hide,
  all-passed branch, failing summary, expand-collapse, severity
  ordering, onFix wiring + suppression rules, subject title
  interpolation, score in ring.
- **`RoleSelector` component** — current label, disabled read-only,
  ariaLabel, four-role menu in canonical order, onChange-only-on-diff.
- **`lib/roles.ts`** — exhaustive UserRole coverage + exact mapping
  pin as a silent-rename regression guard.
- **`lib/motion.ts`** — EDITORIAL_EASE shape + value, MOTION_DURATION
  tier ascending order, seconds-not-ms sanity, exact value pin.

## Design notes

- `useCourseReadiness.test.ts` mocks `@/lib/supabase` so the
  transitive `services/api.ts` import doesn't crash on missing
  `VITE_SUPABASE_*` env vars in the test env. Pattern lifted from
  `src/services/__tests__/api.test.ts`.
- `RoleSelector` assertions avoid reaching into Radix internals —
  positioning, focus management, and keyboard handling are owned by
  Radix and have their own coverage.
- `CourseReadinessCard` tests use the real i18n bundle so the
  `t(check.message_key, { title: … })` interpolation is exercised
  end-to-end.

## Test plan

- [x] `cd frontend && npm run test:run` — 179 passed (up from 140)
- [x] No production-code changes (RoleSelector / lib/roles untouched
      per audit constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)