### PR TITLE
chore(contributors): AGENTS.md, AI-disclosure flow, auto-label, welcome bot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,18 @@
 - [ ] CI / tooling
 - [ ] Breaking change (explain in the summary above)
 
+## How was this developed?
+
+<!--
+We transparently track AI assistance to keep the contribution history
+honest. This is informational — PRs are never rejected on the basis of
+the answer. See AGENTS.md for the Co-Authored-By trailer convention.
+-->
+
+- [ ] Hand-written, no AI assistance
+- [ ] AI-assisted (tool: _____)
+- [ ] Pair-programmed with AI (I drove the design; the agent helped with boilerplate, typing, or suggestions)
+
 ## Checklist
 
 - [ ] Follows [`docs/DESIGN.md`](../docs/DESIGN.md) — no raw palette classes,

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,42 @@
+# Configuration for actions/labeler@v5 — auto-applies labels to pull
+# requests based on the paths of files they touch. New label names added
+# here must already exist on the repo (created via `gh api -X POST
+# /repos/{owner}/{repo}/labels …`).
+#
+# Format reference:
+#   https://github.com/actions/labeler/blob/main/README.md
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'backend/**'
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'frontend/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/labeler.yml'
+          - '.github/dependabot.yml'
+
+migrations:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'supabase/migrations/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/package.json'
+          - '**/package-lock.json'
+          - 'backend/requirements*.txt'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,33 @@
+name: Label PR
+
+# Auto-applies path-based labels to pull requests so the triage view
+# at a glance shows which area of the codebase a PR touches. Uses
+# `pull_request_target` (not `pull_request`) so the workflow has the
+# write permission required to add labels, including on fork PRs. We
+# do NOT check out PR head code in this workflow — `actions/labeler`
+# reads only the file-change list from the PR metadata, so the elevated
+# token surface is safe.
+#
+# Label configuration: .github/labeler.yml
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,51 @@
+name: Welcome new contributors
+
+# Posts a friendly orientation comment the first time someone opens an
+# issue or pull request in this repo. Helps new contributors land on the
+# template + AGENTS.md without having to dig.
+#
+# Uses `pull_request_target` so the comment can be posted even from
+# forked PRs. We do NOT check out PR head code here — the action only
+# posts a comment via the GitHub API.
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  greet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Greet first-time contributor
+        uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          issue-message: |
+            Welcome to Equip 🌱 — thanks for opening your first issue here.
+
+            A few things that help us help you fast:
+
+            - **Bugs:** include reproduction steps and the expected behavior. A screenshot or browser console snippet goes a long way.
+            - **Feature requests:** mention the school / ministry context — what are you trying to do that Equip is making hard?
+            - **Looking for something to work on?** Filter the issue tracker by [`good first issue`](https://github.com/ArVaViT/equip/labels/good%20first%20issue) or [`help wanted`](https://github.com/ArVaViT/equip/labels/help%20wanted). Comment on any of them to claim it.
+
+            A maintainer will respond within a few days. If it's something time-sensitive (security, broken production), please follow the disclosure path in [SECURITY.md](https://github.com/ArVaViT/equip/blob/main/SECURITY.md) or email arvavitcorp@gmail.com directly.
+
+          pr-message: |
+            Thanks for your first pull request to Equip 🎉
+
+            Quick checklist while CI runs:
+
+            - **PR template filled out?** Summary, type of change, AI-assistance disclosure, and the per-area checklist.
+            - **Local lint and tests passing?** `npm run lint && npm run test:run` for frontend; `ruff check . && mypy app/ && python -m pytest tests/` for backend.
+            - **Used an AI coding assistant?** Please credit the tool with a `Co-Authored-By:` trailer for transparency — see [`AGENTS.md`](https://github.com/ArVaViT/equip/blob/main/AGENTS.md) for the convention. (Not a gate — PRs aren't rejected for missing trailers, we just want the history to be honest.)
+            - **CI red?** Open the failing job, look at the bottom of the log, and iterate. Happy to help if you get stuck — comment on this PR and a maintainer will jump in.
+
+            We'll review within a few days.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md — Guidance for AI Coding Agents
+
+This file orients AI coding assistants (Claude Code, Cursor, Aider, Codex,
+Continue, Windsurf, Cline, etc.) working on this repository. Human
+contributors should read [`CONTRIBUTING.md`](CONTRIBUTING.md) instead;
+this is a tighter agent-focused mirror of the same conventions.
+
+If you are an AI agent reading this in a contributor's local checkout:
+follow these rules. If they conflict with explicit instructions from the
+user, the user wins — but flag the conflict in your reply so the user
+knows there is one.
+
+## What this project is
+
+**Equip** is an open-source learning management system for Bible schools,
+church ministries, and nonprofit educational programs. Live instance at
+https://equipbible.com. MIT-licensed. Stack:
+
+- **Frontend** — React 18 + TypeScript + Vite, shadcn/ui + Radix, Tailwind, TipTap rich text. Lives in `frontend/`.
+- **Backend** — FastAPI on Python 3.12, SQLAlchemy 2.0 ORM, Pydantic 2 schemas. Lives in `backend/`.
+- **Database / auth / storage** — Supabase (managed Postgres + Auth + Storage). Schema source of truth is `supabase/migrations/`.
+- **Hosting** — Vercel. Frontend at `equipbible.com`, backend at `api.equipbible.com`. Production deploys from `main`; PRs get preview deploys.
+
+The UI is bilingual EN/RU; the design language targets Russian-speaking
+Bible schools first. Code, comments, commits, and docs are written in
+English.
+
+## Source of truth — read these before non-trivial changes
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — dev workflow, branch naming, Conventional Commits, the PowerShell commit-message workflow.
+- [`docs/DESIGN.md`](docs/DESIGN.md) — design tokens, banned patterns, the four-check rule for adding a library.
+- [`docs/COMPONENTS.md`](docs/COMPONENTS.md) — pattern library (`<Badge>`, `<StatCard>`, `<EmptyState>`, `<ErrorState>`, `<InlineEdit>`, `<PageHeader>`, `<Modal>`) — always reach for these before writing a custom equivalent.
+- [`docs/I18N.md`](docs/I18N.md) — bilingual workflow, plural categories, locale parity guard, DB-enum localization recipe.
+- [`docs/UI-DECISIONS.md`](docs/UI-DECISIONS.md) — frozen UI decisions; do not re-litigate without sign-off from a maintainer.
+- [`docs/adr/`](docs/adr) — Architecture Decision Records for cross-module choices.
+- [`supabase/migrations/README.md`](supabase/migrations/README.md) — append-only migration workflow.
+
+## Hard rules — do not violate
+
+These are load-bearing for the project. Violating them produces noisy
+PRs that get bounced.
+
+- **No raw Tailwind palette classes.** No `bg-blue-500`, `text-gray-700`, `border-red-300`. Use the semantic tokens from `docs/DESIGN.md` (`bg-primary`, `text-muted-foreground`, `border-input`, etc.).
+- **No `window.alert / prompt / confirm`.** Confirmations go through `useConfirm()` + Radix `AlertDialog`. Toasts go through `sonner`.
+- **Icons:** `lucide-react` only. Sizes are `16`, `20`, or `24`. `strokeWidth={1.75}` on every icon.
+- **All user-facing strings go through `t(...)`.** Locale bundles live in `frontend/src/i18n/locales/{en,ru}.json` and must stay in parity. CI fails on drift.
+- **Conventional Commits.** `feat(quiz): ...`, `fix(auth): ...`, `chore(ci): ...`. Branch name mirrors the commit prefix (`feat/quiz-extra-attempts`, `fix/audit-invalid-uuid`).
+- **Migrations are append-only.** Never edit an `.sql` file under `supabase/migrations/` that has already been applied. Create a new timestamped file (`YYYYMMDDHHMMSS_<slug>.sql`) instead.
+- **The four-way enum mirror.** A new persisted enum value must be added in **four** places that stay in lockstep: Postgres `CHECK` constraint, Pydantic `Literal[...]`, TypeScript union type, and the TypeScript `const` accessor (e.g. `ROLES`). See `frontend/src/types/index.ts` for the pattern.
+- **No Docker.** The project deliberately avoids container workflows today. Do not suggest one.
+
+## Pre-PR verification
+
+Run locally before pushing — CI is zero-warnings on all of these:
+
+```bash
+# Backend
+cd backend
+ruff check .
+ruff format --check .
+mypy --config-file mypy.ini
+python -m pytest tests/
+
+# Frontend
+cd frontend
+npm run lint        # eslint --max-warnings 0
+npx tsc --noEmit    # strict
+npm run i18n:check  # locale parity
+npm run test:run    # vitest
+npm run build       # tsc && vite build
+```
+
+## Commit conventions — including AI co-authorship
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/).
+**If you are an AI agent committing on behalf of a human contributor, add
+a `Co-Authored-By:` trailer crediting yourself** so the contribution
+history reflects how the change was actually made:
+
+```
+feat(quiz): allow teacher-gifted extra attempts
+
+A student who runs out of attempts can be granted more without
+resetting the whole `attempts_used` counter. Implemented as a new
+`quiz_extra_attempts` row keyed on (quiz_id, user_id).
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+Use the appropriate identity for your tool. If unsure, use your tool's
+documented Co-Authored-By identity or pick the closest:
+
+- Claude Code / Claude — `Co-Authored-By: Claude <noreply@anthropic.com>`
+- Cursor — `Co-Authored-By: Cursor <noreply@cursor.sh>`
+- Aider — `Co-Authored-By: Aider <noreply@aider.chat>`
+- GitHub Copilot — `Co-Authored-By: GitHub Copilot <noreply@github.com>`
+- OpenAI Codex / ChatGPT — `Co-Authored-By: ChatGPT <noreply@openai.com>`
+
+This is a **transparency** convention, not a gate. PRs are not rejected
+for missing trailers. It just lets us — and you, looking back at history
+— see how the codebase actually got built. We want that signal to be
+honest.
+
+## What you must NOT do
+
+- **Do not fabricate API behavior or types.** If you don't know what an endpoint returns, read the route in `backend/app/api/v1/` and the matching Pydantic schema in `backend/app/schemas/`. Never invent fields.
+- **Do not edit applied migrations.** Always add a new timestamped file.
+- **Do not introduce a new library** without running the four-check rule from `docs/DESIGN.md`: (1) is it actually needed, (2) does an existing dep cover it, (3) is it actively maintained, (4) does it fit the stack idioms.
+- **Do not commit secrets.** `.env`, `*.key`, `*.pem`, `credentials.json`, `serviceAccountKey.json` are blocked by the `pr-quality` CI job; GitHub secret-scanning push-protection blocks known token formats at push time.
+- **Do not skip CI hooks** (`--no-verify` etc.) unless the user explicitly asks.
+- **Do not amend already-pushed commits.** Add a new commit instead — the project values legible PR history.
+
+## Getting unstuck
+
+If a convention in this file (or a linked doc) conflicts with the
+existing code, **the existing code is authoritative** unless the
+contradiction is clearly a bug. Mention the conflict in the PR
+description so a maintainer can decide which is canonical.
+
+Open questions go in [GitHub Discussions](https://github.com/ArVaViT/equip/discussions),
+not buried in code comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,35 @@ supabase/
    ```
 4. **Push** and open a pull request against `main`.
 
+## Using AI coding assistants
+
+We welcome contributions developed with AI assistance — Claude Code,
+Cursor, Aider, GitHub Copilot, ChatGPT / Codex, Windsurf, Continue, and
+similar tools. The project ships an [`AGENTS.md`](AGENTS.md) at the
+repo root with the conventions agents should follow.
+
+We ask one thing in return: **be transparent about it.**
+
+- **Tick the PR-template checkbox** that says "AI-assisted" and name the
+  tool you used.
+- **Add a `Co-Authored-By:` trailer** to commits the agent helped
+  produce, so the contribution history reflects how the change was
+  actually made. Many agents (Claude Code, Cursor, Aider) add this
+  automatically when they read `AGENTS.md`; if yours doesn't, add it
+  manually:
+
+  ```
+  Co-Authored-By: Claude <noreply@anthropic.com>
+  ```
+
+  Use the identity that matches your tool. `AGENTS.md` has a short
+  reference table.
+
+This is a transparency convention, not a gate. PRs are never rejected
+for missing trailers — but a clean co-author history makes it legible
+(to us, and to you when you come back to the diff six months from now)
+how the codebase actually got built.
+
 ## Commit conventions
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):


### PR DESCRIPTION
## Summary

Tightens the contributor flow: agent-aware orientation file, AI-disclosure convention through the PR template + `CONTRIBUTING.md`, path-based auto-labeling, and a friendly welcome comment for first-time contributors.

## Type of change

- [x] CI / tooling
- [x] Documentation

## How was this developed?

- [x] AI-assisted (tool: Claude Code)

## What this changes

**`AGENTS.md`** — new file at the repo root following the [agents.md](https://agents.md) convention, recognized out of the box by Claude Code, Cursor, Aider, Codex, Continue, Windsurf, and Cline. It's a tighter agent-focused mirror of `CONTRIBUTING.md` that calls out:

- The stack and source-of-truth docs to read before non-trivial changes
- The hard rules (no raw palette classes, no `window.alert/prompt/confirm`, lucide icons only, t() for all user strings, append-only migrations, the four-way enum mirror, etc.)
- Pre-PR verification commands
- The `Co-Authored-By:` trailer convention for AI-assisted commits, with a tool→identity reference table

**`CONTRIBUTING.md`** — new "Using AI coding assistants" section that documents the transparency convention (PR checkbox + commit trailer) and links to `AGENTS.md`. Framed as a request, not a gate — PRs are never rejected for missing trailers.

**`.github/PULL_REQUEST_TEMPLATE.md`** — new "How was this developed?" section with three options (no-AI / AI-assisted / paired) and a free-text tool field. Sits between "Type of change" and "Checklist".

**`.github/labeler.yml` + `.github/workflows/label.yml`** — `actions/labeler@v5` auto-applies path-based labels:

| Path | Label |
|------|-------|
| `backend/**` | `backend` |
| `frontend/**` | `frontend` |
| `**/*.md`, `docs/**` | `documentation` |
| `.github/workflows/**`, `.github/labeler.yml`, `.github/dependabot.yml` | `ci` |
| `supabase/migrations/**` | `migrations` |
| `**/package*.json`, `backend/requirements*.txt` | `dependencies` |

Three new labels (`ci`, `migrations`, `dependencies`) were created on the repo so the config has targets. Runs on `pull_request_target` so fork PRs are labeled too; does NOT check out PR head code (labeler reads metadata only — safe pattern for elevated tokens).

**`.github/workflows/welcome.yml`** — `actions/first-interaction@v1` posts a friendly orientation comment on each contributor's first issue and first PR. Comment links to the template, `AGENTS.md`, and the `good first issue` / `help wanted` filters.

## Operational notes

- Both new workflows are operational, not test gates — they do **not** become required status checks. The existing required set (`pr-quality`, `Backend CI Pass`, `Frontend CI Pass`) is unchanged.
- Both use `pull_request_target` for write-token access; both explicitly do NOT check out PR head code. This is the safe pattern documented by GitHub for these triggers.
- All actions are github-owned (`actions/labeler`, `actions/first-interaction`), so the repo's locked-down `allowed_actions: selected + github_owned + verified` policy is satisfied.

## Test plan

- [x] CI is green on this PR (`pr-quality`, `Backend CI Pass` auto-pass, `Frontend CI Pass` auto-pass — no code paths touched)
- [ ] After merge: open a follow-up PR touching `backend/`, `frontend/`, or `docs/` and confirm the right label is applied automatically
- [ ] After merge: open an issue from a new GitHub account (or unfollow + follow + reopen) to confirm the welcome comment fires

Closes none — initiative-level cleanup.
