### PR TITLE
feat(teacher): smarter file-size formatter for course materials

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -936,7 +936,9 @@
         "title": "Course Materials",
         "upload": "Upload File",
         "empty": "No materials uploaded yet.",
+        "sizeBytes": "{{b}} B",
         "sizeKb": "{{kb}} KB",
+        "sizeMb": "{{mb}} MB",
         "downloadAria": "Download {{name}}",
         "deleteAria": "Delete {{name}}"
       },

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -925,7 +925,9 @@
         "title": "Материалы курса",
         "upload": "Загрузить файл",
         "empty": "Пока нет загруженных материалов.",
+        "sizeBytes": "{{b}} Б",
         "sizeKb": "{{kb}} КБ",
+        "sizeMb": "{{mb}} МБ",
         "downloadAria": "Скачать «{{name}}»",
         "deleteAria": "Удалить «{{name}}»"
       },

--- a/frontend/src/pages/Teacher/editor/MaterialsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/MaterialsModal.tsx
@@ -1,5 +1,6 @@
 import type { Ref } from "react"
 import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import { Button } from "@/components/ui/button"
 import { Download, Loader2, Paperclip, X } from "lucide-react"
 import { EmptyState, Modal } from "@/components/patterns"
@@ -18,6 +19,24 @@ interface Props {
 }
 
 const ACCEPTED_TYPES = ".pdf,.doc,.docx,.ppt,.pptx,.txt,.mp3,.wav,.ogg,.mp4"
+
+const KB = 1024
+const MB = KB * 1024
+
+/**
+ * Human-readable file size in the active locale's unit.
+ *
+ * The previous formatter rendered everything in KB, which produced
+ * misleading output at both ends: a 400-byte text snippet showed as
+ * ``0 KB`` (rounded down via ``toFixed(0)``) and a 2 MB PDF showed as
+ * ``2048 KB``. This picks B / KB / MB so the number always looks
+ * sensible at a glance.
+ */
+function formatFileSize(bytes: number, t: TFunction): string {
+  if (bytes < KB) return t("teacherEditor.modals.materials.sizeBytes", { b: bytes })
+  if (bytes < MB) return t("teacherEditor.modals.materials.sizeKb", { kb: (bytes / KB).toFixed(0) })
+  return t("teacherEditor.modals.materials.sizeMb", { mb: (bytes / MB).toFixed(1) })
+}
 
 export function MaterialsModal({
   open,
@@ -72,7 +91,7 @@ export function MaterialsModal({
                 <span className="text-sm flex-1 truncate">{m.name}</span>
                 {m.size && (
                   <span className="text-xs text-muted-foreground shrink-0">
-                    {t("teacherEditor.modals.materials.sizeKb", { kb: (m.size / 1024).toFixed(0) })}
+                    {formatFileSize(m.size, t)}
                   </span>
                 )}
                 <Button


### PR DESCRIPTION
## Why

Previous formatter rendered every material's size in KB via `(size / 1024).toFixed(0)`. Broken at both ends:

- A 400-byte text file shows as **"0 KB"** — looks like a corrupt empty upload to the teacher (they re-upload, doubling storage cost)
- A 2 MB PDF shows as **"2048 KB"** — readable but ugly

## What

Replace with a 3-tier formatter that picks B / KB / MB based on size:

| Range | EN | RU |
|---|---|---|
| < 1 KB | `512 B` | `512 Б` |
| < 1 MB | `320 KB` | `320 КБ` |
| ≥ 1 MB | `2.4 MB` | `2.4 МБ` |

Adds two new i18n keys (`sizeBytes`, `sizeMb`) under the existing materials namespace; `sizeKb` is kept and reused. Helper lives next to its only call site rather than `lib/format.ts` — materials is the only file-size surface in the teacher tooling today.

## Not in scope

- No backend / DB / schema change
- No new dependencies

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean
- `npm run i18n:check` — 1293 en + 1347 ru, parity holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)