### PR TITLE
chore(repo): add OpenSSF Scorecard, Codecov, SUPPORT.md

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -136,6 +136,18 @@ jobs:
           path: backend/coverage.xml
           if-no-files-found: warn
 
+      # Upload to Codecov. Tokenless flow on public repos, so no secret
+      # is needed. `fail_ci_if_error: false` keeps the gate stable if
+      # Codecov has an outage -- the artifact above is the durable
+      # backup.
+      - name: Upload coverage to Codecov (backend)
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./backend/coverage.xml
+          flags: backend
+          name: backend-coverage
+          fail_ci_if_error: false
+
   # ---------------------------------------------------------------------------
   # Postgres schema smoke test — validates that the SQLAlchemy models can
   # materialize a valid schema against real Postgres (not just SQLite).

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -110,8 +110,19 @@ jobs:
       - name: Build production bundle
         run: npm run build
 
-      - name: Run unit tests
-        run: npm run test:run
+      - name: Run unit tests with coverage
+        run: npm run test:run -- --coverage
+
+      # Upload to Codecov. The action handles the OIDC tokenless flow for
+      # public repos, so no CODECOV_TOKEN secret is required. We keep
+      # `fail_ci_if_error: false` so a Codecov outage doesn't redden the PR.
+      - name: Upload coverage to Codecov (frontend)
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./frontend/coverage/lcov.info
+          flags: frontend
+          name: frontend-coverage
+          fail_ci_if_error: false
 
   # ---------------------------------------------------------------------------
   # Required-check aggregator. See the matching block in backend-ci.yml for

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,68 @@
+name: OpenSSF Scorecard
+
+# OpenSSF Scorecard rates the project against a checklist of secure-OSS
+# practices (branch protection, signed releases, pinned actions, etc.).
+# Results publish to the public scorecard.dev catalogue and a SARIF
+# upload feeds the GitHub Security tab so regressions show up alongside
+# CodeQL findings.
+#
+# Run cadence:
+#   - on every push to main (so changes that lower the score surface fast)
+#   - weekly (Tuesday 06:17 UTC) so the public badge stays warm even
+#     during slow weeks
+#   - on branch_protection_rule events so ruleset changes re-score
+#     immediately
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 6 * * 2'
+  branch_protection_rule:
+  workflow_dispatch: {}
+
+# Default minimum read; the analysis job widens specifically.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for upload-sarif to write into the Security tab.
+      security-events: write
+      # OIDC token used by scorecard-action to publish to scorecard.dev
+      # without a long-lived PAT.
+      id-token: write
+      # Default read so the action can introspect the repo.
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes to https://scorecard.dev/viewer/?uri=github.com/ArVaViT/equip
+          # so the README badge has data to render.
+          publish_results: true
+
+      # Keep the raw SARIF as an artifact for one PR cycle so a contributor
+      # can grab it and see exactly which check moved without re-running.
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -22,12 +22,19 @@
   <a href="https://github.com/ArVaViT/equip/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
     <img src="https://img.shields.io/github/issues/ArVaViT/equip/good%20first%20issue?style=flat-square&color=7057ff&label=good%20first%20issues" alt="Good first issues" />
   </a>
+  <a href="https://app.codecov.io/gh/ArVaViT/equip">
+    <img src="https://img.shields.io/codecov/c/github/ArVaViT/equip?style=flat-square&label=coverage" alt="Code coverage" />
+  </a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/ArVaViT/equip">
+    <img src="https://img.shields.io/ossf-scorecard/github.com/ArVaViT/equip?style=flat-square&label=openssf%20scorecard" alt="OpenSSF Scorecard" />
+  </a>
 </p>
 
 <p align="center">
   <a href="https://equipbible.com">Live demo</a> &middot;
   <a href="ROADMAP.md">Roadmap</a> &middot;
   <a href="CONTRIBUTING.md">Contributing</a> &middot;
+  <a href="SUPPORT.md">Support</a> &middot;
   <a href="CHANGELOG.md">Changelog</a>
 </p>
 
@@ -261,6 +268,7 @@ There are great LMS options out there. Equip exists in a specific gap they don't
 
 - [GitHub Discussions](https://github.com/ArVaViT/equip/discussions) — questions, ideas, show & tell
 - [Issue tracker](https://github.com/ArVaViT/equip/issues) — bug reports and feature requests
+- [Support](SUPPORT.md) — how to get help, response times, the right channel for each kind of question
 - [Changelog](CHANGELOG.md) — what's new in each release
 - [Security policy](SECURITY.md) — how to report vulnerabilities
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,57 @@
+# Getting help with Equip
+
+We try to make sure every question lands in a place where someone can actually answer it. Pick the channel that matches what you need.
+
+## I have a question about how to use Equip
+
+Open a thread in [**GitHub Discussions**](https://github.com/ArVaViT/equip/discussions). Discussions are the home for usage questions, "what's the right way to…" conversations, and feedback that isn't a bug report.
+
+Useful categories:
+
+- **Q&A** &mdash; a specific question with a yes/no or how-to answer.
+- **Ideas** &mdash; a feature you'd like to see, especially with the ministry context that motivated it.
+- **Show and tell** &mdash; a deployment, a course you're running on Equip, a screenshot of how your school uses it.
+
+A maintainer aims to respond within a few days. Discussions are public, so other users facing the same question will find your thread later &mdash; please don't open duplicates as private messages.
+
+## I found a bug
+
+Open a [**bug report issue**](https://github.com/ArVaViT/equip/issues/new?template=bug_report.yml). Please include:
+
+- What you were trying to do.
+- What you expected to happen.
+- What actually happened (a screenshot or browser-console snippet goes a long way).
+- Whether it reproduces every time or only sometimes.
+- Your environment (browser + version, deployment target, whether self-hosted or on equipbible.com).
+
+## I want to request a feature
+
+Open a [**feature request issue**](https://github.com/ArVaViT/equip/issues/new?template=feature_request.yml). The most useful feature requests describe the underlying problem (what teaching or ministry workflow is currently hard) rather than jumping straight to a UI design &mdash; that gives us room to find the simplest solution.
+
+## I want to report a security vulnerability
+
+**Please do not open a public issue.** Follow the disclosure path in [SECURITY.md](SECURITY.md) instead. We respond within a few business days and treat disclosure reports as confidential.
+
+## I want to contribute code or docs
+
+Start with [**CONTRIBUTING.md**](CONTRIBUTING.md). It covers local setup, commit conventions, the PR workflow, and how AI-assisted contributions are credited (see also [AGENTS.md](AGENTS.md)).
+
+If you're looking for somewhere to start, the [`good first issue` label](https://github.com/ArVaViT/equip/labels/good%20first%20issue) lists scoped issues a new contributor can pick up without needing the full architectural context. Comment on the issue to claim it before opening a PR &mdash; that avoids two people working on the same thing.
+
+## I'm a nonprofit considering Equip for our school
+
+Open a [**Discussion**](https://github.com/ArVaViT/equip/discussions/new?category=q-a) describing your school, your rough scale (number of students, courses, languages), and your hosting comfort level (do you want to run it yourselves, or use the free tiers of Vercel + Supabase?). We answer those personally &mdash; "is Equip a fit for us?" is one of the most valuable questions to surface, both for you and for the roadmap.
+
+## Response times, honestly
+
+Equip is maintained primarily by one person, with growing contributor support. Realistic expectations:
+
+| Channel | Typical first response |
+|---|---|
+| Security disclosure (SECURITY.md) | 1&ndash;3 business days |
+| Bug report on a deployed feature | 2&ndash;5 business days |
+| Discussion question | 3&ndash;7 days |
+| Feature request | Triaged within a week; implementation timing varies |
+| Pull request review | 2&ndash;5 business days for small PRs |
+
+If something is urgent and time-sensitive (the production deployment at equipbible.com is broken, a security issue is being actively exploited), email arvavitcorp@gmail.com directly.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,59 @@
+# Codecov configuration.
+#
+# Goal: surface coverage as a public-facing signal without making it a hard
+# gate on PRs. Failing a build over a 0.5% coverage dip on an unrelated PR
+# costs more than it teaches; we keep the *informational* badge accurate
+# and let humans make the call.
+#
+# Two flags carry the split-monorepo split, so the dashboard at
+# https://app.codecov.io/gh/ArVaViT/equip can show backend vs frontend
+# trends independently.
+
+coverage:
+  status:
+    project:
+      default:
+        # Inform-only PR status. Set `informational: true` so a coverage
+        # regression posts a comment but never blocks merging.
+        informational: true
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true
+        target: 70%
+        threshold: 5%
+
+flags:
+  backend:
+    paths:
+      - backend/app/
+    carryforward: true
+  frontend:
+    paths:
+      - frontend/src/
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+# Don't fail Codecov runs themselves when sources are missing locally;
+# the report is what matters, not the file-by-file resolution.
+codecov:
+  require_ci_to_pass: false
+  notify:
+    wait_for_ci: false
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.py"
+  - "**/tests/**"
+  - "**/__tests__/**"
+  - "backend/tests/**"
+  - "frontend/src/test/**"
+  - "**/migrations/**"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -56,6 +56,7 @@
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.6",
         "autoprefixer": "^10.4.16",
         "axios-mock-adapter": "^2.1.0",
         "eslint": "^10.3.0",
@@ -322,9 +323,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -392,6 +393,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -3147,17 +3158,48 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3166,13 +3208,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3193,9 +3235,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3206,13 +3248,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3220,14 +3262,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3236,9 +3278,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3246,13 +3288,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3379,6 +3421,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -4496,6 +4557,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -4564,6 +4635,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
@@ -4744,6 +4822,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -5232,6 +5349,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6416,6 +6574,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -6932,19 +7103,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6972,12 +7143,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.6",
     "autoprefixer": "^10.4.16",
     "axios-mock-adapter": "^2.1.0",
     "eslint": "^10.3.0",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -14,5 +14,22 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     css: false,
+    // Coverage is opt-in via `npm run test:run -- --coverage`. The defaults
+    // here only kick in when that flag is passed (CI), so day-to-day
+    // `npm test` watch sessions stay fast.
+    coverage: {
+      provider: 'v8',
+      reporter: ['text-summary', 'lcov', 'json'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/**/*.test.{ts,tsx}',
+        'src/**/__tests__/**',
+        'src/test/**',
+        'src/main.tsx',
+        'src/vite-env.d.ts',
+      ],
+    },
   },
 })


### PR DESCRIPTION
## Summary

Three credibility signals for visitors evaluating Equip as an institutional or contributor dependency.

### 1. OpenSSF Scorecard workflow
`.github/workflows/scorecard.yml` rates the project against the OpenSSF secure-OSS checklist (branch protection, signed releases, pinned actions, etc.). Runs on push to main, weekly cron, and on `branch_protection_rule` events so ruleset changes re-score immediately. Publishes to `scorecard.dev` for the badge and uploads SARIF to the GitHub Security tab so regressions surface alongside CodeQL findings.

### 2. Codecov for backend + frontend
- Backend already generated `coverage.xml` in CI; new step uploads it under flag `backend`.
- Frontend gets a vitest v8 coverage config (opt-in via `--coverage` so day-to-day `npm test` watch stays fast), a `@vitest/coverage-v8` devDependency, and an upload step under flag `frontend`.
- Tokenless uploads (`codecov/codecov-action@v5` handles OIDC). `fail_ci_if_error: false` keeps the gate stable if Codecov has an outage.
- `codecov.yml` marks both project and patch status as **informational** &mdash; coverage is a public-facing signal, never a hard merge gate.

### 3. SUPPORT.md
Routes visitors to the right channel (Discussions for questions, issue templates for bugs/features, SECURITY.md for vulns, CONTRIBUTING.md for code) with honest first-response SLAs. Linked from the README top nav and the Community section.

### README badges
Two new shields in the existing badge row: Codecov coverage and OpenSSF Scorecard score. Both render "no data" until the first successful main run posts results &mdash; merging this PR is what populates them.

### One-time follow-up after merge
- Visit https://app.codecov.io/gh/ArVaViT/equip once to activate the repo (Codecov tokenless uploads work on activated public repos).
- The OpenSSF Scorecard badge populates automatically on the first run.

## Test plan
- [ ] CI green: `pr-quality`, `Backend CI Pass`, `Frontend CI Pass`.
- [ ] Frontend `lint-and-build` job now runs `npm run test:run -- --coverage` and posts coverage to Codecov.
- [ ] Backend `lint-and-test` job uploads `coverage.xml` to Codecov after the existing artifact step.
- [ ] After merge, Scorecard workflow runs once on main and the README badge populates.
- [ ] No breakage to existing required checks &mdash; the auto-merge gate still fires only for Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
