### PR TITLE
design(courseCard): editorial-quiet card for the catalog grid

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -1,14 +1,12 @@
 import { useState, memo } from "react"
 import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { motion, useReducedMotion } from "motion/react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import type { Course } from "@/types"
-import { BookOpen, ArrowRight } from "lucide-react"
+import { BookOpen } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import { formatDate } from "@/i18n/format"
-import { EDITORIAL_EASE } from "@/lib/motion"
 
 interface CourseCardProps {
   course: Course
@@ -27,26 +25,36 @@ function enrollmentState(start?: string | null, end?: string | null): { state: E
   return { state: "open" }
 }
 
-function EnrollmentBadge({ start, end }: { start?: string | null; end?: string | null }) {
+// One inline pill that summarises access mode + enrollment window for the
+// meta row. Lives below the title (not floating over the cover) so the
+// card reads as an editorial listing instead of a marketing tile.
+function StatusBadge({ course }: { course: Course }) {
   const { t } = useTranslation()
-  const { state, date } = enrollmentState(start, end)
+  if (course.access_mode === "institute") {
+    return (
+      <Badge variant="muted" className="font-normal">
+        {t("courseCard.byInvitation")}
+      </Badge>
+    )
+  }
+  const { state, date } = enrollmentState(course.enrollment_start, course.enrollment_end)
   if (!state) return null
   if (state === "opens") {
     return (
-      <Badge variant="info" className="absolute right-3 top-3 z-10">
+      <Badge variant="info" className="font-normal">
         {t("courseCard.opensOn", { date: formatDate(date!) })}
       </Badge>
     )
   }
   if (state === "closed") {
     return (
-      <Badge variant="destructive" className="absolute right-3 top-3 z-10">
+      <Badge variant="destructive" className="font-normal">
         {t("courseCard.enrollmentClosed")}
       </Badge>
     )
   }
   return (
-    <Badge variant="success" className="absolute right-3 top-3 z-10">
+    <Badge variant="success" className="font-normal">
       {t("courseCard.enrollingNow")}
     </Badge>
   )
@@ -54,61 +62,10 @@ function EnrollmentBadge({ start, end }: { start?: string | null; end?: string |
 
 function CourseCard({ course, style }: CourseCardProps) {
   const { t } = useTranslation()
-  const prefersReducedMotion = useReducedMotion()
   const [imgError, setImgError] = useState(false)
   const coverSrc = toProxyImage(course.image_url)
   const moduleCount = course.modules?.length ?? 0
-
-  const cardInner = (
-    <Card className="flex h-full flex-col overflow-hidden border-border/60 transition-colors hover:border-primary/40">
-      <div className="relative">
-        {course.access_mode === "institute" ? (
-          <Badge variant="muted" className="absolute right-3 top-3 z-10">
-            {t("courseCard.byInvitation")}
-          </Badge>
-        ) : (
-          <EnrollmentBadge start={course.enrollment_start} end={course.enrollment_end} />
-        )}
-        {coverSrc && !imgError ? (
-          <div className="aspect-[16/10] w-full overflow-hidden bg-muted">
-            <img
-              src={coverSrc}
-              alt={course.title}
-              loading="lazy"
-              decoding="async"
-              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.02]"
-              onError={() => setImgError(true)}
-            />
-          </div>
-        ) : (
-          <div className="flex aspect-[16/10] w-full items-center justify-center bg-muted">
-            <BookOpen className="h-10 w-10 text-muted-foreground/30" strokeWidth={1.75} aria-hidden />
-          </div>
-        )}
-      </div>
-      <CardHeader className="pb-2">
-        <CardTitle className="font-serif text-lg leading-snug line-clamp-2 text-wrap-safe">
-          {course.title}
-        </CardTitle>
-        {course.description && (
-          <CardDescription className="line-clamp-2 text-sm leading-relaxed text-wrap-safe sm:text-xs">
-            {course.description}
-          </CardDescription>
-        )}
-      </CardHeader>
-      <CardContent className="mt-auto flex items-center justify-between pt-2 text-xs text-muted-foreground">
-        <span className="uppercase tracking-wide">{t("courseCard.modulesLabel", { count: moduleCount })}</span>
-        <span className="inline-flex items-center gap-1 text-foreground/80 transition-colors group-hover:text-primary">
-          {t("courseCard.openCourse")}
-          <ArrowRight
-            className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5"
-            strokeWidth={1.75}
-            aria-hidden
-          />
-        </span>
-      </CardContent>
-    </Card>
-  )
+  const hasImage = !!coverSrc && !imgError
 
   return (
     <Link
@@ -116,18 +73,59 @@ function CourseCard({ course, style }: CourseCardProps) {
       style={style}
       className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
-      {prefersReducedMotion ? (
-        cardInner
-      ) : (
-        <motion.div
-          whileHover={{ y: -2 }}
-          whileTap={{ scale: 0.985 }}
-          transition={{ duration: 0.28, ease: EDITORIAL_EASE }}
-          className="h-full"
-        >
-          {cardInner}
-        </motion.div>
-      )}
+      <Card className="flex h-full flex-col overflow-hidden hover:border-primary/30">
+        {/* Cover strip. 16:9 (slimmer than the old 16:10) so the image
+            reads as a header band, not a hero. No hover-zoom — that was
+            the loudest "marketing tile" tell. Bg-muted so an image-less
+            card still has a calm coloured band of the same height,
+            keeping every card in the grid the exact same total height. */}
+        <div className="aspect-[16/9] w-full overflow-hidden bg-muted">
+          {hasImage ? (
+            <img
+              src={coverSrc}
+              alt={course.title}
+              loading="lazy"
+              decoding="async"
+              className="h-full w-full object-cover"
+              onError={() => setImgError(true)}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <BookOpen
+                className="h-8 w-8 text-muted-foreground/40"
+                strokeWidth={1.5}
+                aria-hidden
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-1 flex-col gap-3 p-5">
+          <h3 className="font-serif text-lg leading-snug text-foreground line-clamp-2 text-wrap-safe">
+            {course.title}
+          </h3>
+          {course.description && (
+            <p className="text-sm leading-relaxed text-muted-foreground line-clamp-2 text-wrap-safe">
+              {course.description}
+            </p>
+          )}
+
+          {/* Meta row pinned to the bottom of the card. mt-auto pushes
+              this against the lower edge regardless of title/description
+              length, so every card lines up across the grid. The module
+              count and the status pill sit on the same baseline; we drop
+              the previous "Open course →" CTA because the whole card is
+              already a link — the explicit affordance was the second
+              loudest "ad" tell. */}
+          <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-2 pt-2 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5">
+              <BookOpen className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+              {t("courseCard.modulesLabel", { count: moduleCount })}
+            </span>
+            <StatusBadge course={course} />
+          </div>
+        </div>
+      </Card>
     </Link>
   )
 }

--- a/frontend/src/components/skeletons/CourseCardSkeleton.tsx
+++ b/frontend/src/components/skeletons/CourseCardSkeleton.tsx
@@ -1,21 +1,22 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 
+// Mirrors the CourseCard structure exactly so the loading state has the
+// same overall height + aspect ratio + spacing as the loaded state —
+// otherwise the grid jumps when the data lands.
 export default function CourseCardSkeleton() {
   return (
-    <Card className="flex flex-col overflow-hidden">
-      <Skeleton className="w-full h-44 rounded-none" />
-      <CardHeader className="pb-2">
+    <Card className="flex h-full flex-col overflow-hidden">
+      <Skeleton className="aspect-[16/9] w-full rounded-none" />
+      <div className="flex flex-1 flex-col gap-3 p-5">
         <Skeleton className="h-5 w-3/4" />
-        <Skeleton className="h-3 w-full mt-2" />
-        <Skeleton className="h-3 w-2/3 mt-1" />
-      </CardHeader>
-      <CardContent className="mt-auto pt-2">
-        <div className="flex items-center justify-between">
-          <Skeleton className="h-3 w-20" />
-          <Skeleton className="h-8 w-16" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+        <div className="mt-auto flex items-center gap-3 pt-2">
+          <Skeleton className="h-3.5 w-24" />
+          <Skeleton className="h-5 w-20 rounded-full" />
         </div>
-      </CardContent>
+      </div>
     </Card>
   )
 }


### PR DESCRIPTION
## Summary

The catalog tiles were reading as marketing units. The cover image was a 16:10 hero with a status badge floating over it, the footer carried an explicit \"Open course →\" CTA with a translating arrow, and the card layered a hover lift + image scale + border tint + CTA color shift + arrow translate — six concurrent hover affordances on a dense grid.

Per `docs/DESIGN.md`: catalog views are part of the \"quiet and flat\" default surface. Expressive moments are reserved for hero areas / CTA buttons / page transitions, not list items.

## Changes

| Old | New |
|---|---|
| 16:10 image with hover-zoom | `aspect-[16/9]`, no zoom |
| Status badge absolute-positioned over the image | Inline pill in the meta row, `font-normal` |
| \"Open course →\" CTA with translating arrow | Removed (whole card is `<Link>`) |
| `motion.div` `y: -2` lift + `scale: 0.985` on tap | Removed (only border tint shifts on hover) |
| `uppercase tracking-wide` eyebrow on modules count | Plain metadata text |
| Skeleton with `h-44` image + CTA stub | Skeleton mirrors new structure (`aspect-[16/9]` + pill stub) |

Image alt stays as `course.title` so the nine existing tests pass unchanged. Both themes work; only semantic CSS tokens are used; no raw Tailwind palette classes; module count + badge fit the same `text-xs text-muted-foreground` row.

## Test plan
- [x] `npx vitest run src/components/course/__tests__/CourseCard.test.tsx` — 9 passed
- [x] `npm run test:run` — 222 passed
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] **Vadym: visually verify the preview deploy** (couldn't run a browser from this session) — check the catalog grid at 320 / 768 / 1280 widths, in both light and dark themes, with cards that have covers and cards without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)