### PR TITLE
refactor(audit): use 'with db.begin_nested()' for implicit SAVEPOINT lifecycle

### DIFF
--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -11,7 +10,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from fastapi import Request
-    from sqlalchemy.orm import Session, SessionTransaction
+    from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
@@ -26,30 +25,32 @@ def log_action(
     request: Request | None = None,
 ) -> None:
     """Persist an audit log entry inside a SAVEPOINT so it never
-    interferes with the caller's transaction."""
-    nested: SessionTransaction | None = None
-    try:
-        ip_address: str | None = None
-        user_agent: str | None = None
-        if request is not None:
-            ip_address = get_client_ip(request)
-            user_agent = request.headers.get("user-agent", "")[:500]
+    interferes with the caller's transaction.
 
-        nested = db.begin_nested()
-        entry = AuditLog(
-            user_id=user_id,
-            action=action,
-            resource_type=resource_type,
-            resource_id=str(resource_id),
-            details=details,
-            ip_address=ip_address,
-            user_agent=user_agent,
-        )
-        db.add(entry)
-        db.flush()
-        nested.commit()
+    Failure here is non-fatal — audit-log writes must not crash the
+    request that triggered them. The ``with db.begin_nested()`` block
+    rolls the savepoint back on its own if the INSERT raises, leaving
+    the caller's outer transaction intact.
+    """
+    ip_address: str | None = None
+    user_agent: str | None = None
+    if request is not None:
+        ip_address = get_client_ip(request)
+        user_agent = request.headers.get("user-agent", "")[:500]
+
+    try:
+        with db.begin_nested():
+            db.add(
+                AuditLog(
+                    user_id=user_id,
+                    action=action,
+                    resource_type=resource_type,
+                    resource_id=str(resource_id),
+                    details=details,
+                    ip_address=ip_address,
+                    user_agent=user_agent,
+                )
+            )
+            db.flush()
     except Exception:
         logger.exception("Failed to write audit log")
-        if nested is not None:
-            with contextlib.suppress(Exception):
-                nested.rollback()


### PR DESCRIPTION
## Win in one sentence

`audit_service.log_action` is now easier to read because the SAVEPOINT lifecycle is managed by a `with` block instead of a hand-rolled nullable `SessionTransaction` + manual `commit()` / `contextlib.suppress(rollback)`.

## Summary

- Replaces manual SAVEPOINT bookkeeping with `with db.begin_nested():`, which is the form already used by every other call site (`api/v1/assignments.py:177`, `services/quiz_service.py:221`, `services/translation/orchestrator.py:329`).
- Drops `contextlib` import and the now-unused `SessionTransaction` type hint.
- Preserves the outer `try/except Exception` because audit-log failures must never propagate to the caller's request.
- Adds a short comment explaining the savepoint-rollback contract for the next reader.

## Net delta

`1 file changed, 27 insertions(+), 26 deletions(-)` - roughly net-neutral on lines, but the function no longer juggles a `nested` ref variable, no longer has two places that touch the savepoint, and stops importing `contextlib` for a single `suppress`.

## Tests

- `python -m pytest tests/` - 663 passed.
- `ruff check` / `ruff format --check` / `mypy` - clean.

## Test plan

- [x] All existing backend tests pass (663)
- [x] Ruff lint and format check clean
- [x] mypy clean
- [x] No new tests needed - behaviour preserving, single file, fully covered by existing audit-log tests

Generated with Claude Code.
