### PR TITLE
fix(routing): "browse courses" links → /courses after PR #381 split

### DIFF
--- a/frontend/src/pages/Calendar/CalendarPage.tsx
+++ b/frontend/src/pages/Calendar/CalendarPage.tsx
@@ -104,7 +104,11 @@ export default function CalendarPage() {
           title={t("calendar.noEnrollmentsTitle")}
           description={t("calendar.noEnrollmentsDescription")}
           action={
-            <Link to="/">
+            // ``/courses`` (the catalog) since the home/courses split in
+            // PR #381; ``/`` is now the Dashboard, which is empty for a
+            // user with no enrollments and would just bounce them right
+            // back here.
+            <Link to="/courses">
               <Button size="sm">{t("calendar.browseCourses")}</Button>
             </Link>
           }

--- a/frontend/src/pages/Certificates/CertificatesPage.tsx
+++ b/frontend/src/pages/Certificates/CertificatesPage.tsx
@@ -59,7 +59,7 @@ export default function CertificatesPage() {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-5xl">
-      <Link to="/">
+      <Link to="/courses">
         <Button variant="ghost" size="sm" className="mb-6 h-8 text-xs">
           <ArrowLeft className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.75} />
           {t("certificates.backToCourses")}
@@ -90,7 +90,7 @@ export default function CertificatesPage() {
             <p className="mb-6 max-w-sm text-sm text-muted-foreground">
               {t("certificates.emptyDescription")}
             </p>
-            <Link to="/">
+            <Link to="/courses">
               <Button size="sm">{t("certificates.browseCourses")}</Button>
             </Link>
           </CardContent>

--- a/frontend/src/pages/Course/CourseDetail.tsx
+++ b/frontend/src/pages/Course/CourseDetail.tsx
@@ -134,7 +134,7 @@ export default function CourseDetail() {
           icon={<BookOpen strokeWidth={1.75} />}
           title={error ?? t("toast.courseNotFound")}
           action={
-            <Link to="/">
+            <Link to="/courses">
               <Button variant="outline" size="sm">
                 {t("course.backToCourses")}
               </Button>


### PR DESCRIPTION
## Summary

PR #381 split the old combined home into Dashboard (`/`) + Catalog (`/courses`). Four `Link to="/"` callsites that semantically mean "show me the course catalog" stayed pointed at the old path. After the split, `/` is the empty Dashboard for a user with no enrollments — clicking "Browse courses" from Calendar / Certificates / Course-not-found state bounced the user to the dashboard's splash, which then has its own "Browse all courses" button pointing them right back. A two-click loop.

Fixed four callsites:
- `CalendarPage` empty-state "Browse courses" CTA → `/courses`
- `CertificatesPage` header "← Back to courses" → `/courses`
- `CertificatesPage` empty-state "Browse courses" button → `/courses`
- `CourseDetail` error state "Back to courses" → `/courses`

Left alone:
- `NotFound` / `ChapterView` "Go home" — they really mean home
- `Header` / `Footer` brand mark links — home, by design
- Teacher pages' "Back to courses" links to `/teacher` (the teacher dashboard course list, not the public catalog)

## Checks
249 tests pass, lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)