### PR TITLE
refactor(readiness): factor open_quiz / open_assignment action builders

### DIFF
--- a/backend/app/services/course_readiness.py
+++ b/backend/app/services/course_readiness.py
@@ -152,6 +152,20 @@ def _open_chapter_action(chapter: Chapter) -> ReadinessAction:
     )
 
 
+def _open_quiz_action(chapter: Chapter) -> ReadinessAction:
+    return ReadinessAction(
+        type="open_quiz",
+        params={"module_id": chapter.module_id, "chapter_id": chapter.id},
+    )
+
+
+def _open_assignment_action(chapter: Chapter) -> ReadinessAction:
+    return ReadinessAction(
+        type="open_assignment",
+        params={"module_id": chapter.module_id, "chapter_id": chapter.id},
+    )
+
+
 # ─── Main entry point ───────────────────────────────────────────────────
 
 
@@ -297,10 +311,7 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
                             else "courseReadiness.checks.quizHasQuestion"
                         ),
                         subject=_make_chapter_subject(chapter),
-                        action=ReadinessAction(
-                            type="open_quiz",
-                            params={"module_id": chapter.module_id, "chapter_id": chapter.id},
-                        ),
+                        action=_open_quiz_action(chapter),
                     )
                 )
                 if quiz is not None:
@@ -312,10 +323,7 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
                             passed=not bad_questions,
                             message_key="courseReadiness.checks.quizQuestionsComplete",
                             subject=_make_chapter_subject(chapter),
-                            action=ReadinessAction(
-                                type="open_quiz",
-                                params={"module_id": chapter.module_id, "chapter_id": chapter.id},
-                            ),
+                            action=_open_quiz_action(chapter),
                         )
                     )
 
@@ -329,10 +337,7 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
                         passed=assignment is not None and bool((assignment.description or "").strip()),
                         message_key="courseReadiness.checks.assignmentHasBrief",
                         subject=_make_chapter_subject(chapter),
-                        action=ReadinessAction(
-                            type="open_assignment",
-                            params={"module_id": chapter.module_id, "chapter_id": chapter.id},
-                        ),
+                        action=_open_assignment_action(chapter),
                     )
                 )
 


### PR DESCRIPTION
## Win in one sentence

`compute_readiness` checks now read uniformly because every deep-link action is built by a one-line helper (`_open_chapter_action`, `_open_quiz_action`, `_open_assignment_action`), instead of inlining the same `ReadinessAction(type=..., params={module_id, chapter_id})` shape three different times.

## Summary

The file already had `_open_chapter_action(chapter)` extracted as a helper for the reading-chapter check, but the quiz/exam check, the quiz-questions-complete check, and the assignment-has-brief check still constructed the same `ReadinessAction` shape inline. This adds the two missing sibling helpers and uses them at all three call sites.

## Net delta

`1 file changed, 17 insertions(+), 12 deletions(-)` - +5 net (two small helper definitions); the body of `compute_readiness` reads more uniformly because every check looks like `action=_open_X_action(chapter)`.

## Tests

- `python -m pytest tests/test_course_readiness.py` - 25 passed.
- `python -m pytest tests/` - 663 passed.
- `ruff check` / `ruff format --check` / `mypy` - clean.

## Test plan

- [x] All 25 course-readiness tests pass unchanged
- [x] Full backend test suite passes
- [x] Ruff and mypy clean
- [x] Behaviour preserving; the constructed `ReadinessAction` objects are byte-for-byte identical

Generated with Claude Code.
