### PR TITLE
design(cohorts): cohort-status badge IS the picker; tighten detail header rhythm

### DIFF
--- a/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
@@ -13,7 +13,6 @@ import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { NativeSelect } from "@/components/ui/native-select"
 import { useConfirm } from "@/components/ui/alert-dialog"
 import { useAuth } from "@/context/useAuth"
 import PageSpinner from "@/components/ui/PageSpinner"
@@ -25,12 +24,7 @@ import { formatDate, isoToLocalInput, localInputToIso } from "@/i18n/format"
 import type { Cohort, Course } from "@/types"
 import { AttachCourseDialog } from "./AttachCourseDialog"
 import { AddStudentDialog } from "./AddStudentDialog"
-
-const STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
-  upcoming: "info",
-  active: "success",
-  completed: "muted",
-}
+import { CohortStatusPicker } from "./CohortStatusPicker"
 
 export default function CohortDetailPage() {
   const { cohortId } = useParams<{ cohortId: string }>()
@@ -93,12 +87,14 @@ export default function CohortDetailPage() {
   }
 
   /**
-   * Status is edited through the single ``NativeSelect`` in the Details
-   * card — the dedicated "Complete cohort" button used to be a third path
-   * to the same ``status="completed"`` transition (alongside the header
-   * Badge and that select), so it was collapsed away. Transitioning to
-   * ``completed`` still confirms first because it's a one-way operation
-   * in practice (the cohort stops being editable).
+   * Status is edited through the single ``CohortStatusPicker`` in the
+   * page header — the badge IS the picker (same pattern as
+   * ``RoleSelector``). Previously the status was rendered twice (the
+   * coloured header badge and a separate ``NativeSelect`` in the
+   * Details card); collapsed to one affordance.
+   *
+   * Transitioning to ``completed`` still confirms first because it's
+   * a one-way operation in practice (the cohort stops being editable).
    */
   const handleStatusChange = async (next: Cohort["status"]) => {
     if (!cohortId || next === cohort?.status) return
@@ -200,12 +196,17 @@ export default function CohortDetailPage() {
       </Link>
 
       <div className="flex items-start justify-between gap-4 flex-wrap mb-8">
-        <div>
-          <div className="flex items-center gap-3 mb-2">
-            <h1 className="text-3xl font-serif font-bold tracking-tight">{cohort.name}</h1>
-            <Badge variant={STATUS_BADGE[cohort.status]} className="capitalize">
-              {t(`admin.cohorts.status${capitalize(cohort.status)}`)}
-            </Badge>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-3 mb-2">
+            <h1 className="text-3xl font-serif font-bold tracking-tight text-wrap-safe">
+              {cohort.name}
+            </h1>
+            <CohortStatusPicker
+              status={cohort.status}
+              disabled={savingField}
+              onChange={(next) => void handleStatusChange(next)}
+              ariaLabel={t("admin.cohorts.fieldStatus")}
+            />
           </div>
           <p className="text-sm text-muted-foreground">
             {formatDate(cohort.start_date)} &mdash; {formatDate(cohort.end_date)}
@@ -233,20 +234,18 @@ export default function CohortDetailPage() {
             onBlurSave={(v) => v !== cohort.name && patch({ name: v })}
             disabled={savingField}
           />
-          <div className="space-y-1.5">
-            <Label className="text-xs">{t("admin.cohorts.fieldStatus")}</Label>
-            <NativeSelect
-              value={cohort.status}
-              disabled={savingField}
-              onChange={(e) =>
-                void handleStatusChange(e.target.value as Cohort["status"])
-              }
-            >
-              <option value="upcoming">{t("admin.cohorts.statusUpcoming")}</option>
-              <option value="active">{t("admin.cohorts.statusActive")}</option>
-              <option value="completed">{t("admin.cohorts.statusCompleted")}</option>
-            </NativeSelect>
-          </div>
+          <Field
+            label={t("admin.cohorts.fieldMaxStudents")}
+            value={cohort.max_students == null ? "" : String(cohort.max_students)}
+            placeholder={t("admin.cohorts.unlimited")}
+            disabled={savingField}
+            onBlurSave={(v) => {
+              const n = v ? Number(v) : null
+              if (n === cohort.max_students) return
+              void patch({ max_students: n })
+            }}
+            inputType="number"
+          />
           <DateField
             label={t("admin.cohorts.fieldStart")}
             value={cohort.start_date}
@@ -276,18 +275,6 @@ export default function CohortDetailPage() {
             onSave={(iso) => patch({ enrollment_end: iso })}
             disabled={savingField}
             nullable
-          />
-          <Field
-            label={t("admin.cohorts.fieldMaxStudents")}
-            value={cohort.max_students == null ? "" : String(cohort.max_students)}
-            placeholder={t("admin.cohorts.unlimited")}
-            disabled={savingField}
-            onBlurSave={(v) => {
-              const n = v ? Number(v) : null
-              if (n === cohort.max_students) return
-              void patch({ max_students: n })
-            }}
-            inputType="number"
           />
         </CardContent>
       </Card>
@@ -421,10 +408,6 @@ export default function CohortDetailPage() {
       />
     </div>
   )
-}
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 interface FieldProps {

--- a/frontend/src/pages/Admin/cohorts/CohortStatusPicker.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortStatusPicker.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from "react-i18next"
+import { Check, ChevronDown } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import type { Cohort } from "@/types"
+
+interface Props {
+  status: Cohort["status"]
+  disabled?: boolean
+  onChange: (next: Cohort["status"]) => void
+  /** Optional label for assistive tech, e.g. "Change cohort status". */
+  ariaLabel?: string
+}
+
+const STATUS_ORDER: Cohort["status"][] = ["upcoming", "active", "completed"]
+
+const STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
+  upcoming: "info",
+  active: "success",
+  completed: "muted",
+}
+
+const STATUS_I18N_KEY: Record<Cohort["status"], string> = {
+  upcoming: "admin.cohorts.statusUpcoming",
+  active: "admin.cohorts.statusActive",
+  completed: "admin.cohorts.statusCompleted",
+}
+
+/**
+ * The cohort-status badge IS the status picker — no separate select alongside.
+ *
+ * Same pattern as ``RoleSelector``: the previous layout showed the current
+ * status twice (a coloured pill in the page header AND a ``NativeSelect``
+ * inside the Details card). One affordance, one place to click. Keyboard
+ * works: ``Enter`` / ``Space`` opens the menu, arrows navigate, ``Esc``
+ * closes.
+ *
+ * When ``disabled`` is true the badge renders flat without the dropdown
+ * chevron, signalling read-only without changing layout. Moving from
+ * ``active`` → ``completed`` is one-way in practice, but the confirm
+ * happens in the parent so this component stays presentational.
+ */
+export function CohortStatusPicker({ status, disabled = false, onChange, ariaLabel }: Props) {
+  const { t } = useTranslation()
+
+  const badge = (
+    <Badge
+      variant={STATUS_BADGE[status]}
+      className={cn(
+        "gap-1.5 select-none capitalize",
+        disabled && "cursor-default",
+        !disabled &&
+          "cursor-pointer transition-shadow hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      )}
+    >
+      {t(STATUS_I18N_KEY[status])}
+      {!disabled && <ChevronDown className="h-3 w-3 opacity-70" strokeWidth={1.75} aria-hidden />}
+    </Badge>
+  )
+
+  if (disabled) {
+    return badge
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild aria-label={ariaLabel}>
+        <button
+          type="button"
+          className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          {badge}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[10rem]">
+        {STATUS_ORDER.map((value) => {
+          const selected = value === status
+          return (
+            <DropdownMenuItem
+              key={value}
+              onSelect={() => {
+                if (!selected) onChange(value)
+              }}
+              className={cn(
+                "justify-between",
+                selected && "font-medium text-foreground",
+              )}
+            >
+              <span>{t(STATUS_I18N_KEY[value])}</span>
+              {selected && (
+                <Check className="h-3.5 w-3.5 text-primary" strokeWidth={1.75} aria-hidden />
+              )}
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/pages/Admin/cohorts/__tests__/CohortStatusPicker.test.tsx
+++ b/frontend/src/pages/Admin/cohorts/__tests__/CohortStatusPicker.test.tsx
@@ -1,0 +1,126 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { I18nextProvider } from "react-i18next"
+import { describe, it, expect, vi } from "vitest"
+
+import i18n from "@/i18n/config"
+import { CohortStatusPicker } from "@/pages/Admin/cohorts/CohortStatusPicker"
+
+/**
+ * The cohort-status badge IS the status picker — same RoleSelector pattern
+ * applied to ``Cohort["status"]``. Observable contract:
+ *
+ *   1. Current status's localized label is visible (badge text).
+ *   2. ``disabled`` collapses to a read-only badge — no trigger.
+ *   3. The menu lists statuses in canonical order:
+ *      upcoming → active → completed.
+ *   4. Picking a different status fires ``onChange(next)``.
+ *   5. Picking the current status does NOT fire ``onChange``.
+ *   6. The ``ariaLabel`` prop wires through to the trigger.
+ *
+ * Radix internals (positioning, focus, keyboard) are not retested here.
+ */
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+const renderOpts = { wrapper: Wrapper }
+
+describe("CohortStatusPicker", () => {
+  it("renders the current status's localized label", async () => {
+    await i18n.changeLanguage("en")
+    render(<CohortStatusPicker status="active" onChange={vi.fn()} />, renderOpts)
+    expect(screen.getByText("Active")).toBeInTheDocument()
+  })
+
+  it("renders a clickable trigger when not disabled", () => {
+    render(<CohortStatusPicker status="upcoming" onChange={vi.fn()} />, renderOpts)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+  })
+
+  it("renders no trigger when disabled (read-only badge)", () => {
+    render(
+      <CohortStatusPicker status="completed" disabled={true} onChange={vi.fn()} />,
+      renderOpts,
+    )
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("propagates ariaLabel to the trigger", () => {
+    render(
+      <CohortStatusPicker
+        status="upcoming"
+        onChange={vi.fn()}
+        ariaLabel="Change cohort status"
+      />,
+      renderOpts,
+    )
+    expect(
+      screen.getByRole("button", { name: "Change cohort status" }),
+    ).toBeInTheDocument()
+  })
+
+  it("opens the menu showing statuses in canonical order", async () => {
+    const user = userEvent.setup()
+    await i18n.changeLanguage("en")
+    render(<CohortStatusPicker status="upcoming" onChange={vi.fn()} />, renderOpts)
+
+    await user.click(screen.getByRole("button"))
+
+    const items = await screen.findAllByRole("menuitem")
+    expect(items.map((i) => i.textContent?.trim())).toEqual([
+      "Upcoming",
+      "Active",
+      "Completed",
+    ])
+  })
+
+  it("fires onChange when a different status is picked", async () => {
+    const user = userEvent.setup()
+    await i18n.changeLanguage("en")
+    const onChange = vi.fn()
+    render(
+      <CohortStatusPicker status="upcoming" onChange={onChange} />,
+      renderOpts,
+    )
+
+    await user.click(screen.getByRole("button"))
+    const activeItem = await screen.findByRole("menuitem", { name: "Active" })
+    await user.click(activeItem)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith("active")
+  })
+
+  it("does NOT fire onChange when the current status is picked", async () => {
+    const user = userEvent.setup()
+    await i18n.changeLanguage("en")
+    const onChange = vi.fn()
+    render(
+      <CohortStatusPicker status="active" onChange={onChange} />,
+      renderOpts,
+    )
+
+    await user.click(screen.getByRole("button"))
+    const activeItem = await screen.findByRole("menuitem", { name: "Active" })
+    await user.click(activeItem)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("renders the localized label under RU as well as EN", async () => {
+    await i18n.changeLanguage("ru")
+    render(
+      <CohortStatusPicker status="active" onChange={vi.fn()} />,
+      renderOpts,
+    )
+    // RU label is "Активный" / similar — we don't pin the exact string,
+    // just assert it's NOT the English one and is non-empty.
+    const buttons = screen.queryAllByRole("button")
+    const text = buttons[0]?.textContent ?? ""
+    expect(text).not.toMatch(/^\s*Active\s*$/i)
+    expect(text.trim().length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## What's now coherent

The cohort detail page used to render the current status **twice** — a coloured Badge in the page header (purely informational) and a `NativeSelect` inside the Details card 200 pixels lower (the actual editor). Two affordances for the same state, in two different visual languages, and you couldn't tell which one was the source of truth without trying to click the badge first.

This is the exact same anti-pattern that `RoleSelector` already fixed for the admin users table: the badge IS the picker. One affordance, one place to click.

## What changed

- New `CohortStatusPicker` component — Radix `DropdownMenu` + `Badge` with a chevron, mirroring `RoleSelector` so the two share visual language across admin surfaces. Tested for: localized label, disabled = read-only badge with no trigger, canonical menu order (`upcoming → active → completed`), `onChange` fires only on real change, `ariaLabel` plumbing, RU label rendering.
- `CohortDetailPage` header now uses `CohortStatusPicker`. The `NativeSelect` row in the Details card grid is gone.
- Side-effect: removing the Status row left a hole in the 2-column grid. Reordered fields so **Name + Max students** form the first row (the two text inputs) and the four date fields fill the 2×2 below. Tighter vertical rhythm than dates straddling rows.
- Header `<h1>` gained `text-wrap-safe` and the surrounding wrapper got `min-w-0` so very long cohort names don't push the picker off-screen.

## The feel I was going for

The status pill in the header was the *first* thing a user looked at — but the *last* place they could change it. Now those are the same place. The Details card becomes purely "structured metadata" (dates, capacity, name) and the page header carries the verb (status transition). Same intuition as the admin users table.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npx vitest run src/pages/Admin/cohorts` — 8 passed
- [ ] Manual: open `/admin/cohorts/<id>` as admin; click the status badge; menu opens with current status checked, picking another transitions and toasts; picking `completed` shows confirm; disabled state when saving
- [ ] Manual: RU locale — labels translate, dropdown order unchanged
- [ ] Manual: dark mode — badge contrast OK in both themes
- [ ] Manual: long cohort name doesn't push the picker off-screen on mobile

Co-author: Claude Opus 4.7 (1M context).

Generated with Claude Code.
