### PR TITLE
fix(translation): RPM throttle + blank-env coercion for Gemini

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -79,3 +79,8 @@ GEMINI_MODEL=gemini-2.5-flash-lite
 # values silently truncate long translations (returns finishReason=MAX_TOKENS
 # which the parser now rejects as failed; better to leave the cap high).
 # GEMINI_MAX_OUTPUT_TOKENS=8192
+# Min seconds between two Gemini calls from the same worker (RPM throttle).
+# Production: leave at 0 — natural request spacing keeps you well under the
+# 15 RPM free-tier cap. Backfill scripts: set to 4.5 (≈13 RPM) to avoid
+# hammering the rate limit and burning the daily quota on retries.
+# GEMINI_MIN_INTERVAL_SECONDS=0

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -74,10 +74,27 @@ class Settings(BaseSettings):
     # plus the new ``finishReason`` check in ``GeminiTranslationProvider``
     # closes that hole. Cost-wise the cap only matters when actually emitted.
     GEMINI_MAX_OUTPUT_TOKENS: int = Field(default=8192, description="Cap on generation length")
+    # Minimum spacing between two Gemini calls from the same worker, in
+    # seconds. ``0`` (default) is the right value for production: course
+    # publishing is naturally bursty-but-sparse and rarely trips Gemini's
+    # 15 RPM free-tier limit. Backfill scripts that fire hundreds of
+    # requests back-to-back should set this to ``4.5`` (≈13 RPM, one slot
+    # of headroom under the 15 RPM cap) to avoid 429-rate-limit storms.
+    GEMINI_MIN_INTERVAL_SECONDS: float = Field(
+        default=0.0,
+        description="Min seconds between two Gemini calls from the same worker (RPM throttle)",
+    )
 
     @model_validator(mode="after")
     def load_alternative_env_vars(self):
         """Support alternative env var names from Vercel/Supabase integration."""
+        # An empty ``GEMINI_MODEL`` env var (e.g. an operator set the Vercel
+        # variable to ``""``) would otherwise become the literal string ""
+        # in the request URL — ``models/:generateContent`` — and Gemini
+        # returns 404. Treat blank as "use the default" instead.
+        if not self.GEMINI_MODEL or not self.GEMINI_MODEL.strip():
+            self.GEMINI_MODEL = Settings.model_fields["GEMINI_MODEL"].default
+
         if not self.SUPABASE_SERVICE_ROLE_KEY:
             # Accept the legacy SUPABASE_KEY name from older deployments.
             # Anon keys are NEVER accepted as a server-side secret.

--- a/backend/app/services/translation/gemini.py
+++ b/backend/app/services/translation/gemini.py
@@ -61,6 +61,7 @@ class GeminiTranslationProvider:
         timeout_seconds: float,
         max_output_tokens: int,
         max_retries: int = 2,
+        min_interval_seconds: float = 0.0,
         client: httpx.Client | None = None,
     ) -> None:
         if not api_key:
@@ -71,6 +72,12 @@ class GeminiTranslationProvider:
         self._model = model
         self._max_output_tokens = max_output_tokens
         self._max_retries = max_retries
+        # Min wall-time between two successive ``translate()`` calls on this
+        # instance. Set to ``4.5`` (≈13 RPM) when running backfill scripts
+        # against the free-tier 15 RPM cap; left at ``0`` in production
+        # where natural request spacing keeps us well under the limit.
+        self._min_interval_seconds = min_interval_seconds
+        self._last_call_monotonic: float = 0.0
         # Split timeout: a slow connect or a stuck pool checkout shouldn't
         # eat the full read budget. Read uses the configured per-call cap
         # (the actual generation latency); connect/write/pool stay short.
@@ -126,6 +133,17 @@ class GeminiTranslationProvider:
         payload = self._build_payload(request)
         url = f"{_API_BASE}/models/{self._model}:generateContent"
         headers = {"Content-Type": "application/json", "X-goog-api-key": self._api_key}
+
+        # Enforce the per-instance minimum interval before the first attempt
+        # of this translate() call. We only gate ``translate()`` entries —
+        # the bounded internal retry loop below should not be throttled too,
+        # since retries already back off on their own.
+        if self._min_interval_seconds > 0:
+            elapsed = time.monotonic() - self._last_call_monotonic
+            wait = self._min_interval_seconds - elapsed
+            if wait > 0:
+                time.sleep(wait)
+        self._last_call_monotonic = time.monotonic()
 
         last_error: Exception | None = None
         for attempt in range(self._max_retries + 1):

--- a/backend/app/services/translation/service.py
+++ b/backend/app/services/translation/service.py
@@ -67,7 +67,7 @@ def is_translation_enabled() -> bool:
 # Cache key includes every setting that influences provider construction.
 # When any of these mutate (e.g. an env-var rotation between requests on a
 # warm serverless instance) the next call detects the mismatch and rebuilds.
-_ProviderCacheKey = tuple[str | None, str, float, int]
+_ProviderCacheKey = tuple[str | None, str, float, int, float]
 
 
 def _current_cache_key() -> _ProviderCacheKey:
@@ -76,6 +76,7 @@ def _current_cache_key() -> _ProviderCacheKey:
         settings.GEMINI_MODEL,
         settings.GEMINI_TIMEOUT_SECONDS,
         settings.GEMINI_MAX_OUTPUT_TOKENS,
+        settings.GEMINI_MIN_INTERVAL_SECONDS,
     )
 
 
@@ -122,6 +123,7 @@ def get_translation_provider() -> TranslationProvider:
                 model=settings.GEMINI_MODEL,
                 timeout_seconds=settings.GEMINI_TIMEOUT_SECONDS,
                 max_output_tokens=settings.GEMINI_MAX_OUTPUT_TOKENS,
+                min_interval_seconds=settings.GEMINI_MIN_INTERVAL_SECONDS,
             )
 
         _cached_provider = provider

--- a/backend/tests/test_translation_service.py
+++ b/backend/tests/test_translation_service.py
@@ -372,3 +372,92 @@ def test_gemini_closes_owned_client_via_context_manager():
         owned = provider._client
         assert owned.is_closed is False
     assert owned.is_closed is True
+
+
+def test_gemini_throttles_consecutive_calls(monkeypatch):
+    """With ``min_interval_seconds`` set, back-to-back ``translate()`` calls
+    must sleep enough to honor the configured RPM ceiling. We swap in a fake
+    monotonic clock + capture every ``time.sleep`` so the test runs in
+    microseconds while still asserting the real spacing the throttle would
+    enforce against Gemini's 15 RPM free-tier limit during backfill."""
+    from app.services.translation import gemini as gemini_mod
+
+    sleeps: list[float] = []
+    now = {"t": 1000.0}
+
+    monkeypatch.setattr(gemini_mod.time, "monotonic", lambda: now["t"])
+    monkeypatch.setattr(gemini_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Each call consumes 0.5s of wall clock so the next call's
+        # remaining-budget calculation has something to subtract.
+        now["t"] += 0.5
+        return httpx.Response(
+            200,
+            json={"candidates": [{"content": {"parts": [{"text": "ok"}]}}]},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, timeout=5.0)
+    provider = GeminiTranslationProvider(
+        api_key="fake-key",
+        model="gemini-flash-latest",
+        timeout_seconds=5.0,
+        max_output_tokens=256,
+        min_interval_seconds=4.5,
+        client=client,
+    )
+
+    for _ in range(3):
+        provider.translate(TranslationRequest(text="hi", source_locale="en", target_locale="ru"))
+
+    # First call: no prior call → no throttle sleep. Subsequent calls: the
+    # previous call took 0.5s, so we owe 4.5 - 0.5 = 4.0s of wait.
+    assert sleeps == [4.0, 4.0]
+
+
+def test_gemini_does_not_throttle_when_interval_is_zero(monkeypatch):
+    """Production default (``min_interval_seconds=0``) must not introduce
+    artificial latency — course publishing already throttles itself by user
+    cadence and a hot-path sleep would block the FastAPI worker."""
+    from app.services.translation import gemini as gemini_mod
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(gemini_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    transport = httpx.MockTransport(
+        lambda req: httpx.Response(
+            200,
+            json={"candidates": [{"content": {"parts": [{"text": "ok"}]}}]},
+        )
+    )
+    client = httpx.Client(transport=transport, timeout=5.0)
+    provider = GeminiTranslationProvider(
+        api_key="fake-key",
+        model="gemini-flash-latest",
+        timeout_seconds=5.0,
+        max_output_tokens=256,
+        client=client,
+    )
+    for _ in range(5):
+        provider.translate(TranslationRequest(text="hi", source_locale="en", target_locale="ru"))
+    assert sleeps == []
+
+
+def test_empty_gemini_model_env_falls_back_to_default(monkeypatch):
+    """A blank ``GEMINI_MODEL`` (e.g. ``GEMINI_MODEL=""`` in Vercel) used
+    to slip through and build a broken ``models/:generateContent`` URL.
+    The model-validator now coerces blank/whitespace values to the field
+    default so the provider always has a real model id."""
+    # Import lazily inside the test so monkeypatched env applies at construction.
+    from app.core.config import Settings
+
+    # Ensure other required env vars don't trip the validator.
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://x@localhost/x")
+    monkeypatch.setenv("JWT_SECRET_KEY", "x")
+
+    for blank in ("", "   "):
+        monkeypatch.setenv("GEMINI_MODEL", blank)
+        s = Settings(_env_file=None)
+        assert s.GEMINI_MODEL == "gemini-2.5-flash-lite"


### PR DESCRIPTION
## Summary

Backfilling translations against the free-tier Gemini API surfaced two related bugs that together turned a quota burp into hundreds of `status='failed'` rows on the way to `failed_permanent` (post #354 cap).

- **No RPM ceiling in `GeminiTranslationProvider`.** `backfill_one_course` fired requests back-to-back and instantly tripped the per-minute free-tier limit. Adds an optional `min_interval_seconds` parameter, plumbed through `Settings.GEMINI_MIN_INTERVAL_SECONDS` (default `0` — production hot path untouched; backfill scripts set it to ~5s ≈ 12 RPM).
- **Blank `GEMINI_MODEL` slipped through to the request URL.** Vercel prod env had `GEMINI_MODEL=""`, producing `models/:generateContent` (404). The `model_validator` now coerces blank/whitespace to the field default `gemini-2.5-flash-lite`.

## Why this matters

The pipeline is wired with bounded retries and a per-row `attempts` counter (#354). Without a request-side throttle, *one* unthrottled backfill run can pump dozens of rows from `attempts=0` straight to `failed_permanent` once it hits the rate cap. The throttle keeps the worst-case bounded; the env coercion removes a separate footgun that was silently masquerading as a quota issue.

## Files

- `backend/app/services/translation/gemini.py` — `min_interval_seconds` param + sleep before each `translate()` entry.
- `backend/app/services/translation/service.py` — plumb the new setting through the provider cache key.
- `backend/app/core/config.py` — new `GEMINI_MIN_INTERVAL_SECONDS` field; blank-string coercion for `GEMINI_MODEL`.
- `backend/.env.example` — documents the new knob.
- `backend/tests/test_translation_service.py` — three new tests:
  - throttle enforces spacing (fake clock + captured sleeps; runs in microseconds)
  - throttle = 0 introduces no artificial latency (production default)
  - blank/whitespace `GEMINI_MODEL` falls back to default

## Test plan
- [x] `python -m pytest tests/ -q` — 679 passed
- [x] `python -m ruff check` — clean
- [x] `python -m ruff format --check` — clean
- [x] `python -m mypy --config-file mypy.ini` — no issues
- [ ] After merge: replace prod `GEMINI_MODEL=""` with `gemini-2.5-flash-lite` so the coercion is just a safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)