### PR TITLE
design(courseCard): modern polish — confident title, dot-indicator status

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -1,8 +1,8 @@
 import { useState, memo } from "react"
 import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import { Card } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import type { Course } from "@/types"
 import { BookOpen } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
@@ -13,50 +13,52 @@ interface CourseCardProps {
   style?: React.CSSProperties
 }
 
-type EnrollmentState = "opens" | "closed" | "open" | null
-
-function enrollmentState(start?: string | null, end?: string | null): { state: EnrollmentState; date?: Date } {
-  if (!start && !end) return { state: null }
-  const now = new Date()
-  const s = start ? new Date(start) : null
-  const e = end ? new Date(end) : null
-  if (s && now < s) return { state: "opens", date: s }
-  if (e && now > e) return { state: "closed" }
-  return { state: "open" }
+type StatusKind = "open" | "opens" | "closed" | "institute" | null
+interface Status {
+  kind: Exclude<StatusKind, null>
+  label: string
 }
 
-// One inline pill that summarises access mode + enrollment window for the
-// meta row. Lives below the title (not floating over the cover) so the
-// card reads as an editorial listing instead of a marketing tile.
-function StatusBadge({ course }: { course: Course }) {
-  const { t } = useTranslation()
+// Distill the access mode + enrollment window into one (label, tone) tuple
+// so the render path doesn't carry a conditional ladder. ``institute``
+// suppresses the enrollment-window check — invitation-only courses don't
+// expose a public window, and showing both would mis-signal "anyone can
+// enroll if they hurry".
+function resolveStatus(course: Course, t: TFunction): Status | null {
   if (course.access_mode === "institute") {
-    return (
-      <Badge variant="muted" className="font-normal">
-        {t("courseCard.byInvitation")}
-      </Badge>
-    )
+    return { kind: "institute", label: t("courseCard.byInvitation") }
   }
-  const { state, date } = enrollmentState(course.enrollment_start, course.enrollment_end)
-  if (!state) return null
-  if (state === "opens") {
-    return (
-      <Badge variant="info" className="font-normal">
-        {t("courseCard.opensOn", { date: formatDate(date!) })}
-      </Badge>
-    )
+  const start = course.enrollment_start
+  const end = course.enrollment_end
+  if (!start && !end) return null
+  const now = Date.now()
+  if (start && new Date(start).getTime() > now) {
+    return { kind: "opens", label: t("courseCard.opensOn", { date: formatDate(new Date(start)) }) }
   }
-  if (state === "closed") {
-    return (
-      <Badge variant="destructive" className="font-normal">
-        {t("courseCard.enrollmentClosed")}
-      </Badge>
-    )
+  if (end && new Date(end).getTime() < now) {
+    return { kind: "closed", label: t("courseCard.enrollmentClosed") }
   }
+  return { kind: "open", label: t("courseCard.enrollingNow") }
+}
+
+// Dot + colored label instead of a filled pill. The filled-pill variant
+// reads as a marketing tag (Sale, New, etc.); dot + label reads as a
+// status indicator -- the modern Linear / Vercel pattern. Tones map
+// 1:1 to our semantic CSS tokens so dark-mode parity is automatic.
+const STATUS_TONE: Record<Status["kind"], { dot: string; text: string }> = {
+  open: { dot: "bg-success", text: "text-success" },
+  opens: { dot: "bg-info", text: "text-info" },
+  closed: { dot: "bg-destructive", text: "text-destructive" },
+  institute: { dot: "bg-muted-foreground/60", text: "text-muted-foreground" },
+}
+
+function StatusIndicator({ status }: { status: Status }) {
+  const tone = STATUS_TONE[status.kind]
   return (
-    <Badge variant="success" className="font-normal">
-      {t("courseCard.enrollingNow")}
-    </Badge>
+    <span className="inline-flex items-center gap-1.5">
+      <span className={`h-1.5 w-1.5 rounded-full ${tone.dot}`} aria-hidden />
+      <span className={tone.text}>{status.label}</span>
+    </span>
   )
 }
 
@@ -66,6 +68,7 @@ function CourseCard({ course, style }: CourseCardProps) {
   const coverSrc = toProxyImage(course.image_url)
   const moduleCount = course.modules?.length ?? 0
   const hasImage = !!coverSrc && !imgError
+  const status = resolveStatus(course, t)
 
   return (
     <Link
@@ -73,13 +76,12 @@ function CourseCard({ course, style }: CourseCardProps) {
       style={style}
       className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
-      <Card className="flex h-full flex-col overflow-hidden hover:border-primary/30">
-        {/* Cover strip. 16:9 (slimmer than the old 16:10) so the image
-            reads as a header band, not a hero. No hover-zoom — that was
-            the loudest "marketing tile" tell. Bg-muted so an image-less
-            card still has a calm coloured band of the same height,
-            keeping every card in the grid the exact same total height. */}
-        <div className="aspect-[16/9] w-full overflow-hidden bg-muted">
+      <Card className="flex h-full flex-col overflow-hidden hover:border-primary/40">
+        {/* Cover band. 16:9 keeps the image a header strip, not a hero.
+            The gradient on the empty state gives image-less cards a real
+            designed surface instead of a flat muted block -- pre-fill
+            material was the most "placeholder-y" tell of the old card. */}
+        <div className="aspect-[16/9] w-full overflow-hidden bg-gradient-to-br from-muted to-muted/40">
           {hasImage ? (
             <img
               src={coverSrc}
@@ -92,7 +94,7 @@ function CourseCard({ course, style }: CourseCardProps) {
           ) : (
             <div className="flex h-full w-full items-center justify-center">
               <BookOpen
-                className="h-8 w-8 text-muted-foreground/40"
+                className="h-10 w-10 text-primary/25"
                 strokeWidth={1.5}
                 aria-hidden
               />
@@ -101,7 +103,11 @@ function CourseCard({ course, style }: CourseCardProps) {
         </div>
 
         <div className="flex flex-1 flex-col gap-3 p-5">
-          <h3 className="font-serif text-lg leading-snug text-foreground line-clamp-2 text-wrap-safe">
+          {/* text-xl + font-medium on Fraunces: confident headline without
+              tipping into "marketing" territory. text-lg (the previous
+              size) read as a subhead next to the image and let the page
+              feel timid. font-semibold here makes Fraunces too heavy. */}
+          <h3 className="font-serif text-xl font-medium leading-snug tracking-tight text-foreground line-clamp-2 text-wrap-safe">
             {course.title}
           </h3>
           {course.description && (
@@ -110,19 +116,19 @@ function CourseCard({ course, style }: CourseCardProps) {
             </p>
           )}
 
-          {/* Meta row pinned to the bottom of the card. mt-auto pushes
-              this against the lower edge regardless of title/description
-              length, so every card lines up across the grid. The module
-              count and the status pill sit on the same baseline; we drop
-              the previous "Open course →" CTA because the whole card is
-              already a link — the explicit affordance was the second
-              loudest "ad" tell. */}
-          <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-2 pt-2 text-xs text-muted-foreground">
-            <span className="inline-flex items-center gap-1.5">
-              <BookOpen className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
-              {t("courseCard.modulesLabel", { count: moduleCount })}
-            </span>
-            <StatusBadge course={course} />
+          {/* Meta row: modules count, middle-dot separator, status as a
+              colored dot + label. The whole row is one quiet line that
+              sits at the bottom of every card via mt-auto. flex-wrap so
+              a long localised status string ("Открывается 5 марта 2026")
+              breaks under the modules count rather than getting clipped. */}
+          <div className="mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-2 text-xs text-muted-foreground">
+            <span>{t("courseCard.modulesLabel", { count: moduleCount })}</span>
+            {status && (
+              <>
+                <span aria-hidden className="text-muted-foreground/40">·</span>
+                <StatusIndicator status={status} />
+              </>
+            )}
           </div>
         </div>
       </Card>


### PR DESCRIPTION
## Summary

Second pass after #370. Vadym: \"better but still not ideal — make it look modern.\"

Three deliberate moves; everything else stays.

### 1. Title carries the card

\`font-serif text-xl font-medium\` (was \`text-lg\` default-weight). At the smaller size Fraunces sat as a subhead next to the image; at \`text-xl font-medium\` the title is the focal point. \`semibold\` makes Fraunces too heavy in a list; \`medium\` reads as confident without shouting.

### 2. Status: dot + label, not a filled pill

Filled \`<Badge>\` variants (success / destructive / info / muted) read as marketing tags — Sale / New / Featured. The dot + coloured label is the modern Linear / Vercel pattern:

- \`• Enrolling now\` — \`bg-success\` dot, \`text-success\` label
- \`• Closed\` — \`bg-destructive\`
- \`• Opens Mar 5\` — \`bg-info\`
- \`• By invitation\` — \`bg-muted-foreground/60\`

Same semantic tokens, half the visual weight. Tone mapping lives in one \`STATUS_TONE\` table.

### 3. Designed empty-state cover

Flat \`bg-muted\` made image-less cards look placeholder-y. Now \`bg-gradient-to-br from-muted to-muted/40\` + a brand-tinted \`BookOpen\` (\`text-primary/25\`, \`h-10 w-10\`) — the no-image state feels intentional.

### Small moves

- Middle-dot separator (\`·\`) between modules count and status — one quiet line, not two stacked elements.
- \`hover:border-primary/40\` (was \`/30\`) — tiny bump; still the only hover effect.
- \`resolveStatus()\` extracted so the JSX is a flat render path, not a nested ternary ladder.

## Test plan
- [x] \`npx vitest run src/components/course/__tests__/CourseCard.test.tsx\` — 9 passed
- [x] \`npm run test:run\` — 222 passed
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [ ] Vadym: hard-refresh equipbible.com after deploy and verify catalog grid in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)