### PR TITLE
ci(codecov): pass CODECOV_TOKEN secret to both upload steps

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -136,16 +136,19 @@ jobs:
           path: backend/coverage.xml
           if-no-files-found: warn
 
-      # Upload to Codecov. Tokenless flow on public repos, so no secret
-      # is needed. `fail_ci_if_error: false` keeps the gate stable if
-      # Codecov has an outage -- the artifact above is the durable
-      # backup.
+      # Upload to Codecov. Public repos with branch protection require
+      # an explicit token (tokenless uploads are rejected by Codecov when
+      # the target branch is protected); we read it from the
+      # `CODECOV_TOKEN` repo secret. `fail_ci_if_error: false` keeps the
+      # gate stable if Codecov has an outage -- the artifact above is the
+      # durable backup.
       - name: Upload coverage to Codecov (backend)
         uses: codecov/codecov-action@v5
         with:
           files: ./backend/coverage.xml
           flags: backend
           name: backend-coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -113,15 +113,18 @@ jobs:
       - name: Run unit tests with coverage
         run: npm run test:run -- --coverage
 
-      # Upload to Codecov. The action handles the OIDC tokenless flow for
-      # public repos, so no CODECOV_TOKEN secret is required. We keep
-      # `fail_ci_if_error: false` so a Codecov outage doesn't redden the PR.
+      # Upload to Codecov. Public repos with branch protection require
+      # an explicit token (tokenless uploads are rejected by Codecov when
+      # the target branch is protected); we read it from the
+      # `CODECOV_TOKEN` repo secret. `fail_ci_if_error: false` keeps the
+      # gate stable if Codecov has an outage.
       - name: Upload coverage to Codecov (frontend)
         uses: codecov/codecov-action@v5
         with:
           files: ./frontend/coverage/lcov.info
           flags: frontend
           name: frontend-coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `token: ${{ secrets.CODECOV_TOKEN }}` to both Codecov upload steps.

## Why

The first Codecov upload after PR #375 merged rejected the upload with:

```
Upload queued for processing failed:
{"message":"Token required because branch is protected"}
```

Codecov's protected-branch policy fires on any branch with rulesets enabled, regardless of repo visibility. The tokenless flow that public repos usually get is bypassed here because `main` has the existing branch ruleset (the one that requires `pr-quality`, `Backend CI Pass`, `Frontend CI Pass`).

The fix is to pass the `CODECOV_TOKEN` secret (already added to repo secrets) to the action. The action falls back to its tokenless flow when the secret resolves to an empty string, so this stays safe for any fork that doesn't have the secret.

## Test plan

- [ ] CI green on this PR (required: `pr-quality`, `Backend CI Pass`, `Frontend CI Pass`).
- [ ] After merge, the next push to main triggers both CI workflows.
- [ ] In the backend / frontend job logs, the "Upload coverage to Codecov" step shows a 200 response and a link like `https://app.codecov.io/gh/ArVaViT/equip/commit/<sha>`.
- [ ] The Codecov badge in the README populates within a few minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
