### PR TITLE
fix(progress): wrap ChapterProgress INSERT in SAVEPOINT to survive race

### DIFF
--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import (
@@ -165,11 +166,33 @@ def submit_assignment(
         .first()
     )
     if not progress:
-        progress = ChapterProgress(
-            user_id=current_user.id,
-            chapter_id=assignment.chapter_id,
-        )
-        db.add(progress)
+        # Insert the new ChapterProgress inside a SAVEPOINT so a
+        # concurrent writer (teacher manually marking the chapter
+        # complete at the same instant, or another resubmit) racing us
+        # to the ``uq_progress_user_chapter`` unique key does not abort
+        # the whole submit and lose the AssignmentSubmission row. On
+        # collision we re-fetch the winner row and use it instead.
+        # Mirrors the race fix in ``teacher_complete_chapter`` (#301).
+        try:
+            with db.begin_nested():
+                progress = ChapterProgress(
+                    user_id=current_user.id,
+                    chapter_id=assignment.chapter_id,
+                )
+                db.add(progress)
+                db.flush()
+        except IntegrityError:
+            progress = (
+                db.query(ChapterProgress)
+                .filter(
+                    ChapterProgress.user_id == current_user.id,
+                    ChapterProgress.chapter_id == assignment.chapter_id,
+                )
+                .first()
+            )
+            if progress is None:
+                raise
+
     if not progress.completed:
         progress.completed = True
         progress.completed_at = datetime.now(UTC)

--- a/backend/app/services/quiz_service.py
+++ b/backend/app/services/quiz_service.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
 
 from app.api.dependencies import resolve_chapter_course_id
 from app.models.chapter_progress import ChapterProgress
@@ -198,7 +199,15 @@ def persist_answers(
 
 
 def upsert_passed_chapter_progress(db: Session, user_id: UUID, chapter_id: str) -> None:
-    """Mark the chapter as ``quiz``-completed for the student (idempotent)."""
+    """Mark the chapter as ``quiz``-completed for the student (idempotent).
+
+    Race-safe: a concurrent teacher-mark-complete or assignment-submit
+    for the same ``(user, chapter)`` may also be inserting a progress
+    row. We wrap the INSERT in a SAVEPOINT so the unique-constraint
+    collision aborts only the savepoint — not the caller's transaction
+    — and re-fetch the winner row to apply the "completed = true"
+    update on top of it.
+    """
     cp = (
         db.query(ChapterProgress)
         .filter(
@@ -208,8 +217,22 @@ def upsert_passed_chapter_progress(db: Session, user_id: UUID, chapter_id: str) 
         .first()
     )
     if not cp:
-        cp = ChapterProgress(user_id=user_id, chapter_id=chapter_id)
-        db.add(cp)
+        try:
+            with db.begin_nested():
+                cp = ChapterProgress(user_id=user_id, chapter_id=chapter_id)
+                db.add(cp)
+                db.flush()
+        except IntegrityError:
+            cp = (
+                db.query(ChapterProgress)
+                .filter(
+                    ChapterProgress.user_id == user_id,
+                    ChapterProgress.chapter_id == chapter_id,
+                )
+                .first()
+            )
+            if cp is None:
+                raise
     if not cp.completed:
         cp.completed = True
         cp.completed_at = datetime.now(UTC)

--- a/backend/tests/test_progress_and_assignments.py
+++ b/backend/tests/test_progress_and_assignments.py
@@ -392,6 +392,80 @@ def test_my_progress_returns_only_completed_course_chapters(student_client: Test
     assert response.json() == [chapter.id]
 
 
+def test_submit_assignment_survives_concurrent_chapter_progress_insert(student_client: TestClient, db: Session):
+    """The submit handler races a teacher manually marking the chapter
+    complete: both can hit the ``uq_progress_user_chapter`` unique key
+    at commit. Before the SAVEPOINT fix the entire submit transaction
+    rolled back and the ``AssignmentSubmission`` was lost.
+
+    Reproduces the race by pre-inserting a competing ChapterProgress
+    row (so the unique key is already taken) and forcing the handler's
+    initial ChapterProgress lookup to MISS so it falls into the INSERT
+    path. In production the lookup miss would happen because the
+    competing writer hasn't committed yet; in test we patch ``.first()``
+    once.
+    """
+    from sqlalchemy.orm import Query
+
+    _course, _module, chapter = _seed_course_graph(db)
+    assignment = Assignment(
+        id=uuid.uuid4(),
+        chapter_id=chapter.id,
+        title="Reflection",
+        max_score=10,
+    )
+    db.add(assignment)
+    db.add(
+        ChapterProgress(
+            user_id=STUDENT_ID,
+            chapter_id=chapter.id,
+            completed=True,
+            completion_type="teacher",
+        )
+    )
+    db.commit()
+
+    real_first = Query.first
+    state = {"missed": False}
+
+    def _maybe_miss(self):
+        descs = self.column_descriptions
+        if not state["missed"] and descs and getattr(descs[0].get("type"), "__name__", "") == "ChapterProgress":
+            state["missed"] = True
+            return None
+        return real_first(self)
+
+    Query.first = _maybe_miss
+    try:
+        resp = student_client.post(
+            f"/api/v1/assignments/{assignment.id}/submit",
+            json={"content": "x"},
+        )
+    finally:
+        Query.first = real_first
+
+    # Before the fix this came back as 409 (IntegrityError middleware);
+    # after, the SAVEPOINT absorbs the collision and the submit commits.
+    assert resp.status_code == 201, resp.text
+
+    db.expire_all()
+    progress_rows = (
+        db.query(ChapterProgress)
+        .filter(
+            ChapterProgress.user_id == STUDENT_ID,
+            ChapterProgress.chapter_id == chapter.id,
+        )
+        .all()
+    )
+    assert len(progress_rows) == 1
+    assert progress_rows[0].completed is True
+
+    from app.models.assignment import AssignmentSubmission
+
+    sub_count = db.query(AssignmentSubmission).filter(AssignmentSubmission.assignment_id == assignment.id).count()
+    assert sub_count == 1
+
+
 def test_student_can_fetch_own_assignment_submissions(student_client: TestClient, db: Session):
     course, _module, chapter = _seed_course_graph(db)
     assignment = Assignment(

--- a/backend/tests/test_quizzes_and_blocks.py
+++ b/backend/tests/test_quizzes_and_blocks.py
@@ -666,6 +666,78 @@ def test_delete_quiz_anon_unauthorized(anon_client: TestClient):
 # ── POST /api/v1/quizzes/{quiz_id}/submit ─────────────────────────────────
 
 
+def test_submit_quiz_survives_concurrent_chapter_progress_insert(student_client: TestClient, db: Session):
+    """``submit_quiz`` upserts a ChapterProgress row when the student
+    passes. A teacher manually marking the chapter complete (or a
+    parallel quiz submission) at the same instant can race the INSERT,
+    tripping the ``uq_progress_user_chapter`` unique key. Before the
+    SAVEPOINT wrap in ``upsert_passed_chapter_progress`` this took
+    down the whole submit transaction.
+    """
+    from sqlalchemy.orm import Query
+
+    from app.models.chapter_progress import ChapterProgress
+
+    _seed_course_with_enrollment(db)
+    quiz, questions, opts = _seed_quiz_with_questions(db)
+
+    db.add(
+        ChapterProgress(
+            user_id=STUDENT_ID,
+            chapter_id="ch-1",
+            completed=True,
+            completion_type="teacher",
+        )
+    )
+    db.commit()
+
+    real_first = Query.first
+    state = {"missed": False}
+
+    def _maybe_miss(self):
+        descs = self.column_descriptions
+        if not state["missed"] and descs and getattr(descs[0].get("type"), "__name__", "") == "ChapterProgress":
+            state["missed"] = True
+            return None
+        return real_first(self)
+
+    Query.first = _maybe_miss
+    try:
+        resp = student_client.post(
+            f"/api/v1/quizzes/{quiz.id}/submit",
+            json={
+                "answers": [
+                    {
+                        "question_id": str(questions[0].id),
+                        "selected_option_id": str(opts["q1_correct"]),
+                    },
+                    {
+                        "question_id": str(questions[1].id),
+                        "selected_option_id": str(opts["q2_correct"]),
+                    },
+                ],
+            },
+        )
+    finally:
+        Query.first = real_first
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["passed"] is True
+
+    db.expire_all()
+    progress_rows = (
+        db.query(ChapterProgress)
+        .filter(
+            ChapterProgress.user_id == STUDENT_ID,
+            ChapterProgress.chapter_id == "ch-1",
+        )
+        .all()
+    )
+    assert len(progress_rows) == 1
+    assert progress_rows[0].completed is True
+
+
 def test_submit_quiz_perfect_score(student_client: TestClient, db: Session):
     _seed_course_with_enrollment(db)
     quiz, questions, opts = _seed_quiz_with_questions(db)


### PR DESCRIPTION
## Summary
- `POST /assignments/{id}/submit` and `POST /quizzes/{id}/submit` both do "find or create" on `ChapterProgress(user, chapter)`. The unique constraint `uq_progress_user_chapter` enforces one row per pair, so a teacher manually marking the chapter complete (or another submit flow) racing the same INSERT trips the constraint at commit. The whole submit transaction aborts, the submission row is lost, and the student sees a 409/500.
- `teacher_complete_chapter` already handles this race (#301). This change applies the same SAVEPOINT pattern to the two student-side write paths: `submit_assignment` (inline) and `quiz_service.upsert_passed_chapter_progress` (called from `submit_quiz` + `recompute_attempt_grade`).

## Test plan
- [x] New regression `test_submit_assignment_survives_concurrent_chapter_progress_insert` — fails (409) before, passes (201) after.
- [x] New regression `test_submit_quiz_survives_concurrent_chapter_progress_insert` — covers the quiz path through `upsert_passed_chapter_progress`.
- [x] `python -m pytest tests/` 613 pass.
- [x] `python -m ruff check .` + `ruff format --check` clean.
- [x] `mypy --config-file mypy.ini` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
