### PR TITLE
fix(i18n): locale wins on student-facing reads (owner + admin too)

### DIFF
--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -142,15 +142,9 @@ def get_module_detail(
 
     response.headers["Vary"] = "Accept-Language"
 
-    # Owner + admin always see source for editorial accuracy (matches the
-    # rule in ``should_apply_course_translation_overlay`` for the parent
-    # course-detail endpoint). Everyone else (students, anonymous catalog
-    # browsers, other teachers) gets the locale overlay.
-    is_owner = current_user is not None and str(course_owner_id) == str(current_user.id)
-    is_admin = current_user is not None and current_user.role == UserRole.ADMIN.value
-    if is_owner or is_admin:
-        return ModuleResponse.model_validate(module, from_attributes=True)
-
+    # Locale wins. Student-facing reads always respect the viewer's locale —
+    # owners and admins included. Editor pages that need source text must
+    # use dedicated authoring endpoints.
     display_locale: LocaleCode = normalize_locale(accept_language)
     source_locale: LocaleCode = normalize_locale(course_source_locale)
     return build_localized_module_response(

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -6,15 +6,16 @@ manual human edits) materialised one with ``status='ok'``. We **always prefer**
 that text for the **same** display locale, even if ``courses.source_locale`` is
 set to the same code but the source columns still contain a different
 language (legacy authoring drift). The canonical text still lives on
-``courses.*`` for owners/admins and as a fallback when no row exists.
+``courses.*`` as a fallback when no row exists.
 
-Authoring views (owner + admin) always see the source columns so editors are
-not surprised by machine translations when the UI is in another language.
+**Locale wins.** Student-facing reads always respect the viewer's
+``preferred_locale``/``Accept-Language``, regardless of role. Edit surfaces
+must use dedicated authoring endpoints that read source columns directly
+and never invoke this overlay.
 """
 
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass
 from typing import cast
 
@@ -28,7 +29,7 @@ from app.models.content_translation import ContentTranslation
 from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent  # noqa: TC001
 from app.models.quiz import Quiz  # noqa: TC001
-from app.models.user import User, UserRole
+from app.models.user import User  # noqa: TC001
 from app.schemas.announcement import AnnouncementResponse
 from app.schemas.assignment import AssignmentResponse
 from app.schemas.calendar import CourseEventResponse
@@ -38,19 +39,24 @@ from app.schemas.locale import LocaleCode, normalize_locale
 from app.schemas.quiz import QuizOptionStudentResponse, QuizQuestionStudentResponse, QuizStudentResponse
 
 
-def _str_uuid(v: str | uuid.UUID) -> str:
-    """Case-normalise UUIDs so SQLite/Postgres string forms compare equal."""
-    return str(uuid.UUID(str(v)))
-
-
 def should_apply_course_translation_overlay(*, course: Course, current_user: User | None) -> bool:
-    """Return True when the API should show localized metadata to this caller."""
-    if current_user is None:
-        return True
-    if current_user.role == UserRole.ADMIN.value:
-        return False
-    is_owner = course.created_by is not None and _str_uuid(course.created_by) == _str_uuid(current_user.id)
-    return not is_owner
+    """Return True when the API should show localized metadata to this caller.
+
+    **Locale wins.** Edit surfaces read source columns directly; this overlay
+    only fires on student-facing reads, where the viewer's locale should
+    always be respected — including for the course owner and admins. The
+    previous behaviour (skip overlay for admin/owner so editors saw source)
+    leaked into every student-facing read path, leaving owners and admins
+    unable to use their own platform as a user in a non-source UI locale.
+    Editor pages that need the canonical source language must call the
+    teacher-only endpoints (e.g. ``GET /quizzes/{quiz_id}``) which never
+    touch this overlay.
+    """
+    # ``current_user`` and ``course`` are kept in the signature so call sites
+    # don't have to change, and so future per-course exemptions remain easy
+    # to add. Today the rule is: always overlay when a translation exists.
+    del course, current_user
+    return True
 
 
 def batch_fetch_course_translations(

--- a/backend/tests/test_courses.py
+++ b/backend/tests/test_courses.py
@@ -311,12 +311,21 @@ class TestCatalogLocalizedMetadata:
         assert row_en["title"] == "English catalog title"
         assert row_en["description"] == "English catalog description"
 
-    def test_get_detail_owner_sees_source_when_ui_is_en(
+    def test_get_detail_owner_sees_translation_when_ui_is_en(
         self,
         client: TestClient,
         db: Session,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """Regression: locale wins, even for the course owner.
+
+        Previously the overlay was skipped for owners/admins so editor pages
+        would render source text — but the student-facing course-detail
+        endpoint is the same endpoint, so owners (Vadym in production) could
+        not use their own platform in EN when the course source was RU. The
+        new rule is locale wins on this read path. Editors must use the
+        dedicated authoring endpoints to get source text.
+        """
         # Do not request ``anon_client`` in the same test: it shares
         # ``app.dependency_overrides`` and whichever fixture runs last would
         # clobber the other's ``get_optional_user`` override.
@@ -338,7 +347,36 @@ class TestCatalogLocalizedMetadata:
             headers={"Accept-Language": "en"},
         )
         assert owner.status_code == 200
-        assert owner.json()["title"] == "Заголовок RU"
+        assert owner.json()["title"] == "English catalog title"
+        assert owner.json()["description"] == "English catalog description"
+
+    def test_get_detail_admin_sees_translation_when_ui_is_en(
+        self,
+        client: TestClient,
+        admin_client: TestClient,
+        db: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Same regression as the owner case, but for the ADMIN role."""
+        monkeypatch.setattr(
+            "app.api.v1.courses.crud.translate_course_content",
+            lambda *args, **kwargs: OrchestratorReport(),
+        )
+        course = _create_course(
+            client,
+            title="Заголовок RU",
+            description="Описание RU",
+        )
+        cid = course["id"]
+        client.put(f"{PREFIX}/{cid}", json={"status": "published"})
+        self._seed_en_translations(db, cid)
+
+        admin = admin_client.get(
+            f"{PREFIX}/{cid}",
+            headers={"Accept-Language": "en"},
+        )
+        assert admin.status_code == 200
+        assert admin.json()["title"] == "English catalog title"
 
     def test_get_detail_anon_sees_translated_metadata_with_accept_language(
         self,


### PR DESCRIPTION
## Summary
- The translation overlay was skipped for `ADMIN` and the course owner so editors would render source-language text. But the same endpoints serve both editor and student-facing views, so admins and course owners (Vadym in production) could not use their own platform in EN when a course's `source_locale` was RU. This propagated everywhere user-authored content surfaces.
- `should_apply_course_translation_overlay` now always returns `True`. The inline admin/owner skip in `get_module_detail` is removed.
- Comment block on the function documents the new rule: **"Locale wins. Edit surfaces read source columns directly; this overlay only fires on student-facing reads, where the viewer's locale should always be respected."**

## Regression test
- `test_get_detail_owner_sees_translation_when_ui_is_en` (formerly `..._sees_source...`) — a course owner with `Accept-Language: en` viewing their own RU course must see the `content_translations` EN row.
- `test_get_detail_admin_sees_translation_when_ui_is_en` — equivalent assertion for `ADMIN`.

## Editor-page audit (verification of the assumption in the task)
The task said: _"The editor pages already read source columns directly (they don't go through `resolve_for_display`) — verify this is true."_

**Verified — and the assumption is partially wrong.** Today's editor pages share endpoints with the student-facing pages:
- `pages/Teacher/CourseEditor.tsx` and `editor/useCourseData.ts` call `coursesService.getCourse(id)` → `GET /api/v1/courses/{course_id}` (overlay path).
- `pages/Teacher/ChapterEditor.tsx` calls `coursesService.getModule(courseId, moduleId)` → `GET /api/v1/courses/{course_id}/modules/{module_id}` (overlay path).
- `components/quiz/QuizEditor.tsx` + `editor/useQuizDraft.ts` call `quizzesService.getChapterQuiz(chapterId)` → `GET /api/v1/quizzes/chapter/{chapter_id}` (overlay path).
- Assignment editor follows the same pattern via `assignments` endpoints.

A dedicated teacher-only quiz endpoint exists (`GET /api/v1/quizzes/{quiz_id}` behind `require_teacher`) but the QuizEditor doesn't use it. **So with this PR, editors viewing in `en` UI on an `ru` source course will now see EN translations in the title/description fields.** The right next step is to route editors to the dedicated authoring endpoints (or add a `?source=true` flag) — that's the third PR in this sequence. The user explicitly accepted this trade-off: bilingual student/admin reads are the urgent fix; editor source-preservation is the follow-up.

## Test plan
- [x] `pytest tests/` — 664 passed
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] `mypy --config-file mypy.ini` — clean
- [x] `npm run i18n:check` — locale parity OK
- [ ] Manually verify in staging: log in as the admin/owner with EN UI, view a quiz on an RU course, confirm question text renders in EN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
