### PR TITLE
fix(health): add /api/v1/health alias for external monitors

### DIFF
--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -13,6 +13,19 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/health", tags=["health"])
 
 
+@router.get("", include_in_schema=False)
+def health_root() -> dict:
+    """API-namespaced alias for the root ``/health`` liveness probe.
+
+    External monitors (Datadog synthetics, Uptime Robot, etc.) sometimes
+    default to the API-prefixed path. Without this alias they hit a 404
+    and add noise to the error-rate panel. Body shape matches ``/health``
+    so a synthetic switching between the two doesn't see a behavior
+    change.
+    """
+    return {"status": "ok"}
+
+
 @router.get("/db")
 def check_database(
     db: Session = Depends(get_db),

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -33,6 +33,17 @@ def test_health_returns_ok():
     assert resp.json() == {"status": "ok"}
 
 
+def test_api_v1_health_alias_returns_ok():
+    """External monitors (Datadog synthetics) defaulted to the
+    API-namespaced ``/api/v1/health`` and hit 404s, padding the
+    error-rate panel. The alias body must match ``/health`` so a
+    synthetic switching between the two URLs reads identically."""
+    with TestClient(app) as tc:
+        resp = tc.get("/api/v1/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
 def test_response_includes_x_request_id_header():
     """Every response must carry an ``X-Request-Id`` header so a user
     reporting a bug can quote it and we can pivot from a single browser


### PR DESCRIPTION
## Summary

External monitors (most likely Datadog synthetics — `DD_SERVICE` / `DD_ENV` env vars are present in prod) were calling `/api/v1/health` and getting 404s. Only 4/day, but the 4xx noise lands in the same error-rate panel as real bugs and makes a real spike harder to spot.

## Fix

Add `GET /api/v1/health` that returns `{"status": "ok"}` — same body as the existing root `/health`. Marked `include_in_schema=False` so it doesn't show up as a duplicate endpoint in OpenAPI; it's a deliberate compatibility shim, not a new contract.

## Test plan
- [x] `python -m pytest tests/test_health.py -v` — 6 passed (5 existing + 1 new)
- [x] `python -m ruff check` — clean
- [ ] After merge: confirm the `/api/v1/health` 404s drop off in Vercel logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)