### PR TITLE
design(courses): magazine-style catalog — horizontal cards + 2-col grid

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -19,10 +19,10 @@ interface Status {
   label: string
 }
 
-// (label, tone) resolution for the status eyebrow. ``institute`` shadows
-// the enrollment-window check — invitation-only courses don't surface a
-// public window, and "Opens Mar 5" on a private course would mis-signal
-// "anyone can enroll if they hurry".
+// Distill access mode + enrollment window into one (label, tone) tuple.
+// ``institute`` shadows the enrollment-window check — invitation-only
+// courses don't surface a public window, and showing both would
+// mis-signal "anyone can enroll if they hurry".
 function resolveStatus(course: Course, t: TFunction): Status | null {
   if (course.access_mode === "institute") {
     return { kind: "institute", label: t("courseCard.byInvitation") }
@@ -40,9 +40,9 @@ function resolveStatus(course: Course, t: TFunction): Status | null {
   return { kind: "open", label: t("courseCard.enrollingNow") }
 }
 
-// Tones map 1:1 to our semantic CSS tokens so dark-mode parity is
-// automatic. Dot + label (not a filled pill) so the status reads as a
-// status indicator rather than a marketing tag.
+// Dot + colored label = status indicator (Linear / Vercel). The filled
+// ``<Badge>`` variant read as a marketing tag (Sale / New / Featured)
+// in the previous revision; this is the modern equivalent.
 const STATUS_TONE: Record<StatusKind, { dot: string; text: string }> = {
   open: { dot: "bg-success", text: "text-success" },
   opens: { dot: "bg-info", text: "text-info" },
@@ -50,20 +50,13 @@ const STATUS_TONE: Record<StatusKind, { dot: string; text: string }> = {
   institute: { dot: "bg-muted-foreground/60", text: "text-muted-foreground" },
 }
 
-// The status now sits ABOVE the title as an editorial eyebrow — the
-// pattern DESIGN.md formalised for VerseOfTheDayCard and
-// CourseReadinessCard ("text-xs font-medium uppercase tracking-[0.18em]
-// text-muted-foreground"). The wide tracking is load-bearing: that's
-// what makes it read as an eyebrow rather than a shrunk body line.
-function StatusEyebrow({ status }: { status: Status }) {
+function StatusIndicator({ status }: { status: Status }) {
   const tone = STATUS_TONE[status.kind]
   return (
-    <p
-      className={`inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] ${tone.text}`}
-    >
+    <span className="inline-flex items-center gap-1.5 text-xs">
       <span className={`h-1.5 w-1.5 rounded-full ${tone.dot}`} aria-hidden />
-      {status.label}
-    </p>
+      <span className={tone.text}>{status.label}</span>
+    </span>
   )
 }
 
@@ -81,12 +74,27 @@ function CourseCard({ course, style }: CourseCardProps) {
       style={style}
       className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
-      <Card className="flex h-full flex-col overflow-hidden hover:border-primary/40">
-        {/* Cinematic 21:9 cover band — slimmer than the old 16:10 / 16:9
-            so the typography below gets the visual weight. Gradient bg
-            on the empty state turns the image-less card from "missing"
-            into "designed". */}
-        <div className="aspect-[21/9] w-full overflow-hidden bg-gradient-to-br from-muted to-muted/40">
+      <Card
+        className={
+          // Vertical on mobile (cover-then-text, like every other card),
+          // horizontal on sm+ (cover-left, text-right, magazine listing).
+          // The horizontal layout is what stops the page from reading as
+          // a product grid — at sm+ widths each card has the proportions
+          // of a book in a catalogue rather than a tile in a marketplace.
+          "flex h-full flex-col overflow-hidden hover:border-primary/40 sm:flex-row"
+        }
+      >
+        {/* Cover: 21:9 strip on mobile (so the type below gets the
+            weight), 4:3 square-ish panel on sm+ (anchors the listing
+            from the left without taking more than ~38% of the row).
+            Image-less state uses a gradient + brand-tinted icon so it
+            reads as designed, not missing. */}
+        <div
+          className={
+            "aspect-[21/9] w-full overflow-hidden bg-gradient-to-br from-muted to-muted/40 " +
+            "sm:aspect-auto sm:h-full sm:w-[38%] sm:max-w-[260px] sm:flex-shrink-0"
+          }
+        >
           {hasImage ? (
             <img
               src={coverSrc}
@@ -97,9 +105,9 @@ function CourseCard({ course, style }: CourseCardProps) {
               onError={() => setImgError(true)}
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center">
+            <div className="flex h-full min-h-32 w-full items-center justify-center">
               <BookOpen
-                className="h-9 w-9 text-primary/25"
+                className="h-10 w-10 text-primary/25"
                 strokeWidth={1.5}
                 aria-hidden
               />
@@ -107,34 +115,43 @@ function CourseCard({ course, style }: CourseCardProps) {
           )}
         </div>
 
-        <div className="flex flex-1 flex-col gap-4 p-5">
-          {/* Status eyebrow above the title. When there's no status (no
-              enrollment window, public access mode), nothing reserves
-              its row — the title slides up against the cover. */}
-          {status && <StatusEyebrow status={status} />}
+        {/* Body. p-6 (deviates from the DESIGN.md p-5 default
+            deliberately) because the horizontal layout gives the text
+            column more horizontal room and the rhythm needs vertical
+            breathing to match — without it the title and description
+            crowd together against the cover edge. */}
+        <div className="flex flex-1 flex-col gap-3 p-6">
+          {/* Eyebrow: module count, uppercase tracked. Per DESIGN.md the
+              wide tracking is load-bearing — that's what makes it read
+              as an editorial label rather than a shrunk body line. */}
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            {t("courseCard.modulesLabel", { count: moduleCount })}
+          </p>
 
-          {/* The title is the focal point of the card. text-2xl Fraunces
-              medium with tight tracking reads as a confident editorial
-              headline; the previous text-lg / text-xl sat as a subhead
-              under the image. font-semibold on Fraunces is too heavy in
-              a list view — medium is the calibrated choice. */}
+          {/* Title: text-2xl Fraunces medium with tight leading and
+              negative tracking — confident editorial headline. Smaller
+              weights / sizes read as a subhead under the image; heavier
+              weights tip Fraunces into "marketing display". Medium at
+              2xl is the calibrated point. */}
           <h3 className="font-serif text-2xl font-medium leading-[1.15] tracking-tight text-foreground line-clamp-2 text-wrap-safe">
             {course.title}
           </h3>
 
           {course.description && (
-            <p className="text-[15px] leading-relaxed text-muted-foreground line-clamp-2 text-wrap-safe">
+            <p className="text-[15px] leading-relaxed text-muted-foreground line-clamp-3 text-wrap-safe">
               {course.description}
             </p>
           )}
 
-          {/* Single quiet line at the bottom: modules count only — the
-              status is the eyebrow above the title now, no need to
-              repeat it here. mt-auto pins this against the lower edge
-              so every card aligns across the grid. */}
-          <p className="mt-auto pt-2 text-xs text-muted-foreground">
-            {t("courseCard.modulesLabel", { count: moduleCount })}
-          </p>
+          {/* Status anchors the bottom of the body. mt-auto pins it
+              against the lower edge so it lines up across cards
+              regardless of title or description length. When there's no
+              status the row collapses entirely. */}
+          {status && (
+            <div className="mt-auto pt-3">
+              <StatusIndicator status={status} />
+            </div>
+          )}
         </div>
       </Card>
     </Link>

--- a/frontend/src/components/skeletons/CourseCardSkeleton.tsx
+++ b/frontend/src/components/skeletons/CourseCardSkeleton.tsx
@@ -1,18 +1,19 @@
 import { Card } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 
-// Mirrors CourseCard exactly (21:9 cover, eyebrow + big title + body +
-// modules line) so the grid doesn't jump when data lands.
+// Mirrors CourseCard exactly (horizontal on sm+, cover-on-left + body
+// stack), so the loading grid has the same overall height as the
+// loaded grid and nothing jumps when the data lands.
 export default function CourseCardSkeleton() {
   return (
-    <Card className="flex h-full flex-col overflow-hidden">
-      <Skeleton className="aspect-[21/9] w-full rounded-none" />
-      <div className="flex flex-1 flex-col gap-4 p-5">
+    <Card className="flex h-full flex-col overflow-hidden sm:flex-row">
+      <Skeleton className="aspect-[21/9] w-full rounded-none sm:aspect-auto sm:h-full sm:min-h-44 sm:w-[38%] sm:max-w-[260px] sm:flex-shrink-0" />
+      <div className="flex flex-1 flex-col gap-3 p-6">
         <Skeleton className="h-3 w-28" />
         <Skeleton className="h-7 w-4/5" />
         <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-2/3" />
-        <Skeleton className="mt-auto h-3 w-24" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="mt-auto h-4 w-32" />
       </div>
     </Card>
   )

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -290,7 +290,7 @@ export default function HomePage() {
       )}
 
       {loading ? (
-        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-7 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:gap-6">
           {Array.from({ length: 6 }).map((_, i) => <CourseCardSkeleton key={i} />)}
         </div>
       ) : error ? (
@@ -311,7 +311,7 @@ export default function HomePage() {
           className="border-none bg-transparent py-20"
         />
       ) : (
-        <div className="stagger-fade-in grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-7 lg:grid-cols-3">
+        <div className="stagger-fade-in grid grid-cols-1 gap-5 lg:grid-cols-2 lg:gap-6">
           {courses.map((course, index) => (
             <CourseCard
               key={course.id}


### PR DESCRIPTION
## Summary

Vadym: \"you just made titles bigger — that's not a redesign, think through the grid\". Right. Previous passes (#370, #371, #373) were cosmetic on the same shape. This is a layout rethink.

## What changes structurally

1. **Card orientation flips at the `sm` breakpoint.** Mobile keeps the vertical cover-then-text stack. From `sm:` up the card goes **horizontal**: cover panel on the left (~38% of the row, max 260px), text column on the right. That single change is what stops the page reading as a product grid — at desktop widths each card has the proportions of a book in a serious catalogue, not a tile in a marketplace.

2. **Grid drops from 3 columns to 2 on `lg`.** Horizontal cards need width to breathe; 3-up crushed the typography. 2-up at `lg` lets the title carry its weight and descriptions wrap naturally. The `sm:grid-cols-2` bump is gone too — horizontal cards at tablet 2-up would be too narrow.

3. **Body padding `p-6` (was `p-5`).** Deviates from the DESIGN.md default deliberately: the wider text column needs vertical breathing to match, otherwise the title crowds against the cover edge.

4. **Module count moves up into an editorial eyebrow** (uppercase, tracking-[0.18em]) above the title. Status moves to the bottom of the body as a dot + coloured label (Linear/Vercel pattern from v3). Description allowed 3 lines (was 2) — there's room now.

5. **Skeleton mirrors the new shape exactly** so the loading grid doesn't jump when data lands.

## Files
- `frontend/src/components/course/CourseCard.tsx` — horizontal layout, eyebrow + 2xl title + body + status anchor
- `frontend/src/pages/Home/HomePage.tsx` — grid drops `sm:grid-cols-2 lg:grid-cols-3` → `lg:grid-cols-2`
- `frontend/src/components/skeletons/CourseCardSkeleton.tsx` — mirrors new shape

## Test plan
- [x] \`npx vitest run src/components/course/__tests__/CourseCard.test.tsx\` — 9 passed
- [x] \`npm run test:run\` — 222 passed
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [ ] Vadym: hard-refresh equipbible.com after deploy. Verify on mobile (vertical stack) AND desktop (horizontal listing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)