### PR TITLE
refactor(courses): centralize cache-invalidation graph into 3 named helpers

### DIFF
--- a/frontend/src/services/courses.ts
+++ b/frontend/src/services/courses.ts
@@ -29,6 +29,30 @@ import { analyticsService } from "./analytics"
  * keep working during migration. New code should import the specific
  * per-domain service (e.g. `import { quizzesService } from "./quizzes"`).
  */
+
+// ─── Cache invalidation helpers ─────────────────────────────────────────
+// Mutations to courses/modules/chapters have to nudge several keys in
+// lockstep — these three helpers centralize the "graph" so the picture
+// of which mutation invalidates what is in one place.
+
+/** Course list pages (search-scoped and teacher-scoped). Touched by any course mutation. */
+function invalidateCourseLists(): void {
+  cacheInvalidatePrefix("courses:list:")
+  cacheInvalidate("courses:teacher")
+}
+
+/** A specific course's detail and a specific module's snapshot. Touched by module/chapter mutations. */
+function invalidateModuleScope(courseId: string, moduleId: string): void {
+  cacheInvalidate(`courses:detail:${courseId}`)
+  cacheInvalidate(`courses:module:${courseId}:${moduleId}`)
+}
+
+/** All modules under a course plus the course's detail. Used when wiping a whole course. */
+function invalidateAllModulesUnderCourse(courseId: string): void {
+  cacheInvalidate(`courses:detail:${courseId}`)
+  cacheInvalidatePrefix(`courses:module:${courseId}:`)
+}
+
 const courseCrud = {
   async getCourses(search?: string): Promise<Course[]> {
     const key = `courses:list:${search ?? ""}`
@@ -62,8 +86,7 @@ const courseCrud = {
     data: { title: string; description?: string; image_url?: string },
   ): Promise<Course> {
     const response = await api.post<Course>("/courses", data)
-    cacheInvalidatePrefix("courses:list:")
-    cacheInvalidate("courses:teacher")
+    invalidateCourseLists()
     return response.data
   },
 
@@ -81,17 +104,14 @@ const courseCrud = {
   ): Promise<Course> {
     const response = await api.put<Course>(`/courses/${id}`, data)
     cacheInvalidate(`courses:detail:${id}`)
-    cacheInvalidatePrefix("courses:list:")
-    cacheInvalidate("courses:teacher")
+    invalidateCourseLists()
     return response.data
   },
 
   async deleteCourse(id: string): Promise<void> {
     await api.delete(`/courses/${id}`)
-    cacheInvalidate(`courses:detail:${id}`)
-    cacheInvalidatePrefix("courses:list:")
-    cacheInvalidatePrefix(`courses:module:${id}:`)
-    cacheInvalidate("courses:teacher")
+    invalidateAllModulesUnderCourse(id)
+    invalidateCourseLists()
   },
 
   async getTrashedCourses(): Promise<Course[]> {
@@ -101,23 +121,19 @@ const courseCrud = {
 
   async restoreCourse(id: string): Promise<Course> {
     const response = await api.post<Course>(`/courses/${id}/restore`)
-    cacheInvalidatePrefix("courses:list:")
-    cacheInvalidate("courses:teacher")
+    invalidateCourseLists()
     return response.data
   },
 
   async permanentlyDeleteCourse(id: string): Promise<void> {
     await api.delete(`/courses/${id}/permanent`)
-    cacheInvalidate(`courses:detail:${id}`)
-    cacheInvalidatePrefix("courses:list:")
-    cacheInvalidatePrefix(`courses:module:${id}:`)
-    cacheInvalidate("courses:teacher")
+    invalidateAllModulesUnderCourse(id)
+    invalidateCourseLists()
   },
 
   async cloneCourse(id: string): Promise<Course> {
     const response = await api.post<Course>(`/courses/${id}/clone`)
-    cacheInvalidatePrefix("courses:list:")
-    cacheInvalidate("courses:teacher")
+    invalidateCourseLists()
     return response.data
   },
 
@@ -135,8 +151,7 @@ const courseCrud = {
     data: { title: string; description?: string; order_index?: number },
   ): Promise<Module> {
     const response = await api.post<Module>(`/courses/${courseId}/modules`, data)
-    cacheInvalidate(`courses:detail:${courseId}`)
-    cacheInvalidatePrefix(`courses:module:${courseId}:`)
+    invalidateAllModulesUnderCourse(courseId)
     return response.data
   },
 
@@ -154,15 +169,13 @@ const courseCrud = {
       `/courses/${courseId}/modules/${moduleId}`,
       data,
     )
-    cacheInvalidate(`courses:detail:${courseId}`)
-    cacheInvalidate(`courses:module:${courseId}:${moduleId}`)
+    invalidateModuleScope(courseId, moduleId)
     return response.data
   },
 
   async deleteModule(courseId: string, moduleId: string): Promise<void> {
     await api.delete(`/courses/${courseId}/modules/${moduleId}`)
-    cacheInvalidate(`courses:detail:${courseId}`)
-    cacheInvalidate(`courses:module:${courseId}:${moduleId}`)
+    invalidateModuleScope(courseId, moduleId)
   },
 
   async createChapter(
@@ -174,8 +187,7 @@ const courseCrud = {
       `/courses/${courseId}/modules/${moduleId}/chapters`,
       data,
     )
-    cacheInvalidate(`courses:detail:${courseId}`)
-    cacheInvalidate(`courses:module:${courseId}:${moduleId}`)
+    invalidateModuleScope(courseId, moduleId)
     return response.data
   },
 
@@ -195,8 +207,7 @@ const courseCrud = {
       `/courses/${courseId}/modules/${moduleId}/chapters/${chapterId}`,
       data,
     )
-    cacheInvalidate(`courses:detail:${courseId}`)
-    cacheInvalidate(`courses:module:${courseId}:${moduleId}`)
+    invalidateModuleScope(courseId, moduleId)
     return response.data
   },
 
@@ -208,8 +219,7 @@ const courseCrud = {
     await api.delete(
       `/courses/${courseId}/modules/${moduleId}/chapters/${chapterId}`,
     )
-    cacheInvalidate(`courses:detail:${courseId}`)
-    cacheInvalidate(`courses:module:${courseId}:${moduleId}`)
+    invalidateModuleScope(courseId, moduleId)
   },
 }
 


### PR DESCRIPTION
## Win in one sentence

`courses.ts` mutations now document their cache impact in one named line each, because the three repeating invalidation chains live in named helpers at the top of the file instead of being copy-pasted into 13 method bodies.

## Summary

Three invalidation patterns recurred across 13 mutation methods in `frontend/src/services/courses.ts`:

- `cacheInvalidatePrefix("courses:list:") + cacheInvalidate("courses:teacher")` -> `invalidateCourseLists()` (6 callers)
- `cacheInvalidate("courses:detail:${courseId}") + cacheInvalidate("courses:module:${courseId}:${moduleId}")` -> `invalidateModuleScope(courseId, moduleId)` (5 callers)
- `cacheInvalidate("courses:detail:${courseId}") + cacheInvalidatePrefix("courses:module:${courseId}:")` -> `invalidateAllModulesUnderCourse(courseId)` (3 callers)

Each helper has a short comment explaining what scope it covers and what triggers it, so the cache-graph picture lives in one place.

## Net delta

`1 file changed, 38 insertions(+), 28 deletions(-)` - +10 net. The extra lines are the three helper definitions + their explanatory comments; the inline call sites shrink from 2-4 lines each down to one.

## Tests

- `npm run test:run` - 210 passed.
- `npx tsc --noEmit` - clean.
- `npm run lint` - zero warnings.
- No new tests needed; the invalidation chains are exercised by existing service tests and the helpers are pure shorthand.

## Test plan

- [x] All frontend tests pass
- [x] Lint and typecheck clean
- [x] Behaviour-preserving: every caller still invalidates the same exact keys

Generated with Claude Code.
