### PR TITLE
fix(i18n): translation walker finds quizzes/assignments via chapter_id (production bug)

### DIFF
--- a/backend/app/services/translation/course_pipeline.py
+++ b/backend/app/services/translation/course_pipeline.py
@@ -146,6 +146,44 @@ def translate_course_content(
                     reconcile_entity(db, "assignment", assignment, provider=provider),
                 )
 
+    # Production teacher flow attaches quizzes + assignments via the
+    # ``chapter_id`` FK directly; the chapter-block-mediated walk above
+    # is an aspirational shape that the create flows have never
+    # populated. Pick up anything the block walk missed by querying for
+    # quizzes / assignments bound to this course's chapters and
+    # reconcile any that ``seen_*`` hasn't already covered.
+    #
+    # This is what makes the pipeline actually translate quiz text in
+    # production. See 2026-05-16 audit; without this query, every
+    # course in prod had zero ``content_translations`` rows for
+    # ``quiz`` / ``quiz_question`` / ``quiz_option`` / ``assignment``.
+    chapter_bound_quizzes = (
+        db.query(Quiz)
+        .options(selectinload(Quiz.questions).selectinload(QuizQuestion.options))
+        .filter(Quiz.chapter_id.in_(chapter_ids))
+        .all()
+    )
+    for quiz in chapter_bound_quizzes:
+        qid = str(quiz.id)
+        if qid in seen_quiz:
+            continue
+        seen_quiz.add(qid)
+        total = merge_orchestrator_reports(
+            total,
+            _walk_quiz_tree(db, quiz, provider=provider),
+        )
+
+    chapter_bound_assignments = db.query(Assignment).filter(Assignment.chapter_id.in_(chapter_ids)).all()
+    for assignment in chapter_bound_assignments:
+        aid = str(assignment.id)
+        if aid in seen_assignment:
+            continue
+        seen_assignment.add(aid)
+        total = merge_orchestrator_reports(
+            total,
+            reconcile_entity(db, "assignment", assignment, provider=provider),
+        )
+
     side = _translate_course_side_entities(db, course, provider=provider)
     return merge_orchestrator_reports(total, side)
 

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -470,3 +470,117 @@ def test_manual_translate_endpoint_returns_disabled_when_provider_off(monkeypatc
     body = resp.json()
     assert body["enabled"] is False
     assert body["translated"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: walker must find quizzes + assignments via ``chapter_id``
+# ---------------------------------------------------------------------------
+#
+# Production teacher flow creates quizzes by inserting ``quizzes`` rows with
+# ``chapter_id`` set and never inserts a ``chapter_block`` with
+# ``quiz_id`` pointing at them. Before the 2026-05-16 fix the walker only
+# reached quizzes through the ``chapter_block.quiz_id`` indirection — so in
+# prod every quiz had ZERO translation rows even on courses where every
+# other entity was fully translated. Same shape for assignments.
+#
+# This test mirrors the prod attachment exactly: the chapter has NO
+# chapter_block with ``quiz_id`` (or any block at all); the quiz attaches
+# to the chapter only via its ``chapter_id`` FK. The walker must still
+# reach it and produce translation rows for the quiz tree.
+
+
+def test_walker_finds_quizzes_attached_via_chapter_id_only(db: Session):
+    """Production-shape attachment: quiz tied to a chapter via ``Quiz.chapter_id``
+    with no ``chapter_block`` mediating row. Walker must still translate it.
+
+    Regression for 2026-05-16: see commit message.
+    """
+    from app.models.course import Chapter, Module
+    from app.models.quiz import Quiz, QuizOption, QuizQuestion
+
+    course = _make_course(db, status="published")
+    module = Module(id=str(uuid.uuid4()), course_id=course.id, title="M1", order_index=0)
+    db.add(module)
+    db.flush()
+    chapter = Chapter(
+        id=str(uuid.uuid4()),
+        module_id=module.id,
+        title="Ch1",
+        order_index=0,
+        chapter_type="quiz",
+    )
+    db.add(chapter)
+    db.flush()
+    quiz = Quiz(chapter_id=chapter.id, title="Pop quiz", description="Test")
+    db.add(quiz)
+    db.flush()
+    question = QuizQuestion(
+        quiz_id=quiz.id,
+        question_text="What is the answer?",
+        question_type="multiple_choice",
+        order_index=0,
+        points=1,
+    )
+    db.add(question)
+    db.flush()
+    option = QuizOption(
+        question_id=question.id,
+        option_text="The answer",
+        is_correct=True,
+        order_index=0,
+    )
+    db.add(option)
+    db.commit()
+
+    provider = _RecordingProvider()
+    report = translate_course_content(db, course, provider=provider)
+
+    assert report.failed == 0
+    quiz_translations = db.query(ContentTranslation).filter_by(entity_type="quiz", entity_id=str(quiz.id)).all()
+    question_translations = (
+        db.query(ContentTranslation).filter_by(entity_type="quiz_question", entity_id=str(question.id)).all()
+    )
+    option_translations = (
+        db.query(ContentTranslation).filter_by(entity_type="quiz_option", entity_id=str(option.id)).all()
+    )
+    assert quiz_translations, "expected at least one translation row for the quiz"
+    assert question_translations, "expected at least one translation row for the quiz_question"
+    assert option_translations, "expected at least one translation row for the quiz_option"
+    # Source = ru, target = en, so each translation should be the
+    # ``[en]<source>`` shape the recording provider emits.
+    assert any(t.text.startswith("[en]") for t in question_translations)
+
+
+def test_walker_finds_assignments_attached_via_chapter_id_only(db: Session):
+    """Same regression shape for assignments — they also attach via
+    ``Assignment.chapter_id`` directly without a chapter_block bridge."""
+    from app.models.assignment import Assignment
+    from app.models.course import Chapter, Module
+
+    course = _make_course(db, status="published")
+    module = Module(id=str(uuid.uuid4()), course_id=course.id, title="M1", order_index=0)
+    db.add(module)
+    db.flush()
+    chapter = Chapter(
+        id=str(uuid.uuid4()),
+        module_id=module.id,
+        title="Ch1",
+        order_index=0,
+        chapter_type="assignment",
+    )
+    db.add(chapter)
+    db.flush()
+    assignment = Assignment(
+        chapter_id=chapter.id,
+        title="Reflection",
+        description="Write 500 words on the chapter.",
+    )
+    db.add(assignment)
+    db.commit()
+
+    provider = _RecordingProvider()
+    report = translate_course_content(db, course, provider=provider)
+
+    assert report.failed == 0
+    rows = db.query(ContentTranslation).filter_by(entity_type="assignment", entity_id=str(assignment.id)).all()
+    assert rows, "expected at least one translation row for the chapter-bound assignment"


### PR DESCRIPTION
## 🔥 Production bug — student sees source language even with translated UI

Vadym (logged in as a student account, English UI) saw quiz content render in Russian on a Russian-authored course. Every other surface on the same course (course title / description, module title, chapter title, chapter blocks) showed correctly in English. Just the quiz was stuck.

## Root cause

Verified via `supabase:supabase` `execute_sql` against prod (`rrisqutxlkamwfhcashl`):

| entity_type | en translation rows | ru translation rows |
|---|---:|---:|
| course | 8 | 2 |
| module | 18 | 2 |
| chapter | 28 | 1 |
| chapter_block | 26 | 1 |
| announcement | 4 | 0 |
| course_event | 2 | 0 |
| **quiz** | **0** | **0** |
| **quiz_question** | **0** | **0** |
| **quiz_option** | **0** | **0** |
| **assignment** | **0** | **0** |

Six published quizzes in prod. **Zero translation rows for any of them.** Same for every assignment.

`translate_course_content` (the walker) only reaches a quiz / assignment when it finds a `chapter_blocks` row with a non-null `quiz_id` / `assignment_id`. In prod, **no `chapter_blocks` row has those FKs set** — `block_type` is only `'text'` or `'file'`. All quizzes / assignments attach to chapters via `quizzes.chapter_id` / `assignments.chapter_id` directly (which is what the student GET endpoints read).

Existing tests masked the bug by hand-seeding `chapter_block.quiz_id` — fixtures matched the dead code path, not how `create_quiz` actually shapes data.

## Fix

After the chapter-block walk, query `quizzes` / `assignments` directly by `chapter_id IN <course chapters>` and reconcile any not-yet-seen entries. Idempotent via `source_hash` short-circuit, so re-publish on each existing prod course backfills translations without redoing already-covered content.

Two regression tests added: each seeds a quiz / assignment attached to a chapter via the `chapter_id` FK only, with **no mediating `chapter_block` row**. Both fail before this commit, pass after.

## Prod backfill

After this lands and deploys to `api.equipbible.com`, the existing 6 quizzes + their assignments need a translation backfill. Easiest path: re-publish each affected course (the publish hook triggers `translate_course_content`). I'll do this manually right after the PR merges.

## Test plan

- [x] `cd backend && pytest tests/` — **665 passing** (2 new).
- [x] `ruff check` + `ruff format --check` — clean.
- [x] Two new regression tests fail on the previous code, pass on this fix (verified by reverting the diff locally and re-running).
- [ ] After merge + deploy: re-publish each of the 6 affected prod courses; verify `content_translations` rows appear for `quiz` / `quiz_question` / `quiz_option` / `assignment`; log in as student with English locale and verify quiz now renders English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
