### PR TITLE
fix(db): certificates.course_id ON DELETE SET NULL + archived_course_title

### DIFF
--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -333,10 +333,15 @@ def verify_certificate(
         return CertificateVerifyResponse(valid=False, certificate_number=certificate_number)
 
     cert, user, course = row
+    # Fall back to ``archived_course_title`` (snapshotted by the
+    # BEFORE-DELETE trigger on ``courses``) when the source course has
+    # been deleted — the credential still has to verify even after the
+    # underlying course is gone.
+    course_title = course.title if course else cert.archived_course_title
     return CertificateVerifyResponse(
         valid=True,
         certificate_number=cert.certificate_number,
         user_name=user.full_name if user else None,
-        course_title=course.title if course else None,
+        course_title=course_title,
         issued_at=cert.issued_at,
     )

--- a/backend/app/models/certificate.py
+++ b/backend/app/models/certificate.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, UniqueConstraint, func
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -35,7 +35,14 @@ class Certificate(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column()
-    course_id: Mapped[str] = mapped_column(ForeignKey("courses.id", ondelete="CASCADE"))
+    # ``course_id`` is nullable so that deleting a course doesn't hard-delete
+    # the certificate row — the FK fires ``ON DELETE SET NULL`` and a Postgres
+    # trigger snapshots the course title into ``archived_course_title``,
+    # leaving the verify endpoint with enough metadata to keep rendering the
+    # credential after the source course is gone. See migration
+    # ``20260516020225_certificates_course_set_null_with_archive.sql``.
+    course_id: Mapped[str | None] = mapped_column(ForeignKey("courses.id", ondelete="SET NULL"), nullable=True)
+    archived_course_title: Mapped[str | None] = mapped_column(Text, nullable=True)
     issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
     certificate_number: Mapped[str | None] = mapped_column(String(50), unique=True)
     status: Mapped[str] = mapped_column(String(20), default="pending")

--- a/backend/app/schemas/certificate.py
+++ b/backend/app/schemas/certificate.py
@@ -9,7 +9,10 @@ class CertificateResponse(BaseModel):
 
     id: UUID
     user_id: UUID
-    course_id: str
+    # Nullable: the course this certificate was issued for may have been
+    # deleted. ``archived_course_title`` preserves the title for verification.
+    course_id: str | None = None
+    archived_course_title: str | None = None
     issued_at: datetime | None = None
     certificate_number: str | None = None
     status: str = "pending"

--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -68,14 +68,22 @@ def _load_cert_or_404(db: Session, cert_id: UUID, *, for_update: bool = False) -
 
 def _load_active_course_or_403(
     db: Session,
-    course_id: str,
+    course_id: str | None,
     *,
     ownership_detail: str,
 ) -> Course:
     """Load a non-deleted course. If it's gone, surface a 403 with the
     provided ownership-denied message — a missing course for a cert is
     indistinguishable to the caller from "you don't own it".
+
+    ``course_id`` is nullable on ``Certificate`` because the FK fires
+    ``ON DELETE SET NULL`` when the underlying course is hard-deleted (see
+    migration ``20260516020225``). An archived certificate can no longer be
+    teacher-approved or admin-approved — there's no course to verify
+    ownership against — so we collapse that to the same 403.
     """
+    if course_id is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ownership_detail)
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ownership_detail)

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -565,6 +565,58 @@ class TestVerifyCertificate:
         assert r.json()["valid"] is False
 
 
+class TestCertificateSurvivesCourseDeletion:
+    """Regression: deleting a course must not hard-delete its certificates.
+
+    Before migration ``20260516020225``, ``certificates.course_id`` was
+    ``ON DELETE CASCADE``, so a permanent course delete blew away every
+    issued certificate for that course — a publicly-shared verify URL
+    would silently become invalid. The fix flips the FK to ``SET NULL``
+    so the certificate row survives with ``course_id = NULL`` and a
+    snapshotted ``archived_course_title`` (populated by a Postgres
+    BEFORE-DELETE trigger; in SQLite we set it manually to mirror the
+    contract).
+    """
+
+    def test_course_delete_sets_course_id_null_and_preserves_cert(self, client: TestClient, db: Session) -> None:
+        _seed_enrolled_course(db, progress=100)
+        cert = _seed_certificate(db, "course-1", cert_status="approved")
+        cert.certificate_number = "CERT-SURVIVES01"
+        # Simulate what the production trigger does atomically — snapshot the
+        # course title into the certificate before the course row is deleted.
+        # The SQLAlchemy model owns this column now, so the test path
+        # validates the model + endpoint contract without needing Postgres.
+        course = db.query(Course).filter(Course.id == "course-1").first()
+        assert course is not None
+        cert.archived_course_title = course.title
+        db.commit()
+
+        # Cascade by hand for the SQLite test path: delete the dependent rows
+        # the migration drops via ``ON DELETE CASCADE`` on those FKs so we
+        # don't trip those constraints here. The point of *this* test is the
+        # certificate row, not the unrelated cascades.
+        db.query(Enrollment).filter(Enrollment.course_id == "course-1").delete()
+        db.query(Chapter).filter(Chapter.module_id == "course-1-mod").delete()
+        db.query(Module).filter(Module.course_id == "course-1").delete()
+        db.commit()
+        db.delete(course)
+        db.commit()
+
+        # The cert row must still be there, with course_id nulled.
+        surviving = db.query(Certificate).filter(Certificate.id == cert.id).first()
+        assert surviving is not None
+        assert surviving.course_id is None
+        assert surviving.archived_course_title == "Test Course"
+
+        # The public verify endpoint reads ``archived_course_title`` when
+        # ``course`` is no longer joinable — the credential keeps verifying.
+        r = client.get("/api/v1/certificates/verify/CERT-SURVIVES01")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["valid"] is True
+        assert body["course_title"] == "Test Course"
+
+
 class TestFullCertificateLifecycle:
     """Integration: seed → teacher-approve → admin-approve → verify."""
 

--- a/supabase/migrations/20260516020225_certificates_course_set_null_with_archive.sql
+++ b/supabase/migrations/20260516020225_certificates_course_set_null_with_archive.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- Certificate FK to courses: CASCADE → SET NULL, with archived_course_title.
+-- ----------------------------------------------------------------------------
+-- The certificate-verify URL (``/verify/{number}``) is a public credential
+-- recipients share with employers / committees. Previously, ``ON DELETE
+-- CASCADE`` on ``certificates.course_id`` meant that when an admin
+-- permanently deletes a course, every issued certificate for that course
+-- silently disappears from the DB — the verify URL would then resolve to
+-- ``valid=false`` and the recipient's credential would look fraudulent.
+--
+-- We switch to ``ON DELETE SET NULL`` so the certificate row survives the
+-- course deletion, *and* we materialise the historical course title into a
+-- new ``archived_course_title`` column so the verify endpoint can still
+-- render a meaningful "Course X — verified" page even after the source
+-- course is gone. The verify endpoint already does an OUTER JOIN against
+-- courses (``cert.outerjoin(Course, …)``) and renders ``course_title`` as a
+-- nullable string, so the surviving cert lands in a clean "course archived"
+-- state instead of breaking the response.
+--
+-- The ``(user_id, course_id)`` unique constraint is preserved: with course_id
+-- nullable, Postgres treats NULL as distinct under that constraint, which
+-- is the behaviour we want — a future, separately-keyed course re-using the
+-- same slug doesn't collide with an archived certificate.
+-- ============================================================================
+
+-- 1. Allow course_id to be NULL so SET NULL can fire.
+ALTER TABLE public.certificates
+  ALTER COLUMN course_id DROP NOT NULL;
+
+-- 2. Replace the cascade FK with SET NULL.
+ALTER TABLE public.certificates
+  DROP CONSTRAINT IF EXISTS certificates_course_id_fkey;
+
+ALTER TABLE public.certificates
+  ADD CONSTRAINT certificates_course_id_fkey
+    FOREIGN KEY (course_id) REFERENCES public.courses(id) ON DELETE SET NULL;
+
+-- 3. Capture the historical course title so the verify URL keeps working
+--    after the underlying course is deleted. Nullable on purpose: existing
+--    rows stay NULL until the course is deleted, at which point a trigger
+--    snapshots ``courses.title`` into this column (see step 4).
+ALTER TABLE public.certificates
+  ADD COLUMN IF NOT EXISTS archived_course_title TEXT;
+
+-- 4. BEFORE-DELETE trigger on courses: stamp the title into every certificate
+--    that points at the row being deleted, before SET NULL nulls course_id.
+--    Runs as ``SECURITY DEFINER`` with an empty ``search_path`` so it can't
+--    be hijacked by a malicious schema in the caller's search path (matches
+--    the lock_function_search_paths migration's pattern).
+CREATE OR REPLACE FUNCTION public.snapshot_certificate_course_title()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  UPDATE public.certificates
+    SET archived_course_title = OLD.title
+  WHERE course_id = OLD.id
+    AND archived_course_title IS NULL;
+  RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_snapshot_certificate_course_title ON public.courses;
+
+CREATE TRIGGER trg_snapshot_certificate_course_title
+  BEFORE DELETE ON public.courses
+  FOR EACH ROW
+  EXECUTE FUNCTION public.snapshot_certificate_course_title();
+
+-- 5. Lock down the helper function: only the table owner (postgres) executes
+--    it via the trigger machinery. No direct call surface needed.
+REVOKE ALL ON FUNCTION public.snapshot_certificate_course_title() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.snapshot_certificate_course_title() FROM anon;
+REVOKE ALL ON FUNCTION public.snapshot_certificate_course_title() FROM authenticated;


### PR DESCRIPTION
## Summary

- `certificates.course_id` was `ON DELETE CASCADE`: permanently deleting a course silently destroyed every certificate issued for it, breaking the public `/verify/{number}` URL that recipients share with employers.
- Flip the FK to `ON DELETE SET NULL` and add `archived_course_title TEXT`. A `BEFORE DELETE` trigger on `courses` snapshots the title into every certificate that points at the row before SET NULL nulls `course_id`, so the verify endpoint can keep rendering the credential ("Course X — verified") even after the source course is gone.
- `CertificateResponse.course_id` is now `str | None`; the verify endpoint falls back to `archived_course_title` when the joined course row is missing.

## Decision: SET NULL + archive vs RESTRICT

Picked **SET NULL + archive**. Rationale:

- The credential the recipient already shared keeps verifying. Migration `RESTRICT` would have forced admins to either (a) soft-delete every course (already what the regular UI does — soft delete is what most "delete" actions go through), or (b) manually find and reassign certs before being allowed to hard-delete.
- The verify endpoint already does an OUTER JOIN against courses (`outerjoin(Course, …)`) and renders `course_title` as nullable, so a SET NULL row drops into a clean "course archived" state instead of failing.
- The trigger is `SECURITY DEFINER` with empty `search_path` to match the lock-down pattern already established in `20260422215624_lock_function_search_paths.sql`.
- `(user_id, course_id)` unique constraint is preserved — Postgres treats NULL as distinct under unique constraints, so a future cert for the same user re-using the slug doesn't collide with an archived one.

## Files

- `supabase/migrations/20260516020225_certificates_course_set_null_with_archive.sql` — DROP NOT NULL on `course_id`, recreate FK as SET NULL, add `archived_course_title` column, create `snapshot_certificate_course_title` trigger.
- `backend/app/models/certificate.py` — `course_id: Mapped[str | None]`, `ondelete="SET NULL"`, new `archived_course_title` column.
- `backend/app/schemas/certificate.py` — `CertificateResponse.course_id` nullable; expose `archived_course_title`.
- `backend/app/api/v1/certificates.py` — `verify_certificate` falls back to archived title when the join misses.
- `backend/app/services/certificate_service.py` — `_load_active_course_or_403` accepts `str | None` and 403s if `course_id` is null (archived certs can't be re-approved).
- `backend/tests/test_certificates_and_grades.py` — regression: deleting a course preserves the certificate row, nulls `course_id`, and keeps the verify endpoint returning `valid=true` with the archived title.

## Test plan

- [x] Migration applied to prod-shape DB via Supabase MCP; constraint and column verified.
- [x] `python -m pytest tests/` → 664 passed (+1 new regression).
- [x] `python -m ruff check .` clean, `ruff format --check .` clean.
- [x] `python -m mypy --config-file mypy.ini app/` clean.
- [ ] Postgres schema-smoke CI job validates model ↔ migration sync.
