### PR TITLE
feat(admin): "what changed" column, custom DateRangePicker, sticky-header tables

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@supabase/supabase-js": "^2.105.4",
@@ -1488,6 +1489,61 @@
       }
     },
     "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@supabase/supabase-js": "^2.105.4",

--- a/frontend/src/components/ui/__tests__/date-range-picker.test.tsx
+++ b/frontend/src/components/ui/__tests__/date-range-picker.test.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { I18nextProvider } from "react-i18next"
+import { describe, expect, it, vi } from "vitest"
+import i18n from "@/i18n/config"
+import { DateRangePicker } from "../date-range-picker"
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+describe("DateRangePicker", () => {
+  it("renders the placeholder when no range is set", () => {
+    render(
+      <DateRangePicker value={{ from: "", to: "" }} onChange={() => {}} />,
+      { wrapper: Wrapper },
+    )
+    expect(
+      screen.getByText(/pick date range|выберите диапазон/i),
+    ).toBeInTheDocument()
+  })
+
+  it("renders the chosen range in the trigger label", () => {
+    render(
+      <DateRangePicker
+        value={{ from: "2026-05-01", to: "2026-05-15" }}
+        onChange={() => {}}
+      />,
+      { wrapper: Wrapper },
+    )
+    // Trigger label uses a localised "May 1, 2026 – May 15, 2026" shape;
+    // assert the en-dash separator is present rather than chase the
+    // locale-specific date format.
+    expect(screen.getByRole("button", { name: /–/ })).toBeInTheDocument()
+  })
+
+  it("opens the calendar on trigger click and emits onChange when a day is picked", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <DateRangePicker value={{ from: "", to: "" }} onChange={onChange} />,
+      { wrapper: Wrapper },
+    )
+    await user.click(screen.getByRole("button"))
+
+    // Pick day 15 of the visible month. The calendar always shows the
+    // anchor month (today's month when no value), so 15 is always present.
+    const day15 = await waitFor(() =>
+      screen.getAllByRole("button").find((b) => b.textContent === "15"),
+    )
+    expect(day15).toBeDefined()
+    await user.click(day15!)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const arg = onChange.mock.calls[0]?.[0] as { from: string; to: string }
+    expect(arg.from).toMatch(/^\d{4}-\d{2}-15$/)
+    expect(arg.to).toBe("")
+  })
+
+  it("clear button wipes both bounds", async () => {
+    const onChange = vi.fn()
+    render(
+      <DateRangePicker
+        value={{ from: "2026-05-01", to: "2026-05-15" }}
+        onChange={onChange}
+      />,
+      { wrapper: Wrapper },
+    )
+    fireEvent.click(screen.getByRole("button", { name: /–/ }))
+
+    const clearBtn = await screen.findByRole("button", {
+      name: /^(clear|очистить)$/i,
+    })
+    fireEvent.click(clearBtn)
+
+    expect(onChange).toHaveBeenCalledWith({ from: "", to: "" })
+  })
+})

--- a/frontend/src/components/ui/date-range-picker.tsx
+++ b/frontend/src/components/ui/date-range-picker.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+const DAYS_IN_WEEK = 7
+
+export interface DateRange {
+  /** YYYY-MM-DD string. ``""`` means "no lower bound". */
+  from: string
+  /** YYYY-MM-DD string. ``""`` means "no upper bound". */
+  to: string
+}
+
+interface Props {
+  value: DateRange
+  onChange: (next: DateRange) => void
+  /** Label for the field; rendered above the trigger by callers. */
+  label?: string
+  /** Placeholder shown inside the trigger when neither bound is set. */
+  placeholder?: string
+  /** Disable the trigger. */
+  disabled?: boolean
+  /** Visually mark the trigger as "this filter is active" — same ring
+   *  treatment the surrounding admin filters use. */
+  active?: boolean
+  className?: string
+}
+
+function ymdKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}
+
+function parseYmd(s: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null
+  const y = Number(s.slice(0, 4))
+  const m = Number(s.slice(5, 7))
+  const d = Number(s.slice(8, 10))
+  const out = new Date(y, m - 1, d)
+  return Number.isNaN(out.getTime()) ? null : out
+}
+
+function weekdayMonStart(d: Date): number {
+  return (d.getDay() + 6) % DAYS_IN_WEEK
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1)
+}
+
+function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1)
+}
+
+function compareYmd(a: string, b: string): number {
+  // ISO YYYY-MM-DD strings compare lexicographically.
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+interface MonthCell {
+  date: Date
+  inCurrentMonth: boolean
+  isToday: boolean
+  isStart: boolean
+  isEnd: boolean
+  inRange: boolean
+}
+
+function buildMonthGrid(anchor: Date, from: string, to: string): MonthCell[] {
+  const year = anchor.getFullYear()
+  const month = anchor.getMonth()
+  const first = new Date(year, month, 1)
+  const offset = weekdayMonStart(first)
+  const gridStart = new Date(year, month, 1 - offset)
+  const todayKey = ymdKey(new Date())
+
+  // Normalise so ``from`` is the lower bound regardless of click order
+  // (lets the second click be either earlier or later than the first).
+  const [lo, hi] = from && to && compareYmd(from, to) > 0 ? [to, from] : [from, to]
+
+  const cells: MonthCell[] = []
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i)
+    const key = ymdKey(d)
+    const isStart = !!lo && key === lo
+    const isEnd = !!hi && hi !== lo && key === hi
+    const inRange = !!lo && !!hi && key >= lo && key <= hi
+    cells.push({
+      date: d,
+      inCurrentMonth: d.getMonth() === month,
+      isToday: key === todayKey,
+      isStart,
+      isEnd,
+      inRange,
+    })
+  }
+  return cells
+}
+
+/**
+ * Single-trigger range picker. Click once to set the lower bound,
+ * click again to set the upper bound. The bounds normalise on render
+ * so clicking earlier then later — or later then earlier — both
+ * produce a valid range; callers receive ``{from, to}`` already
+ * sorted.
+ *
+ * Native ``<input type=date>`` was the previous filter pattern in
+ * the admin audit log; it renders differently in every browser, has
+ * no range semantics, and reads as a debug control rather than part
+ * of the system. This widget uses the same Mon-start week + 6-row
+ * month grid the dashboard already uses, so the visual vocabulary
+ * stays consistent across the app.
+ */
+export function DateRangePicker({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  active,
+  className,
+}: Props) {
+  const { t, i18n } = useTranslation()
+  const [open, setOpen] = useState(false)
+  // The visible month: defaults to the month of ``from`` (so the
+  // calendar opens already showing the range), then falls back to
+  // today. Stored in state so the chevron nav doesn't clobber the
+  // selection.
+  const [anchor, setAnchor] = useState<Date>(() => {
+    const fromDate = parseYmd(value.from)
+    return startOfMonth(fromDate ?? new Date())
+  })
+
+  const cells = useMemo(
+    () => buildMonthGrid(anchor, value.from, value.to),
+    [anchor, value.from, value.to],
+  )
+
+  const weekdayHeads = [
+    t("streak.days.mon"),
+    t("streak.days.tue"),
+    t("streak.days.wed"),
+    t("streak.days.thu"),
+    t("streak.days.fri"),
+    t("streak.days.sat"),
+    t("streak.days.sun"),
+  ]
+
+  const triggerLabel = (() => {
+    if (value.from && value.to) {
+      return `${formatShort(value.from, i18n.language)} – ${formatShort(value.to, i18n.language)}`
+    }
+    if (value.from) return `${formatShort(value.from, i18n.language)} – …`
+    if (value.to) return `… – ${formatShort(value.to, i18n.language)}`
+    return placeholder ?? t("dateRangePicker.placeholder")
+  })()
+
+  const monthLabel = anchor.toLocaleDateString(i18n.language, {
+    month: "long",
+    year: "numeric",
+  })
+
+  function pick(d: Date) {
+    const key = ymdKey(d)
+    // First click (no bounds yet) → set the lower bound.
+    // Second click (one bound) → set the other bound.
+    // Both bounds set → start a fresh range from this click.
+    if (!value.from && !value.to) {
+      onChange({ from: key, to: "" })
+      return
+    }
+    if (value.from && !value.to) {
+      // Order doesn't matter — normalise on render
+      onChange({ from: value.from, to: key })
+      // Close after a complete range so the admin can see the table
+      // refresh; the trigger label reflects the picked range.
+      setOpen(false)
+      return
+    }
+    if (!value.from && value.to) {
+      onChange({ from: key, to: value.to })
+      setOpen(false)
+      return
+    }
+    // Both bounds present — restart.
+    onChange({ from: key, to: "" })
+  }
+
+  function clear() {
+    onChange({ from: "", to: "" })
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          className={cn(
+            "h-9 justify-start gap-2 px-3 font-normal",
+            !value.from && !value.to && "text-muted-foreground",
+            active && "border-primary/40 ring-1 ring-primary/40",
+            className,
+          )}
+        >
+          <CalendarIcon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
+          <span className="truncate text-xs sm:text-sm">{triggerLabel}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[300px] p-0" align="start">
+        {/* Header: prev / month label / next */}
+        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setAnchor((a) => addMonths(a, -1))}
+            aria-label={t("dateRangePicker.prevMonth")}
+          >
+            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+          <p className="text-sm font-medium capitalize text-foreground">{monthLabel}</p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setAnchor((a) => addMonths(a, 1))}
+            aria-label={t("dateRangePicker.nextMonth")}
+          >
+            <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        </div>
+
+        {/* Weekday heads + grid */}
+        <div className="p-2">
+          <div className="grid grid-cols-7 gap-0.5">
+            {weekdayHeads.map((d, i) => (
+              <div
+                key={i}
+                className="pb-1 text-center text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
+              >
+                {d}
+              </div>
+            ))}
+            {cells.map((c, i) => {
+              const buttonClasses = cn(
+                "relative flex h-8 w-full items-center justify-center rounded-sm text-xs tabular-nums",
+                "transition-colors hover:bg-muted",
+                c.inCurrentMonth ? "text-foreground" : "text-muted-foreground/40",
+                c.isToday && !c.isStart && !c.isEnd && "ring-1 ring-primary/60",
+                c.inRange && !c.isStart && !c.isEnd && "bg-primary/15 text-foreground",
+                (c.isStart || c.isEnd) && "bg-primary font-medium text-primary-foreground hover:bg-primary/90",
+              )
+              return (
+                <button
+                  type="button"
+                  key={i}
+                  onClick={() => pick(c.date)}
+                  className={buttonClasses}
+                  aria-label={c.date.toLocaleDateString(i18n.language, {
+                    weekday: "long",
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                  })}
+                  aria-pressed={c.isStart || c.isEnd}
+                >
+                  {c.date.getDate()}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Footer: Clear */}
+        <div className="flex items-center justify-end gap-2 border-t border-border px-2 py-1.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={clear}
+            disabled={!value.from && !value.to}
+            className="h-7 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <X className="mr-1 h-3 w-3" strokeWidth={1.75} aria-hidden />
+            {t("dateRangePicker.clear")}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function formatShort(ymd: string, locale: string): string {
+  const d = parseYmd(ymd)
+  if (!d) return ymd
+  return d.toLocaleDateString(locale, { day: "numeric", month: "short", year: "numeric" })
+}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,37 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+const PopoverTrigger = PopoverPrimitive.Trigger
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "start", sideOffset = 6, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      // Matches the existing dropdown-menu surface treatment: bg-popover
+      // with text-popover-foreground from the semantic token set, soft
+      // shadow (overlays-only is in our shadow rules), 1px border, and
+      // rounded-md per the radius rule in DESIGN.md.
+      className={cn(
+        "z-50 rounded-md border border-border bg-popover p-3 text-popover-foreground shadow-md outline-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1",
+        "data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1324,7 +1324,11 @@
         "removeFailed": "Failed to remove student",
         "deleted": "Cohort deleted",
         "deleteFailed": "Failed to delete cohort"
-      }
+      },
+      "filterStatus": "Status",
+      "filterStartRange": "Start date",
+      "searchLabel": "Search",
+      "totalShown": "Showing {{shown}} of {{total}}"
     },
     "users": {
       "title": "Users",
@@ -1411,8 +1415,6 @@
     "audit": {
       "filterAction": "Action",
       "filterResource": "Resource",
-      "filterFrom": "From",
-      "filterTo": "To",
       "filterClear": "Clear filters",
       "filterAllActions": "All actions",
       "filterAllResources": "All resources",
@@ -1448,7 +1450,11 @@
         "certificate": "Certificate",
         "assignment_submission": "Assignment submission",
         "user": "User"
-      }
+      },
+      "filterRange": "Date range",
+      "thDetails": "Details",
+      "pageSizeLabel": "Rows per page",
+      "detailsEmpty": "No details"
     }
   },
   "roles": {
@@ -1579,5 +1585,11 @@
       "quizWeightNonzero": "Quizzes count toward the final grade.",
       "assignmentWeightNonzero": "Assignments count toward the final grade."
     }
+  },
+  "dateRangePicker": {
+    "placeholder": "Pick date range",
+    "clear": "Clear",
+    "prevMonth": "Previous month",
+    "nextMonth": "Next month"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1317,7 +1317,11 @@
         "removeFailed": "Не удалось убрать студента",
         "deleted": "Когорта удалена",
         "deleteFailed": "Не удалось удалить когорту"
-      }
+      },
+      "filterStatus": "Статус",
+      "filterStartRange": "Дата начала",
+      "searchLabel": "Поиск",
+      "totalShown": "Показано {{shown}} из {{total}}"
     },
     "users": {
       "title": "Пользователи",
@@ -1404,8 +1408,6 @@
     "audit": {
       "filterAction": "Действие",
       "filterResource": "Объект",
-      "filterFrom": "С",
-      "filterTo": "По",
       "filterClear": "Сбросить фильтры",
       "filterAllActions": "Все действия",
       "filterAllResources": "Все объекты",
@@ -1441,7 +1443,11 @@
         "certificate": "Сертификат",
         "assignment_submission": "Сданная работа",
         "user": "Пользователь"
-      }
+      },
+      "filterRange": "Период",
+      "thDetails": "Что изменилось",
+      "pageSizeLabel": "Строк на странице",
+      "detailsEmpty": "Нет деталей"
     }
   },
   "roles": {
@@ -1631,5 +1637,11 @@
       "readChapter": "Прочитать сегодняшнюю главу",
       "memoryVerse": "Повторить памятный стих"
     }
+  },
+  "dateRangePicker": {
+    "placeholder": "Выберите диапазон",
+    "clear": "Очистить",
+    "prevMonth": "Предыдущий месяц",
+    "nextMonth": "Следующий месяц"
   }
 }

--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -142,6 +142,7 @@ export default function AdminDashboard() {
             onDateTo={audit.setDateTo}
             onReset={audit.resetFilters}
             onPageChange={audit.setPage}
+            onPageSizeChange={audit.setPageSize}
           />
         </Suspense>
       )}

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -1,18 +1,20 @@
-import { useCallback, useEffect, useState } from "react"
-import { Link } from "react-router-dom"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Link, useSearchParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { GraduationCap, Plus, Search } from "lucide-react"
+import { ChevronLeft, ChevronRight, GraduationCap, Plus, Search, X } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { NativeSelect } from "@/components/ui/native-select"
 import { Skeleton } from "@/components/ui/skeleton"
+import { DateRangePicker } from "@/components/ui/date-range-picker"
 import { EmptyState } from "@/components/patterns/EmptyState"
 import { cohortsService } from "@/services/cohorts"
 import { formatDate } from "@/i18n/format"
 import type { Cohort } from "@/types"
 import { CreateCohortDialog } from "./CreateCohortDialog"
+import { cn } from "@/lib/utils"
 
 const STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
   upcoming: "info",
@@ -20,19 +22,74 @@ const STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
   completed: "muted",
 }
 
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const
+type PageSize = (typeof PAGE_SIZE_OPTIONS)[number]
+const DEFAULT_PAGE_SIZE: PageSize = 25
+const STATUS_VALUES = ["", "upcoming", "active", "completed"] as const
+
+function isPageSize(n: number): n is PageSize {
+  return (PAGE_SIZE_OPTIONS as readonly number[]).includes(n)
+}
+
+function ymdKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}
+
 /**
- * Admin cohort list — top-level `?tab=cohorts` view. Lets the director
- * create a new cohort and drill into any existing one. Detail page
- * (`/admin/cohorts/:id`) is a separate route so the URL is shareable.
+ * Admin cohort list — top-level ``?tab=cohorts`` view.
+ *
+ * Mirrors the audit-log shape: filters in the card header, sticky-
+ * header table with internal scroll, page-size selector + pagination
+ * at the bottom. All filter state lives in the URL (``?cs`` status,
+ * ``?cq`` query, ``?cf``/``?ct`` start-date range, ``?cp`` page,
+ * ``?cps`` page size) so a director can bookmark or share a
+ * specific slice ("active cohorts starting in May").
  */
 export function CohortsTab() {
   const { t } = useTranslation()
+  const [params, setParams] = useSearchParams()
   const [cohorts, setCohorts] = useState<Cohort[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [search, setSearch] = useState("")
-  const [statusFilter, setStatusFilter] = useState<"" | Cohort["status"]>("")
   const [createOpen, setCreateOpen] = useState(false)
+
+  // URL-state. ``pickOption`` keeps it well-typed and rejects
+  // anything that didn't come from our own UI (drop a garbage
+  // ``?cs=999`` and we land on the default).
+  const rawStatus = params.get("cs") ?? ""
+  const statusFilter = (STATUS_VALUES as readonly string[]).includes(rawStatus)
+    ? (rawStatus as "" | Cohort["status"])
+    : ""
+  const search = (params.get("cq") ?? "").slice(0, 100)
+  const startFrom = /^\d{4}-\d{2}-\d{2}$/.test(params.get("cf") ?? "")
+    ? params.get("cf")!
+    : ""
+  const startTo = /^\d{4}-\d{2}-\d{2}$/.test(params.get("ct") ?? "")
+    ? params.get("ct")!
+    : ""
+  const rawPage = Number.parseInt(params.get("cp") ?? "1", 10)
+  const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1
+  const rawPageSize = Number.parseInt(params.get("cps") ?? "", 10)
+  const pageSize: PageSize = isPageSize(rawPageSize) ? rawPageSize : DEFAULT_PAGE_SIZE
+
+  const filtersActive = Boolean(statusFilter || search || startFrom || startTo)
+
+  const updateCohorts = useCallback(
+    (patch: Record<string, string | null>, opts: { resetPage?: boolean } = {}) =>
+      setParams(
+        (prev) => {
+          const n = new URLSearchParams(prev)
+          for (const [k, v] of Object.entries(patch)) {
+            if (v) n.set(k, v)
+            else n.delete(k)
+          }
+          if (opts.resetPage) n.delete("cp")
+          return n
+        },
+        { replace: true },
+      ),
+    [setParams],
+  )
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -51,150 +108,182 @@ export function CohortsTab() {
     void load()
   }, [load])
 
-  const filtered = search
-    ? cohorts.filter((c) => c.name.toLowerCase().includes(search.toLowerCase()))
-    : cohorts
+  // Client-side filter + paginate over the per-status fetch. Cohort
+  // counts in production stay in the dozens, so we don't need a
+  // server-side search/range yet — keeping it client-side avoids two
+  // round trips for one keystroke.
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return cohorts.filter((c) => {
+      if (q && !c.name.toLowerCase().includes(q)) return false
+      const startKey = ymdKey(new Date(c.start_date))
+      if (startFrom && startKey < startFrom) return false
+      if (startTo && startKey > startTo) return false
+      return true
+    })
+  }, [cohorts, search, startFrom, startTo])
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize))
+  const safePage = Math.min(page, totalPages)
+  const pageItems = useMemo(
+    () => filtered.slice((safePage - 1) * pageSize, safePage * pageSize),
+    [filtered, safePage, pageSize],
+  )
+
+  const setStatus = (v: typeof statusFilter) =>
+    updateCohorts({ cs: v || null }, { resetPage: true })
+  const setSearch = (v: string) => updateCohorts({ cq: v || null }, { resetPage: true })
+  const setStartRange = (range: { from: string; to: string }) =>
+    updateCohorts({ cf: range.from || null, ct: range.to || null }, { resetPage: true })
+  const setPage = (n: number) => updateCohorts({ cp: n <= 1 ? null : String(n) })
+  const setPageSize = (n: PageSize) =>
+    updateCohorts(
+      { cps: n === DEFAULT_PAGE_SIZE ? null : String(n) },
+      { resetPage: true },
+    )
+  const resetFilters = () =>
+    updateCohorts({ cs: null, cq: null, cf: null, ct: null, cp: null })
 
   return (
     <Card>
-      <CardHeader className="flex-col items-stretch gap-3 space-y-0 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-4">
-        <CardTitle className="text-xl">{t("admin.cohorts.title")}</CardTitle>
-        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-          <NativeSelect
-            fieldSize="sm"
-            value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value as typeof statusFilter)}
-            className="w-40"
-          >
-            <option value="">{t("admin.cohorts.allStatuses")}</option>
-            <option value="upcoming">{t("admin.cohorts.statusUpcoming")}</option>
-            <option value="active">{t("admin.cohorts.statusActive")}</option>
-            <option value="completed">{t("admin.cohorts.statusCompleted")}</option>
-          </NativeSelect>
-          <div className="relative w-full max-w-xs">
-            <Search
-              className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
-              strokeWidth={1.75}
-              aria-hidden
-            />
-            <Input
-              placeholder={t("admin.cohorts.searchPlaceholder")}
-              value={search}
-              onChange={(e) => setSearch(e.target.value.slice(0, 100))}
-              maxLength={100}
-              className="pl-9"
-            />
-          </div>
-          <Button size="sm" onClick={() => setCreateOpen(true)} className="h-11 sm:h-9">
-            <Plus className="h-4 w-4 mr-1.5" strokeWidth={1.75} aria-hidden />
+      <CardHeader className="gap-3 space-y-0 border-b">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-xl">{t("admin.cohorts.title")}</CardTitle>
+          <Button size="sm" onClick={() => setCreateOpen(true)} className="h-9 shrink-0">
+            <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.createButton")}
           </Button>
         </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              {t("admin.cohorts.filterStatus")}
+            </label>
+            <NativeSelect
+              fieldSize="sm"
+              value={statusFilter}
+              onChange={(e) => setStatus(e.target.value as typeof statusFilter)}
+              className={cn(
+                "w-full sm:w-44",
+                statusFilter && "border-primary/40 ring-1 ring-primary/40",
+              )}
+            >
+              <option value="">{t("admin.cohorts.allStatuses")}</option>
+              <option value="upcoming">{t("admin.cohorts.statusUpcoming")}</option>
+              <option value="active">{t("admin.cohorts.statusActive")}</option>
+              <option value="completed">{t("admin.cohorts.statusCompleted")}</option>
+            </NativeSelect>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              {t("admin.cohorts.filterStartRange")}
+            </label>
+            <DateRangePicker
+              value={{ from: startFrom, to: startTo }}
+              onChange={setStartRange}
+              active={Boolean(startFrom || startTo)}
+            />
+          </div>
+          <div className="space-y-1 sm:flex-1">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="cohort-search">
+              {t("admin.cohorts.searchLabel")}
+            </label>
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                strokeWidth={1.75}
+                aria-hidden
+              />
+              <Input
+                id="cohort-search"
+                fieldSize="sm"
+                placeholder={t("admin.cohorts.searchPlaceholder")}
+                value={search}
+                onChange={(e) => setSearch(e.target.value.slice(0, 100))}
+                maxLength={100}
+                className="pl-9"
+              />
+            </div>
+          </div>
+          {filtersActive && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={resetFilters}
+              className="h-9 self-start text-muted-foreground hover:text-foreground sm:self-end"
+            >
+              <X className="mr-1 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+              {t("admin.audit.filterClear")}
+            </Button>
+          )}
+        </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="p-0">
         {loading ? (
           <CohortsTableSkeleton />
         ) : error ? (
-          <div className="py-10 text-center">
+          <div className="px-6 py-10 text-center">
             <p className="text-sm text-destructive">{error}</p>
             <Button size="sm" variant="outline" className="mt-3" onClick={() => void load()}>
               {t("common.tryAgain")}
             </Button>
           </div>
         ) : filtered.length === 0 ? (
-          <EmptyCohorts hasQuery={Boolean(search)} onCreate={() => setCreateOpen(true)} />
+          <div className="px-6 py-10">
+            <EmptyCohorts hasQuery={filtersActive} onCreate={() => setCreateOpen(true)} />
+          </div>
         ) : (
-          <>
-            {/* Mobile: stack of cards. Each card is the full row, link-wrapped. */}
-            <div className="space-y-2 sm:hidden">
-              {filtered.map((c) => (
-                <Link
-                  key={c.id}
-                  to={`/admin/cohorts/${c.id}`}
-                  className="block rounded-md border border-border bg-card p-3 transition-colors hover:border-primary/30 hover:bg-muted/40"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium text-foreground">{c.name}</p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
-                      </p>
-                    </div>
-                    <Badge variant={STATUS_BADGE[c.status]} className="shrink-0 capitalize">
-                      {t(`admin.cohorts.status${capitalize(c.status)}`)}
-                    </Badge>
-                  </div>
-                  <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
-                    <span>
-                      {t("admin.cohorts.thCourses")}: <span className="text-foreground">{c.course_ids.length}</span>
-                    </span>
-                    <span>
-                      {t("admin.cohorts.thStudents")}:{" "}
-                      <span className="text-foreground">
-                        {c.student_count}
-                        {c.max_students ? ` / ${c.max_students}` : ""}
-                      </span>
-                    </span>
-                  </div>
-                </Link>
-              ))}
-            </div>
-
-            {/* Desktop: classic table */}
-            <div className="hidden overflow-x-auto -mx-6 sm:block">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b text-left">
-                    <th className="px-6 py-3 font-medium text-muted-foreground">
-                      {t("admin.cohorts.thName")}
-                    </th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">
-                      {t("admin.cohorts.thStatus")}
-                    </th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">
-                      {t("admin.cohorts.thDates")}
-                    </th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">
-                      {t("admin.cohorts.thCourses")}
-                    </th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">
-                      {t("admin.cohorts.thStudents")}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {filtered.map((c) => (
-                    <tr key={c.id} className="hover:bg-muted/50 transition-colors">
-                      <td className="px-6 py-3">
-                        <Link
-                          to={`/admin/cohorts/${c.id}`}
-                          className="font-medium hover:text-primary"
-                        >
-                          {c.name}
-                        </Link>
-                      </td>
-                      <td className="px-6 py-3">
-                        <Badge variant={STATUS_BADGE[c.status]} className="capitalize">
-                          {t(`admin.cohorts.status${capitalize(c.status)}`)}
-                        </Badge>
-                      </td>
-                      <td className="px-6 py-3 text-muted-foreground">
-                        {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
-                      </td>
-                      <td className="px-6 py-3 text-muted-foreground">
-                        {c.course_ids.length}
-                      </td>
-                      <td className="px-6 py-3 text-muted-foreground">
-                        {c.student_count}
-                        {c.max_students ? ` / ${c.max_students}` : ""}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </>
+          <CohortsTable items={pageItems} />
         )}
+
+        <div className="flex flex-col items-stretch gap-2 border-t border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <label htmlFor="cohort-page-size">{t("admin.audit.pageSizeLabel")}</label>
+            <NativeSelect
+              id="cohort-page-size"
+              fieldSize="sm"
+              value={String(pageSize)}
+              onChange={(e) => setPageSize(Number(e.target.value) as PageSize)}
+              className="w-20"
+            >
+              {PAGE_SIZE_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </NativeSelect>
+            <span className="ml-2">
+              {t("admin.cohorts.totalShown", { shown: pageItems.length, total: filtered.length })}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-3 sm:justify-end">
+            <p className="text-xs text-muted-foreground">
+              {t("admin.audit.page", { page: safePage, total: totalPages })}
+            </p>
+            <div className="flex items-center gap-1.5">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={safePage <= 1}
+                onClick={() => setPage(safePage - 1)}
+                className="h-9 w-9 p-0"
+                aria-label={t("admin.audit.prevPageAria")}
+              >
+                <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={safePage >= totalPages}
+                onClick={() => setPage(safePage + 1)}
+                className="h-9 w-9 p-0"
+                aria-label={t("admin.audit.nextPageAria")}
+              >
+                <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+              </Button>
+            </div>
+          </div>
+        </div>
       </CardContent>
 
       <CreateCohortDialog
@@ -206,6 +295,88 @@ export function CohortsTab() {
         }}
       />
     </Card>
+  )
+}
+
+function CohortsTable({ items }: { items: Cohort[] }) {
+  const { t } = useTranslation()
+  return (
+    <>
+      {/* Mobile stack — each row is a tappable card. */}
+      <div className="space-y-2 px-4 py-3 sm:hidden">
+        {items.map((c) => (
+          <Link
+            key={c.id}
+            to={`/admin/cohorts/${c.id}`}
+            className="block rounded-md border border-border bg-card p-3 transition-colors hover:border-primary/30 hover:bg-muted/40"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-foreground">{c.name}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
+                </p>
+              </div>
+              <Badge variant={STATUS_BADGE[c.status]} className="shrink-0 capitalize">
+                {t(`admin.cohorts.status${capitalize(c.status)}`)}
+              </Badge>
+            </div>
+            <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+              <span>
+                {t("admin.cohorts.thCourses")}:{" "}
+                <span className="text-foreground">{c.course_ids.length}</span>
+              </span>
+              <span>
+                {t("admin.cohorts.thStudents")}:{" "}
+                <span className="text-foreground">
+                  {c.student_count}
+                  {c.max_students ? ` / ${c.max_students}` : ""}
+                </span>
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {/* Desktop sticky-header table with internal scroll. */}
+      <div className="hidden max-h-[60vh] overflow-y-auto sm:block">
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 z-10 bg-card">
+            <tr className="border-b text-left">
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thName")}</th>
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thStatus")}</th>
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thDates")}</th>
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thCourses")}</th>
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thStudents")}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {items.map((c) => (
+              <tr key={c.id} className="transition-colors hover:bg-muted/40">
+                <td className="px-5 py-3">
+                  <Link to={`/admin/cohorts/${c.id}`} className="font-medium hover:text-primary">
+                    {c.name}
+                  </Link>
+                </td>
+                <td className="px-5 py-3">
+                  <Badge variant={STATUS_BADGE[c.status]} className="capitalize">
+                    {t(`admin.cohorts.status${capitalize(c.status)}`)}
+                  </Badge>
+                </td>
+                <td className="px-5 py-3 text-xs text-muted-foreground">
+                  {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
+                </td>
+                <td className="px-5 py-3 text-muted-foreground">{c.course_ids.length}</td>
+                <td className="px-5 py-3 text-muted-foreground">
+                  {c.student_count}
+                  {c.max_students ? ` / ${c.max_students}` : ""}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
   )
 }
 
@@ -223,7 +394,7 @@ function EmptyCohorts({ hasQuery, onCreate }: { hasQuery: boolean; onCreate: () 
       action={
         !hasQuery ? (
           <Button size="sm" onClick={onCreate}>
-            <Plus className="h-4 w-4 mr-1.5" strokeWidth={1.75} aria-hidden />
+            <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.createButton")}
           </Button>
         ) : undefined
@@ -232,15 +403,11 @@ function EmptyCohorts({ hasQuery, onCreate }: { hasQuery: boolean; onCreate: () 
   )
 }
 
-/**
- * Cohort list loading placeholder. Mirrors the table on desktop and the
- * stacked card list on mobile so the layout doesn't snap when data arrives.
- */
+/** Loading placeholder. Mirrors the table layout so the grid doesn't snap. */
 function CohortsTableSkeleton() {
   return (
     <div aria-busy="true">
-      {/* Mobile stack */}
-      <div className="space-y-2 sm:hidden">
+      <div className="space-y-2 px-4 py-3 sm:hidden">
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className="rounded-md border border-border bg-card p-3">
             <div className="flex items-start justify-between gap-3">
@@ -257,10 +424,9 @@ function CohortsTableSkeleton() {
           </div>
         ))}
       </div>
-      {/* Desktop table */}
-      <div className="hidden overflow-x-auto -mx-6 sm:block">
+      <div className="hidden max-h-[60vh] overflow-y-auto sm:block">
         {Array.from({ length: 6 }).map((_, row) => (
-          <div key={row} className="px-6 py-3 border-b flex items-center gap-4">
+          <div key={row} className="flex items-center gap-4 border-b px-5 py-3">
             {Array.from({ length: 5 }).map((_, col) => (
               <Skeleton key={col} className="h-4 flex-1" />
             ))}

--- a/frontend/src/pages/Admin/dashboard/AuditDetailsCell.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditDetailsCell.tsx
@@ -1,0 +1,85 @@
+import { useTranslation } from "react-i18next"
+
+interface Props {
+  details: Record<string, unknown> | null
+}
+
+/**
+ * Render the audit-log ``details`` payload as a tight key→value list.
+ *
+ * The backend writes whichever fields are meaningful per action — for
+ * an ``update`` that's typically ``{field: 'title', old: '...', new: '...'}``
+ * or a nested object of changed columns; for an ``approve`` it might be
+ * the approver id; for ``enroll`` the cohort. We don't try to be
+ * exhaustive — we render whatever's there, formatted to be readable
+ * inside one cell, and fall back to a dim em-dash when the field is
+ * empty (admin reviews scan for "what changed", an empty cell tells
+ * them "nothing actionable in the payload" rather than "broken").
+ *
+ * No dangerouslySetInnerHTML — every value is stringified and rendered
+ * as plain text so the audit table can't host stored-XSS payloads.
+ */
+export function AuditDetailsCell({ details }: Props) {
+  const { t } = useTranslation()
+  if (!details || typeof details !== "object" || Object.keys(details).length === 0) {
+    return <span className="text-muted-foreground/60">—</span>
+  }
+
+  const entries = Object.entries(details)
+
+  // Special-case the most common "field/old/new" pattern from
+  // service-layer writes: render as "title: 'old' → 'new'" instead of
+  // three rows. Pulled in alphabetical order from the keys so we
+  // recognise it whether the writer used 'field/old/new' or any of
+  // those keys with different casing.
+  if (
+    entries.length === 3 &&
+    "field" in details &&
+    ("old" in details || "before" in details) &&
+    ("new" in details || "after" in details)
+  ) {
+    const field = String(details.field ?? "")
+    const oldVal = formatValue(details.old ?? details.before)
+    const newVal = formatValue(details.new ?? details.after)
+    return (
+      <div className="flex flex-wrap items-baseline gap-1.5 text-xs">
+        <span className="font-medium text-foreground">{field}:</span>
+        <span className="font-mono text-muted-foreground line-through">{oldVal}</span>
+        <span aria-hidden className="text-muted-foreground/60">→</span>
+        <span className="font-mono text-foreground">{newVal}</span>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="space-y-0.5 text-xs">
+      {entries.map(([key, raw]) => (
+        <li key={key} className="flex flex-wrap items-baseline gap-1.5">
+          <span className="font-medium text-foreground">{key}:</span>
+          <span className="font-mono text-muted-foreground">{formatValue(raw)}</span>
+        </li>
+      ))}
+      {entries.length === 0 && (
+        <li className="text-muted-foreground/60">{t("admin.audit.detailsEmpty")}</li>
+      )}
+    </ul>
+  )
+}
+
+function formatValue(v: unknown): string {
+  if (v === null) return "null"
+  if (v === undefined) return "—"
+  if (typeof v === "string") {
+    if (v === "") return '""'
+    // Truncate long strings so a 5KB HTML diff doesn't blow the row
+    // height; admins can click into the resource for full context.
+    return v.length > 80 ? `${v.slice(0, 80)}…` : v
+  }
+  if (typeof v === "number" || typeof v === "boolean") return String(v)
+  try {
+    const json = JSON.stringify(v)
+    return json.length > 80 ? `${json.slice(0, 80)}…` : json
+  } catch {
+    return "[unserializable]"
+  }
+}

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
 import { NativeSelect } from "@/components/ui/native-select"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import { DateRangePicker } from "@/components/ui/date-range-picker"
 import { cn } from "@/lib/utils"
 import { EmptyState } from "@/components/patterns/EmptyState"
 import { FileText, ChevronLeft, ChevronRight, X } from "lucide-react"
@@ -14,6 +14,8 @@ import {
   RESOURCE_OPTIONS,
   ACTION_BADGE_VARIANT,
 } from "./constants"
+import { AUDIT_PAGE_SIZE_OPTIONS, type AuditPageSize } from "./useAdminAudit"
+import { AuditDetailsCell } from "./AuditDetailsCell"
 import { formatDateTime } from "@/i18n/format"
 
 interface Props {
@@ -21,7 +23,7 @@ interface Props {
   total: number
   loading: boolean
   page: number
-  pageSize: number
+  pageSize: AuditPageSize
   userMap: Record<string, string>
   action: string
   resource: string
@@ -33,14 +35,15 @@ interface Props {
   onDateTo: (next: string) => void
   onReset: () => void
   onPageChange: (nextPage: number) => void
+  onPageSizeChange: (next: AuditPageSize) => void
 }
 
 /**
- * Full audit-log tab: filter bar, table, pagination — all inside one
- * Card. Filters and table share a surface so the bar feels like part
- * of the same view rather than a separate widget floating above. Each
- * filter has a label, but the filter row itself doesn't get an outer
- * card border to compete with the table border below.
+ * Full audit-log tab: filter bar, scrollable table with sticky
+ * header, pagination + page-size selector. Filters live in the card
+ * header so the bar reads as part of the table view (not as a
+ * floating widget). The table body uses internal overflow so a long
+ * page doesn't push the rest of the admin UI off-screen.
  */
 export function AuditLogTab({
   logs,
@@ -59,6 +62,7 @@ export function AuditLogTab({
   onDateTo,
   onReset,
   onPageChange,
+  onPageSizeChange,
 }: Props) {
   const { t } = useTranslation()
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
@@ -67,14 +71,17 @@ export function AuditLogTab({
   return (
     <Card>
       <CardHeader className="gap-3 space-y-0 border-b">
-        <CardTitle className="text-xl flex items-center gap-2">
+        <CardTitle className="flex items-center gap-2 text-xl">
           <FileText className="h-5 w-5 shrink-0" strokeWidth={1.75} aria-hidden />
           {t("admin.audit.title")}
-          <span className="text-sm font-normal text-muted-foreground ml-1.5">
+          <span className="ml-1.5 text-sm font-normal text-muted-foreground">
             {t("admin.audit.entriesCount", { count: total })}
           </span>
         </CardTitle>
-        <div className="grid grid-cols-1 gap-3 sm:flex sm:flex-wrap sm:items-end">
+        {/* Filter row. Selects sit on the left, the range picker on the
+            right of the same row on sm+; on mobile everything stacks
+            full-width so the touch targets stay tappable. */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
           <FilterSelect
             label={t("admin.audit.filterAction")}
             value={action}
@@ -91,14 +98,25 @@ export function AuditLogTab({
             optionLabel={(o) => t(`admin.audit.resourceValue.${o}`)}
             placeholder={t("admin.audit.filterAllResources")}
           />
-          <FilterDate label={t("admin.audit.filterFrom")} value={dateFrom} onChange={onDateFrom} />
-          <FilterDate label={t("admin.audit.filterTo")} value={dateTo} onChange={onDateTo} />
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              {t("admin.audit.filterRange")}
+            </label>
+            <DateRangePicker
+              value={{ from: dateFrom, to: dateTo }}
+              onChange={({ from, to }) => {
+                onDateFrom(from)
+                onDateTo(to)
+              }}
+              active={Boolean(dateFrom || dateTo)}
+            />
+          </div>
           {filtersActive && (
             <Button
               variant="ghost"
               size="sm"
               onClick={onReset}
-              className="h-11 self-end text-muted-foreground hover:text-foreground sm:h-9"
+              className="h-9 self-start text-muted-foreground hover:text-foreground sm:self-end"
             >
               <X className="mr-1 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
               {t("admin.audit.filterClear")}
@@ -106,47 +124,68 @@ export function AuditLogTab({
           )}
         </div>
       </CardHeader>
-      <CardContent className="pt-0">
+      <CardContent className="p-0">
         {loading ? (
           <AuditTableSkeleton />
         ) : logs.length === 0 ? (
-          <EmptyState
-            variant="compact"
-            icon={<FileText strokeWidth={1.75} aria-hidden />}
-            title={t("admin.audit.empty")}
-          />
+          <div className="px-6 py-10">
+            <EmptyState
+              variant="compact"
+              icon={<FileText strokeWidth={1.75} aria-hidden />}
+              title={t("admin.audit.empty")}
+            />
+          </div>
         ) : (
-          <>
-            <AuditTable logs={logs} userMap={userMap} />
-            <div className="flex items-center justify-between px-5 pb-1 pt-4">
-              <p className="text-xs text-muted-foreground">
-                {t("admin.audit.page", { page, total: totalPages })}
-              </p>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={page <= 1}
-                  onClick={() => onPageChange(page - 1)}
-                  className="h-11 w-11 p-0 sm:h-9 sm:w-9"
-                  aria-label={t("admin.audit.prevPageAria")}
-                >
-                  <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={page >= totalPages}
-                  onClick={() => onPageChange(page + 1)}
-                  className="h-11 w-11 p-0 sm:h-9 sm:w-9"
-                  aria-label={t("admin.audit.nextPageAria")}
-                >
-                  <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-                </Button>
-              </div>
-            </div>
-          </>
+          <AuditTable logs={logs} userMap={userMap} />
         )}
+
+        {/* Pagination + page-size selector. Always shown so the admin
+            can dial the density up/down even on an empty filter set. */}
+        <div className="flex flex-col items-stretch gap-2 border-t border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <label htmlFor="audit-page-size">{t("admin.audit.pageSizeLabel")}</label>
+            <NativeSelect
+              id="audit-page-size"
+              fieldSize="sm"
+              value={String(pageSize)}
+              onChange={(e) => onPageSizeChange(Number(e.target.value) as AuditPageSize)}
+              className="w-20"
+            >
+              {AUDIT_PAGE_SIZE_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </NativeSelect>
+          </div>
+          <div className="flex items-center justify-between gap-3 sm:justify-end">
+            <p className="text-xs text-muted-foreground">
+              {t("admin.audit.page", { page, total: totalPages })}
+            </p>
+            <div className="flex items-center gap-1.5">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => onPageChange(page - 1)}
+                className="h-9 w-9 p-0"
+                aria-label={t("admin.audit.prevPageAria")}
+              >
+                <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => onPageChange(page + 1)}
+                className="h-9 w-9 p-0"
+                aria-label={t("admin.audit.nextPageAria")}
+              >
+                <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+              </Button>
+            </div>
+          </div>
+        </div>
       </CardContent>
     </Card>
   )
@@ -171,8 +210,8 @@ function FilterSelect({ label, value, onChange, options, optionLabel, placeholde
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className={cn(
-          "w-full sm:w-auto",
-          isActive && "ring-1 ring-primary/40 border-primary/40",
+          "w-full sm:w-44",
+          isActive && "border-primary/40 ring-1 ring-primary/40",
         )}
       >
         <option value="">{placeholder}</option>
@@ -186,33 +225,6 @@ function FilterSelect({ label, value, onChange, options, optionLabel, placeholde
   )
 }
 
-function FilterDate({
-  label,
-  value,
-  onChange,
-}: {
-  label: string
-  value: string
-  onChange: (next: string) => void
-}) {
-  const isActive = value !== ""
-  return (
-    <div className="space-y-1">
-      <label className="text-xs font-medium text-muted-foreground">{label}</label>
-      <Input
-        type="date"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        fieldSize="sm"
-        className={cn(
-          "w-full sm:w-40",
-          isActive && "ring-1 ring-primary/40 border-primary/40",
-        )}
-      />
-    </div>
-  )
-}
-
 function AuditTable({
   logs,
   userMap,
@@ -222,50 +234,58 @@ function AuditTable({
 }) {
   const { t } = useTranslation()
   return (
-    <div className="overflow-x-auto -mx-6">
+    // Internal scroll: ``max-h`` is sized so up to ~12 rows show
+    // before the body becomes scrollable on a typical viewport.
+    // ``sticky top-0`` on <thead> keeps the column heads visible while
+    // the body scrolls; the bg fill is required so rows don't bleed
+    // through the sticky cells.
+    <div className="max-h-[60vh] overflow-y-auto">
       <table className="w-full text-sm">
-        <thead>
+        <thead className="sticky top-0 z-10 bg-card">
           <tr className="border-b text-left">
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thDate")}</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thUser")}</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thAction")}</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thResource")}</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thResourceId")}</th>
-            <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.audit.thIp")}</th>
+            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thDate")}</th>
+            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thUser")}</th>
+            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thAction")}</th>
+            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thResource")}</th>
+            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thDetails")}</th>
+            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thIp")}</th>
           </tr>
         </thead>
         <tbody className="divide-y">
           {logs.map((log) => (
-            <tr key={log.id} className="hover:bg-muted/50 transition-colors">
-              <td className="px-6 py-3 text-muted-foreground whitespace-nowrap">
+            <tr key={log.id} className="align-top transition-colors hover:bg-muted/40">
+              <td className="whitespace-nowrap px-5 py-3 text-xs text-muted-foreground">
                 {formatDateTime(log.created_at)}
               </td>
-              <td className="px-6 py-3 max-w-[160px] truncate" title={log.user_id ?? ""}>
-                {log.user_id
-                  ? userMap[log.user_id] || log.user_id.slice(0, 8) + "…"
-                  : "—"}
+              <td className="max-w-[160px] truncate px-5 py-3 text-xs" title={log.user_id ?? ""}>
+                {log.user_id ? userMap[log.user_id] || `${log.user_id.slice(0, 8)}…` : "—"}
               </td>
-              <td className="px-6 py-3">
+              <td className="px-5 py-3">
                 <Badge variant={ACTION_BADGE_VARIANT[log.action] ?? "muted"}>
-                  {t(`admin.audit.actionValue.${log.action}`, {
-                    defaultValue: log.action,
-                  })}
+                  {t(`admin.audit.actionValue.${log.action}`, { defaultValue: log.action })}
                 </Badge>
               </td>
-              <td className="px-6 py-3 text-muted-foreground">
-                {t(`admin.audit.resourceValue.${log.resource_type}`, { defaultValue: log.resource_type })}
+              <td className="px-5 py-3 text-xs">
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-muted-foreground">
+                    {t(`admin.audit.resourceValue.${log.resource_type}`, {
+                      defaultValue: log.resource_type,
+                    })}
+                  </span>
+                  <span
+                    className="max-w-[160px] truncate font-mono text-[10px] text-muted-foreground/70"
+                    title={log.resource_id}
+                  >
+                    {log.resource_id.length > 14
+                      ? `${log.resource_id.slice(0, 14)}…`
+                      : log.resource_id}
+                  </span>
+                </div>
               </td>
-              <td
-                className="px-6 py-3 font-mono text-xs text-muted-foreground max-w-[120px] truncate"
-                title={log.resource_id}
-              >
-                {log.resource_id.length > 12
-                  ? log.resource_id.slice(0, 12) + "…"
-                  : log.resource_id}
+              <td className="max-w-[320px] px-5 py-3">
+                <AuditDetailsCell details={log.details} />
               </td>
-              <td className="px-6 py-3 text-muted-foreground text-xs">
-                {log.ip_address || "—"}
-              </td>
+              <td className="px-5 py-3 text-xs text-muted-foreground">{log.ip_address || "—"}</td>
             </tr>
           ))}
         </tbody>
@@ -275,21 +295,20 @@ function AuditTable({
 }
 
 /**
- * Audit-table loading placeholder. Renders 8 ghost rows in the table layout
- * so column widths don't snap when real data arrives. Calling 8 because that's
- * the default page size for the audit log.
+ * Audit-table loading placeholder. Renders 8 ghost rows in the table
+ * layout so column widths don't snap when real data arrives.
  */
 function AuditTableSkeleton() {
   return (
-    <div className="-mx-6 overflow-x-auto" aria-busy="true">
-      <div className="px-6 py-3 border-b flex gap-4">
-        {Array.from({ length: 5 }).map((_, i) => (
+    <div className="max-h-[60vh] overflow-y-auto" aria-busy="true">
+      <div className="flex gap-4 border-b px-5 py-3">
+        {Array.from({ length: 6 }).map((_, i) => (
           <Skeleton key={i} className="h-3 flex-1" />
         ))}
       </div>
       {Array.from({ length: 8 }).map((_, row) => (
-        <div key={row} className="px-6 py-3 border-b flex gap-4 items-center">
-          {Array.from({ length: 5 }).map((_, col) => (
+        <div key={row} className="flex items-center gap-4 border-b px-5 py-3">
+          {Array.from({ length: 6 }).map((_, col) => (
             <Skeleton key={col} className="h-4 flex-1" />
           ))}
         </div>

--- a/frontend/src/pages/Admin/dashboard/__tests__/AuditDetailsCell.test.tsx
+++ b/frontend/src/pages/Admin/dashboard/__tests__/AuditDetailsCell.test.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react"
+import { render, screen, within } from "@testing-library/react"
+import { I18nextProvider } from "react-i18next"
+import { describe, expect, it } from "vitest"
+import i18n from "@/i18n/config"
+import { AuditDetailsCell } from "../AuditDetailsCell"
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+describe("AuditDetailsCell", () => {
+  it("renders an em-dash when details is null", () => {
+    render(<AuditDetailsCell details={null} />, { wrapper: Wrapper })
+    expect(screen.getByText("—")).toBeInTheDocument()
+  })
+
+  it("renders an em-dash when details is empty", () => {
+    render(<AuditDetailsCell details={{}} />, { wrapper: Wrapper })
+    expect(screen.getByText("—")).toBeInTheDocument()
+  })
+
+  it("renders the field/old/new shape as 'field: old → new'", () => {
+    render(
+      <AuditDetailsCell
+        details={{ field: "title", old: "Old name", new: "New name" }}
+      />,
+      { wrapper: Wrapper },
+    )
+    expect(screen.getByText("title:")).toBeInTheDocument()
+    expect(screen.getByText("Old name")).toBeInTheDocument()
+    expect(screen.getByText("New name")).toBeInTheDocument()
+    expect(screen.getByText("→")).toBeInTheDocument()
+  })
+
+  it("accepts before/after synonyms in place of old/new", () => {
+    render(
+      <AuditDetailsCell details={{ field: "status", before: "draft", after: "published" }} />,
+      { wrapper: Wrapper },
+    )
+    expect(screen.getByText("draft")).toBeInTheDocument()
+    expect(screen.getByText("published")).toBeInTheDocument()
+  })
+
+  it("falls back to a key:value list for arbitrary payloads", () => {
+    render(
+      <AuditDetailsCell details={{ approver: "u-123", cohort: "c-abc" }} />,
+      { wrapper: Wrapper },
+    )
+    const items = screen.getAllByRole("listitem")
+    expect(items).toHaveLength(2)
+    const first = items[0]!
+    expect(within(first).getByText("approver:")).toBeInTheDocument()
+    expect(within(first).getByText("u-123")).toBeInTheDocument()
+  })
+
+  it("truncates long string values so the row height stays bounded", () => {
+    const longString = "a".repeat(200)
+    render(<AuditDetailsCell details={{ note: longString }} />, { wrapper: Wrapper })
+    const rendered = screen.getByText(/^a+…$/)
+    expect(rendered.textContent!.length).toBeLessThanOrEqual(81)
+  })
+
+  it("stringifies booleans and numbers safely", () => {
+    render(<AuditDetailsCell details={{ count: 42, active: true, empty: null }} />, {
+      wrapper: Wrapper,
+    })
+    expect(screen.getByText("42")).toBeInTheDocument()
+    expect(screen.getByText("true")).toBeInTheDocument()
+    expect(screen.getByText("null")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/Admin/dashboard/useAdminAudit.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminAudit.ts
@@ -13,7 +13,13 @@ import {
   RESOURCE_OPTIONS,
 } from "./constants"
 
-const AUDIT_PAGE_SIZE = 25
+export const AUDIT_PAGE_SIZE_OPTIONS = [25, 50, 100] as const
+export type AuditPageSize = (typeof AUDIT_PAGE_SIZE_OPTIONS)[number]
+const DEFAULT_PAGE_SIZE: AuditPageSize = 25
+
+function isAuditPageSize(n: number): n is AuditPageSize {
+  return (AUDIT_PAGE_SIZE_OPTIONS as readonly number[]).includes(n)
+}
 
 interface UseAdminAuditArgs {
   /** When `false` the hook skips fetching — used to avoid loading the
@@ -42,6 +48,11 @@ export function useAdminAudit({ enabled }: UseAdminAuditArgs) {
   const dateTo = ISO_DATE_REGEX.test(params.get("at") ?? "") ? params.get("at")! : ""
   const rawPage = Number.parseInt(params.get("ap") ?? "1", 10)
   const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1
+  // Page size is also URL-state so a bookmarked admin link round-trips.
+  // Reject anything not in the allow-list (defaults to 25) so a crafted
+  // ``?aps=99999`` can't trigger a backend OOM.
+  const rawPageSize = Number.parseInt(params.get("aps") ?? "", 10)
+  const pageSize: AuditPageSize = isAuditPageSize(rawPageSize) ? rawPageSize : DEFAULT_PAGE_SIZE
 
   const [logs, setLogs] = useState<AuditLogEntry[]>([])
   const [total, setTotal] = useState(0)
@@ -66,7 +77,7 @@ export function useAdminAudit({ enabled }: UseAdminAuditArgs) {
   const { data: fetchedData, loading, error: fetchError } = useAsyncData(
     async (isCancelled) => {
       if (!enabled) return undefined
-      const query: AuditLogQuery = { page, page_size: AUDIT_PAGE_SIZE }
+      const query: AuditLogQuery = { page, page_size: pageSize }
       if (action) query.action = action
       if (resource) query.resource_type = resource
       // Both bounds anchor to the **local** calendar day the admin
@@ -95,7 +106,7 @@ export function useAdminAudit({ enabled }: UseAdminAuditArgs) {
       if (isCancelled()) return undefined
       return data
     },
-    [enabled, page, action, resource, dateFrom, dateTo],
+    [enabled, page, pageSize, action, resource, dateFrom, dateTo],
   )
 
   // Sync fetched data into individual state
@@ -120,7 +131,7 @@ export function useAdminAudit({ enabled }: UseAdminAuditArgs) {
     total,
     loading,
     page,
-    pageSize: AUDIT_PAGE_SIZE,
+    pageSize,
     action,
     resource,
     dateFrom,
@@ -130,6 +141,10 @@ export function useAdminAudit({ enabled }: UseAdminAuditArgs) {
     setDateFrom: (v: string) => updateAudit({ af: v || null }, { resetPage: true }),
     setDateTo: (v: string) => updateAudit({ at: v || null }, { resetPage: true }),
     setPage: (next: number) => updateAudit({ ap: next <= 1 ? null : String(next) }),
+    // Setting page size resets to page 1: the offset that was valid
+    // for the old size is meaningless under the new one.
+    setPageSize: (next: AuditPageSize) =>
+      updateAudit({ aps: next === DEFAULT_PAGE_SIZE ? null : String(next) }, { resetPage: true }),
     resetFilters,
   }
 }


### PR DESCRIPTION
## Summary

Admin Dashboard rework after Vadym's "make it readable + safer" pass. Five connected changes; the user-visible win is the audit log finally shows **what changed**, not just **that something changed**.

### 1. Audit log "Details" column
`audit_logs.details` JSONB was always written but never rendered. New `AuditDetailsCell` formats it inline:
- `{field, old, new}` (or `before/after`) → `title: 'Old' → 'New'` on one line
- Anything else → tight `key: value` list
- Long strings truncate at 80 chars (admin drills into resource for full context)
- Plain-text only — no `dangerouslySetInnerHTML`, no stored-XSS surface

### 2. Custom DateRangePicker
Two `<input type="date">` filters were browser-styled (renders differently per browser), had no range semantics, and read as a debug control. Replaced with a single Popover-hosted calendar trigger; click once for lower bound, click again for upper. Bounds normalise on render so click order doesn't matter.

New dep: `@radix-ui/react-popover` (small, accessible, matches the rest of the Radix stack). New `components/ui/popover.tsx` + `date-range-picker.tsx`.

### 3. Audit table: sticky header + internal scroll + page-size selector
`max-h-[60vh] overflow-y-auto` body with `sticky top-0` `<thead>` — admins on long pages scroll rows without losing column heads or pushing the rest of admin off-screen. Page size 25/50/100 (URL-state, `?aps`), allowlist-guarded so `?aps=999999` can't trigger a backend OOM.

### 4. Cohorts tab — same treatment + start-date range filter
Cohorts was the unfinished sibling. Same upgrades: sticky-header table inside its own scroll container, status + search + start-date range filters + reset, page-size + pagination. Full URL state (`?cs ?cq ?cf ?ct ?cp ?cps`). Shared `DateRangePicker` keeps visual vocabulary consistent across panels.

### 5. i18n
- `admin.audit.{filterRange,thDetails,pageSizeLabel,detailsEmpty}` (EN+RU); dropped per-bound `filterFrom/filterTo`.
- `admin.cohorts.{filterStatus,filterStartRange,searchLabel,totalShown}`.
- `dateRangePicker.{placeholder,clear,prevMonth,nextMonth}`.

## Checks
- 249 tests pass (11 new: 4 DateRangePicker + 7 AuditDetailsCell)
- `npm run lint` + `tsc --noEmit` clean
- `npm audit` 0 vulns

## Test plan
- [x] vitest + lint + tsc green
- [ ] Vadym: open `/admin?tab=audit`, confirm Details column shows readable diffs; range picker opens cleanly; page size + pagination round-trip the URL. `/admin?tab=cohorts` has the same controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)