### PR TITLE
fix(i18n): apply translation overlay for admin + owner on remaining surfaces

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -88,11 +88,9 @@ def list_announcements(
 
     rows = query.order_by(Announcement.created_at.desc()).offset(skip).limit(limit).all()
 
-    # Admins see canonical source for moderation; everyone else (students,
-    # other teachers) gets the locale overlay if one exists.
-    if is_admin:
-        return [AnnouncementResponse.model_validate(a, from_attributes=True) for a in rows]
-
+    # Locale wins. Every reader — students, teachers, admins — gets the
+    # locale overlay when one exists. Moderators who need raw source
+    # content use the admin-only audit/edit surfaces, not this list.
     display_locale: LocaleCode = normalize_locale(accept_language)
     course_ids = [str(a.course_id) for a in rows if a.course_id]
     source_locales = _course_source_locale_map(db, course_ids)

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -34,7 +34,6 @@ def get_calendar_events(
     db: Session = Depends(get_db),
 ) -> list[CalendarEvent]:
     response.headers["Vary"] = "Accept-Language"
-    is_admin = current_user.role == UserRole.ADMIN.value
     display_locale: LocaleCode = normalize_locale(accept_language)
     enrolled_q = db.query(Enrollment.course_id).filter(Enrollment.user_id == current_user.id)
     if course_id:
@@ -136,10 +135,11 @@ def get_calendar_events(
 
     course_events = db.query(CourseEvent).filter(CourseEvent.course_id.in_(enrolled_course_ids)).all()
 
-    # Bulk-fetch overlay rows for every course_event title + non-empty description
-    # so non-admin students see the localized version. Admins always see source.
+    # Bulk-fetch overlay rows for every course_event title + non-empty
+    # description. Locale wins for every reader, including admins — moderators
+    # who need raw source content use admin-only audit/edit surfaces.
     overlay_event: dict[tuple[str, str, str], str] = {}
-    if not is_admin and course_events:
+    if course_events:
         specs: list[tuple[str, str, str]] = []
         for ce in course_events:
             specs.append(("course_event", str(ce.id), "title"))
@@ -149,30 +149,27 @@ def get_calendar_events(
 
     for ce in course_events:
         course_src = course_source_locales.get(ce.course_id, normalize_locale(None))
-        title = ce.title
-        description = ce.description
-        if not is_admin:
-            title = (
-                pick_overlay_value(
-                    overlay_event,
-                    "course_event",
-                    str(ce.id),
-                    "title",
-                    ce.title,
-                    source_locale=course_src,
-                    display_locale=display_locale,
-                )
-                or ce.title
-            )
-            description = pick_overlay_value(
+        title = (
+            pick_overlay_value(
                 overlay_event,
                 "course_event",
                 str(ce.id),
-                "description",
-                ce.description,
+                "title",
+                ce.title,
                 source_locale=course_src,
                 display_locale=display_locale,
             )
+            or ce.title
+        )
+        description = pick_overlay_value(
+            overlay_event,
+            "course_event",
+            str(ce.id),
+            "description",
+            ce.description,
+            source_locale=course_src,
+            display_locale=display_locale,
+        )
         events.append(
             CalendarEvent(
                 id=str(ce.id),
@@ -254,10 +251,9 @@ def list_course_events(
                 detail="You must be enrolled in this course to view events",
             )
     rows = db.query(CourseEvent).filter(CourseEvent.course_id == course_id).order_by(CourseEvent.event_date).all()
-    # Owner + admin see source for editorial accuracy; everyone else gets the
-    # locale overlay if the translation pipeline has materialised one.
-    if is_owner or is_admin:
-        return [CourseEventResponse.model_validate(e, from_attributes=True) for e in rows]
+    # Locale wins. Every reader — students, owners, admins — gets the locale
+    # overlay when one exists. Editors that need raw source must use dedicated
+    # authoring endpoints (the PUT/POST routes below operate on raw columns).
     display_locale: LocaleCode = normalize_locale(accept_language)
     source_locale: LocaleCode = normalize_locale(course_row.source_locale)
     return localize_course_event_rows(db, rows, display_locale=display_locale, source_locale=source_locale)

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -33,7 +33,7 @@ from app.core.database import get_db
 from app.models.cohort import Cohort, CohortCourse, CohortStatus
 from app.models.course import Course, CourseStatus
 from app.models.enrollment import Enrollment
-from app.models.user import User, UserRole
+from app.models.user import User
 from app.schemas.cohort import (
     CohortCourseAttach,
     CohortCreate,
@@ -549,11 +549,9 @@ def list_cohorts_for_course(
     if not cohorts:
         return []
 
-    is_owner = current_user is not None and str(course.created_by) == str(current_user.id)
-    is_admin = current_user is not None and current_user.role == UserRole.ADMIN.value
-    if is_owner or is_admin:
-        return _serialize_many(db, cohorts)
-
+    # Locale wins. Every reader — students, owners, admins — gets the locale
+    # overlay when one exists. The admin cohort CRUD surface (``/cohorts`` and
+    # ``/cohorts/{id}``) still returns source for moderation and editing.
     loc = Localizer.build(
         db,
         [("cohort", str(c.id), "title") for c in cohorts],


### PR DESCRIPTION
## Summary
Follow-up audit to PR #340. The primary fix flipped `should_apply_course_translation_overlay` to always return True, but three endpoints had their own inline `is_owner / is_admin` short-circuit that bypassed the function and returned raw source columns. This PR closes those gaps.

## Surfaces fixed
- `GET /api/v1/announcements` — skipped overlay for admin.
- `GET /api/v1/calendar/events` — skipped overlay for admin on the `course_event` rows in the merged feed.
- `GET /api/v1/courses/{course_id}/events` — skipped overlay for owner and admin.
- `GET /api/v1/cohorts/course/{course_id}` — skipped cohort-name overlay for owner and admin.

All four now overlay for every reader. Editors that need raw source should use the dedicated authoring endpoints, which all live behind `require_teacher` / `require_admin` and never touch `resolve_for_display`.

## Surfaces already correct (audit confirmation)
- `GET /api/v1/quizzes/chapter/{chapter_id}` → `build_localized_quiz_student_response`
- `GET /api/v1/assignments/chapter/{chapter_id}` → `localize_assignment_rows`
- `GET /api/v1/blocks/chapter/{chapter_id}` → `localize_chapter_block_rows`
- `GET /api/v1/courses` → `build_localized_course_summary`
- `GET /api/v1/courses/{course_id}` → `build_localized_course_response_with_tree`
- `GET /api/v1/courses/{course_id}/modules/{module_id}` → `build_localized_module_response`
- `GET /api/v1/users/me/courses` → `build_localized_course_summary`
- `GET /api/v1/certificates/course/{course_id}` + `/my` → `_localize_cert_responses`
- `GET /api/v1/prerequisites/course/{course_id}` → `_localized_title_map`

The static coverage guard in `test_translation_coverage` keeps every GET endpoint returning a translatable schema in this contract.

## Intentionally not changed
- `GET /api/v1/courses/my` and `/courses/my/trash` — teacher dashboard endpoints, `require_teacher`, return source columns by design (editor list).
- `GET /api/v1/cohorts` / `/cohorts/{id}` — admin CRUD, `require_admin`, source columns by design (moderator surfaces).
- `GET /api/v1/certificates/pending` and `/admin/pending` — teacher/admin gates, source columns by design.

## Test plan
- [x] `pytest tests/` — 663 passed
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] `mypy --config-file mypy.ini` — clean
- [x] `npm run i18n:check` — locale parity OK

## Sequencing
This PR is independent of #340 — both branch off `main`, both touch disjoint files. If #340 lands first, the indirect call sites that delegate to `should_apply_course_translation_overlay` (e.g. `users.get_my_courses`, `blocks.list_blocks`, `assignments.list_chapter_assignments`, `quizzes.get_chapter_quiz`) auto-flip via that single-function change. This PR catches the four surfaces that bypass that function with their own inline check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
