### PR TITLE
feat(teacher): localize auto-seeded module + chapter titles

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -903,6 +903,9 @@
       "closed": "Closed",
       "open": "Open"
     },
+    "defaults": {
+      "moduleTitle": "Module {{n}}"
+    },
     "modulesHeading": "Modules",
     "addModule": "Add module",
     "noModulesYet": "No modules yet",
@@ -999,6 +1002,9 @@
     }
   },
   "moduleEditor": {
+    "defaults": {
+      "chapterTitle": "Chapter {{n}}"
+    },
     "toast": {
       "moduleNotFound": "Module not found",
       "failedSaveModule": "Failed to save module",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -890,6 +890,9 @@
       "closed": "Закрыт",
       "open": "Открыт"
     },
+    "defaults": {
+      "moduleTitle": "Модуль {{n}}"
+    },
     "modulesHeading": "Модули",
     "addModule": "Добавить модуль",
     "noModulesYet": "Пока нет модулей",
@@ -988,6 +991,9 @@
     }
   },
   "moduleEditor": {
+    "defaults": {
+      "chapterTitle": "Глава {{n}}"
+    },
     "toast": {
       "moduleNotFound": "Модуль не найден",
       "failedSaveModule": "Не удалось сохранить модуль",

--- a/frontend/src/pages/Teacher/editor/useCourseData.ts
+++ b/frontend/src/pages/Teacher/editor/useCourseData.ts
@@ -167,7 +167,11 @@ export function useCourseData(
     const order = course?.modules?.length ?? 0
     try {
       const m = await coursesService.createModule(courseId, {
-        title: `Module ${order + 1}`,
+        // Seed in the teacher's UI locale. The previous ``Module N``
+        // literal was persisted as-is, so a Russian-UI teacher had to
+        // rename every freshly-added module or live with an English
+        // word in their course tree.
+        title: t("teacherEditor.defaults.moduleTitle", { n: order + 1 }),
         order_index: order,
       })
       setCourse((p) =>

--- a/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
+++ b/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
@@ -112,7 +112,10 @@ export function useModuleEditor(
     const order = mod.chapters?.length ?? 0;
     try {
       const ch = await coursesService.createChapter(courseId, moduleId, {
-        title: `Chapter ${order + 1}`,
+        // Seed in the teacher's UI locale. Persisted as-is, so the
+        // previous ``Chapter N`` literal stuck English into every
+        // Russian-UI teacher's course tree until they renamed it.
+        title: t("moduleEditor.defaults.chapterTitle", { n: order + 1 }),
         order_index: order,
       });
       setMod((prev) =>


### PR DESCRIPTION
## Bug

"Add module" / "Add chapter" seeded the new row with the literal English strings `Module N` / `Chapter N` and immediately **persisted** them. A Russian-UI teacher saw English in their own course tree until they renamed every freshly-added row — small but constant authoring friction.

## Fix

Read the seed from i18n in the teacher's active locale:

- `teacherEditor.defaults.moduleTitle` → `Module {{n}}` / `Модуль {{n}}`
- `moduleEditor.defaults.chapterTitle` → `Chapter {{n}}` / `Глава {{n}}`

Editable inline as before. Callers passing an explicit `title` are unaffected — this only changes the click-to-add seed.

## Not in scope

- No DB / backend / schema change
- No new dependencies
- Old rows already persisted as `Module 1` / `Chapter 3` stay as-is (rewriting them would be presumptuous)

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean  
- `npm run i18n:check` — locale parity (1290 en + 1344 ru keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)