### PR TITLE
perf(teacher): skip chapter PATCH when title didn't actually change

### DIFF
--- a/frontend/src/pages/Teacher/moduleEditor/ChapterRow.tsx
+++ b/frontend/src/pages/Teacher/moduleEditor/ChapterRow.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { Draggable } from "@hello-pangea/dnd";
 import { GripVertical, Lock, Pencil, Trash2, Unlock } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -36,6 +37,12 @@ export function ChapterRow({
   const { t } = useTranslation();
   const type = normalizeChapterType(chapter.chapter_type);
 
+  // Capture the title at focus time so blur can skip the PATCH when
+  // nothing actually changed. Without this, every Tab-through or
+  // accidental click on the row's title field fired a no-op update —
+  // wasted network round-trip and an audit-log row per visit.
+  const focusValueRef = useRef<string>("");
+
   return (
     <Draggable draggableId={chapter.id} index={index}>
       {(dragProvided, snapshot) => (
@@ -62,7 +69,15 @@ export function ChapterRow({
               <Input
                 value={chapter.title}
                 onChange={(e) => onTitleChange(e.target.value)}
-                onBlur={(e) => onRename(e.target.value)}
+                onFocus={(e) => {
+                  focusValueRef.current = e.target.value;
+                }}
+                onBlur={(e) => {
+                  if (e.target.value.trim() === focusValueRef.current.trim()) {
+                    return;
+                  }
+                  onRename(e.target.value);
+                }}
                 className="h-9 flex-1 border-none font-medium shadow-none focus-visible:ring-1 sm:h-8 sm:text-sm"
               />
             </div>


### PR DESCRIPTION
## What was happening

The chapter-row's inline title input committed on every blur:

```tsx
<Input onBlur={(e) => onRename(e.target.value)} />
```

A blur fires regardless of whether the user changed anything — Tab-through during a course-wide review, an accidental click on the row, even just focusing the field to read it all triggered a `PATCH /chapters/{id}` round-trip **plus an audit-log INSERT**. Costs add up fast for a teacher working through a long course.

Also fits Vadym's *"как можно меньше забивать память нашей БД"* — every no-op rename was a wasted audit row.

## Fix

Capture the value at focus time in a ref; on blur, only call `onRename` if the trimmed value actually differs. Trim matches the server-side normalisation so whitespace-only "edits" don't trip a write either.

Legit edits still flow through unchanged.

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)