### PR TITLE
fix(csp): allow Datadog US5 intake hosts in connect-src

### DIFF
--- a/frontend/src/__tests__/vercelCsp.test.ts
+++ b/frontend/src/__tests__/vercelCsp.test.ts
@@ -61,11 +61,20 @@ const REQUIRED_TOKENS: ReadonlyArray<string> = [
   "default-src 'self'",
   // Scripts only from same-origin -- no inline, no eval.
   "script-src 'self'",
-  // Datadog RUM intake (us5 and any region; the SDK builds the host
-  // dynamically). Anchored to a wildcard subdomain to avoid having to
-  // chase each region rename.
+  // Datadog RUM intake. Two host-naming patterns coexist:
+  //   - subdomain form: ``us5.browser-intake-datadoghq.com`` (matched by
+  //     the wildcard)
+  //   - flat single-host form: ``browser-intake-us5-datadoghq.com`` (NOT
+  //     a subdomain of datadoghq.com -- separate registered domain). The
+  //     RUM SDK uses the flat form for US5, so we need an explicit entry.
+  // Without the explicit US5 host, each RUM POST tripped a
+  // ``securitypolicyviolation`` event, the RUM SDK reported it back to
+  // Datadog as a frontend error, and the "RUM error spike" monitor
+  // alerted on Datadog being blocked by our CSP -- a feedback loop.
   "https://*.datadoghq.com",
   "https://*.browser-intake-datadoghq.com",
+  "https://browser-intake-us5-datadoghq.com",
+  "https://session-replay-us5-datadoghq.com",
   // Supabase project endpoint (auth + REST + realtime websocket).
   "https://rrisqutxlkamwfhcashl.supabase.co",
   "wss://rrisqutxlkamwfhcashl.supabase.co",

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -23,7 +23,7 @@
         },
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://rrisqutxlkamwfhcashl.supabase.co; font-src 'self' data:; connect-src 'self' https://api.equipbible.com https://rrisqutxlkamwfhcashl.supabase.co wss://rrisqutxlkamwfhcashl.supabase.co https://*.datadoghq.com https://*.browser-intake-datadoghq.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; worker-src 'self' blob:"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://rrisqutxlkamwfhcashl.supabase.co; font-src 'self' data:; connect-src 'self' https://api.equipbible.com https://rrisqutxlkamwfhcashl.supabase.co wss://rrisqutxlkamwfhcashl.supabase.co https://*.datadoghq.com https://*.browser-intake-datadoghq.com https://browser-intake-us5-datadoghq.com https://session-replay-us5-datadoghq.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; worker-src 'self' blob:"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Datadog \"RUM error spike\" alert is firing because of a feedback loop: every frontend RUM POST trips a CSP \`securitypolicyviolation\` event, the RUM SDK reports the violation **back** to Datadog as a frontend error, and the monitor fires on Datadog being blocked by our own CSP.

## Root cause

Datadog uses two host-naming patterns and only one was allow-listed in \`connect-src\`:

| Pattern | Example | Wildcard match |
|---|---|---|
| subdomain | \`us5.browser-intake-datadoghq.com\` | ✅ \`*.browser-intake-datadoghq.com\` |
| flat single-host | \`browser-intake-us5-datadoghq.com\` | ❌ separate registered domain — no wildcard catches it |

The RUM SDK uses the flat form for US5, so every event POST violated the (report-only) CSP. Same for Session Replay (\`session-replay-us5-datadoghq.com\`).

## Fix

Add the two missing US5 hosts explicitly to \`connect-src\` in \`frontend/vercel.json\`, and mirror them in the \`REQUIRED_TOKENS\` regression list in \`vercelCsp.test.ts\` so a future edit that drops them gets caught.

CSP is still \`Report-Only\`, so this is non-breaking either way — only observable change is that the violation reports stop firing, which makes the RUM error monitor flip back to OK.

## Files
- \`frontend/vercel.json\` — two new \`connect-src\` entries
- \`frontend/src/__tests__/vercelCsp.test.ts\` — assert both new tokens present + explainer comment

## Test plan
- [x] \`npx vitest run src/__tests__/vercelCsp.test.ts\` — 4 passed
- [x] \`npm run lint\` — clean
- [ ] After deploy: verify Datadog \"RUM error spike\" monitor returns to OK within ~10 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)