### PR TITLE
perf(announcements): add global_only filter so banner stops pulling course-scoped rows

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -39,6 +39,7 @@ def _course_source_locale_map(db: Session, course_ids: list[str]) -> dict[str, L
 def list_announcements(
     response: Response,
     course_id: str | None = Query(None),
+    global_only: bool = Query(False),
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
@@ -49,7 +50,13 @@ def list_announcements(
     query = db.query(Announcement)
     is_admin = current_user.role in (UserRole.ADMIN.value, "admin")
 
-    if course_id is not None:
+    if global_only:
+        # AnnouncementBanner asks for site-wide-only rows; previously it
+        # pulled every announcement the user could see and filtered on
+        # the client. ``course_id`` is ignored when ``global_only`` is set
+        # (mutually exclusive intent; explicit param wins).
+        query = query.filter(Announcement.course_id.is_(None))
+    elif course_id is not None:
         if not is_admin:
             # Non-admin must be enrolled in or own this course to see its announcements.
             # Previously this branch skipped the check entirely (IDOR). See audit P0.4.

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -1366,6 +1366,18 @@ class TestListAnnouncements:
         resp = client.get(ANNOUNCEMENT_PREFIX)
         assert len(resp.json()) == 2
 
+    def test_global_only_filters_out_course_scoped(self, client: TestClient):
+        course = _create_course_via_api(client)
+        client.post(ANNOUNCEMENT_PREFIX, json=_announcement_payload(title="GlobalAnnouncement"))
+        client.post(ANNOUNCEMENT_PREFIX, json=_announcement_payload(title="CourseAnnouncement", course_id=course["id"]))
+
+        resp = client.get(ANNOUNCEMENT_PREFIX, params={"global_only": True})
+        assert resp.status_code == 200
+        rows = resp.json()
+        titles = [a["title"] for a in rows]
+        assert titles == ["GlobalAnnouncement"]
+        assert all(a["course_id"] is None for a in rows)
+
 
 class TestCreateAnnouncement:
     def test_create_global_returns_201(self, client: TestClient):

--- a/frontend/src/components/announcements/AnnouncementBanner.tsx
+++ b/frontend/src/components/announcements/AnnouncementBanner.tsx
@@ -26,12 +26,12 @@ export default function AnnouncementBanner() {
       return
     }
     let cancelled = false
-    coursesService.getAnnouncements().then((list) => {
+    coursesService.getGlobalAnnouncements().then((list) => {
       if (cancelled) return
       // ``setAnnouncement(null)`` for the no-match case is load-
       // bearing: without it a previously-shown banner stays mounted
       // after the system-wide announcement is unpublished.
-      setAnnouncement(list.find((a) => !a.course_id) ?? null)
+      setAnnouncement(list[0] ?? null)
     }).catch(() => {
       /* non-critical UI, degrade silently */
     })

--- a/frontend/src/services/announcements.ts
+++ b/frontend/src/services/announcements.ts
@@ -12,6 +12,20 @@ export const announcementsService = {
     })
   },
 
+  // Banner-only feed. ``getAnnouncements()`` returns every row visible
+  // to the user (enrolled + owned + site-wide), so the banner used to
+  // pull dozens of course-scoped rows just to ``find`` the site-wide
+  // one. ``global_only=true`` lets the backend filter to ``course_id
+  // IS NULL`` so the wire payload matches what the banner renders.
+  async getGlobalAnnouncements(): Promise<Announcement[]> {
+    return cached(`announcements:global-only`, CACHE_TTL.TWO_MINUTES, async () => {
+      const response = await api.get<Announcement[]>("/announcements", {
+        params: { global_only: true, limit: 10 },
+      })
+      return response.data
+    })
+  },
+
   async createAnnouncement(data: {
     title: string
     content: string
@@ -19,6 +33,7 @@ export const announcementsService = {
   }): Promise<Announcement> {
     const response = await api.post<Announcement>("/announcements", data)
     cacheInvalidate(`announcements:global`)
+    if (!data.course_id) cacheInvalidate(`announcements:global-only`)
     if (data.course_id) cacheInvalidate(`announcements:course:${data.course_id}`)
     return response.data
   },


### PR DESCRIPTION
## Why

Site-wide AnnouncementBanner used to call `getAnnouncements()` (no filter) and then `list.find(a => !a.course_id)` to keep the single global row it renders. For users enrolled in multiple courses, the request returned every course-scoped row they could see — dozens of localized rows over the wire just to drop all but one on the client.

## What

**Backend** — new `global_only` query param on `GET /announcements`. When set, ignores `course_id` and filters to `course_id IS NULL`. Any authenticated user may read site-wide rows, so no extra access check.

**Frontend** — new `announcementsService.getGlobalAnnouncements()` with `limit=10` and its own 2-min cache key (`announcements:global-only`). Banner calls it and takes `list[0]`. Old `getAnnouncements()` keeps working for the admin announcements tab and per-course views.

**Cache invalidation:** create-global invalidates both `announcements:global` and `announcements:global-only`; delete still wipes the whole `announcements:` prefix.

## Verification

- `pytest tests/test_cohorts_calendar_notifications.py -k Announcement` → **21/21 pass** (incl. new `test_global_only_filters_out_course_scoped`)
- `ruff check` + `ruff format --check` → clean
- `tsc --noEmit` + `eslint --max-warnings 0` → clean
- `vitest run src/services` → 8/8 pass