### PR TITLE
feat(admin): relative time, resource links, summary row, overview deltas, cohort capacity

### DIFF
--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -1,0 +1,235 @@
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+const DAYS_IN_WEEK = 7
+
+interface Props {
+  /** YYYY-MM-DD string. ``""`` means "no date selected". */
+  value: string
+  onChange: (next: string) => void
+  /** Trigger placeholder when value is empty. */
+  placeholder?: string
+  /** Whether to allow clearing the value (renders a Clear footer). */
+  clearable?: boolean
+  disabled?: boolean
+  active?: boolean
+  className?: string
+}
+
+function ymdKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}
+
+function parseYmd(s: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null
+  const y = Number(s.slice(0, 4))
+  const m = Number(s.slice(5, 7))
+  const d = Number(s.slice(8, 10))
+  const out = new Date(y, m - 1, d)
+  return Number.isNaN(out.getTime()) ? null : out
+}
+
+function weekdayMonStart(d: Date): number {
+  return (d.getDay() + 6) % DAYS_IN_WEEK
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1)
+}
+
+function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1)
+}
+
+interface MonthCell {
+  date: Date
+  inCurrentMonth: boolean
+  isToday: boolean
+  isSelected: boolean
+}
+
+function buildMonthGrid(anchor: Date, selected: string): MonthCell[] {
+  const year = anchor.getFullYear()
+  const month = anchor.getMonth()
+  const first = new Date(year, month, 1)
+  const offset = weekdayMonStart(first)
+  const gridStart = new Date(year, month, 1 - offset)
+  const todayKey = ymdKey(new Date())
+
+  const cells: MonthCell[] = []
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i)
+    const key = ymdKey(d)
+    cells.push({
+      date: d,
+      inCurrentMonth: d.getMonth() === month,
+      isToday: key === todayKey,
+      isSelected: !!selected && key === selected,
+    })
+  }
+  return cells
+}
+
+/**
+ * Single-date picker — Popover-hosted month grid, same week-start
+ * convention + day-cell treatment as ``DateRangePicker``. Click a day
+ * to select it; the popover closes automatically since the only
+ * meaningful interaction is one click. ``clearable`` adds an "X
+ * Clear" footer button for nullable date fields (e.g. enrollment
+ * start/end on a cohort).
+ *
+ * Replaces ``<input type=date>`` in admin editors where browser
+ * inconsistency was a real complaint (Vadym: "дейт пикер не
+ * кастомный").
+ */
+export function DatePicker({
+  value,
+  onChange,
+  placeholder,
+  clearable,
+  disabled,
+  active,
+  className,
+}: Props) {
+  const { t, i18n } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [anchor, setAnchor] = useState<Date>(() => {
+    const v = parseYmd(value)
+    return startOfMonth(v ?? new Date())
+  })
+
+  const cells = useMemo(() => buildMonthGrid(anchor, value), [anchor, value])
+
+  const weekdayHeads = [
+    t("streak.days.mon"),
+    t("streak.days.tue"),
+    t("streak.days.wed"),
+    t("streak.days.thu"),
+    t("streak.days.fri"),
+    t("streak.days.sat"),
+    t("streak.days.sun"),
+  ]
+
+  const monthLabel = anchor.toLocaleDateString(i18n.language, {
+    month: "long",
+    year: "numeric",
+  })
+
+  const triggerLabel = value
+    ? (() => {
+        const d = parseYmd(value)
+        return d
+          ? d.toLocaleDateString(i18n.language, { day: "numeric", month: "short", year: "numeric" })
+          : value
+      })()
+    : (placeholder ?? t("dateRangePicker.placeholder"))
+
+  function pick(d: Date) {
+    onChange(ymdKey(d))
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          className={cn(
+            "h-9 justify-start gap-2 px-3 font-normal",
+            !value && "text-muted-foreground",
+            active && "border-primary/40 ring-1 ring-primary/40",
+            className,
+          )}
+        >
+          <CalendarIcon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
+          <span className="truncate text-xs sm:text-sm">{triggerLabel}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[280px] p-0" align="start">
+        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setAnchor((a) => addMonths(a, -1))}
+            aria-label={t("dateRangePicker.prevMonth")}
+          >
+            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+          <p className="text-sm font-medium capitalize text-foreground">{monthLabel}</p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setAnchor((a) => addMonths(a, 1))}
+            aria-label={t("dateRangePicker.nextMonth")}
+          >
+            <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        </div>
+        <div className="p-2">
+          <div className="grid grid-cols-7 gap-0.5">
+            {weekdayHeads.map((d, i) => (
+              <div
+                key={i}
+                className="pb-1 text-center text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
+              >
+                {d}
+              </div>
+            ))}
+            {cells.map((c, i) => (
+              <button
+                type="button"
+                key={i}
+                onClick={() => pick(c.date)}
+                className={cn(
+                  "relative flex h-8 w-full items-center justify-center rounded-sm text-xs tabular-nums transition-colors hover:bg-muted",
+                  c.inCurrentMonth ? "text-foreground" : "text-muted-foreground/40",
+                  c.isToday && !c.isSelected && "ring-1 ring-primary/60",
+                  c.isSelected &&
+                    "bg-primary font-medium text-primary-foreground hover:bg-primary/90",
+                )}
+                aria-label={c.date.toLocaleDateString(i18n.language, {
+                  weekday: "long",
+                  day: "numeric",
+                  month: "long",
+                  year: "numeric",
+                })}
+                aria-pressed={c.isSelected}
+              >
+                {c.date.getDate()}
+              </button>
+            ))}
+          </div>
+        </div>
+        {clearable && (
+          <div className="flex items-center justify-end border-t border-border px-2 py-1.5">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                onChange("")
+                setOpen(false)
+              }}
+              disabled={!value}
+              className="h-7 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <X className="mr-1 h-3 w-3" strokeWidth={1.75} aria-hidden />
+              {t("dateRangePicker.clear")}
+            </Button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/i18n/format.ts
+++ b/frontend/src/i18n/format.ts
@@ -79,6 +79,39 @@ export function formatDateTimeMs(date: Date | string | number | null | undefined
 }
 
 /**
+ * Locale-aware relative time ("5m ago", "5 мин назад") for compact
+ * table cells where an absolute timestamp would dominate the row.
+ *
+ * Pair with ``title={formatDateTime(date)}`` on the rendering element
+ * so a hover (or screen reader) still surfaces the exact moment —
+ * relative ts is scannable but loses precision once you cross a day
+ * boundary, and an admin reading the audit log needs the exact value.
+ *
+ * Granularity rolls up: under a minute → "just now", under an hour →
+ * "Xm ago", under a day → "Xh ago", under a month → "Xd ago", else
+ * the absolute date so "3 months ago" doesn't muddy a real timeline.
+ */
+export function formatRelative(date: Date | string | number | null | undefined): string {
+  if (date == null) return ""
+  const d = toDate(date)
+  if (!d) return ""
+  const lang = (i18n.resolvedLanguage ?? i18n.language ?? "en").toLowerCase()
+  const locale = lang.startsWith("ru") ? "ru-RU" : "en-US"
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto", style: "short" })
+  const diffMs = d.getTime() - Date.now()
+  const absSec = Math.abs(diffMs) / 1000
+
+  if (absSec < 45) return rtf.format(0, "second").replace("0", "")
+  if (absSec < 3600) return rtf.format(Math.round(diffMs / 60_000), "minute")
+  if (absSec < 86_400) return rtf.format(Math.round(diffMs / 3_600_000), "hour")
+  if (absSec < 30 * 86_400) return rtf.format(Math.round(diffMs / 86_400_000), "day")
+  // For anything older, the absolute date reads more honestly than
+  // ``3 months ago`` (and is sortable, which is the rest of the
+  // module's promise).
+  return formatDate(d)
+}
+
+/**
  * Locale-aware long form (``Intl.DateTimeFormat``). EN and RU render
  * different strings on purpose — this is the editorial / ceremonial
  * format. Use it for prose: certificate body, calendar day header,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1328,7 +1328,10 @@
       "filterStatus": "Status",
       "filterStartRange": "Start date",
       "searchLabel": "Search",
-      "totalShown": "Showing {{shown}} of {{total}}"
+      "totalShown": "Showing {{shown}} of {{total}}",
+      "capacityLabel": "{{pct}}% full",
+      "studentSearchPlaceholder": "Search students…",
+      "studentSearchNoMatch": "No students match."
     },
     "users": {
       "title": "Users",
@@ -1410,7 +1413,10 @@
         "bulkRoleTitle": "Change role for selected users?",
         "bulkRoleDescription": "{{count}} user(s) will be set to role \"{{role}}\".",
         "bulkRoleAction": "Apply"
-      }
+      },
+      "usersLast7Days_one": "+{{count}} this week",
+      "usersLast7Days_other": "+{{count}} this week",
+      "usersLast7Days_zero": "No new signups this week"
     },
     "audit": {
       "filterAction": "Action",
@@ -1454,7 +1460,8 @@
       "filterRange": "Date range",
       "thDetails": "Details",
       "pageSizeLabel": "Rows per page",
-      "detailsEmpty": "No details"
+      "detailsEmpty": "No details",
+      "summaryLabel": "On this page"
     }
   },
   "roles": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1321,7 +1321,10 @@
       "filterStatus": "Статус",
       "filterStartRange": "Дата начала",
       "searchLabel": "Поиск",
-      "totalShown": "Показано {{shown}} из {{total}}"
+      "totalShown": "Показано {{shown}} из {{total}}",
+      "capacityLabel": "{{pct}}% заполнено",
+      "studentSearchPlaceholder": "Поиск студентов…",
+      "studentSearchNoMatch": "Ничего не найдено."
     },
     "users": {
       "title": "Пользователи",
@@ -1403,7 +1406,12 @@
         "bulkRoleTitle": "Изменить роль для выбранных пользователей?",
         "bulkRoleDescription": "Выбрано пользователей: {{count}}. Для них будет установлена роль «{{role}}».",
         "bulkRoleAction": "Применить"
-      }
+      },
+      "usersLast7Days_one": "+{{count}} за неделю",
+      "usersLast7Days_few": "+{{count}} за неделю",
+      "usersLast7Days_many": "+{{count}} за неделю",
+      "usersLast7Days_other": "+{{count}} за неделю",
+      "usersLast7Days_zero": "Новых регистраций нет"
     },
     "audit": {
       "filterAction": "Действие",
@@ -1447,7 +1455,8 @@
       "filterRange": "Период",
       "thDetails": "Что изменилось",
       "pageSizeLabel": "Строк на странице",
-      "detailsEmpty": "Нет деталей"
+      "detailsEmpty": "Нет деталей",
+      "summaryLabel": "На этой странице"
     }
   },
   "roles": {

--- a/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import {
   ArrowLeft,
   Calendar,
   Plus,
+  Search,
   Trash2,
   Users,
 } from "lucide-react"
@@ -25,6 +26,7 @@ import type { Cohort, Course } from "@/types"
 import { AttachCourseDialog } from "./AttachCourseDialog"
 import { AddStudentDialog } from "./AddStudentDialog"
 import { CohortStatusPicker } from "./CohortStatusPicker"
+import { cn } from "@/lib/utils"
 
 export default function CohortDetailPage() {
   const { cohortId } = useParams<{ cohortId: string }>()
@@ -195,10 +197,10 @@ export default function CohortDetailPage() {
         </Button>
       </Link>
 
-      <div className="flex items-start justify-between gap-4 flex-wrap mb-8">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-3 mb-2">
-            <h1 className="text-3xl font-serif font-bold tracking-tight text-wrap-safe">
+      <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex flex-wrap items-center gap-3">
+            <h1 className="font-serif text-3xl font-bold tracking-tight text-wrap-safe">
               {cohort.name}
             </h1>
             <CohortStatusPicker
@@ -211,10 +213,22 @@ export default function CohortDetailPage() {
           <p className="text-sm text-muted-foreground">
             {formatDate(cohort.start_date)} &mdash; {formatDate(cohort.end_date)}
           </p>
+          {/* Capacity meter — gives the admin an at-a-glance read of
+              how full the cohort is. Hidden when ``max_students`` is
+              null (unlimited) since the "X of unlimited" bar has no
+              meaningful fill state. */}
+          {cohort.max_students != null && (
+            <CapacityMeter current={cohort.student_count} cap={cohort.max_students} />
+          )}
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={handleDelete} className="text-destructive hover:text-destructive">
-            <Trash2 className="h-4 w-4 mr-1.5" strokeWidth={1.75} aria-hidden />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDelete}
+            className="text-destructive hover:text-destructive"
+          >
+            <Trash2 className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.deleteButton")}
           </Button>
         </div>
@@ -324,68 +338,7 @@ export default function CohortDetailPage() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader className="flex-row items-center justify-between space-y-0">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <Users className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-            {t("admin.cohorts.studentsHeading", { count: students.length })}
-          </CardTitle>
-          <Button size="sm" onClick={() => setAddOpen(true)}>
-            <Plus className="h-4 w-4 mr-1.5" strokeWidth={1.75} aria-hidden />
-            {t("admin.cohorts.addStudentButton")}
-          </Button>
-        </CardHeader>
-        <CardContent>
-          {students.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4">
-              {t("admin.cohorts.noStudents")}
-            </p>
-          ) : (
-            <div className="overflow-x-auto -mx-6">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b text-left">
-                    <th className="px-6 py-3 font-medium text-muted-foreground">
-                      {t("admin.cohorts.thStudentName")}
-                    </th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">
-                      {t("admin.cohorts.thStudentEmail")}
-                    </th>
-                    <th className="px-6 py-3 font-medium text-muted-foreground">
-                      {t("admin.cohorts.thEnrolledCourses")}
-                    </th>
-                    <th className="px-6 py-3 w-10" aria-label={t("admin.cohorts.thActions")} />
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {students.map((s) => (
-                    <tr key={s.user_id} className="hover:bg-muted/50 transition-colors">
-                      <td className="px-6 py-3 font-medium">{s.full_name ?? "—"}</td>
-                      <td className="px-6 py-3 text-muted-foreground">{s.email}</td>
-                      <td className="px-6 py-3 text-muted-foreground">
-                        {Object.keys(s.per_course).length}
-                      </td>
-                      <td className="px-3 py-3">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                          onClick={() => removeStudent(s)}
-                          aria-label={t("admin.cohorts.removeStudentAriaPrefix", {
-                            name: s.full_name ?? s.email,
-                          })}
-                        >
-                          <Trash2 className="h-4 w-4" strokeWidth={1.75} />
-                        </Button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <StudentsCard students={students} onAdd={() => setAddOpen(true)} onRemove={removeStudent} />
 
       <AttachCourseDialog
         open={attachOpen}
@@ -468,5 +421,153 @@ function DateField({ label, value, disabled, nullable, onSave }: DateFieldProps)
         }}
       />
     </div>
+  )
+}
+
+/**
+ * Horizontal capacity bar — quick read of "how full is this cohort".
+ * Tone shifts from primary → warning → destructive as utilisation
+ * climbs past 75% / 95% so an admin scanning multiple cohorts can
+ * spot the near-full ones without reading the X/Y numbers each time.
+ */
+function CapacityMeter({ current, cap }: { current: number; cap: number }) {
+  const { t } = useTranslation()
+  const safeCap = Math.max(cap, 1)
+  const pct = Math.min(100, Math.round((current / safeCap) * 100))
+  const tone = pct >= 95 ? "bg-destructive" : pct >= 75 ? "bg-warning" : "bg-primary"
+  return (
+    <div className="mt-3 max-w-xs">
+      <div className="flex items-baseline justify-between gap-3 text-xs">
+        <span className="font-medium tabular-nums text-foreground">
+          {current} / {cap}
+        </span>
+        <span className="text-muted-foreground">
+          {t("admin.cohorts.capacityLabel", { pct })}
+        </span>
+      </div>
+      <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn("h-full rounded-full transition-all duration-500", tone)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Students panel with search + sticky-header internal-scroll table —
+ * same shape as the audit log so the admin's table vocabulary stays
+ * consistent across surfaces. Search is client-side over the already-
+ * loaded ``students`` list; the cohort list size stays in the low
+ * hundreds so a per-keystroke server round-trip isn't worth it.
+ */
+function StudentsCard({
+  students,
+  onAdd,
+  onRemove,
+}: {
+  students: CohortStudent[]
+  onAdd: () => void
+  onRemove: (s: CohortStudent) => void
+}) {
+  const { t } = useTranslation()
+  const [search, setSearch] = useState("")
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return students
+    return students.filter(
+      (s) =>
+        (s.full_name ?? "").toLowerCase().includes(q) ||
+        s.email.toLowerCase().includes(q),
+    )
+  }, [students, search])
+
+  return (
+    <Card>
+      <CardHeader className="gap-3 space-y-0">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Users className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+            {t("admin.cohorts.studentsHeading", { count: students.length })}
+          </CardTitle>
+          <Button size="sm" onClick={onAdd}>
+            <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
+            {t("admin.cohorts.addStudentButton")}
+          </Button>
+        </div>
+        {students.length > 0 && (
+          <div className="relative">
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              strokeWidth={1.75}
+              aria-hidden
+            />
+            <Input
+              fieldSize="sm"
+              placeholder={t("admin.cohorts.studentSearchPlaceholder")}
+              value={search}
+              onChange={(e) => setSearch(e.target.value.slice(0, 100))}
+              maxLength={100}
+              className="pl-9"
+            />
+          </div>
+        )}
+      </CardHeader>
+      <CardContent className="p-0">
+        {students.length === 0 ? (
+          <p className="px-6 py-6 text-sm text-muted-foreground">
+            {t("admin.cohorts.noStudents")}
+          </p>
+        ) : filtered.length === 0 ? (
+          <p className="px-6 py-6 text-sm text-muted-foreground">
+            {t("admin.cohorts.studentSearchNoMatch")}
+          </p>
+        ) : (
+          <div className="max-h-[55vh] overflow-y-auto">
+            <table className="w-full text-sm">
+              <thead className="sticky top-0 z-10 bg-card">
+                <tr className="border-b text-left">
+                  <th className="px-5 py-3 font-medium text-muted-foreground">
+                    {t("admin.cohorts.thStudentName")}
+                  </th>
+                  <th className="px-5 py-3 font-medium text-muted-foreground">
+                    {t("admin.cohorts.thStudentEmail")}
+                  </th>
+                  <th className="px-5 py-3 font-medium text-muted-foreground">
+                    {t("admin.cohorts.thEnrolledCourses")}
+                  </th>
+                  <th className="w-10 px-5 py-3" aria-label={t("admin.cohorts.thActions")} />
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {filtered.map((s) => (
+                  <tr key={s.user_id} className="transition-colors hover:bg-muted/40">
+                    <td className="px-5 py-3 font-medium">{s.full_name ?? "—"}</td>
+                    <td className="px-5 py-3 text-xs text-muted-foreground">{s.email}</td>
+                    <td className="px-5 py-3 text-muted-foreground tabular-nums">
+                      {Object.keys(s.per_course).length}
+                    </td>
+                    <td className="px-3 py-3">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                        onClick={() => onRemove(s)}
+                        aria-label={t("admin.cohorts.removeStudentAriaPrefix", {
+                          name: s.full_name ?? s.email,
+                        })}
+                      >
+                        <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { NativeSelect } from "@/components/ui/native-select"
 import { Button } from "@/components/ui/button"
@@ -16,7 +17,8 @@ import {
 } from "./constants"
 import { AUDIT_PAGE_SIZE_OPTIONS, type AuditPageSize } from "./useAdminAudit"
 import { AuditDetailsCell } from "./AuditDetailsCell"
-import { formatDateTime } from "@/i18n/format"
+import { AuditSummaryRow } from "./AuditSummaryRow"
+import { formatDateTime, formatRelative } from "@/i18n/format"
 
 interface Props {
   logs: AuditLogEntry[]
@@ -136,7 +138,10 @@ export function AuditLogTab({
             />
           </div>
         ) : (
-          <AuditTable logs={logs} userMap={userMap} />
+          <>
+            <AuditSummaryRow logs={logs} />
+            <AuditTable logs={logs} userMap={userMap} />
+          </>
         )}
 
         {/* Pagination + page-size selector. Always shown so the admin
@@ -254,8 +259,14 @@ function AuditTable({
         <tbody className="divide-y">
           {logs.map((log) => (
             <tr key={log.id} className="align-top transition-colors hover:bg-muted/40">
-              <td className="whitespace-nowrap px-5 py-3 text-xs text-muted-foreground">
-                {formatDateTime(log.created_at)}
+              {/* Relative time is scannable; ``title`` carries the
+                  exact timestamp so a hover (or screen reader) still
+                  surfaces sub-minute precision for audit forensics. */}
+              <td
+                className="whitespace-nowrap px-5 py-3 text-xs text-muted-foreground"
+                title={formatDateTime(log.created_at)}
+              >
+                {formatRelative(log.created_at)}
               </td>
               <td className="max-w-[160px] truncate px-5 py-3 text-xs" title={log.user_id ?? ""}>
                 {log.user_id ? userMap[log.user_id] || `${log.user_id.slice(0, 8)}…` : "—"}
@@ -266,21 +277,7 @@ function AuditTable({
                 </Badge>
               </td>
               <td className="px-5 py-3 text-xs">
-                <div className="flex flex-col gap-0.5">
-                  <span className="text-muted-foreground">
-                    {t(`admin.audit.resourceValue.${log.resource_type}`, {
-                      defaultValue: log.resource_type,
-                    })}
-                  </span>
-                  <span
-                    className="max-w-[160px] truncate font-mono text-[10px] text-muted-foreground/70"
-                    title={log.resource_id}
-                  >
-                    {log.resource_id.length > 14
-                      ? `${log.resource_id.slice(0, 14)}…`
-                      : log.resource_id}
-                  </span>
-                </div>
+                <AuditResourceCell type={log.resource_type} id={log.resource_id} />
               </td>
               <td className="max-w-[320px] px-5 py-3">
                 <AuditDetailsCell details={log.details} />
@@ -292,6 +289,55 @@ function AuditTable({
       </table>
     </div>
   )
+}
+
+/**
+ * Resource cell — type label on top, id below. When the resource type
+ * has a public detail page (currently only ``course``), the id becomes
+ * a Link so admins can jump straight to the affected entity. Cohort
+ * routing is admin-scoped but reachable as well. Other types render as
+ * plain mono text — we don't fabricate links to non-existent routes.
+ */
+function AuditResourceCell({ type, id }: { type: string; id: string }) {
+  const { t } = useTranslation()
+  const label = t(`admin.audit.resourceValue.${type}`, { defaultValue: type })
+  const shortId = id.length > 14 ? `${id.slice(0, 14)}…` : id
+  const href = resourceHref(type, id)
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-muted-foreground">{label}</span>
+      {href ? (
+        <Link
+          to={href}
+          className="max-w-[160px] truncate font-mono text-[10px] text-primary hover:underline"
+          title={id}
+        >
+          {shortId}
+        </Link>
+      ) : (
+        <span
+          className="max-w-[160px] truncate font-mono text-[10px] text-muted-foreground/70"
+          title={id}
+        >
+          {shortId}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function resourceHref(type: string, id: string): string | null {
+  switch (type) {
+    case "course":
+      return `/courses/${id}`
+    case "cohort":
+      return `/admin/cohorts/${id}`
+    default:
+      // Modules / chapters need parent ids that aren't on the audit
+      // row; certificates / enrollments / submissions / users have no
+      // public detail route today. Don't fake a link we can't honour.
+      return null
+  }
 }
 
 /**

--- a/frontend/src/pages/Admin/dashboard/AuditSummaryRow.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditSummaryRow.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import type { AuditLogEntry } from "@/types"
+import { ACTION_BADGE_VARIANT } from "./constants"
+import { cn } from "@/lib/utils"
+
+interface Props {
+  logs: AuditLogEntry[]
+}
+
+/**
+ * Compact summary row above the audit table — counts each action
+ * appearing on the current page, broken down by action type. Gives
+ * the admin a one-glance "what's the shape of recent activity" read
+ * before they start scanning rows. Counts are pure derivatives of the
+ * already-loaded page, so adding the row doesn't trigger extra API.
+ *
+ * Intentionally NOT a global "today's stats" — that would need its
+ * own endpoint and slow the tab's first paint. Per-page is enough to
+ * tell "this is the day's churn" from "this is one user's edit
+ * spree" at a glance.
+ */
+export function AuditSummaryRow({ logs }: Props) {
+  const { t } = useTranslation()
+
+  const counts = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const log of logs) map.set(log.action, (map.get(log.action) ?? 0) + 1)
+    return Array.from(map.entries()).sort((a, b) => b[1] - a[1])
+  }, [logs])
+
+  if (counts.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-border bg-muted/20 px-5 py-2.5 text-xs">
+      <span className="font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        {t("admin.audit.summaryLabel")}
+      </span>
+      {counts.map(([action, count]) => {
+        const variant = ACTION_BADGE_VARIANT[action] ?? "muted"
+        // Map the existing badge variants to a quiet inline pill so
+        // the summary row reads as metadata, not as another set of
+        // tappable badges competing with the table cells below.
+        return (
+          <span key={action} className="inline-flex items-center gap-1.5">
+            <span className={cn("h-1.5 w-1.5 rounded-full", DOT_TONE[variant])} aria-hidden />
+            <span className="font-medium tabular-nums text-foreground">{count}</span>
+            <span className="text-muted-foreground">
+              {t(`admin.audit.actionValue.${action}`, { defaultValue: action })}
+            </span>
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+const DOT_TONE: Record<string, string> = {
+  successSubtle: "bg-success",
+  infoSubtle: "bg-info",
+  destructiveSubtle: "bg-destructive",
+  primarySubtle: "bg-primary",
+  warningSubtle: "bg-warning",
+  muted: "bg-muted-foreground/60",
+}

--- a/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
+++ b/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
-import { Users, BookOpen, GraduationCap } from "lucide-react"
-import { StatCard } from "@/components/patterns"
+import { Users, BookOpen, GraduationCap, TrendingUp } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
 import type { AdminStats } from "./constants"
 
 interface Props {
@@ -8,25 +9,83 @@ interface Props {
   loading: boolean
 }
 
-const CARDS = [
-  { key: "users", i18nKey: "admin.overview.totalUsers", icon: Users },
-  { key: "courses", i18nKey: "admin.overview.totalCourses", icon: BookOpen },
-  { key: "enrollments", i18nKey: "admin.overview.totalEnrollments", icon: GraduationCap },
-] as const
-
-/** Three-card stats row on the admin overview tab. */
+/**
+ * Three-card stats row at the top of the admin overview tab.
+ *
+ * Each card carries:
+ * - small framed icon on the left (consistent with the dashboard side-
+ *   rail headers so the visual vocabulary is shared)
+ * - eyebrow label
+ * - the number — Fraunces serif, large + tabular-nums so a trio of
+ *   3-digit metrics line up vertically across cards
+ * - an optional secondary line for trend / context (e.g. ``+3 this
+ *   week`` on the users card)
+ *
+ * Replaces the previous shared ``StatCard`` here because admin-
+ * specific affordances (trend deltas, eyebrow vocabulary) would have
+ * leaked into a primitive that other features also depend on.
+ */
 export function OverviewStats({ stats, loading }: Props) {
   const { t } = useTranslation()
+
+  const cards: ReadonlyArray<{
+    key: keyof Pick<AdminStats, "users" | "courses" | "enrollments">
+    icon: typeof Users
+    label: string
+    secondary?: string
+  }> = [
+    {
+      key: "users",
+      icon: Users,
+      label: t("admin.overview.totalUsers"),
+      // Trend line is shown only when there's something to say —
+      // ``undefined`` while loading, 0 means literally "no signups this
+      // week" which is still worth surfacing.
+      secondary:
+        stats.usersLast7Days !== undefined
+          ? t("admin.overview.usersLast7Days", { count: stats.usersLast7Days })
+          : undefined,
+    },
+    { key: "courses", icon: BookOpen, label: t("admin.overview.totalCourses") },
+    {
+      key: "enrollments",
+      icon: GraduationCap,
+      label: t("admin.overview.totalEnrollments"),
+    },
+  ] as const
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-      {CARDS.map(({ key, i18nKey, icon }) => (
-        <StatCard
-          key={key}
-          variant="icon-leading"
-          icon={icon}
-          label={t(i18nKey)}
-          value={loading ? "—" : stats[key].toLocaleString()}
-        />
+    <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+      {cards.map(({ key, icon: Icon, label, secondary }) => (
+        <Card key={key}>
+          <CardContent className="flex items-start gap-4 p-5">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-border/80 bg-card">
+              <Icon className="h-5 w-5 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                {label}
+              </p>
+              {loading ? (
+                <Skeleton className="mt-1.5 h-8 w-20" />
+              ) : (
+                <p className="mt-0.5 font-serif text-3xl font-semibold tabular-nums leading-tight text-foreground">
+                  {stats[key].toLocaleString()}
+                </p>
+              )}
+              {secondary && !loading && (
+                <p className="mt-1.5 inline-flex items-center gap-1 text-xs text-muted-foreground">
+                  <TrendingUp
+                    className="h-3 w-3 shrink-0 text-success"
+                    strokeWidth={1.75}
+                    aria-hidden
+                  />
+                  {secondary}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
       ))}
     </div>
   )

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -244,12 +244,15 @@ function UsersTable({
         </div>
       </div>
 
-      {/* Desktop: classic semantic table */}
-      <div className="hidden overflow-x-auto -mx-6 sm:block">
+      {/* Desktop: classic semantic table with internal scroll + sticky
+          header. ``max-h-[60vh]`` matches the audit log so the users
+          panel doesn't push the admin overview off-screen when the
+          tenant grows past 20-30 rows. */}
+      <div className="-mx-6 hidden max-h-[60vh] overflow-y-auto sm:block">
         <table className="w-full text-sm">
-          <thead>
+          <thead className="sticky top-0 z-10 bg-card">
             <tr className="border-b text-left">
-              <th className="px-3 py-3 w-10">
+              <th className="w-10 px-3 py-3">
                 <input
                   type="checkbox"
                   checked={allFilteredSelected}
@@ -262,7 +265,7 @@ function UsersTable({
               <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thEmail")}</th>
               <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thRole")}</th>
               <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thJoined")}</th>
-              <th className="px-6 py-3 w-10" aria-label={t("admin.users.thActions")} />
+              <th className="w-10 px-6 py-3" aria-label={t("admin.users.thActions")} />
             </tr>
           </thead>
           <tbody className="divide-y">

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -62,4 +62,9 @@ export interface AdminStats {
   users: number
   courses: number
   enrollments: number
+  /** Users created in the last 7 days. Computed client-side from the
+   *  full ``users`` list (already loaded for the Users tab), so no
+   *  extra API hit. ``undefined`` while loading; concrete number once
+   *  the overview fetch resolves. */
+  usersLast7Days?: number
 }

--- a/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
@@ -65,10 +65,19 @@ export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
     if (!fetchedData) return
     const { allUsers, coursesCount, enrollmentsCount, certs } = fetchedData
     setUsers(allUsers as ProfileRow[])
+    // ``Last 7 days`` is a client-side roll-up of the already-loaded
+    // user list so the overview doesn't pay for an extra API call.
+    // The window anchors at "now - 7d" each render — good enough for
+    // a rough trend, and cheap.
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
+    const usersLast7Days = (allUsers as ProfileRow[]).filter(
+      (u) => new Date(u.created_at).getTime() >= sevenDaysAgo,
+    ).length
     setStats({
       users: allUsers.length,
       courses: coursesCount.count ?? 0,
       enrollments: enrollmentsCount.count ?? 0,
+      usersLast7Days,
     })
     setAdminCerts(certs)
   }, [fetchedData])


### PR DESCRIPTION
## Summary

Deeper polish on the Admin Dashboard after Vadym's "still far from ideal — functionally, informatively, stylistically". Five connected improvements; every panel reads as part of the same system now.

### Audit log
- **Relative time** column (`5m ago`); `title` carries the exact timestamp for forensics
- **Clickable resource id** — `course` → `/courses/{id}`, `cohort` → `/admin/cohorts/{id}`; other types stay plain (no fabricated links)
- **Summary row** above the table — `5 update · 2 create · 1 delete` per page, derivative of loaded data

### OverviewStats
Custom admin layout (framed icon, eyebrow, big serif number) replaces the shared `StatCard` here. Users card now shows `+N this week` trend computed client-side from the already-loaded list.

### Cohort detail
- **Capacity meter** under title (current/cap + %, tone shifts at 75/95%)
- **Students card rewrite** — search input + sticky-header table with `max-h-[55vh]` internal scroll

### UsersCard
Desktop user table now matches: `max-h-[60vh] overflow-y-auto` + `sticky top-0` head. Same contract across all admin tables.

### New primitive: `DatePicker`
Single-date sibling of `DateRangePicker`. Available for the next caller; not wired into `CohortDetailPage.DateField` yet (those are `datetime-local`, would need a datetime picker).

## Checks
- 249 tests pass, lint + tsc clean, `npm audit` 0 vulns

## Test plan
- [x] CI green
- [ ] Vadym: `/admin?tab=audit` shows relative time, course resource is a link, summary row above table reads cleanly. `/admin?tab=cohorts/{id}` shows capacity bar and students search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)