### PR TITLE
chore(frontend): drop dead exports flagged by knip

### DIFF
--- a/frontend/src/components/quiz/editor/types.ts
+++ b/frontend/src/components/quiz/editor/types.ts
@@ -23,13 +23,6 @@ function uid(): string {
   return `draft-${++_uid}-${Date.now()}`
 }
 
-/**
- * The two canonical English values for a True/False question's options.
- * Persisted as-is in Postgres (``quiz_options.option_text``) so the DB
- * stays locale-neutral. Rendering localizes via ``getTrueFalseLabel``.
- */
-export const TRUE_FALSE_VALUES = ["True", "False"] as const
-
 export function makeTrueFalseOptions(): DraftOption[] {
   return [
     { id: uid(), option_text: "True", is_correct: true, order_index: 0 },

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -1,8 +1,8 @@
 import type { UserRole } from "@/types"
 
-// Re-export from the shared location so Profile + other surfaces can
-// use the same role i18n mapping without depending on Admin pages.
-export { ROLE_I18N_KEY, ROLE_BADGE_VARIANT } from "@/lib/roles"
+// Re-export from the shared location so Admin pages don't have to
+// reach into ``@/lib/roles`` directly for the i18n mapping.
+export { ROLE_I18N_KEY } from "@/lib/roles"
 
 export type AdminTab = "overview" | "cohorts" | "audit"
 export const ADMIN_TABS: readonly AdminTab[] = ["overview", "cohorts", "audit"]


### PR DESCRIPTION
## Why

Two leftover exports with no current consumer — pure code-cleanup, no behaviour change.

## What

- `TRUE_FALSE_VALUES` in `quiz/editor/types.ts` — the two callers in the same file inline the `"True"`/`"False"` strings rather than reaching for the const, and nothing else imports it.
- `ROLE_BADGE_VARIANT` re-export from `Admin/dashboard/constants.ts` — `RoleSelector` imports it directly from `@/lib/roles`. Keeping the `ROLE_I18N_KEY` re-export since `useAdminOverview` does consume it.

## Verification

- `tsc --noEmit` → clean
- `eslint --max-warnings 0` → clean
- `knip` no longer flags either symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)