### PR TITLE
fix(audit): log every admin cohort write action

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -23,7 +23,7 @@ the top-level admin UI.
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -42,6 +42,7 @@ from app.schemas.cohort import (
     CohortUpdate,
 )
 from app.schemas.locale import normalize_locale
+from app.services.audit_service import log_action
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import Localizer
 
@@ -137,6 +138,7 @@ def list_cohorts(
 @router.post("", response_model=CohortResponse, status_code=status.HTTP_201_CREATED)
 def create_cohort(
     data: CohortCreate,
+    request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> CohortResponse:
@@ -155,6 +157,15 @@ def create_cohort(
     db.add(cohort)
     db.commit()
     db.refresh(cohort)
+    log_action(
+        db,
+        admin.id,
+        "create",
+        "cohort",
+        str(cohort.id),
+        details={"name": cohort.name},
+        request=request,
+    )
     return _serialize(db, cohort)
 
 
@@ -201,6 +212,7 @@ def update_cohort(
 @router.delete("/{cohort_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_cohort(
     cohort_id: UUID,
+    request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> None:
@@ -209,13 +221,24 @@ def delete_cohort(
     ``cohort_id`` set to NULL (``ON DELETE SET NULL`` on the FK) — that
     way historical grade data is preserved as orphaned solo enrollments."""
     cohort = _get_or_404(db, cohort_id)
+    cohort_name = cohort.name
     db.delete(cohort)
     db.commit()
+    log_action(
+        db,
+        admin.id,
+        "delete",
+        "cohort",
+        str(cohort_id),
+        details={"name": cohort_name},
+        request=request,
+    )
 
 
 @router.post("/{cohort_id}/complete", response_model=CohortResponse)
 def complete_cohort(
     cohort_id: UUID,
+    request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> CohortResponse:
@@ -228,6 +251,15 @@ def complete_cohort(
     cohort.status = CohortStatus.COMPLETED
     db.commit()
     db.refresh(cohort)
+    log_action(
+        db,
+        admin.id,
+        "complete",
+        "cohort",
+        str(cohort.id),
+        details={"name": cohort.name},
+        request=request,
+    )
     return _serialize(db, cohort)
 
 
@@ -252,6 +284,7 @@ def list_cohort_courses(
 def attach_course(
     cohort_id: UUID,
     body: CohortCourseAttach,
+    request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> CohortResponse:
@@ -320,6 +353,15 @@ def attach_course(
         # A concurrent attach raced us; safe to roll back and re-read.
         db.rollback()
     db.refresh(cohort)
+    log_action(
+        db,
+        admin.id,
+        "attach_course",
+        "cohort",
+        str(cohort.id),
+        details={"course_id": course.id},
+        request=request,
+    )
     reconcile_entity_if_course_published(db, "cohort", cohort)
     return _serialize(db, cohort)
 
@@ -331,6 +373,7 @@ def attach_course(
 def detach_course(
     cohort_id: UUID,
     course_id: str,
+    request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> None:
@@ -349,6 +392,15 @@ def detach_course(
     ).update({Enrollment.cohort_id: None}, synchronize_session=False)
     db.delete(link)
     db.commit()
+    log_action(
+        db,
+        admin.id,
+        "detach_course",
+        "cohort",
+        str(cohort.id),
+        details={"course_id": course_id},
+        request=request,
+    )
 
 
 # ---------------------- junction: cohort x students -------------------
@@ -401,6 +453,7 @@ def list_cohort_students(
 def add_student(
     cohort_id: UUID,
     body: CohortStudentAdd,
+    request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> dict:
@@ -491,6 +544,15 @@ def add_student(
         db.commit()
     except IntegrityError:
         db.rollback()
+    log_action(
+        db,
+        admin.id,
+        "add_student",
+        "cohort",
+        str(cohort.id),
+        details={"user_id": str(user.id), "email": user.email, "course_count": len(course_ids)},
+        request=request,
+    )
     return {"user_id": str(user.id), "course_ids": course_ids}
 
 
@@ -501,6 +563,7 @@ def add_student(
 def remove_student(
     cohort_id: UUID,
     user_id: UUID,
+    request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> None:
@@ -511,6 +574,15 @@ def remove_student(
         {Enrollment.cohort_id: None}, synchronize_session=False
     )
     db.commit()
+    log_action(
+        db,
+        admin.id,
+        "remove_student",
+        "cohort",
+        str(cohort.id),
+        details={"user_id": str(user_id)},
+        request=request,
+    )
 
 
 # -------------------------- public-ish read ---------------------------

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -726,6 +726,151 @@ class TestCompleteCohort:
         assert resp.status_code == 403
 
 
+class TestCohortWriteActionsAreAudited:
+    """Every admin-only cohort write surface must leave a paper trail.
+
+    Regression: ``cohorts.py`` previously skipped ``audit_service.log_action``
+    on create/delete/complete/attach_course/detach_course/add_student/
+    remove_student. Those are exactly the actions an external auditor
+    expects to inspect, so a missing audit row is a real compliance hole.
+    Cover all seven surfaces in one parameterised-ish test that asserts a
+    matching ``AuditLog`` row exists after each call.
+    """
+
+    @staticmethod
+    def _seed_user(db: Session, *, role: str = "student") -> "uuid.UUID":
+        from app.models.user import User
+
+        uid = uuid.uuid4()
+        db.add(User(id=uid, email=f"u-{uid}@example.com", full_name="Student", role=role))
+        db.commit()
+        return uid
+
+    def test_create_writes_audit_row(self, admin_client: TestClient, db: Session):
+        from app.models.audit_log import AuditLog
+
+        resp = admin_client.post(COHORT_PREFIX, json=_cohort_payload(name="Audited"))
+        assert resp.status_code == 201
+        cohort_id = resp.json()["id"]
+        row = (
+            db.query(AuditLog)
+            .filter(AuditLog.resource_type == "cohort", AuditLog.resource_id == cohort_id, AuditLog.action == "create")
+            .first()
+        )
+        assert row is not None
+        assert str(row.user_id) == str(ADMIN_ID)
+
+    def test_delete_writes_audit_row(self, admin_client: TestClient, db: Session):
+        from app.models.audit_log import AuditLog
+
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db, name="Doomed")
+        cohort_id = str(cohort.id)
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort_id}")
+        assert resp.status_code == 204
+        row = (
+            db.query(AuditLog)
+            .filter(AuditLog.resource_type == "cohort", AuditLog.resource_id == cohort_id, AuditLog.action == "delete")
+            .first()
+        )
+        assert row is not None
+
+    def test_complete_writes_audit_row(self, admin_client: TestClient, db: Session):
+        from app.models.audit_log import AuditLog
+
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/complete")
+        assert resp.status_code == 200
+        row = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.resource_type == "cohort",
+                AuditLog.resource_id == str(cohort.id),
+                AuditLog.action == "complete",
+            )
+            .first()
+        )
+        assert row is not None
+
+    def test_attach_course_writes_audit_row(self, admin_client: TestClient, db: Session):
+        from app.models.audit_log import AuditLog
+
+        _seed_course(db, course_id="course-attach")
+        cohort = _seed_cohort_with_course(db, course_id="course-attach")
+        # Attach a second course
+        _seed_course(db, course_id="course-2")
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/courses", json={"course_id": "course-2"})
+        assert resp.status_code == 201
+        row = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.resource_type == "cohort",
+                AuditLog.resource_id == str(cohort.id),
+                AuditLog.action == "attach_course",
+            )
+            .first()
+        )
+        assert row is not None
+
+    def test_detach_course_writes_audit_row(self, admin_client: TestClient, db: Session):
+        from app.models.audit_log import AuditLog
+
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort.id}/courses/test-course-1")
+        assert resp.status_code == 204
+        row = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.resource_type == "cohort",
+                AuditLog.resource_id == str(cohort.id),
+                AuditLog.action == "detach_course",
+            )
+            .first()
+        )
+        assert row is not None
+
+    def test_add_student_writes_audit_row(self, admin_client: TestClient, db: Session):
+        from app.models.audit_log import AuditLog
+
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        student_uuid = self._seed_user(db)
+        resp = admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/students", json={"user_id": str(student_uuid)})
+        assert resp.status_code == 201
+        row = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.resource_type == "cohort",
+                AuditLog.resource_id == str(cohort.id),
+                AuditLog.action == "add_student",
+            )
+            .first()
+        )
+        assert row is not None
+
+    def test_remove_student_writes_audit_row(self, admin_client: TestClient, db: Session):
+        from app.models.audit_log import AuditLog
+
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        student_uuid = self._seed_user(db)
+        admin_client.post(f"{COHORT_PREFIX}/{cohort.id}/students", json={"user_id": str(student_uuid)})
+        resp = admin_client.delete(f"{COHORT_PREFIX}/{cohort.id}/students/{student_uuid}")
+        assert resp.status_code == 204
+        row = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.resource_type == "cohort",
+                AuditLog.resource_id == str(cohort.id),
+                AuditLog.action == "remove_student",
+            )
+            .first()
+        )
+        assert row is not None
+
+
 class TestSoloEnrollmentAccessMode:
     """ADR-010 §1: ``access_mode='institute'`` blocks the solo-enroll
     path (no cohort_id in the request body). Cohort-route enrollment


### PR DESCRIPTION
## Summary

Cohorts are admin-only resources but every write surface previously skipped `audit_service.log_action`. Wire it into all 7 endpoints so any forensic question ("who attached this cohort to that course and when") has an answer.

Surfaces covered:
- `POST /cohorts` (create)
- `DELETE /cohorts/{id}` (delete)
- `POST /cohorts/{id}/complete` (complete)
- `POST /cohorts/{id}/courses` (attach_course)
- `DELETE /cohorts/{id}/courses/{course_id}` (detach_course)
- `POST /cohorts/{id}/students` (add_student)
- `DELETE /cohorts/{id}/students/{user_id}` (remove_student)

Each call uses the same shape established in `app.api.v1.users` — action verb, `resource_type="cohort"`, `resource_id=cohort.id`, `details={…}` for per-action context (cohort name on create/delete/complete; `course_id` on attach/detach; `user_id` + `email` + course count on add/remove student). `Request` is now injected into every write endpoint so the auditor's IP + user-agent are captured.

`audit_service.log_action` already wraps each insert in a SAVEPOINT, so a failed audit row can't poison the outer request transaction — same isolation other writers rely on.

## Files

- `backend/app/api/v1/cohorts.py` — `Request` import + parameter on each of the 7 endpoints; `log_action(...)` call after the successful DB write in each.
- `backend/tests/test_cohorts_calendar_notifications.py` — new `TestCohortWriteActionsAreAudited` class with one regression per surface (7 tests), each asserts an `AuditLog` row with the right `resource_type`, `resource_id`, and `action`.

## Test plan

- [x] `python -m pytest tests/` → 670 passed (+7 new regression tests).
- [x] `python -m ruff check .` clean, `ruff format --check .` clean.
- [x] `python -m mypy --config-file mypy.ini app/` clean.
- [x] Existing cohort tests (138 in `test_cohorts_calendar_notifications.py` + `test_cohort_enrollment_gates.py`) still green — the new `Request` parameter is keyword-only via `Depends`, so test clients hitting the routes don't need to change.
