### PR TITLE
design(courses): catalog list rows — system, not magazine

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -19,9 +19,9 @@ interface Status {
   label: string
 }
 
-// Distill access mode + enrollment window into one (label, tone) tuple.
+// (label, tone) resolution for the inline status indicator.
 // ``institute`` shadows the enrollment-window check — invitation-only
-// courses don't surface a public window, and showing both would
+// courses don't surface a public window, and showing one would
 // mis-signal "anyone can enroll if they hurry".
 function resolveStatus(course: Course, t: TFunction): Status | null {
   if (course.access_mode === "institute") {
@@ -40,9 +40,6 @@ function resolveStatus(course: Course, t: TFunction): Status | null {
   return { kind: "open", label: t("courseCard.enrollingNow") }
 }
 
-// Dot + colored label = status indicator (Linear / Vercel). The filled
-// ``<Badge>`` variant read as a marketing tag (Sale / New / Featured)
-// in the previous revision; this is the modern equivalent.
 const STATUS_TONE: Record<StatusKind, { dot: string; text: string }> = {
   open: { dot: "bg-success", text: "text-success" },
   opens: { dot: "bg-info", text: "text-info" },
@@ -74,27 +71,18 @@ function CourseCard({ course, style }: CourseCardProps) {
       style={style}
       className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
-      <Card
-        className={
-          // Vertical on mobile (cover-then-text, like every other card),
-          // horizontal on sm+ (cover-left, text-right, magazine listing).
-          // The horizontal layout is what stops the page from reading as
-          // a product grid — at sm+ widths each card has the proportions
-          // of a book in a catalogue rather than a tile in a marketplace.
-          "flex h-full flex-col overflow-hidden hover:border-primary/40 sm:flex-row"
-        }
-      >
-        {/* Cover: 21:9 strip on mobile (so the type below gets the
-            weight), 4:3 square-ish panel on sm+ (anchors the listing
-            from the left without taking more than ~38% of the row).
-            Image-less state uses a gradient + brand-tinted icon so it
-            reads as designed, not missing. */}
-        <div
-          className={
-            "aspect-[21/9] w-full overflow-hidden bg-gradient-to-br from-muted to-muted/40 " +
-            "sm:aspect-auto sm:h-full sm:w-[38%] sm:max-w-[260px] sm:flex-shrink-0"
-          }
-        >
+      {/* Catalog row, not a tile. Compact horizontal layout (Vercel
+          projects / Linear issues / GitHub repos shape) so the page
+          reads as part of the system rather than a wall of marketing
+          banners. The previous full-bleed cover was the "ad" tell —
+          a 56px thumbnail anchors the row without competing with the
+          title. */}
+      <Card className="flex h-full items-stretch gap-4 p-4 hover:border-primary/40 sm:items-center sm:gap-5">
+        {/* Thumbnail: small enough that vivid cover colours don't
+            dominate the page. ``rounded-md`` ties it to the card. The
+            empty-state gradient + brand-tinted icon keeps the
+            anchor consistent across cards with and without cover art. */}
+        <div className="h-14 w-14 shrink-0 overflow-hidden rounded-md bg-gradient-to-br from-muted to-muted/40 sm:h-16 sm:w-16">
           {hasImage ? (
             <img
               src={coverSrc}
@@ -105,53 +93,35 @@ function CourseCard({ course, style }: CourseCardProps) {
               onError={() => setImgError(true)}
             />
           ) : (
-            <div className="flex h-full min-h-32 w-full items-center justify-center">
-              <BookOpen
-                className="h-10 w-10 text-primary/25"
-                strokeWidth={1.5}
-                aria-hidden
-              />
+            <div className="flex h-full w-full items-center justify-center">
+              <BookOpen className="h-6 w-6 text-primary/30" strokeWidth={1.5} aria-hidden />
             </div>
           )}
         </div>
 
-        {/* Body. p-6 (deviates from the DESIGN.md p-5 default
-            deliberately) because the horizontal layout gives the text
-            column more horizontal room and the rhythm needs vertical
-            breathing to match — without it the title and description
-            crowd together against the cover edge. */}
-        <div className="flex flex-1 flex-col gap-3 p-6">
-          {/* Eyebrow: module count, uppercase tracked. Per DESIGN.md the
-              wide tracking is load-bearing — that's what makes it read
-              as an editorial label rather than a shrunk body line. */}
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            {t("courseCard.modulesLabel", { count: moduleCount })}
-          </p>
-
-          {/* Title: text-2xl Fraunces medium with tight leading and
-              negative tracking — confident editorial headline. Smaller
-              weights / sizes read as a subhead under the image; heavier
-              weights tip Fraunces into "marketing display". Medium at
-              2xl is the calibrated point. */}
-          <h3 className="font-serif text-2xl font-medium leading-[1.15] tracking-tight text-foreground line-clamp-2 text-wrap-safe">
+        {/* Main column. Title first (Inter medium — system sans, not
+            display serif; matches the rest of the dashboard), then a
+            single line of description, then the meta row with module
+            count and the status indicator. ``min-w-0`` so ``flex-1``
+            actually respects the line-clamp on long titles. */}
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <h3 className="text-base font-medium leading-snug text-foreground line-clamp-1 text-wrap-safe">
             {course.title}
           </h3>
-
           {course.description && (
-            <p className="text-[15px] leading-relaxed text-muted-foreground line-clamp-3 text-wrap-safe">
+            <p className="text-sm leading-relaxed text-muted-foreground line-clamp-1 text-wrap-safe">
               {course.description}
             </p>
           )}
-
-          {/* Status anchors the bottom of the body. mt-auto pins it
-              against the lower edge so it lines up across cards
-              regardless of title or description length. When there's no
-              status the row collapses entirely. */}
-          {status && (
-            <div className="mt-auto pt-3">
-              <StatusIndicator status={status} />
-            </div>
-          )}
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            <span>{t("courseCard.modulesLabel", { count: moduleCount })}</span>
+            {status && (
+              <>
+                <span aria-hidden className="text-muted-foreground/40">·</span>
+                <StatusIndicator status={status} />
+              </>
+            )}
+          </div>
         </div>
       </Card>
     </Link>

--- a/frontend/src/components/skeletons/CourseCardSkeleton.tsx
+++ b/frontend/src/components/skeletons/CourseCardSkeleton.tsx
@@ -1,19 +1,16 @@
 import { Card } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 
-// Mirrors CourseCard exactly (horizontal on sm+, cover-on-left + body
-// stack), so the loading grid has the same overall height as the
-// loaded grid and nothing jumps when the data lands.
+// Mirrors the CourseCard row shape exactly (56-64px thumbnail + title +
+// description + meta), so the loading list doesn't jump when data lands.
 export default function CourseCardSkeleton() {
   return (
-    <Card className="flex h-full flex-col overflow-hidden sm:flex-row">
-      <Skeleton className="aspect-[21/9] w-full rounded-none sm:aspect-auto sm:h-full sm:min-h-44 sm:w-[38%] sm:max-w-[260px] sm:flex-shrink-0" />
-      <div className="flex flex-1 flex-col gap-3 p-6">
-        <Skeleton className="h-3 w-28" />
-        <Skeleton className="h-7 w-4/5" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-3/4" />
-        <Skeleton className="mt-auto h-4 w-32" />
+    <Card className="flex items-stretch gap-4 p-4 sm:items-center sm:gap-5">
+      <Skeleton className="h-14 w-14 shrink-0 rounded-md sm:h-16 sm:w-16" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <Skeleton className="h-4 w-3/5" />
+        <Skeleton className="h-3.5 w-4/5" />
+        <Skeleton className="mt-1 h-3 w-32" />
       </div>
     </Card>
   )

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -290,8 +290,8 @@ export default function HomePage() {
       )}
 
       {loading ? (
-        <div className="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:gap-6">
-          {Array.from({ length: 6 }).map((_, i) => <CourseCardSkeleton key={i} />)}
+        <div className="flex flex-col gap-2">
+          {Array.from({ length: 4 }).map((_, i) => <CourseCardSkeleton key={i} />)}
         </div>
       ) : error ? (
         <ErrorState
@@ -311,7 +311,7 @@ export default function HomePage() {
           className="border-none bg-transparent py-20"
         />
       ) : (
-        <div className="stagger-fade-in grid grid-cols-1 gap-5 lg:grid-cols-2 lg:gap-6">
+        <div className="stagger-fade-in flex flex-col gap-2">
           {courses.map((course, index) => (
             <CourseCard
               key={course.id}


### PR DESCRIPTION
## Summary

Vadym: \"still looks like an ad, not part of the system — maybe because of the image-banner colours, and the font is too big\". Both true. Magazine-style cards framed the catalog as marketing surface no matter how subtle the dressing. The fix is structural: stop building a tile grid, build a system list.

## Changes

| Element | v5 (magazine) | v6 (system list) |
|---|---|---|
| Card shape | Tile with full-bleed cover (horizontal on sm+) | **Compact row** with thumbnail (Vercel / Linear / GitHub shape) |
| Cover image | 21:9 banner / square panel | **56-64px thumbnail** — can't dominate the page |
| Title font | \`text-2xl font-medium\` Fraunces | **\`text-base font-medium\` Inter** — system sans, matches the dashboard |
| Description | 3 lines, \`text-[15px]\` | **1 line, \`text-sm\`** |
| Status | Eyebrow above title OR pill | **Inline dot + label** in the meta row |
| Grid | \`lg:grid-cols-2\` | **\`flex flex-col gap-2\`** — single-column list, like a settings page |
| Card padding | \`p-6\` | **\`p-4\`** — tighter row rhythm |

## Why

- Fraunces is reserved by DESIGN.md for page H1/H2 + chapter reader body. Using it on every list row turned each card into an \"editorial card\", which read as marketing. Inter at body size matches the rest of the dashboard.
- A 56px thumbnail anchors the row visually without competing with the title; the cover's colour palette stops being the page's dominant signal.
- Single-column list at ~5-10 courses is scannable top-to-bottom in one beat — like a Vercel project list or a GitHub repo listing.

## Files
- \`frontend/src/components/course/CourseCard.tsx\` — list-row layout
- \`frontend/src/pages/Home/HomePage.tsx\` — grid → \`flex flex-col gap-2\`, skeleton count 6 → 4
- \`frontend/src/components/skeletons/CourseCardSkeleton.tsx\` — mirrors the row shape

## Test plan
- [x] \`npx vitest run src/components/course/__tests__/CourseCard.test.tsx\` — 9 passed
- [x] \`npm run test:run\` — 222 passed
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [ ] Vadym: hard-refresh equipbible.com after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)