### PR TITLE
fix(i18n): add ?source=1 editor escape hatch (unblocks #340)

### DIFF
--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -32,6 +32,7 @@ from app.services.notification_service import create_notification
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
     get_course_source_locale_for_chapter,
+    is_chapter_course_owner_or_admin,
     localize_assignment_rows,
     should_apply_course_translation_overlay_for_chapter,
 )
@@ -44,12 +45,27 @@ def list_chapter_assignments(
     chapter_id: str,
     response: Response,
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    source: bool = Query(
+        False,
+        description=(
+            "Bypass the translation overlay and return source-language columns "
+            "(``title``, ``description``). Owner / admin only — used by the "
+            "assignment editor."
+        ),
+    ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     verify_chapter_access(db, chapter_id, current_user)
     response.headers["Vary"] = "Accept-Language"
     rows = db.query(Assignment).filter(Assignment.chapter_id == chapter_id).order_by(Assignment.created_at).all()
+    if source:
+        if not is_chapter_course_owner_or_admin(db, chapter_id=chapter_id, current_user=current_user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the course owner or an admin can request source-language content",
+            )
+        return rows
     display_locale: LocaleCode = normalize_locale(accept_language)
     src = get_course_source_locale_for_chapter(db, chapter_id)
     if should_apply_course_translation_overlay_for_chapter(db, chapter_id=chapter_id, current_user=current_user):

--- a/backend/app/api/v1/blocks.py
+++ b/backend/app/api/v1/blocks.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -14,6 +14,7 @@ from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
     get_course_source_locale_for_chapter,
+    is_chapter_course_owner_or_admin,
     localize_chapter_block_rows,
     should_apply_course_translation_overlay_for_chapter,
 )
@@ -26,12 +27,28 @@ def list_blocks(
     chapter_id: str,
     response: Response,
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    source: bool = Query(
+        False,
+        description=(
+            "Bypass the translation overlay and return source-language ``content`` "
+            "(rich-text HTML). Owner / admin only — used by the chapter block "
+            "editor so a teacher viewing their RU course in EN UI doesn't "
+            "accidentally save the EN translation back into the source content."
+        ),
+    ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     verify_chapter_access(db, chapter_id, current_user)
     response.headers["Vary"] = "Accept-Language"
     rows = db.query(ChapterBlock).filter(ChapterBlock.chapter_id == chapter_id).order_by(ChapterBlock.order_index).all()
+    if source:
+        if not is_chapter_course_owner_or_admin(db, chapter_id=chapter_id, current_user=current_user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the course owner or an admin can request source-language content",
+            )
+        return rows
     display_locale: LocaleCode = normalize_locale(accept_language)
     src = get_course_source_locale_for_chapter(db, chapter_id)
     if should_apply_course_translation_overlay_for_chapter(db, chapter_id=chapter_id, current_user=current_user):

--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -81,6 +81,15 @@ def get_course_detail(
     course_id: str,
     response: Response,
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    source: bool = Query(
+        False,
+        description=(
+            "Bypass the translation overlay and return source-language columns. "
+            "Owner / admin only — used by the course editor so a teacher viewing "
+            "their RU course in EN UI doesn't accidentally save the EN translation "
+            "back into the source title/description."
+        ),
+    ),
     current_user: User | None = Depends(get_optional_user),
     db: Session = Depends(get_db),
 ) -> CourseResponse:
@@ -96,6 +105,17 @@ def get_course_detail(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Course '{course_id}' not found",
         )
+    if source:
+        # Explicit "give me source columns" path for editor surfaces. Gated to
+        # owner + admin: returning unredacted source text to a regular student
+        # is an information leak (typos, draft notes, unreleased material).
+        if not is_owner_or_admin(course, current_user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the course owner or an admin can request source-language content",
+            )
+        response.headers["Vary"] = "Accept-Language"
+        return CourseResponse.model_validate(course, from_attributes=True)
     response.headers["Vary"] = "Accept-Language"
     if not should_apply_course_translation_overlay(course=course, current_user=current_user):
         return CourseResponse.model_validate(course, from_attributes=True)
@@ -108,6 +128,13 @@ def get_module_detail(
     module_id: str,
     response: Response,
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    source: bool = Query(
+        False,
+        description=(
+            "Bypass the translation overlay and return source-language columns. "
+            "Owner / admin only — used by the module editor."
+        ),
+    ),
     current_user: User | None = Depends(get_optional_user),
     db: Session = Depends(get_db),
 ) -> ModuleResponse:
@@ -142,12 +169,25 @@ def get_module_detail(
 
     response.headers["Vary"] = "Accept-Language"
 
+    is_owner = current_user is not None and str(course_owner_id) == str(current_user.id)
+    is_admin = current_user is not None and current_user.role == UserRole.ADMIN.value
+
+    # Explicit "give me source columns" path for editor surfaces. Owner / admin
+    # only. Today's main also routes owner + admin to source via the implicit
+    # ``should_apply_course_translation_overlay`` rule; the explicit param
+    # survives once that implicit skip is removed (see PR #340).
+    if source:
+        if not (is_owner or is_admin):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the course owner or an admin can request source-language content",
+            )
+        return ModuleResponse.model_validate(module, from_attributes=True)
+
     # Owner + admin always see source for editorial accuracy (matches the
     # rule in ``should_apply_course_translation_overlay`` for the parent
     # course-detail endpoint). Everyone else (students, anonymous catalog
     # browsers, other teachers) gets the locale overlay.
-    is_owner = current_user is not None and str(course_owner_id) == str(current_user.id)
-    is_admin = current_user is not None and current_user.role == UserRole.ADMIN.value
     if is_owner or is_admin:
         return ModuleResponse.model_validate(module, from_attributes=True)
 

--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -6,7 +6,7 @@ Every route here attaches to the shared ``router`` in ``_router.py``.
 import uuid
 from uuid import UUID
 
-from fastapi import Depends, Header, HTTPException, Response, status
+from fastapi import Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session, selectinload
 
 from app.api.dependencies import (
@@ -32,6 +32,7 @@ from app.services.translation.pipeline_hooks import (
 from app.services.translation.resolve_for_display import (
     build_localized_quiz_student_response,
     get_course_source_locale_for_chapter,
+    is_chapter_course_owner_or_admin,
     should_apply_course_translation_overlay_for_chapter,
 )
 
@@ -44,6 +45,14 @@ def get_chapter_quiz(
     chapter_id: str,
     response: Response,
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    source: bool = Query(
+        False,
+        description=(
+            "Bypass the translation overlay and return source-language columns "
+            "(``title``, ``description``, ``question_text``, ``option_text``). "
+            "Owner / admin only — used by the quiz editor."
+        ),
+    ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -58,12 +67,20 @@ def get_chapter_quiz(
     if not quiz:
         return None
 
-    display_locale: LocaleCode = normalize_locale(accept_language)
-    src = get_course_source_locale_for_chapter(db, chapter_id)
-    if should_apply_course_translation_overlay_for_chapter(db, chapter_id=chapter_id, current_user=current_user):
-        resp = build_localized_quiz_student_response(db, quiz, display_locale=display_locale, source_locale=src)
-    else:
+    if source:
+        if not is_chapter_course_owner_or_admin(db, chapter_id=chapter_id, current_user=current_user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the course owner or an admin can request source-language content",
+            )
         resp = QuizStudentResponse.model_validate(quiz)
+    else:
+        display_locale: LocaleCode = normalize_locale(accept_language)
+        src = get_course_source_locale_for_chapter(db, chapter_id)
+        if should_apply_course_translation_overlay_for_chapter(db, chapter_id=chapter_id, current_user=current_user):
+            resp = build_localized_quiz_student_response(db, quiz, display_locale=display_locale, source_locale=src)
+        else:
+            resp = QuizStudentResponse.model_validate(quiz)
     if resp.max_attempts is not None:
         extra = (
             db.query(QuizExtraAttempt)

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -282,6 +282,40 @@ def should_apply_course_translation_overlay_for_chapter(
     return should_apply_course_translation_overlay(course=course, current_user=current_user)
 
 
+def is_chapter_course_owner_or_admin(
+    db: Session,
+    *,
+    chapter_id: str,
+    current_user: User | None,
+) -> bool:
+    """Return True when ``current_user`` owns the chapter's course or is admin.
+
+    Used by the editor-only ``?source=1`` gate on the chapter-scoped read
+    endpoints (``/quizzes/chapter/{id}``, ``/assignments/chapter/{id}``,
+    ``/blocks/chapter/{id}``). Returning source content to a regular student
+    would leak unredacted teacher drafts, so the param is gated.
+    """
+    if current_user is None:
+        return False
+    if current_user.role == UserRole.ADMIN.value:
+        return True
+    row = (
+        db.query(Course.created_by)
+        .join(Module, Module.course_id == Course.id)
+        .join(Chapter, Chapter.module_id == Module.id)
+        .filter(
+            Chapter.id == chapter_id,
+            Chapter.deleted_at.is_(None),
+            Module.deleted_at.is_(None),
+            Course.deleted_at.is_(None),
+        )
+        .first()
+    )
+    if row is None:
+        return False
+    return _str_uuid(row[0]) == _str_uuid(current_user.id)
+
+
 def build_localized_course_response_with_tree(
     db: Session,
     course: Course,
@@ -507,6 +541,7 @@ __all__ = [
     "build_localized_quiz_student_response",
     "fetch_overlay_triples_bulk",
     "get_course_source_locale_for_chapter",
+    "is_chapter_course_owner_or_admin",
     "localize_announcement_rows",
     "localize_assignment_rows",
     "localize_chapter_block_rows",

--- a/backend/tests/test_courses.py
+++ b/backend/tests/test_courses.py
@@ -367,6 +367,187 @@ class TestCatalogLocalizedMetadata:
         assert r.status_code == 200
         assert r.json()["title"] == "English catalog title"
 
+    def test_get_detail_source_param_returns_raw_columns_for_owner(
+        self,
+        client: TestClient,
+        db: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``?source=1`` bypasses the overlay even with an explicit EN
+        ``Accept-Language``. This is the editor-page escape hatch — without
+        it a teacher in EN UI viewing their RU course would see EN text in
+        the inline-edit fields and a PATCH would overwrite the source
+        ``title`` column with English.
+        """
+        monkeypatch.setattr(
+            "app.api.v1.courses.crud.translate_course_content",
+            lambda *args, **kwargs: OrchestratorReport(),
+        )
+        course = _create_course(
+            client,
+            title="Заголовок RU",
+            description="Описание RU",
+        )
+        cid = course["id"]
+        client.put(f"{PREFIX}/{cid}", json={"status": "published"})
+        self._seed_en_translations(db, cid)
+
+        # Sanity check: the same endpoint without ``?source=1`` still applies
+        # the EN overlay for the owner once we remove the implicit owner skip
+        # (today's main still skips for owner, so the assertion here is the
+        # source contract — that ``?source=1`` always returns source).
+        owner_with_source = client.get(
+            f"{PREFIX}/{cid}",
+            params={"source": "1"},
+            headers={"Accept-Language": "en"},
+        )
+        assert owner_with_source.status_code == 200
+        body = owner_with_source.json()
+        assert body["title"] == "Заголовок RU"
+        assert body["description"] == "Описание RU"
+
+    def test_get_detail_source_param_returns_raw_columns_for_admin(
+        self,
+        admin_client: TestClient,
+        client: TestClient,
+        db: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Admins managing a teacher's course also need source columns for
+        editor surfaces. ``client`` seeds the teacher + course; ``admin_client``
+        then opens the same course."""
+        monkeypatch.setattr(
+            "app.api.v1.courses.crud.translate_course_content",
+            lambda *args, **kwargs: OrchestratorReport(),
+        )
+        course = _create_course(
+            client,
+            title="Заголовок RU",
+            description="Описание RU",
+        )
+        cid = course["id"]
+        client.put(f"{PREFIX}/{cid}", json={"status": "published"})
+        self._seed_en_translations(db, cid)
+
+        resp = admin_client.get(
+            f"{PREFIX}/{cid}",
+            params={"source": "1"},
+            headers={"Accept-Language": "en"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"] == "Заголовок RU"
+        assert body["description"] == "Описание RU"
+
+    def test_get_detail_source_param_403_for_non_owner_student(
+        self,
+        student_client: TestClient,
+        db: Session,
+    ) -> None:
+        """Source content can include unredacted teacher drafts / typos —
+        returning it to a regular student would be an information leak.
+        The endpoint denies loudly (403) so frontend regressions surface
+        immediately instead of leaking text on a slow rollout."""
+        # Seed via the DB directly so we don't share ``dependency_overrides``
+        # with another TestClient fixture (only ``student_client`` is in play).
+        course = Course(
+            id="course-source-403",
+            title="Заголовок RU",
+            description="Описание RU",
+            status="published",
+            created_by=TEACHER_ID,
+        )
+        db.add(course)
+        db.commit()
+        self._seed_en_translations(db, course.id)
+
+        resp = student_client.get(
+            f"{PREFIX}/{course.id}",
+            params={"source": "1"},
+            headers={"Accept-Language": "en"},
+        )
+        assert resp.status_code == 403
+
+    def test_get_module_detail_source_param_returns_raw_columns_for_owner(
+        self,
+        client: TestClient,
+        db: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The module-detail editor endpoint (``CourseEditor`` opens it for
+        each module via ``ModuleEditor``) must hand back source columns even
+        when the viewer is in EN UI."""
+        monkeypatch.setattr(
+            "app.api.v1.courses.crud.translate_course_content",
+            lambda *args, **kwargs: OrchestratorReport(),
+        )
+        course = _create_course(client, title="RU course", description="RU desc")
+        cid = course["id"]
+        client.put(f"{PREFIX}/{cid}", json={"status": "published"})
+
+        mod_resp = client.post(
+            f"{PREFIX}/{cid}/modules",
+            json={"title": "Модуль RU", "description": "Описание модуля", "order_index": 0},
+        )
+        assert mod_resp.status_code == 201, mod_resp.text
+        mod_id = mod_resp.json()["id"]
+
+        db.add(
+            ContentTranslation(
+                entity_type="module",
+                entity_id=str(mod_id),
+                field="title",
+                locale="en",
+                text="Module title EN",
+                source_hash="m1",
+                status="ok",
+                origin="mt",
+            )
+        )
+        db.commit()
+
+        resp = client.get(
+            f"{PREFIX}/{cid}/modules/{mod_id}",
+            params={"source": "1"},
+            headers={"Accept-Language": "en"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Модуль RU"
+
+    def test_get_module_detail_source_param_403_for_non_owner_student(
+        self,
+        student_client: TestClient,
+        db: Session,
+    ) -> None:
+        from app.models.course import Module
+
+        course = Course(
+            id="course-mod-source-403",
+            title="RU course",
+            description="RU desc",
+            status="published",
+            created_by=TEACHER_ID,
+        )
+        module = Module(
+            id="mod-source-403",
+            course_id=course.id,
+            title="Модуль RU",
+            description="x",
+            order_index=0,
+        )
+        db.add_all([course, module])
+        db.commit()
+
+        # ``get_module_detail`` doesn't enforce enrollment for published
+        # courses — any authenticated user can call it. The 403 must come
+        # from the ``?source=1`` gate, not from enrollment.
+        resp = student_client.get(
+            f"{PREFIX}/{course.id}/modules/{module.id}",
+            params={"source": "1"},
+            headers={"Accept-Language": "en"},
+        )
+        assert resp.status_code == 403
+
     def test_ru_ct_row_preferred_over_course_columns_when_source_locale_mismatch(
         self,
         client: TestClient,

--- a/backend/tests/test_progress_and_assignments.py
+++ b/backend/tests/test_progress_and_assignments.py
@@ -136,6 +136,75 @@ class TestListChapterAssignments:
         assert r.status_code == 403
 
 
+class TestListChapterAssignmentsSourceParam:
+    """``?source=1`` is the editor's escape hatch — bypass the translation
+    overlay and return source columns regardless of ``Accept-Language``.
+    Gated to course owner + admin so source content (typos / unredacted
+    teacher drafts) never leaks to a student."""
+
+    def _seed_with_translation(self, db: Session, chapter_id: str) -> str:
+        from app.models.content_translation import ContentTranslation
+
+        asg_id = uuid.uuid4()
+        db.add(
+            Assignment(
+                id=asg_id,
+                chapter_id=chapter_id,
+                title="RU задание",
+                description="Описание RU",
+                max_score=10,
+            )
+        )
+        db.add(
+            ContentTranslation(
+                entity_type="assignment",
+                entity_id=str(asg_id),
+                field="title",
+                locale="en",
+                text="EN translation title",
+                source_hash="ah1",
+                status="ok",
+                origin="mt",
+            )
+        )
+        db.commit()
+        return str(asg_id)
+
+    def test_owner_with_source_param_gets_raw_columns(self, client: TestClient, db: Session):
+        _course, _mod, chapter = _seed_course_graph(db)
+        self._seed_with_translation(db, chapter.id)
+        r = client.get(
+            f"/api/v1/assignments/chapter/{chapter.id}",
+            params={"source": "1"},
+            headers={"Accept-Language": "en"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body) == 1
+        assert body[0]["title"] == "RU задание"
+
+    def test_admin_with_source_param_gets_raw_columns(self, admin_client: TestClient, db: Session):
+        _course, _mod, chapter = _seed_course_graph(db)
+        self._seed_with_translation(db, chapter.id)
+        r = admin_client.get(
+            f"/api/v1/assignments/chapter/{chapter.id}",
+            params={"source": "1"},
+            headers={"Accept-Language": "en"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()[0]["title"] == "RU задание"
+
+    def test_enrolled_student_with_source_param_403(self, student_client: TestClient, db: Session):
+        _course, _mod, chapter = _seed_course_graph(db)
+        self._seed_with_translation(db, chapter.id)
+        r = student_client.get(
+            f"/api/v1/assignments/chapter/{chapter.id}",
+            params={"source": "1"},
+            headers={"Accept-Language": "en"},
+        )
+        assert r.status_code == 403
+
+
 class TestCreateAssignment:
     """POST /api/v1/assignments"""
 

--- a/backend/tests/test_quizzes_and_blocks.py
+++ b/backend/tests/test_quizzes_and_blocks.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.models.chapter_block import ChapterBlock
+from app.models.content_translation import ContentTranslation
 from app.models.course import Chapter, Course, Module
 from app.models.enrollment import Enrollment
 from app.models.quiz import Quiz, QuizAttempt, QuizOption, QuizQuestion
@@ -178,6 +179,77 @@ def test_list_blocks_chapter_not_found(client: TestClient, db: Session):
 def test_list_blocks_anon_unauthorized(anon_client: TestClient):
     resp = anon_client.get("/api/v1/blocks/chapter/ch-1")
     assert resp.status_code == 401
+
+
+# ── GET /api/v1/blocks/chapter/{chapter_id}?source=1 (editor escape hatch) ──
+
+
+def _seed_block_with_en_translation(db: Session):
+    """Seed a chapter block with RU content and an EN translation overlay."""
+    block = ChapterBlock(
+        chapter_id="ch-1",
+        block_type="text",
+        order_index=0,
+        content="Русский контент",
+    )
+    db.add(block)
+    db.flush()
+    db.add(
+        ContentTranslation(
+            entity_type="chapter_block",
+            entity_id=str(block.id),
+            field="content",
+            locale="en",
+            text="<p>English content</p>",
+            source_hash="bh1",
+            status="ok",
+            origin="mt",
+        )
+    )
+    db.commit()
+    return block
+
+
+def test_list_blocks_source_param_returns_raw_for_owner(client: TestClient, db: Session):
+    """Editor path: teacher in EN UI editing their RU course must see the
+    source HTML (or PATCH would overwrite ``content`` with the EN translation)."""
+    _seed_course(db)
+    _seed_block_with_en_translation(db)
+
+    resp = client.get(
+        "/api/v1/blocks/chapter/ch-1",
+        params={"source": "1"},
+        headers={"Accept-Language": "en"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["content"] == "Русский контент"
+
+
+def test_list_blocks_source_param_returns_raw_for_admin(admin_client: TestClient, db: Session):
+    _seed_course(db)
+    _seed_block_with_en_translation(db)
+
+    resp = admin_client.get(
+        "/api/v1/blocks/chapter/ch-1",
+        params={"source": "1"},
+        headers={"Accept-Language": "en"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()[0]["content"] == "Русский контент"
+
+
+def test_list_blocks_source_param_403_for_enrolled_student(student_client: TestClient, db: Session):
+    _seed_course_with_enrollment(db)
+    _seed_block_with_en_translation(db)
+
+    resp = student_client.get(
+        "/api/v1/blocks/chapter/ch-1",
+        params={"source": "1"},
+        headers={"Accept-Language": "en"},
+    )
+    assert resp.status_code == 403
 
 
 # ── POST /api/v1/blocks/chapter/{chapter_id} ─────────────────────────────
@@ -450,6 +522,92 @@ def test_get_chapter_quiz_chapter_not_found(student_client: TestClient, db: Sess
 def test_get_chapter_quiz_anon_unauthorized(anon_client: TestClient):
     resp = anon_client.get("/api/v1/quizzes/chapter/ch-1")
     assert resp.status_code == 401
+
+
+# ── GET /api/v1/quizzes/chapter/{chapter_id}?source=1 (editor escape hatch) ──
+
+
+def _seed_quiz_with_en_translations(db: Session):
+    """Seed an RU-source quiz plus an EN ``content_translations`` overlay."""
+    quiz, questions, _opts = _seed_quiz_with_questions(db)
+    q1, q2 = questions
+    quiz.title = "RU тест"
+    quiz.description = "Описание"
+    q1.question_text = "Вопрос 1"
+    q2.question_text = "Вопрос 2"
+    db.add(
+        ContentTranslation(
+            entity_type="quiz",
+            entity_id=str(quiz.id),
+            field="title",
+            locale="en",
+            text="EN quiz title",
+            source_hash="qh1",
+            status="ok",
+            origin="mt",
+        )
+    )
+    db.add(
+        ContentTranslation(
+            entity_type="quiz_question",
+            entity_id=str(q1.id),
+            field="question_text",
+            locale="en",
+            text="EN question 1",
+            source_hash="qh2",
+            status="ok",
+            origin="mt",
+        )
+    )
+    db.commit()
+    return quiz, q1, q2
+
+
+def test_get_chapter_quiz_source_param_returns_raw_for_owner(client: TestClient, db: Session):
+    """``?source=1`` returns source columns even with ``Accept-Language: en``,
+    so a teacher in EN UI can't accidentally save the EN translation back to
+    the source ``question_text``."""
+    _seed_course(db)
+    _seed_quiz_with_en_translations(db)
+
+    resp = client.get(
+        "/api/v1/quizzes/chapter/ch-1",
+        params={"source": "1"},
+        headers={"Accept-Language": "en"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "RU тест"
+    questions = sorted(body["questions"], key=lambda q: q["order_index"])
+    assert questions[0]["question_text"] == "Вопрос 1"
+
+
+def test_get_chapter_quiz_source_param_returns_raw_for_admin(admin_client: TestClient, db: Session):
+    _seed_course(db)
+    _seed_quiz_with_en_translations(db)
+
+    resp = admin_client.get(
+        "/api/v1/quizzes/chapter/ch-1",
+        params={"source": "1"},
+        headers={"Accept-Language": "en"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "RU тест"
+
+
+def test_get_chapter_quiz_source_param_403_for_enrolled_student(student_client: TestClient, db: Session):
+    """Source content (typos, unredacted teacher drafts) shouldn't leak to
+    students. Even an enrolled student gets 403 — fail loudly so frontend
+    bugs surface immediately."""
+    _seed_course_with_enrollment(db)
+    _seed_quiz_with_en_translations(db)
+
+    resp = student_client.get(
+        "/api/v1/quizzes/chapter/ch-1",
+        params={"source": "1"},
+        headers={"Accept-Language": "en"},
+    )
+    assert resp.status_code == 403
 
 
 # ── GET /api/v1/quizzes/{quiz_id} (teacher detail) ──────────────────────

--- a/frontend/src/components/assignment/AssignmentEditor.tsx
+++ b/frontend/src/components/assignment/AssignmentEditor.tsx
@@ -42,8 +42,12 @@ export default function AssignmentEditor({
     let cancelled = false
     setLoading(true)
     setFetchError(false)
+    // Editor-only fetch so the form binds to source-language `title` /
+    // `description` columns regardless of UI locale. Without this a
+    // teacher in EN UI editing their RU assignment would see the EN
+    // translation in the form and a PATCH would overwrite the source.
     coursesService
-      .getChapterAssignments(chapterId)
+      .getChapterAssignmentsForEdit(chapterId)
       .then((data) => {
         if (!cancelled) setAssignments(data)
       })

--- a/frontend/src/components/editor/ChapterBlockEditor.tsx
+++ b/frontend/src/components/editor/ChapterBlockEditor.tsx
@@ -32,7 +32,12 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
   const load = useCallback(
     async (signal?: { cancelled: boolean }) => {
       try {
-        const data = await coursesService.getChapterBlocks(chapterId)
+        // Editor-only fetch so the rich-text editor binds to the source
+        // `content` (TipTap HTML) regardless of UI locale. A teacher in
+        // EN UI editing their RU course would otherwise see the EN
+        // translation in the editor and a PATCH would overwrite the
+        // source `content` column with English HTML.
+        const data = await coursesService.getChapterBlocksForEdit(chapterId)
         if (signal?.cancelled) return
         setBlocks(data.sort((a, b) => a.order_index - b.order_index))
       } catch (error: unknown) {

--- a/frontend/src/components/quiz/editor/useQuizDraft.ts
+++ b/frontend/src/components/quiz/editor/useQuizDraft.ts
@@ -58,7 +58,12 @@ export function useQuizDraft({
     const load = async () => {
       setLoading(true)
       try {
-        const q = await coursesService.getChapterQuiz(chapterId)
+        // Editor-only fetch so the form binds to source-language
+        // `question_text` / `option_text` columns regardless of UI locale.
+        // Without this a teacher in EN UI editing their RU quiz would
+        // see EN translations in the question editor and a PATCH would
+        // overwrite the source `question_text`.
+        const q = await coursesService.getChapterQuizForEdit(chapterId)
         if (cancelled) return
         if (q) {
           setExistingQuiz(q)

--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -56,7 +56,11 @@ export default function ChapterEditor() {
     if (!courseId || !moduleId || !chapterId) return
     setLoading(true)
     try {
-      const mod = await coursesService.getModule(courseId, moduleId)
+      // Editor-only fetch so the breadcrumb's ``moduleName`` + the chapter
+      // title render in the source language regardless of the viewer's UI
+      // locale. Keeps the editor unambiguous: what you see is what you'd
+      // PATCH back.
+      const mod = await coursesService.getModuleForEdit(courseId, moduleId)
       if (signal?.cancelled) return
       setModuleName(mod.title)
       const ch = mod.chapters?.find((c) => c.id === chapterId)

--- a/frontend/src/pages/Teacher/editor/useCourseData.ts
+++ b/frontend/src/pages/Teacher/editor/useCourseData.ts
@@ -59,7 +59,12 @@ export function useCourseData(
       if (!courseId) return
       setLoading(true)
       try {
-        const data = await coursesService.getCourse(courseId)
+        // `getCourseForEdit` forces ``?source=1`` so the InlineEdit fields
+        // bind to the source-language `title` / `description` columns,
+        // not the translation overlay. Without this an admin/owner in EN
+        // UI would type into the EN translation and save it back over
+        // the source — see PR #340 follow-up.
+        const data = await coursesService.getCourseForEdit(courseId)
         if (signal.cancelled) return
         setCourse(data)
         setEnrollStart(isoToLocalInput(data.enrollment_start))

--- a/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
+++ b/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
@@ -39,7 +39,11 @@ export function useModuleEditor(
       if (!courseId || !moduleId) return;
       setLoading(true);
       try {
-        const data = await coursesService.getModule(courseId, moduleId);
+        // `getModuleForEdit` forces ``?source=1`` so the editor binds to
+        // source-language `title` / `description` columns regardless of
+        // the viewer's UI locale. Without this an admin/owner in EN UI
+        // would type into the EN translation and overwrite the source.
+        const data = await coursesService.getModuleForEdit(courseId, moduleId);
         if (signal?.cancelled) return;
         setMod(data);
         setModDueDate(isoToLocalInput(data.due_date));

--- a/frontend/src/services/assignments.ts
+++ b/frontend/src/services/assignments.ts
@@ -16,6 +16,23 @@ export const assignmentsService = {
     return response.data
   },
 
+  /**
+   * Editor-only fetch: forces source-language `title` / `description`
+   * columns regardless of the viewer's `preferred_locale`. Use from
+   * `AssignmentEditor` so a teacher in EN UI editing their RU assignment
+   * doesn't see the EN translation in the editable fields (a PATCH would
+   * then overwrite the source `title` column).
+   *
+   * Owner / admin only — the backend returns 403 for anyone else.
+   */
+  async getChapterAssignmentsForEdit(chapterId: string): Promise<Assignment[]> {
+    const response = await api.get<Assignment[]>(
+      `/assignments/chapter/${chapterId}`,
+      { params: { source: 1 } },
+    )
+    return response.data
+  },
+
   async createAssignment(data: AssignmentCreateData): Promise<Assignment> {
     const response = await api.post<Assignment>("/assignments", data)
     return response.data

--- a/frontend/src/services/blocks.ts
+++ b/frontend/src/services/blocks.ts
@@ -27,6 +27,25 @@ export const blocksService = {
     return response.data
   },
 
+  /**
+   * Editor-only fetch: forces source-language `content` (TipTap HTML)
+   * regardless of the viewer's `preferred_locale`. Use from
+   * `ChapterBlockEditor` so a teacher in EN UI editing their RU course
+   * doesn't see the EN translation in the rich-text editor (a PATCH would
+   * then overwrite the source `content` column with English HTML).
+   *
+   * Owner / admin only — the backend returns 403 for anyone else.
+   * Intentionally bypasses the `blocks:chapter:{id}` cache so the editor
+   * view and the student view don't share state.
+   */
+  async getChapterBlocksForEdit(chapterId: string): Promise<ChapterBlock[]> {
+    const response = await api.get<ChapterBlock[]>(
+      `/blocks/chapter/${chapterId}`,
+      { params: { source: 1 } },
+    )
+    return response.data
+  },
+
   async createBlock(chapterId: string, data: ChapterBlockCreateData): Promise<ChapterBlock> {
     const response = await api.post<ChapterBlock>(`/blocks/chapter/${chapterId}`, data)
     cacheInvalidate(`blocks:chapter:${chapterId}`)

--- a/frontend/src/services/courses.ts
+++ b/frontend/src/services/courses.ts
@@ -49,6 +49,27 @@ const courseCrud = {
     return response.data
   },
 
+  /**
+   * Editor-only fetch: forces the API to return source-language columns
+   * regardless of the viewer's `preferred_locale`. Use from `CourseEditor` /
+   * `useCourseData` so a teacher editing their RU course in EN UI doesn't
+   * see the EN translation in InlineEdit fields (and PATCH it back into the
+   * source `title` column).
+   *
+   * Owner / admin only — the backend returns 403 for anyone else, so this
+   * function is safe to call from teacher-only routes.
+   *
+   * Intentionally bypasses the `courses:detail:{id}` cache: the student-
+   * facing read populates the same key with the localized payload, and we
+   * don't want one view to clobber the other.
+   */
+  async getCourseForEdit(id: string): Promise<Course> {
+    const response = await api.get<Course>(`/courses/${id}`, {
+      params: { source: 1 },
+    })
+    return response.data
+  },
+
   async getTeacherCourses(): Promise<Course[]> {
     const key = "courses:teacher"
     const cached = cacheGet<Course[]>(key)
@@ -127,6 +148,20 @@ const courseCrud = {
     if (cached) return cached
     const response = await api.get<Module>(`/courses/${courseId}/modules/${moduleId}`)
     cacheSet(key, response.data, CACHE_TTL.THREE_MINUTES)
+    return response.data
+  },
+
+  /**
+   * Editor-only fetch: see `getCourseForEdit`. Forces source-language
+   * columns from the module-detail endpoint so `ModuleEditor` and
+   * `ChapterEditor` (which loads its chapter list via the module response)
+   * don't see translation overlays in editable fields.
+   */
+  async getModuleForEdit(courseId: string, moduleId: string): Promise<Module> {
+    const response = await api.get<Module>(
+      `/courses/${courseId}/modules/${moduleId}`,
+      { params: { source: 1 } },
+    )
     return response.data
   },
 

--- a/frontend/src/services/quizzes.ts
+++ b/frontend/src/services/quizzes.ts
@@ -54,6 +54,33 @@ export const quizzesService = {
     }
   },
 
+  /**
+   * Editor-only fetch: forces source-language columns (title, description,
+   * question_text, option_text) regardless of the viewer's `preferred_locale`.
+   * Use from `QuizEditor` / `useQuizDraft` so a teacher in EN UI editing
+   * their RU quiz doesn't see EN translations in the editable fields (a
+   * PATCH would then overwrite the source `question_text` column).
+   *
+   * Owner / admin only — the backend returns 403 for anyone else.
+   * Intentionally bypasses the `quiz:chapter:{id}` cache so a teacher
+   * switching between taking and editing the same quiz doesn't see one
+   * view's payload bleed into the other.
+   */
+  async getChapterQuizForEdit(chapterId: string): Promise<Quiz | null> {
+    try {
+      const response = await api.get<Quiz | null>(
+        `/quizzes/chapter/${chapterId}`,
+        { params: { source: 1 } },
+      )
+      return response.data
+    } catch (err: unknown) {
+      if (isAxiosError(err) && err.response?.status === 404) {
+        return null
+      }
+      throw err
+    }
+  },
+
   async createQuiz(data: QuizCreateData): Promise<Quiz> {
     const response = await api.post<Quiz>("/quizzes", data)
     cacheInvalidate(`quiz:chapter:${data.chapter_id}`)


### PR DESCRIPTION
## Summary
- Unblocks #340 by adding an explicit `?source=1` query param to every editor-consumed GET endpoint plus matching `*ForEdit()` frontend wrappers.
- Owner / admin only — anyone else gets 403 so source content (teacher drafts, typos, unredacted notes) never leaks to students.
- With this in place, #340 can safely remove the implicit owner/admin skip from `should_apply_course_translation_overlay`: student-facing reads will follow viewer locale (the urgent bilingual fix), editor surfaces will keep getting source columns via the explicit flag.

## The bug we're preventing
Without this follow-up, merging #340 would let an admin / owner viewing their RU course in EN UI:
1. Open `CourseEditor` / `ModuleEditor` / `ChapterEditor` / `QuizEditor` / `AssignmentEditor`.
2. See the EN translation in the editable `InlineEdit` / `TipTap` / form fields.
3. Type a tweak and save — `PATCH` overwrites the **source** column (`courses.title`, `chapter_blocks.content`, `quiz_questions.question_text`, etc.) with English text.
4. Course is now `source_locale='ru'` but the source row contains English — corrupts data, breaks every future translation cycle.

## Backend
Added `?source=1` to:
- `GET /api/v1/courses/{course_id}`
- `GET /api/v1/courses/{course_id}/modules/{module_id}`
- `GET /api/v1/quizzes/chapter/{chapter_id}`
- `GET /api/v1/assignments/chapter/{chapter_id}`
- `GET /api/v1/blocks/chapter/{chapter_id}`

`GET /api/v1/quizzes/{quiz_id}` already returns source columns natively (teacher-gated authoring shape, no overlay) — no change.

When `?source=1` is set the endpoint bypasses `resolve_for_display` and returns raw source columns. Non-owner / non-admin → 403. We deny loudly rather than silently ignore so frontend regressions surface immediately instead of leaking text on a slow rollout.

New `is_chapter_course_owner_or_admin` helper lives next to `should_apply_course_translation_overlay_for_chapter` so the three chapter-scoped editor endpoints share one DB roundtrip pattern.

## Frontend
New service wrappers (explicit "for edit" instead of a boolean flag — more discoverable than `getCourse(id, { source: true })`):

- `coursesService.getCourseForEdit` / `getModuleForEdit`
- `quizzesService.getChapterQuizForEdit`
- `assignmentsService.getChapterAssignmentsForEdit`
- `blocksService.getChapterBlocksForEdit`

The `*ForEdit` wrappers intentionally bypass the response cache so the editor view and student view never share cached state.

Editor pages now consume the `*ForEdit` variants:
- `pages/Teacher/editor/useCourseData.ts` → `getCourseForEdit`
- `pages/Teacher/moduleEditor/useModuleEditor.ts` → `getModuleForEdit`
- `pages/Teacher/ChapterEditor.tsx` → `getModuleForEdit` (for the breadcrumb's `moduleName`)
- `components/editor/ChapterBlockEditor.tsx` → `getChapterBlocksForEdit`
- `components/quiz/editor/useQuizDraft.ts` → `getChapterQuizForEdit`
- `components/assignment/AssignmentEditor.tsx` → `getChapterAssignmentsForEdit`

Student-facing callers (`pages/Course/ModuleView`, `ChapterView`, `CourseDetail`, `TeacherGradebook`, `QuizTaker`, `AssignmentPanel`) keep the original methods so the overlay still applies for them.

## Tests
14 new backend tests cover:
- **Regression**: owner / admin with `preferred_locale='en'` calling `?source=1` on an `ru` source course / module / chapter quiz / chapter assignments / chapter blocks → response carries Russian text, **not** the `en` translation.
- **Permission**: a regular student calling `?source=1` → 403 on every endpoint.

## Test plan
- [x] Backend: `pytest tests/` — 679 passed
- [x] Backend: `ruff check .` + `ruff format --check .` — clean
- [x] Backend: `mypy --config-file mypy.ini` — clean
- [x] Frontend: `npm run lint` — clean
- [x] Frontend: `tsc --noEmit` — clean
- [x] Frontend: `npm run test:run` — 210 passed
- [x] Frontend: `npm run build` — clean
- [x] Frontend: `npm run i18n:check` — locale parity OK
- [ ] Manual smoke: log in as admin/owner with `preferred_locale='en'`, open `CourseEditor` / `ModuleEditor` / `ChapterEditor` / `QuizEditor` / `AssignmentEditor` on an RU course — confirm source RU text shows in editable fields (not EN translations).

## Unblocks
PR #340 — once this lands, that PR's removal of the implicit owner/admin skip is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
