### PR TITLE
fix(i18n): use schema factories at call site so validation errors track locale

### DIFF
--- a/frontend/src/lib/validations/__tests__/course.test.ts
+++ b/frontend/src/lib/validations/__tests__/course.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect } from "vitest"
 import {
-  chapterSchema,
-  courseSchema,
-  moduleSchema,
-  profileSchema,
+  makeChapterSchema,
+  makeCourseSchema,
+  makeModuleSchema,
+  makeProfileSchema,
 } from "../course"
 import { CHAPTER_TYPES } from "@/lib/chapterTypes"
+
+// Tests are locale-agnostic, so building the schema once at module scope
+// matches the previous static-export semantics without re-running the
+// factory per assertion.
+const courseSchema = makeCourseSchema()
+const moduleSchema = makeModuleSchema()
+const chapterSchema = makeChapterSchema()
+const profileSchema = makeProfileSchema()
 
 describe("courseSchema", () => {
   it("accepts a valid minimal course", () => {

--- a/frontend/src/lib/validations/auth.ts
+++ b/frontend/src/lib/validations/auth.ts
@@ -4,14 +4,11 @@ import i18n from "@/i18n/config"
 /**
  * Auth validation schemas.
  *
- * Error messages are translated via i18next at schema-construction time and
- * also re-resolved each time a builder is invoked, so the messages match
- * the active UI language whenever a form actually validates.
- *
- * Static `loginSchema` / `registerSchema` exports are kept for backwards
- * compatibility — they snapshot the bootstrap language. Components that
- * need the current locale (i.e. anything user-facing) should call
- * `makeLoginSchema()` / `makeRegisterSchema()` inside their submit handler.
+ * Error messages resolve via i18next at schema-construction time, so
+ * every caller MUST invoke the ``make…Schema()`` factory inside its
+ * submit handler — never cache the returned schema at module scope.
+ * Caching would snapshot the bootstrap-locale strings and leave error
+ * messages stuck in the wrong language after a locale switch.
  */
 const t = (key: string) => i18n.t(key)
 
@@ -39,7 +36,8 @@ export function makeRegisterSchema() {
     })
 }
 
-export const loginSchema = makeLoginSchema()
-export const registerSchema = makeRegisterSchema()
+// Static snapshots removed — every caller now invokes the factory
+// inside the submit handler so error messages match the active
+// locale (see ``Login.tsx`` / ``useRegister.ts`` / ``ResetPassword.tsx``).
 
 export type LoginFormData = z.infer<ReturnType<typeof makeLoginSchema>>

--- a/frontend/src/lib/validations/course.ts
+++ b/frontend/src/lib/validations/course.ts
@@ -8,11 +8,11 @@ import i18n from "@/i18n/config"
  * schemas in ``backend/app/schemas/course.py`` so invalid input fails fast
  * client-side before we hit the server.
  *
- * User-facing message keys are resolved via i18next; the static schema
- * exports snapshot the bootstrap language at module-load. Components that
- * surface these errors to the user (course/module editors, profile page)
- * should call the matching `make*Schema()` factory inside their submit
- * handler so the error string matches the active UI language.
+ * Error messages resolve via i18next at schema-construction time, so
+ * every caller MUST invoke the ``make…Schema()`` factory inside its
+ * submit handler — never cache the returned schema at module scope.
+ * Caching snapshots the bootstrap-locale strings and leaves messages
+ * stuck in the wrong language after a locale switch.
  */
 
 const t = (key: string) => i18n.t(key)
@@ -73,9 +73,10 @@ export function makeProfileSchema() {
   })
 }
 
-export const courseSchema = makeCourseSchema()
-export const moduleSchema = makeModuleSchema()
-export const chapterSchema = makeChapterSchema()
-export const profileSchema = makeProfileSchema()
+// Static schema exports were ``= make…Schema()`` snapshots that froze
+// error messages at bootstrap-locale. Every callsite has been converted
+// to invoke the ``make…Schema()`` factory inside the submit handler so
+// validation messages update with the active locale; the snapshots are
+// gone now. Re-add them only if a non-user-facing caller appears (rare).
 
 export type CourseFormData = z.infer<ReturnType<typeof makeCourseSchema>>

--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -12,7 +12,7 @@ import AssignmentEditor from "@/components/assignment/AssignmentEditor"
 import { coursesService } from "@/services/courses"
 import type { Chapter } from "@/types"
 import { toast } from "@/lib/toast"
-import { chapterSchema } from "@/lib/validations/course"
+import { makeChapterSchema } from "@/lib/validations/course"
 import { useConfirm } from "@/components/ui/alert-dialog"
 import {
   ChevronRight, Save, Loader2, ArrowLeft,
@@ -119,7 +119,9 @@ export default function ChapterEditor() {
     // Only title + chapter_type live on the chapter row now. Reading content
     // is owned by chapter_blocks (edited inline inside ChapterBlockEditor,
     // which auto-saves). Quiz/exam/assignment editors write their own rows.
-    const validation = chapterSchema.safeParse({
+    // Build the schema inside the handler so error messages match
+    // the *current* locale, not the bootstrap snapshot.
+    const validation = makeChapterSchema().safeParse({
       title: title.trim(),
       chapter_type: chapterType,
     })

--- a/frontend/src/pages/Teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { useConfirm } from "@/components/ui/alert-dialog"
 import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
-import { courseSchema, type CourseFormData } from "@/lib/validations/course"
+import { makeCourseSchema, type CourseFormData } from "@/lib/validations/course"
 import { getErrorDetail } from "@/lib/errorDetail"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
@@ -139,7 +139,9 @@ export default function TeacherDashboard() {
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
-    const result = courseSchema.safeParse(form)
+    // Build the schema inside the handler so error messages match
+    // the *current* locale, not the bootstrap snapshot.
+    const result = makeCourseSchema().safeParse(form)
     if (!result.success) {
       const fieldErrors: typeof errors = {}
       for (const issue of result.error.issues) {

--- a/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
+++ b/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
@@ -7,7 +7,7 @@ import { coursesService } from "@/services/courses";
 import { getErrorDetail } from "@/lib/errorDetail";
 import { toast } from "@/lib/toast";
 import { isoToLocalInput, localInputToIso } from "@/i18n/format";
-import { chapterSchema, moduleSchema } from "@/lib/validations/course";
+import { makeChapterSchema, makeModuleSchema } from "@/lib/validations/course";
 import type { Chapter, Module } from "@/types";
 import type { useConfirm } from "@/components/ui/alert-dialog";
 
@@ -68,7 +68,9 @@ export function useModuleEditor(
 
   const saveModuleField = async (field: "title" | "description", value: string) => {
     if (!courseId || !moduleId) return;
-    const check = moduleSchema
+    // Build inside the handler so error messages match the current
+    // locale, not the bootstrap snapshot.
+    const check = makeModuleSchema()
       .pick({ title: true, description: true })
       .partial()
       .safeParse({ [field]: value });
@@ -141,7 +143,7 @@ export function useModuleEditor(
   const renameChapter = async (ch: Chapter, newTitle: string) => {
     if (!courseId || !moduleId || !newTitle.trim()) return;
     const trimmed = newTitle.trim();
-    const check = chapterSchema.pick({ title: true }).safeParse({ title: trimmed });
+    const check = makeChapterSchema().pick({ title: true }).safeParse({ title: trimmed });
     if (!check.success) {
       toast({
         title:


### PR DESCRIPTION
## Summary

Validation modules shipped a `make…Schema()` factory (locale-reactive) *and* a static `…Schema = make…Schema()` snapshot frozen at bootstrap-locale. The docstring already said "use the factory inside submit handlers" — but half the callsites used the snapshot, so flipping the language switcher and submitting an invalid form left the error in the old language until reload.

Converted the four offending callsites:

| Caller | Before | After |
|---|---|---|
| `TeacherDashboard` create course | `courseSchema` | `makeCourseSchema()` |
| `ChapterEditor` save | `chapterSchema` | `makeChapterSchema()` |
| `useModuleEditor` saveModuleField | `moduleSchema` | `makeModuleSchema()` |
| `useModuleEditor` renameChapter | `chapterSchema` | `makeChapterSchema()` |

Login/Register/ResetPassword/ProfilePage were already using factories.

With every caller migrated, the six static `…Schema` exports are dead surface area — dropped. Rewrote the module docstrings as a hard contract ("never cache the returned schema at module scope") instead of a permission slip for the original bug.

Course validation tests now snapshot the factory once at file scope (tests are locale-agnostic).

## Checks
249 tests pass, lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)