### PR TITLE
fix(model+sec): declare cohort_id FK on certificate model; sanitize course-event input

### DIFF
--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_teacher, verify_course_owner
 from app.core.database import get_db
+from app.core.sanitize import sanitize_string
 from app.models.assignment import Assignment
 from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent
@@ -205,10 +206,16 @@ def create_course_event(
     db: Session = Depends(get_db),
 ) -> CourseEvent:
     verify_course_owner(db, course_id, teacher)
+    # Defence-in-depth: the frontend strips HTML before submit, but a direct
+    # API caller can post arbitrary markup. Same shape as
+    # ``announcements.create`` and ``courses.create`` — title is a plain
+    # short string, description may carry rich content (TipTap output),
+    # both go through ``sanitize_string`` which keeps the allowlisted tags
+    # and drops anything that could turn into stored XSS at render time.
     event = CourseEvent(
         course_id=course_id,
-        title=data.title,
-        description=data.description,
+        title=sanitize_string(data.title),
+        description=sanitize_string(data.description) if data.description else data.description,
         event_type=data.event_type,
         event_date=data.event_date,
         created_by=teacher.id,

--- a/backend/app/models/certificate.py
+++ b/backend/app/models/certificate.py
@@ -44,4 +44,10 @@ class Certificate(Base):
     teacher_approved_by: Mapped[uuid.UUID | None] = mapped_column()
     admin_approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     admin_approved_by: Mapped[uuid.UUID | None] = mapped_column()
-    cohort_id: Mapped[uuid.UUID | None] = mapped_column()
+    # ``cohort_id`` carries an FK to ``cohorts.id`` with ``ON DELETE SET NULL``
+    # — cohorts are metadata, not a load-bearing identity for the cert, so
+    # deleting a cohort must not destroy issued certs. The constraint already
+    # lives in prod; the model just never declared it, leaving the CI
+    # schema-smoke job blind to the relationship. See migration
+    # ``20260516021349_certificates_cohort_fk_ensure.sql``.
+    cohort_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("cohorts.id", ondelete="SET NULL"), nullable=True)

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -855,6 +855,30 @@ class TestCreateCourseEvent:
         )
         assert resp.status_code == 422
 
+    def test_create_strips_script_tag_from_title_and_description(self, client: TestClient):
+        """Regression: ``create_course_event`` must run user-supplied title /
+        description through ``sanitize_string`` so a direct API caller can't
+        store ``<script>`` or other dangerous markup that would later render
+        verbatim in the calendar or course-event list. The frontend already
+        sanitises before POSTing, but server-side is the defence-in-depth
+        layer — same shape as ``announcements.create``."""
+        course = _create_course_via_api(client)
+        resp = client.post(
+            f"{COURSES_PREFIX}/{course['id']}/events",
+            json=_event_payload(
+                title='Exam <script>alert(1)</script> <img src=x onerror="x()"> Time',
+                description='Be ready<a href="javascript:steal()">x</a>.',
+            ),
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        # The sanitiser drops ``<script>`` tags, on* event handlers, and
+        # javascript: URLs — that's the XSS-execution surface. Visible
+        # plain text the user typed around the tags is preserved.
+        assert "<script>" not in body["title"]
+        assert "onerror" not in body["title"]
+        assert "javascript:" not in body["description"]
+
 
 class TestListCourseEvents:
     def test_owner_can_list(self, client: TestClient):

--- a/supabase/migrations/20260516021349_certificates_cohort_fk_ensure.sql
+++ b/supabase/migrations/20260516021349_certificates_cohort_fk_ensure.sql
@@ -1,0 +1,31 @@
+-- ============================================================================
+-- Ensure ``certificates.cohort_id`` carries a FK to ``cohorts(id)``.
+-- ----------------------------------------------------------------------------
+-- Audit found: the SQLAlchemy model declared ``cohort_id`` as a plain
+-- ``Mapped[uuid.UUID | None]`` with no ``ForeignKey(…)``, so the CI
+-- schema-smoke job that materialises models against a fresh Postgres did
+-- not emit the FK either. The live prod DB does have a FK
+-- (``certificates_cohort_id_fkey`` ON DELETE SET NULL), added implicitly
+-- during the cohort-top-level rollout, but we want the model + smoke to
+-- agree so the next person reading the schema doesn't see an orphan-risk
+-- column.
+--
+-- This migration is idempotent: if the constraint is already in place
+-- (current prod), it's a no-op; if it was somehow dropped or absent on a
+-- branch DB, we recreate it with the desired shape.
+-- ============================================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'certificates_cohort_id_fkey'
+      AND conrelid = 'public.certificates'::regclass
+  ) THEN
+    ALTER TABLE public.certificates
+      ADD CONSTRAINT certificates_cohort_id_fkey
+        FOREIGN KEY (cohort_id) REFERENCES public.cohorts(id) ON DELETE SET NULL;
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary

Two small backend-audit follow-ups bundled together because each is a single file plus one regression test:

**(1) `certificates.cohort_id` model FK sync.** Live DB has `certificates_cohort_id_fkey` (`ON DELETE SET NULL`) but the SQLAlchemy model declared the column as a bare `Mapped[uuid.UUID | None]` with no `ForeignKey(...)`. The CI schema-smoke job was therefore creating a Postgres schema that *lacked* this FK, masking the existence of the constraint from anyone reading the model. Sync the model and add an idempotent migration that ensures the constraint exists with the same shape (no-op on current prod, safe to apply to a branch / smoke DB).

**(2) `/api/v1/courses/{id}/events` POST: sanitize_string on title + description.** The frontend already DOMPurify's before sending, but every other creation surface (announcements, courses, blocks, chapters) treats server-side sanitisation as defence-in-depth — direct API callers and imported content must not store stored-XSS markup. One-line wrap on each field; matches the shape of `app.api.v1.announcements.create_announcement`.

## Files

- `supabase/migrations/20260516021349_certificates_cohort_fk_ensure.sql` — `DO` block: add the FK if absent, leave alone if present.
- `backend/app/models/certificate.py` — `cohort_id` now declares `ForeignKey("cohorts.id", ondelete="SET NULL")`.
- `backend/app/api/v1/calendar.py` — `create_course_event` wraps `title` and `description` in `sanitize_string` (skipping the call when description is `None`).
- `backend/tests/test_cohorts_calendar_notifications.py` — regression: posting `<script>`, `onerror=`, and `javascript:` payloads results in stored content stripped of the dangerous markup.

## Test plan

- [x] Migration applied to prod via Supabase MCP; no-op as expected.
- [x] `python -m pytest tests/` → 664 passed (+1 new sanitize test, same `_event_payload` helper).
- [x] `python -m ruff check .` clean, `ruff format --check .` clean.
- [x] `python -m mypy --config-file mypy.ini app/` clean.
- [ ] Postgres schema-smoke CI now emits the cohort FK because the model declares it.
