### PR TITLE
design(courseCard): bolder v4 — eyebrow status, 21:9 cover, 2xl serif title

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -13,17 +13,16 @@ interface CourseCardProps {
   style?: React.CSSProperties
 }
 
-type StatusKind = "open" | "opens" | "closed" | "institute" | null
+type StatusKind = "open" | "opens" | "closed" | "institute"
 interface Status {
-  kind: Exclude<StatusKind, null>
+  kind: StatusKind
   label: string
 }
 
-// Distill the access mode + enrollment window into one (label, tone) tuple
-// so the render path doesn't carry a conditional ladder. ``institute``
-// suppresses the enrollment-window check — invitation-only courses don't
-// expose a public window, and showing both would mis-signal "anyone can
-// enroll if they hurry".
+// (label, tone) resolution for the status eyebrow. ``institute`` shadows
+// the enrollment-window check — invitation-only courses don't surface a
+// public window, and "Opens Mar 5" on a private course would mis-signal
+// "anyone can enroll if they hurry".
 function resolveStatus(course: Course, t: TFunction): Status | null {
   if (course.access_mode === "institute") {
     return { kind: "institute", label: t("courseCard.byInvitation") }
@@ -41,24 +40,30 @@ function resolveStatus(course: Course, t: TFunction): Status | null {
   return { kind: "open", label: t("courseCard.enrollingNow") }
 }
 
-// Dot + colored label instead of a filled pill. The filled-pill variant
-// reads as a marketing tag (Sale, New, etc.); dot + label reads as a
-// status indicator -- the modern Linear / Vercel pattern. Tones map
-// 1:1 to our semantic CSS tokens so dark-mode parity is automatic.
-const STATUS_TONE: Record<Status["kind"], { dot: string; text: string }> = {
+// Tones map 1:1 to our semantic CSS tokens so dark-mode parity is
+// automatic. Dot + label (not a filled pill) so the status reads as a
+// status indicator rather than a marketing tag.
+const STATUS_TONE: Record<StatusKind, { dot: string; text: string }> = {
   open: { dot: "bg-success", text: "text-success" },
   opens: { dot: "bg-info", text: "text-info" },
   closed: { dot: "bg-destructive", text: "text-destructive" },
   institute: { dot: "bg-muted-foreground/60", text: "text-muted-foreground" },
 }
 
-function StatusIndicator({ status }: { status: Status }) {
+// The status now sits ABOVE the title as an editorial eyebrow — the
+// pattern DESIGN.md formalised for VerseOfTheDayCard and
+// CourseReadinessCard ("text-xs font-medium uppercase tracking-[0.18em]
+// text-muted-foreground"). The wide tracking is load-bearing: that's
+// what makes it read as an eyebrow rather than a shrunk body line.
+function StatusEyebrow({ status }: { status: Status }) {
   const tone = STATUS_TONE[status.kind]
   return (
-    <span className="inline-flex items-center gap-1.5">
+    <p
+      className={`inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] ${tone.text}`}
+    >
       <span className={`h-1.5 w-1.5 rounded-full ${tone.dot}`} aria-hidden />
-      <span className={tone.text}>{status.label}</span>
-    </span>
+      {status.label}
+    </p>
   )
 }
 
@@ -77,11 +82,11 @@ function CourseCard({ course, style }: CourseCardProps) {
       className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <Card className="flex h-full flex-col overflow-hidden hover:border-primary/40">
-        {/* Cover band. 16:9 keeps the image a header strip, not a hero.
-            The gradient on the empty state gives image-less cards a real
-            designed surface instead of a flat muted block -- pre-fill
-            material was the most "placeholder-y" tell of the old card. */}
-        <div className="aspect-[16/9] w-full overflow-hidden bg-gradient-to-br from-muted to-muted/40">
+        {/* Cinematic 21:9 cover band — slimmer than the old 16:10 / 16:9
+            so the typography below gets the visual weight. Gradient bg
+            on the empty state turns the image-less card from "missing"
+            into "designed". */}
+        <div className="aspect-[21/9] w-full overflow-hidden bg-gradient-to-br from-muted to-muted/40">
           {hasImage ? (
             <img
               src={coverSrc}
@@ -94,7 +99,7 @@ function CourseCard({ course, style }: CourseCardProps) {
           ) : (
             <div className="flex h-full w-full items-center justify-center">
               <BookOpen
-                className="h-10 w-10 text-primary/25"
+                className="h-9 w-9 text-primary/25"
                 strokeWidth={1.5}
                 aria-hidden
               />
@@ -102,34 +107,34 @@ function CourseCard({ course, style }: CourseCardProps) {
           )}
         </div>
 
-        <div className="flex flex-1 flex-col gap-3 p-5">
-          {/* text-xl + font-medium on Fraunces: confident headline without
-              tipping into "marketing" territory. text-lg (the previous
-              size) read as a subhead next to the image and let the page
-              feel timid. font-semibold here makes Fraunces too heavy. */}
-          <h3 className="font-serif text-xl font-medium leading-snug tracking-tight text-foreground line-clamp-2 text-wrap-safe">
+        <div className="flex flex-1 flex-col gap-4 p-5">
+          {/* Status eyebrow above the title. When there's no status (no
+              enrollment window, public access mode), nothing reserves
+              its row — the title slides up against the cover. */}
+          {status && <StatusEyebrow status={status} />}
+
+          {/* The title is the focal point of the card. text-2xl Fraunces
+              medium with tight tracking reads as a confident editorial
+              headline; the previous text-lg / text-xl sat as a subhead
+              under the image. font-semibold on Fraunces is too heavy in
+              a list view — medium is the calibrated choice. */}
+          <h3 className="font-serif text-2xl font-medium leading-[1.15] tracking-tight text-foreground line-clamp-2 text-wrap-safe">
             {course.title}
           </h3>
+
           {course.description && (
-            <p className="text-sm leading-relaxed text-muted-foreground line-clamp-2 text-wrap-safe">
+            <p className="text-[15px] leading-relaxed text-muted-foreground line-clamp-2 text-wrap-safe">
               {course.description}
             </p>
           )}
 
-          {/* Meta row: modules count, middle-dot separator, status as a
-              colored dot + label. The whole row is one quiet line that
-              sits at the bottom of every card via mt-auto. flex-wrap so
-              a long localised status string ("Открывается 5 марта 2026")
-              breaks under the modules count rather than getting clipped. */}
-          <div className="mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-2 text-xs text-muted-foreground">
-            <span>{t("courseCard.modulesLabel", { count: moduleCount })}</span>
-            {status && (
-              <>
-                <span aria-hidden className="text-muted-foreground/40">·</span>
-                <StatusIndicator status={status} />
-              </>
-            )}
-          </div>
+          {/* Single quiet line at the bottom: modules count only — the
+              status is the eyebrow above the title now, no need to
+              repeat it here. mt-auto pins this against the lower edge
+              so every card aligns across the grid. */}
+          <p className="mt-auto pt-2 text-xs text-muted-foreground">
+            {t("courseCard.modulesLabel", { count: moduleCount })}
+          </p>
         </div>
       </Card>
     </Link>

--- a/frontend/src/components/skeletons/CourseCardSkeleton.tsx
+++ b/frontend/src/components/skeletons/CourseCardSkeleton.tsx
@@ -1,21 +1,18 @@
 import { Card } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 
-// Mirrors the CourseCard structure exactly so the loading state has the
-// same overall height + aspect ratio + spacing as the loaded state —
-// otherwise the grid jumps when the data lands.
+// Mirrors CourseCard exactly (21:9 cover, eyebrow + big title + body +
+// modules line) so the grid doesn't jump when data lands.
 export default function CourseCardSkeleton() {
   return (
     <Card className="flex h-full flex-col overflow-hidden">
-      <Skeleton className="aspect-[16/9] w-full rounded-none" />
-      <div className="flex flex-1 flex-col gap-3 p-5">
-        <Skeleton className="h-5 w-3/4" />
+      <Skeleton className="aspect-[21/9] w-full rounded-none" />
+      <div className="flex flex-1 flex-col gap-4 p-5">
+        <Skeleton className="h-3 w-28" />
+        <Skeleton className="h-7 w-4/5" />
         <Skeleton className="h-4 w-full" />
         <Skeleton className="h-4 w-2/3" />
-        <div className="mt-auto flex items-center gap-3 pt-2">
-          <Skeleton className="h-3.5 w-24" />
-          <Skeleton className="h-5 w-20 rounded-full" />
-        </div>
+        <Skeleton className="mt-auto h-3 w-24" />
       </div>
     </Card>
   )


### PR DESCRIPTION
## Summary

v3 was too subtle (Vadym: \"only a little bit lightly\"). v4 redistributes visual weight: less to the image, more to the type.

## Changes

| Element | v3 | v4 |
|---|---|---|
| Cover band | 16:9 | **21:9** cinematic |
| Status placement | meta footer, dot + label | **editorial eyebrow above the title**, uppercase, wide tracking, dot prefix |
| Title | `text-xl font-medium` Fraunces | **`text-2xl font-medium` Fraunces** with `leading-[1.15] tracking-tight` |
| Description | `text-sm` | **`text-[15px]` `leading-relaxed`** |
| Footer | modules + middle-dot + status | modules count, alone |

## Why each move

- **21:9 cover** — frees ~⅓ of the old image height for the body without changing card width or grid columns. The image stops dominating.
- **Status as eyebrow** — uses the existing DESIGN.md eyebrow recipe (`text-xs font-medium uppercase tracking-[0.18em]`). Wide tracking is load-bearing: it's what makes the line read as an editorial eyebrow instead of a shrunken body line. When the course has no status the row collapses entirely — no blank reservation.
- **2xl Fraunces title** — at 18-20px Fraunces was sitting as a subhead under the image. At 24px medium-weight with tight tracking it carries the card. Semibold on Fraunces is too heavy for a list — medium is the calibrated choice.
- **15px description, relaxed leading** — body copy, not a label. Stops the description from feeling like fine print.

Skeleton mirrors the new structure (21:9, eyebrow stub, larger title row, body, modules) so the grid doesn't jump on data arrival.

## Test plan
- [x] `npx vitest run src/components/course/__tests__/CourseCard.test.tsx` — 9 passed
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Vadym: hard-refresh equipbible.com after deploy and verify catalog grid in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)