### PR TITLE
ci(dependabot): auto-merge patch + minor npm/pip bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,47 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot pull requests for patch and minor version bumps in
+# the npm and pip ecosystems once every required status check passes. Major
+# version bumps and github-actions updates always require manual review --
+# major bumps almost always need a migration step (see dependabot.yml ignore
+# block), and workflow changes affect CI itself.
+#
+# Safety model:
+#   - `gh pr merge --auto` does NOT bypass the branch ruleset. GitHub merges
+#     only after every required check on `main` reports success (currently
+#     pr-quality, Backend CI Pass, Frontend CI Pass).
+#   - `if: github.actor == 'dependabot[bot]'` guarantees this job only acts
+#     on Dependabot-authored PRs, regardless of what triggers the workflow.
+#   - `pull_request_target` is required so the job has the
+#     `pull-requests: write` permission needed to call the merge endpoint
+#     for Dependabot PRs (which run from a bot-owned ref, treated like a
+#     fork). We do NOT check out PR head code -- only Dependabot metadata
+#     and the merge API call run here.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch / minor npm + pip updates
+        if: >-
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor') &&
+          (steps.meta.outputs.package-ecosystem == 'npm' ||
+           steps.meta.outputs.package-ecosystem == 'pip')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml` so patch + minor Dependabot PRs for npm and pip ecosystems merge themselves once required CI passes. Major bumps and `github-actions` ecosystem updates stay manual.
- Uses `gh pr merge --auto` so the existing branch ruleset (`pr-quality`, `Backend CI Pass`, `Frontend CI Pass`) is still the gate -- nothing merges without green CI.
- Out of band, the two orphaned workflow records `backend-ci-fallback.yml` and `frontend-ci-fallback.yml` (files already deleted in the consolidation that landed earlier, but the GitHub workflow rows lingered as `active`) were disabled via API, so they no longer appear in the workflow list.

## Why this is safe
- The job is gated on `github.actor == 'dependabot[bot]'`, so it only acts on Dependabot-authored PRs even though the trigger is `pull_request_target`.
- No checkout of PR head code happens here. The job only reads Dependabot metadata and calls the merge API.
- `gh pr merge --auto` cannot bypass the ruleset; GitHub blocks the merge until every required check reports success.

## Test plan
- [ ] PR shows three required checks (pr-quality, Backend CI Pass, Frontend CI Pass) and they all go green.
- [ ] No new active workflows appear in the repo Actions list other than `Dependabot auto-merge`.
- [ ] After merge, the next Dependabot patch PR enables auto-merge automatically and lands without a manual click.

Closes the notification-volume part of the inbox cleanup we did this afternoon (319 unread -> 0, watching downgraded from All Activity to Participating).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
