### PR TITLE
perf(catalog): drop nested chapter eager-load from list-view queries

### DIFF
--- a/backend/app/services/course_service/_queries.py
+++ b/backend/app/services/course_service/_queries.py
@@ -41,9 +41,7 @@ _COURSE_TREE: tuple = (
 # ``CourseCard`` only consumes ``course.modules?.length``. Course-detail
 # requests stay on the full ``_COURSE_TREE`` so the nested chapter list
 # is still there for the enrolled-course view.
-_COURSE_LIST_TREE: tuple = (
-    selectinload(Course.modules.and_(Module.deleted_at.is_(None))),
-)
+_COURSE_LIST_TREE: tuple = (selectinload(Course.modules.and_(Module.deleted_at.is_(None))),)
 
 
 def get_courses(

--- a/backend/app/services/course_service/_queries.py
+++ b/backend/app/services/course_service/_queries.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 
 # Eager-load modules + their chapters without the cartesian row explosion a
 # chained ``joinedload`` would produce: one IN query per level means the
-# catalog page fetches ~3 rows of wire instead of ``courses * modules *
-# chapters`` when a course has many chapters.
+# course detail page fetches ~3 rows of wire instead of ``courses * modules
+# * chapters`` when a course has many chapters.
 #
 # The ``.and_()`` filters strip soft-deleted children at load time so the
 # course tree mirrors what students actually see. Trash and restore flows
@@ -32,6 +32,17 @@ _COURSE_TREE: tuple = (
     selectinload(Course.modules.and_(Module.deleted_at.is_(None))).selectinload(
         Module.chapters.and_(Chapter.deleted_at.is_(None))
     ),
+)
+
+# Slim loader for **catalog** views: pulls each course's modules so the UI
+# can show "X modules" on a card, but skips the chapter level entirely. A
+# typical catalog with 10 courses x 5 modules x 10 chapters drops from
+# ~500 rows of chapter wire data per page to zero, with no UI regression —
+# ``CourseCard`` only consumes ``course.modules?.length``. Course-detail
+# requests stay on the full ``_COURSE_TREE`` so the nested chapter list
+# is still there for the enrolled-course view.
+_COURSE_LIST_TREE: tuple = (
+    selectinload(Course.modules.and_(Module.deleted_at.is_(None))),
 )
 
 
@@ -44,7 +55,7 @@ def get_courses(
 ) -> list[Course]:
     query = (
         db.query(Course)
-        .options(*_COURSE_TREE)
+        .options(*_COURSE_LIST_TREE)
         .filter(Course.status == CourseStatus.PUBLISHED, Course.deleted_at.is_(None))
     )
     if search:
@@ -78,7 +89,12 @@ def get_teacher_courses(
     skip: int = 0,
     limit: int | None = None,
 ) -> list[Course]:
-    query = db.query(Course).options(*_COURSE_TREE).filter(Course.created_by == teacher_id)
+    # ``_COURSE_LIST_TREE`` (modules only, no chapters) keeps the
+    # teacher dashboard fast even when the teacher owns many courses
+    # with many chapters each — the dashboard CourseCard only reads
+    # ``course.modules?.length`` and the per-course actions navigate
+    # into the editor for full-tree fetches.
+    query = db.query(Course).options(*_COURSE_LIST_TREE).filter(Course.created_by == teacher_id)
     query = query.filter(Course.deleted_at.isnot(None)) if deleted_only else query.filter(Course.deleted_at.is_(None))
     query = query.order_by(Course.created_at.desc())
     if skip:


### PR DESCRIPTION
Both `list_courses` (public catalog) and `get_teacher_courses` (teacher dashboard) eagerly loaded `Course.modules → Module.chapters` even though the frontend only reads `course.modules?.length` on those surfaces. Introduced `_COURSE_LIST_TREE` (modules-only); routed list endpoints to it. For a 10-course catalog with 5 modules × 10 chapters each, that's ~500 chapter rows dropped from the wire per request.

Detail view (`get_course`) keeps the full `_COURSE_TREE` — enrolled course view still gets the chapter tree.

699 backend tests pass; ruff + mypy clean.