### PR TITLE
fix(rate-limit): bucket on matched prefix, not full path

### DIFF
--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -79,11 +79,20 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._hits: dict[str, list[float]] = defaultdict(list)
         self._last_cleanup: float = time.time()
 
-    def _resolve_limit(self, path: str) -> tuple[int, int]:
+    def _resolve_limit(self, path: str) -> tuple[str | None, int, int]:
+        """Return ``(matched_prefix, max_calls, window)``.
+
+        ``matched_prefix`` is the ``ENDPOINT_LIMITS`` key that matched
+        ``path``, or ``None`` when no override matched and the global
+        default applies. The caller uses the prefix (not the full path)
+        as the per-IP bucket key so a brute-force enumeration of
+        ``/certificates/verify/{cert_number}`` doesn't get a fresh budget
+        for every guess — every guess from one IP shares one bucket.
+        """
         for prefix, limit in ENDPOINT_LIMITS.items():
             if path.startswith(prefix):
-                return limit
-        return self.calls, self.window
+                return prefix, *limit
+        return None, self.calls, self.window
 
     def _cleanup_stale_buckets(self, now: float) -> None:
         if now - self._last_cleanup < CLEANUP_INTERVAL and len(self._hits) < MAX_BUCKETS:
@@ -102,9 +111,14 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         client_ip = get_client_ip(request, fallback="unknown") or "unknown"
         path = request.url.path
-        max_calls, window = self._resolve_limit(path)
+        matched_prefix, max_calls, window = self._resolve_limit(path)
 
-        bucket_key = f"{client_ip}:{path}" if max_calls != self.calls else client_ip
+        # Bucket on the matched PREFIX, not the full path. ``/certificates/
+        # verify/abc`` and ``/certificates/verify/xyz`` share one bucket per
+        # IP — otherwise an attacker enumerating cert numbers gets a fresh
+        # 30/min budget for every guess. Falls back to plain ``client_ip``
+        # for the global limiter so unrelated routes still share one bucket.
+        bucket_key = f"{client_ip}:{matched_prefix}" if matched_prefix else client_ip
         now = time.time()
         cutoff = now - window
 

--- a/backend/tests/test_rate_limit_coverage.py
+++ b/backend/tests/test_rate_limit_coverage.py
@@ -40,7 +40,8 @@ def test_endpoint_resolves_to_per_route_override(path: str, expected_calls: int,
     not the global 100/60s default.
     """
     mw = RateLimitMiddleware(app=None, calls=100, window=60)
-    calls, window = mw._resolve_limit(path)
+    matched_prefix, calls, window = mw._resolve_limit(path)
+    assert matched_prefix is not None, f"{path} should have matched an override prefix"
     assert (calls, window) == (expected_calls, expected_window), (
         f"{path} resolved to ({calls}, {window}); expected ({expected_calls}, {expected_window}). "
         "Did someone drop the per-route override from ENDPOINT_LIMITS?"
@@ -53,8 +54,23 @@ def test_default_route_keeps_global_limit() -> None:
     added to ENDPOINT_LIMITS that would tighten everything.
     """
     mw = RateLimitMiddleware(app=None, calls=100, window=60)
-    calls, window = mw._resolve_limit("/api/v1/courses")
+    matched_prefix, calls, window = mw._resolve_limit("/api/v1/courses")
+    assert matched_prefix is None, "unmatched routes must signal no override"
     assert (calls, window) == (100, 60)
+
+
+def test_verify_paths_share_one_bucket_per_ip() -> None:
+    """Two different ``/certificates/verify/<X>`` requests from the same
+    IP must resolve to the SAME bucket-key prefix so an attacker who
+    varies the cert number can't get a fresh 30/min budget per guess.
+    Regression for the pre-fix bug where the bucket key included the
+    full path (cert-number tail), making the rate limit effectively
+    per-cert instead of per-IP.
+    """
+    mw = RateLimitMiddleware(app=None, calls=100, window=60)
+    prefix_a, _, _ = mw._resolve_limit("/api/v1/certificates/verify/aaa-111")
+    prefix_b, _, _ = mw._resolve_limit("/api/v1/certificates/verify/bbb-222")
+    assert prefix_a == prefix_b == "/api/v1/certificates/verify/"
 
 
 def test_sensitive_prefixes_are_all_present() -> None:


### PR DESCRIPTION
## Bug

The per-endpoint rate-limiter used the FULL request path as the bucket key for any route with a custom limit:

```python
bucket_key = f"{client_ip}:{path}" if max_calls != self.calls else client_ip
```

That works for endpoints whose path doesn't carry caller data — only one `/api/v1/auth/me` and one `/api/v1/verse-of-the-day`. But `/api/v1/certificates/verify/{certificate_number}` carries caller data in the path, so every cert number produced a fresh bucket. **An attacker brute-forcing cert IDs got a fresh 30/min budget per guess.** Comment on the override says "30/min/IP"; implementation was effectively 30/min per (IP × cert-number).

## Fix

`_resolve_limit` now returns `(matched_prefix, max_calls, window)`. The dispatcher uses the prefix (not the full path) as the per-IP bucket key. All `/verify/<X>` paths from one IP now share one 30/min bucket. Behaviour unchanged for the other two overrides (each has only one route) and for the global default (still plain IP bucket).

## Verification

- `pytest tests/test_rate_limit_coverage.py` — 7/7 pass (incl. new regression `test_verify_paths_share_one_bucket_per_ip`)
- `ruff check` + `ruff format --check` — clean
- `mypy app/middleware/rate_limit.py` — clean

## Severity

Low-moderate. Certificate numbers are random UUIDs (per the file's own comment, "the cap is defence-in-depth, not the primary control") so this isn't an open door — but the override existed precisely as defence-in-depth, and was silently broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)