### PR TITLE
design(gradebook): tighten table rhythm + sticky-column scroll shadow

### DIFF
--- a/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { EmptyState } from "@/components/patterns"
 import {
   BookOpen, Users, Circle, CheckCircle2,
   ChevronDown, ChevronRight, Award, MessageSquare, Save,
@@ -60,9 +61,12 @@ export function GradeTableTab({
   if (!progressData) {
     return (
       <Card>
-        <CardContent className="py-12 text-center">
-          <BookOpen className="h-10 w-10 text-muted-foreground/30 mx-auto mb-3" strokeWidth={1.75} />
-          <p className="text-sm text-muted-foreground">{t("gradebook.failedLoad")}</p>
+        <CardContent className="py-10">
+          <EmptyState
+            variant="compact"
+            icon={<BookOpen strokeWidth={1.75} aria-hidden />}
+            title={t("gradebook.failedLoad")}
+          />
         </CardContent>
       </Card>
     )
@@ -71,9 +75,12 @@ export function GradeTableTab({
   if (tableStudents.length === 0) {
     return (
       <Card>
-        <CardContent className="py-12 text-center">
-          <Users className="h-10 w-10 text-muted-foreground/30 mx-auto mb-3" strokeWidth={1.75} />
-          <p className="text-sm text-muted-foreground">{t("gradebook.summary.empty")}</p>
+        <CardContent className="py-10">
+          <EmptyState
+            variant="compact"
+            icon={<Users strokeWidth={1.75} aria-hidden />}
+            title={t("gradebook.summary.empty")}
+          />
         </CardContent>
       </Card>
     )
@@ -119,6 +126,14 @@ export function GradeTableTab({
   )
 }
 
+// Sticky student-column shadow that hints "this column is pinned" even when
+// the user hasn't scrolled yet. ``inset-y-0 right-0 -mr-px w-2`` paints a
+// 2-px wide gradient strip on the column's right edge; soft enough to fade
+// into the table border when stationary, strong enough to read as depth
+// when content scrolls underneath.
+const STICKY_COL_SHADOW =
+  "after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-2 after:-mr-2 after:bg-gradient-to-r after:from-foreground/[0.06] after:to-transparent"
+
 function GradeTableHead({
   orderedModules,
   moduleChapterMap,
@@ -132,7 +147,9 @@ function GradeTableHead({
   return (
     <thead>
       <tr>
-        <th className="sticky left-0 z-10 bg-card border-b border-r px-3 py-2 text-left font-semibold text-sm w-44 min-w-[11rem]">
+        <th
+          className={`sticky left-0 z-10 bg-muted/40 border-b border-r px-3 py-2 text-left font-semibold text-sm w-44 min-w-[11rem] relative ${STICKY_COL_SHADOW}`}
+        >
           {t("gradebook.table.thStudent")}
         </th>
         {orderedModules.map((mod) => {
@@ -148,12 +165,15 @@ function GradeTableHead({
             </th>
           )
         })}
-        <th className="border-b px-2 py-2 text-center font-semibold bg-muted/40 w-20">
+        <th className="border-b border-r px-2 py-2 text-center font-semibold bg-muted/40 w-20">
           {t("gradebook.table.thTotal")}
         </th>
       </tr>
       <tr>
-        <th className="sticky left-0 z-10 bg-card border-b border-r" />
+        <th
+          className={`sticky left-0 z-10 bg-muted/20 border-b border-r relative ${STICKY_COL_SHADOW}`}
+          aria-hidden
+        />
         {allChapters.map((ch) => (
           <th
             key={ch.id}
@@ -166,7 +186,7 @@ function GradeTableHead({
             </div>
           </th>
         ))}
-        <th className="border-b px-1 py-1.5 bg-muted/20" />
+        <th className="border-b border-r px-1 py-1.5 bg-muted/20" aria-hidden />
       </tr>
     </thead>
   )
@@ -211,10 +231,12 @@ const GradeTableRow = memo(function GradeTableRow({
   return (
     <Fragment>
       <tr
-        className="hover:bg-muted/20 cursor-pointer transition-colors"
+        className="group hover:bg-muted/20 cursor-pointer transition-colors"
         onClick={() => onToggleExpand(student.id)}
       >
-        <td className="sticky left-0 z-10 bg-card border-b border-r px-3 py-2 font-medium">
+        <td
+          className={`sticky left-0 z-10 bg-card group-hover:bg-muted/40 border-b border-r px-3 py-2 font-medium relative transition-colors ${STICKY_COL_SHADOW}`}
+        >
           <div className="flex items-center gap-1.5 min-w-0">
             {expanded ? (
               <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" strokeWidth={1.75} />


### PR DESCRIPTION
## What's now coherent

The Grade Table tab is the densest screen in the app — students × chapters, sticky student column on the left, two-row header (modules above, chapters below), totals on the right. The skeleton was right. Several small inconsistencies were fighting it:

- The sticky student-column cells used `bg-card` while the surrounding header rows used `bg-muted/40` and `bg-muted/20`. When you scrolled horizontally the sticky column became a visually lighter strip in the middle of darker headers — looked like a missing fill, not a feature.
- The `Total` column header in the second row was an empty `<th>` with `bg-muted/20` and no `border-r` — a visual gap next to the chapters.
- Row hover stopped at the sticky cell. Hovering anywhere in a row tinted the chapters but the student name cell stayed white. Killed the row-as-unit feel.
- The "no data" branches both rendered ad-hoc centered cards with a dimmed icon — different visual language than the project's `EmptyState` pattern that the Summary tab already uses.

## What changed

- Sticky header cells now match the header row tint they sit in (`bg-muted/40` for the module row, `bg-muted/20` for the chapter row). Body cells keep `bg-card` so the student name stays legible over scrolling colour cells underneath.
- CSS-only scroll shadow on every sticky column cell — a soft `after`-pseudo gradient on the right edge that reads as pinned chrome when stationary and as depth when content slides under it. No scroll listener, no JS.
- The `Total` column gets `border-r` in the second header row too. Vertical lines now run unbroken across the whole table.
- Row hover propagates to the sticky cell via `group-hover`: the whole row tints together.
- Replaced both "no data" cards with `EmptyState` (compact). All three empty paths in the gradebook (summary tab, table tab no-data, table tab no-students) now share one visual language.

## The feel I was going for

A spreadsheet that *feels* like a spreadsheet. Sticky columns should look pinned. Header rows should look like header rows. The user's eye should be able to walk a single horizontal line of cells without the sticky column being a discontinuity in the middle. It's the same instinct as Excel's frozen-pane shadow — but lighter, semantic-token coloured, and CSS-only.

## What I left alone (and why)

- The two-row header structure (modules row + chapters row). It's the right answer for nested headers; only the colours needed work.
- The `CardTitle text-base` / `CardDescription text-xs` overrides on the table card. They look intentional for a dense surface — making it `text-lg` would compete with the table itself.
- The cell-level colour logic (success/destructive/info/warning tint per cell type). That's the data; the chrome was the problem.
- The legend at the bottom. Already good.
- The expanded-row form (override grade + comment + Save). Density is fine, it's a sometimes-affordance.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npx vitest run src/pages/Teacher/gradebook` — 3 passed
- [x] `npm run test:run` — 210 passed across 26 files
- [ ] Manual: `/teacher/courses/<id>/gradebook?tab=table` — scroll horizontally, watch the sticky student column hold position and cast a soft right shadow
- [ ] Manual: hover a row — whole row tints including the student name cell
- [ ] Manual: course with zero students — `EmptyState` renders instead of ad-hoc card
- [ ] Manual: dark mode — sticky column and shadow contrast OK

Co-author: Claude Opus 4.7 (1M context).

Generated with Claude Code.
