### PR TITLE
design(courseDetail): NotEnrolled marketing surface — at-a-glance + i18n badge

### DIFF
--- a/frontend/src/pages/Course/detail/NotEnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/NotEnrolledView.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { ArrowLeft, CalendarDays, Clock, Users } from "lucide-react"
+import { ArrowLeft, CalendarDays, Clock, Layers, Users } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -17,6 +17,18 @@ interface Props {
   isSignedIn: boolean
   enrolling: boolean
   onEnroll: (cohortId?: string) => Promise<void> | void
+}
+
+const COHORT_STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
+  upcoming: "info",
+  active: "success",
+  completed: "muted",
+}
+
+const COHORT_STATUS_KEY: Record<Cohort["status"], string> = {
+  upcoming: "admin.cohorts.statusUpcoming",
+  active: "admin.cohorts.statusActive",
+  completed: "admin.cohorts.statusCompleted",
 }
 
 export function NotEnrolledView({
@@ -39,6 +51,17 @@ export function NotEnrolledView({
   const isInstituteGate = course.access_mode === "institute" && !isOwner
   const canEnroll =
     !isInstituteGate && (enrollableCohorts.length > 0 || cohorts.length === 0)
+
+  // Course-at-a-glance counts. Memoised because `course.modules` is a
+  // fresh array each render and we'd otherwise reduce twice (once for
+  // module count, once for chapter total) on every keystroke / state.
+  const { moduleCount, chapterCount } = useMemo(() => {
+    const mods = course.modules ?? []
+    return {
+      moduleCount: mods.length,
+      chapterCount: mods.reduce((sum, m) => sum + (m.chapters?.length ?? 0), 0),
+    }
+  }, [course.modules])
 
   const handleEnrollClick = () => {
     if (enrollableCohorts.length === 0) {
@@ -89,6 +112,25 @@ export function NotEnrolledView({
         {course.title}
       </h1>
 
+      {/* Course-at-a-glance: editorial eyebrow with module/chapter counts.
+          Renders only when the API returned modules (course.modules is the
+          eager-loaded list from /courses/:id). Keeps the surface honest
+          when a course is still a stub — no fake "0 modules" line. */}
+      {moduleCount > 0 && (
+        <p className="mb-5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5">
+            <Layers className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
+            {t("courseDetail.moduleCount", { count: moduleCount })}
+          </span>
+          {chapterCount > 0 && (
+            <>
+              <span aria-hidden className="text-muted-foreground/40">·</span>
+              <span>{t("courseDetail.chapterCount", { count: chapterCount })}</span>
+            </>
+          )}
+        </p>
+      )}
+
       {course.description && (
         <p className="text-muted-foreground leading-relaxed mb-6 whitespace-pre-line text-wrap-safe">
           {course.description}
@@ -98,11 +140,11 @@ export function NotEnrolledView({
       {activeCohort && (
         <Card className="mb-6">
           <CardContent className="py-4">
-            <div className="flex items-center gap-2 mb-1">
+            <div className="flex flex-wrap items-center gap-2 mb-1">
               <CalendarDays className="h-4 w-4 text-primary" strokeWidth={1.75} aria-hidden />
               <span className="font-medium">{activeCohort.name}</span>
-              <Badge variant={activeCohort.status === "active" ? "success" : "info"}>
-                {activeCohort.status}
+              <Badge variant={COHORT_STATUS_BADGE[activeCohort.status]}>
+                {t(COHORT_STATUS_KEY[activeCohort.status])}
               </Badge>
             </div>
             <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## What's now coherent

`NotEnrolledView` is the largest conversion surface in the app — it's the page a prospective student sees **before** clicking Enroll. The hero ran image → title → description → optional cohort card → CTA, with no signal of what the course actually contained. Worse, the cohort-status Badge in the cohort card rendered the raw enum value (`"active"` / `"upcoming"`) in English, regardless of locale — a hardcoded English string in the middle of a Russian page.

## What changed

- **Localized the cohort-status Badge.** Re-uses existing `admin.cohorts.statusUpcoming/Active/Completed` keys (no new locale strings — the bilingual agent's `i18n/locales/*.json` files weren't touched). RU users now see "Активный" instead of "active" mid-paragraph.
- **Added an editorial eyebrow line between title and description**, showing module count and chapter count. Uses the existing `courseDetail.moduleCount` / `chapterCount` plural keys. The line uses the same `uppercase tracking-[0.18em]` pattern as `ChapterView` so it reads as page chrome, not body copy.
- The eyebrow only renders when the API actually returned modules — no fake "0 modules" line on a stub course.
- Memoised the count computation because `course.modules` is a fresh array reference per render and the parent rerenders on enrollment flow state changes.
- Cohort-card header now `flex-wrap` so a long cohort name + status badge doesn't bust the layout on narrow screens.

## The feel I was going for

Editorial. Like the cover page of a thick book: title, then a small line telling you how long it is, then the blurb, then "buy". The eyebrow has the same visual weight as the wayfinding eyebrows in `ChapterView` (Prev / Next), so the entire surface speaks the same dialect.

## What I left alone (and why)

- The hero image (`aspect-[16/9]` cropped). Already correct: optional, lazy-loaded, falls back gracefully if the URL 404s.
- The four CTA branches (owner / institute / signed-in / signed-out). Each has the right copy and right button shape; the brief asks for design polish, not flow rewrites.
- The dimmed enrollment-range fallback shown when there are zero cohorts. Small case, already restrained.
- The `<Link to="/">` "All Courses" back button. `h-8 text-xs` is intentionally small (page chrome, not navigation hub) — promoting it to `h-11` would compete with the title.
- The `CohortSelectModal`. Out of scope.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:run` — 210 passed across 26 files
- [ ] Manual: open `/courses/<id>` as anonymous user on a course with modules — eyebrow shows below title with module + chapter counts
- [ ] Manual: same as anonymous user on a stub course with zero modules — eyebrow hides cleanly
- [ ] Manual: active cohort exists — status badge text matches current locale (EN: "Active", RU: "Активный")
- [ ] Manual: long cohort name (40+ chars) — wraps properly under the badge
- [ ] Manual: dark mode — eyebrow contrast OK

Co-author: Claude Opus 4.7 (1M context).

Generated with Claude Code.
