### PR TITLE
fix(translation): cap retry budget for permanently-failing rows

### DIFF
--- a/backend/app/models/content_translation.py
+++ b/backend/app/models/content_translation.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from sqlalchemy import DateTime, Index, String, Text, UniqueConstraint, func
+from sqlalchemy import DateTime, Index, Integer, String, Text, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -42,8 +42,16 @@ TranslationField = Literal[
     "option_text",
     "instructions",
 ]
-TranslationStatus = Literal["ok", "stale", "failed"]
+TranslationStatus = Literal["ok", "stale", "failed", "failed_permanent"]
 TranslationOrigin = Literal["mt", "human"]
+
+# How many transient failures we tolerate before promoting a row to
+# ``failed_permanent``. Five was picked to absorb a transient Gemini
+# outage / rate-limit burst without burning indefinite retries on rows
+# that fail for permanent reasons (safety filter trip, content too
+# large, bad encoding). Centralized here so admin tooling that re-queues
+# a row can refer back to the same constant.
+TRANSLATION_MAX_ATTEMPTS = 5
 
 
 class ContentTranslation(Base):
@@ -63,9 +71,14 @@ class ContentTranslation(Base):
     # we flip ``status`` to ``stale`` and re-queue the row instead of blowing
     # the translation away.
     source_hash: Mapped[str] = mapped_column(String(64))
-    status: Mapped[str] = mapped_column(String(16), default="ok", server_default="ok")
+    status: Mapped[str] = mapped_column(String(20), default="ok", server_default="ok")
     # ``origin = 'human'`` rows are never overwritten by the auto-pipeline.
     origin: Mapped[str] = mapped_column(String(16), default="mt", server_default="mt")
+    # How many translation attempts this row has burned. Increments on every
+    # provider failure; resets to 0 implicitly when a row goes back to ``ok``.
+    # When it reaches ``TRANSLATION_MAX_ATTEMPTS`` the orchestrator promotes
+    # the row to ``failed_permanent`` so the reconcile loop stops retrying.
+    attempts: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/app/services/translation/orchestrator.py
+++ b/backend/app/services/translation/orchestrator.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app.models.content_translation import (
+    TRANSLATION_MAX_ATTEMPTS,
     ContentTranslation,
     TranslationEntityType,
     TranslationField,
@@ -240,6 +241,15 @@ def _translate_one_field(
     if existing is not None and existing.status == "ok" and existing.source_hash == source_hash:
         return "skipped"
 
+    # Rows that hit the retry cap (``failed_permanent``) are terminal as far
+    # as the auto-pipeline is concerned. They stay terminal even if the
+    # source text mutates — a row that fails for a permanent reason (safety
+    # filter, oversize input) won't suddenly succeed because the prompt
+    # changed by one word. An operator who wants to retry must explicitly
+    # reset ``status='pending'`` + ``attempts=0`` from admin tooling.
+    if existing is not None and existing.status == "failed_permanent":
+        return "skipped"
+
     request = TranslationRequest(
         text=text,
         source_locale=source_locale,
@@ -250,12 +260,20 @@ def _translate_one_field(
     try:
         result = provider.translate(request)
     except TranslationError as exc:
+        # Compute the new attempts count first: existing.attempts + 1 if a
+        # row is already on disk, else 1 for the fresh failure. When we cross
+        # the cap, promote the row to ``failed_permanent`` so reconcile stops
+        # paying for retries that will never succeed.
+        attempts = (existing.attempts if existing is not None else 0) + 1
+        failed_status = "failed_permanent" if attempts >= TRANSLATION_MAX_ATTEMPTS else "failed"
         logger.warning(
-            "Translation failed entity=%s:%s field=%s locale=%s err=%s",
+            "Translation failed entity=%s:%s field=%s locale=%s attempts=%d status=%s err=%s",
             entity_type,
             entity_id,
             field,
             target_locale,
+            attempts,
+            failed_status,
             exc,
         )
         _persist_translation(
@@ -267,7 +285,8 @@ def _translate_one_field(
             target_locale=target_locale,
             text=existing.text if existing is not None else text,
             source_hash=source_hash,
-            status="failed",
+            status=failed_status,
+            attempts=attempts,
         )
         return "failed"
 
@@ -281,6 +300,9 @@ def _translate_one_field(
         text=result.text,
         source_hash=source_hash,
         status="ok",
+        # Success clears the failure budget — a successful translate after
+        # a transient failure shouldn't carry the previous attempts forward.
+        attempts=0,
     )
     return "translated"
 
@@ -296,6 +318,7 @@ def _persist_translation(
     text: str,
     source_hash: str,
     status: str,
+    attempts: int = 0,
 ) -> None:
     """Insert or update one translation row.
 
@@ -313,6 +336,7 @@ def _persist_translation(
         existing.text = text
         existing.source_hash = source_hash
         existing.status = status
+        existing.attempts = attempts
         return
 
     row = ContentTranslation(
@@ -324,6 +348,7 @@ def _persist_translation(
         source_hash=source_hash,
         status=status,
         origin="mt",
+        attempts=attempts,
     )
     try:
         with db.begin_nested():
@@ -355,6 +380,7 @@ def _persist_translation(
         winner.text = text
         winner.source_hash = source_hash
         winner.status = status
+        winner.attempts = attempts
 
 
 __all__ = [

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -246,6 +246,95 @@ def test_translate_entity_fields_records_failed_rows(db: Session):
         .one()
     )
     assert title_row.status == "failed"
+    # First failure must surface on ``attempts`` so future cycles can count.
+    assert title_row.attempts == 1
+
+
+def test_translate_entity_fields_promotes_to_failed_permanent_after_cap(db: Session):
+    """A row that fails five times in a row must transition to
+    ``failed_permanent`` and stay there. Reconciling again must short-circuit
+    instead of burning another provider call — that's the whole point of the
+    retry cap (Gemini API calls aren't free, and a permanent failure won't
+    flip just because we retry it the sixth time).
+    """
+    course = _make_course(db)
+    failing_title = course.title or ""
+    provider = _RecordingProvider(failures={failing_title})
+
+    # Five attempts → row promotes to ``failed_permanent``.
+    for _ in range(5):
+        translate_entity_fields(
+            db,
+            entity_type="course",
+            entity_id=str(course.id),
+            source_locale="ru",
+            fields=[TranslationFieldSpec(field="title", text=course.title, content_kind="title")],
+            provider=provider,
+        )
+
+    row = (
+        db.query(ContentTranslation)
+        .filter_by(entity_type="course", entity_id=course.id, field="title", locale="en")
+        .one()
+    )
+    assert row.status == "failed_permanent"
+    assert row.attempts == 5
+    calls_so_far = len(provider.calls)
+
+    # Sixth pass must skip the provider entirely.
+    report = translate_entity_fields(
+        db,
+        entity_type="course",
+        entity_id=str(course.id),
+        source_locale="ru",
+        fields=[TranslationFieldSpec(field="title", text=course.title, content_kind="title")],
+        provider=provider,
+    )
+    assert report.skipped == 1
+    assert report.failed == 0
+    # Provider was NOT called again — that's the cost-saving guarantee.
+    assert len(provider.calls) == calls_so_far
+
+
+def test_translate_entity_fields_resets_attempts_on_success(db: Session):
+    """A transient failure followed by a success must clear ``attempts``
+    back to 0 — otherwise a single hiccup in a row's history would push it
+    closer to the cap forever."""
+    course = _make_course(db)
+    failing_title = course.title or ""
+    # Fail twice, then succeed.
+    failing_provider = _RecordingProvider(failures={failing_title})
+    for _ in range(2):
+        translate_entity_fields(
+            db,
+            entity_type="course",
+            entity_id=str(course.id),
+            source_locale="ru",
+            fields=[TranslationFieldSpec(field="title", text=course.title, content_kind="title")],
+            provider=failing_provider,
+        )
+
+    row = (
+        db.query(ContentTranslation)
+        .filter_by(entity_type="course", entity_id=course.id, field="title", locale="en")
+        .one()
+    )
+    assert row.status == "failed"
+    assert row.attempts == 2
+
+    happy_provider = _RecordingProvider()
+    translate_entity_fields(
+        db,
+        entity_type="course",
+        entity_id=str(course.id),
+        source_locale="ru",
+        fields=[TranslationFieldSpec(field="title", text=course.title, content_kind="title")],
+        provider=happy_provider,
+    )
+
+    db.refresh(row)
+    assert row.status == "ok"
+    assert row.attempts == 0
 
 
 def test_translate_entity_fields_skips_empty_text(db: Session):

--- a/supabase/migrations/20260516022216_translation_failed_permanent_attempts.sql
+++ b/supabase/migrations/20260516022216_translation_failed_permanent_attempts.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- Translation retry cap: add ``attempts`` counter + ``failed_permanent`` status.
+-- ----------------------------------------------------------------------------
+-- ``content_translations`` rows with ``status='failed'`` were retried on
+-- every course publish + every reconcile cycle. A row that fails for a
+-- *permanent* reason (Gemini safety-filter trip, content too large, bad
+-- encoding) therefore burned a paid API call per retry indefinitely.
+--
+-- The fix is two-part:
+--   1. Add an ``attempts INTEGER NOT NULL DEFAULT 0`` column. The
+--      orchestrator increments it on every failed attempt.
+--   2. Extend the CHECK constraint on ``status`` to allow
+--      ``failed_permanent``. After ``attempts >= max_attempts`` (currently
+--      5, defined in code), the orchestrator promotes the row to
+--      ``failed_permanent`` and the reconcile loop skips it.
+--
+-- An admin / worker can re-queue a permanently-failed row by manually
+-- resetting ``status='pending'`` and ``attempts=0`` (or any non-terminal
+-- status; the orchestrator only treats ``failed_permanent`` as terminal).
+-- ============================================================================
+
+-- 1. Counter column. Backfills to 0 for existing rows — they have no failure
+--    history yet, so they start with a clean budget.
+ALTER TABLE public.content_translations
+  ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0;
+
+-- 2. Replace the status CHECK to allow ``failed_permanent``.
+ALTER TABLE public.content_translations
+  DROP CONSTRAINT IF EXISTS content_translations_status_check;
+
+ALTER TABLE public.content_translations
+  ADD CONSTRAINT content_translations_status_check
+    CHECK (status IN ('ok', 'stale', 'failed', 'failed_permanent'));


### PR DESCRIPTION
## Summary

`content_translations` rows with `status='failed'` were retried on every course publish + every reconcile cycle. A row that fails for a *permanent* reason — Gemini safety-filter trip, content too large, bad encoding — was therefore burning a paid API call per cycle, indefinitely.

Add a retry cap:

- New `attempts INTEGER NOT NULL DEFAULT 0` column on `content_translations`. Backfills to 0 for existing rows.
- Extend the `status` CHECK constraint to allow `'failed_permanent'`.
- Orchestrator increments `attempts` on every provider failure. When it reaches `TRANSLATION_MAX_ATTEMPTS` (5, defined in `app/models/content_translation.py`) the row promotes to `failed_permanent`.
- A new guard before the source-hash short-circuit treats `failed_permanent` rows as terminal — no provider call, returns `"skipped"`. The reconcile loop therefore stops retrying with no extra plumbing.
- Successful translate resets `attempts` to 0 so a transient hiccup doesn't push a healthy row closer to the cap forever.
- An admin / worker can manually re-queue a permanently-failed row by setting `status='pending'` and `attempts=0` from admin tooling — the orchestrator only treats `failed_permanent` as terminal.

5 was picked to absorb a transient Gemini outage / rate-limit burst without burning indefinite retries.

## Files

- `supabase/migrations/20260516022216_translation_failed_permanent_attempts.sql` — `ADD COLUMN attempts`, replace status CHECK to include `failed_permanent`.
- `backend/app/models/content_translation.py` — `attempts: Mapped[int]`, `TranslationStatus` literal extended, `TRANSLATION_MAX_ATTEMPTS` constant, status column widened to `String(20)`.
- `backend/app/services/translation/orchestrator.py` — guard `failed_permanent` → skipped; failure path computes new `attempts` and chooses `failed` vs `failed_permanent`; success path resets attempts to 0; `_persist_translation` writes `attempts` on insert, update, and the IntegrityError-race rebind path.
- `backend/tests/test_translation_orchestrator.py` — three new regressions:
  1. First failure surfaces `attempts == 1` (extends existing failed-row test).
  2. Five failing calls promote to `failed_permanent`; sixth call short-circuits without invoking the provider.
  3. Failure → success resets `attempts` back to 0.

## Test plan

- [x] Migration applied to prod-shape DB via Supabase MCP; column + CHECK verified.
- [x] `python -m pytest tests/` → 667 passed (+3 new orchestrator regressions).
- [x] `python -m ruff check .` clean, `ruff format --check .` clean.
- [x] `python -m mypy --config-file mypy.ini app/` clean.
- [ ] Operator playbook for re-queuing a permanently-failed row to be added to runbook (UPDATE content_translations SET status='pending', attempts=0 WHERE id=…).
