### PR TITLE
fix(ci): use snake_case input names for actions/first-interaction@v3

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -27,7 +27,13 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-          issue-message: |
+          # actions/first-interaction@v3 renamed the message inputs from
+          # kebab-case (``issue-message`` / ``pr-message``) to snake_case.
+          # The kebab spellings now resolve to undefined and the action
+          # exits 1 with ``Input required and not supplied: issue_message``
+          # on every new PR — visible in the CI badge but doesn't block
+          # the merge gate. Snake-case below restores the greeting.
+          issue_message: |
             Welcome to Equip 🌱 — thanks for opening your first issue here.
 
             A few things that help us help you fast:
@@ -38,7 +44,7 @@ jobs:
 
             A maintainer will respond within a few days. If it's something time-sensitive (security, broken production), please follow the disclosure path in [SECURITY.md](https://github.com/ArVaViT/equip/blob/main/SECURITY.md) or email supportequip@gmail.com directly.
 
-          pr-message: |
+          pr_message: |
             Thanks for your first pull request to Equip 🎉
 
             Quick checklist while CI runs:


### PR DESCRIPTION
## What broke

`actions/first-interaction@v3` renamed its inputs from `issue-message`/`pr-message` (kebab) to `issue_message`/`pr_message` (snake). Our `welcome.yml` still passed the kebab names, so every new PR (incl. #406 just now) tripped:

```
Error: Input required and not supplied: issue_message
```

The greet job is non-required so merges weren't blocked, but the badge has been red and no first-time contributor has gotten the welcome comment since v3 was pinned.

## Fix

Switch both inputs to snake_case to match the upstream action API. Also added an inline comment so the next person who sees the kebab spelling in another workflow knows why.

## Verification

YAML-only change — exercised by the next `pull_request_target opened` event. The greet step on this very PR will be the first run with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)