### PR TITLE
feat(teacher): announce 'unsaved changes' on chapter editor sticky bar

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1114,7 +1114,8 @@
     "chapterType": "Chapter Type",
     "save": "Save Chapter",
     "saving": "Saving...",
-    "saveHint": "Ctrl+S to save"
+    "saveHint": "Ctrl+S to save",
+    "unsavedChanges": "You have unsaved changes"
   },
   "courseDetail": {
     "allCourses": "All Courses",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1103,7 +1103,8 @@
     "chapterType": "Тип главы",
     "save": "Сохранить главу",
     "saving": "Сохранение...",
-    "saveHint": "Ctrl+S для сохранения"
+    "saveHint": "Ctrl+S для сохранения",
+    "unsavedChanges": "Есть несохранённые изменения"
   },
   "courseDetail": {
     "allCourses": "Все курсы",

--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -334,18 +334,17 @@ export default function ChapterEditor() {
         <span className="text-xs text-muted-foreground">{t("chapterEditor.saveHint")}</span>
       </div>
 
-      {/* Sticky save bar — only renders while there are unsaved changes.
-          The pulsing warning dot is the visual cue for "unsaved"; the
-          accompanying text reuses the existing `saveHint` ("Ctrl+S to
-          save") string so we don't introduce a new i18n key from this
-          PR. TODO i18n: a future bilingual pass can swap the dot's
-          aria-label and add an explicit `chapterEditor.unsavedChanges`
-          status string. */}
+      {/* Sticky save bar — only renders while there are unsaved
+          changes. The pulsing warning dot is the visual cue, the
+          ``aria-label`` on the parent card is the screen-reader cue
+          (announced via ``aria-live="polite"`` on first transition to
+          dirty). Inline text shows the Ctrl+S shortcut. */}
       {isDirty && (
         <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] sm:pb-6">
           <Card
             role="status"
             aria-live="polite"
+            aria-label={t("chapterEditor.unsavedChanges")}
             className="pointer-events-auto animate-fade-in w-full max-w-2xl bg-card/95 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-card/85"
           >
             <CardContent className="flex items-center gap-3 px-4 py-3">
@@ -357,6 +356,10 @@ export default function ChapterEditor() {
                 <span className="relative inline-flex h-2 w-2 rounded-full bg-warning" />
               </span>
               <span className="flex-1 text-xs text-muted-foreground sm:text-sm">
+                <span className="font-medium text-foreground">
+                  {t("chapterEditor.unsavedChanges")}
+                </span>
+                <span className="mx-1.5 opacity-40">·</span>
                 {t("chapterEditor.saveHint")}
               </span>
               <Button


### PR DESCRIPTION
## What was wrong

The chapter editor's sticky-bottom save reminder relied on a pulsing yellow dot for sighted users and the existing `Ctrl+S to save` hint for everyone else. A screen reader would announce only *"Ctrl+S to save"* when the bar appeared — that's the **remedy**, not the **state** the user needs to know (*"you have unsaved work"*).

Closes the inline `TODO i18n` left when the sticky bar shipped:
> a future bilingual pass can swap the dot's aria-label and add an explicit `chapterEditor.unsavedChanges` status string

## What changed

- New i18n key `chapterEditor.unsavedChanges` → `You have unsaved changes` / `Есть несохранённые изменения`
- Set as `aria-label` on the parent `Card` so the polite live region announces the state plainly on first transition to dirty
- Surfaced visually as the prominent first part of the inline copy; `Ctrl+S to save` demoted to the hint after a separator
- Pulsing dot stays as the at-a-glance cue (unchanged)

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean
- `npm run i18n:check` — 1291 en + 1345 ru, parity holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)