### PR TITLE
feat(teacher): replace announcement list with compact step-through pager

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -930,7 +930,11 @@
         "post": "Post",
         "posting": "Posting…",
         "empty": "No announcements yet.",
-        "deleteAria": "Delete announcement {{title}}"
+        "deleteAria": "Delete announcement {{title}}",
+        "carouselRole": "carousel",
+        "prevAria": "Previous announcement",
+        "nextAria": "Next announcement",
+        "position": "{{current}} / {{total}}"
       },
       "materials": {
         "title": "Course Materials",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -919,7 +919,11 @@
         "post": "Опубликовать",
         "posting": "Публикация…",
         "empty": "Пока нет объявлений.",
-        "deleteAria": "Удалить объявление «{{title}}»"
+        "deleteAria": "Удалить объявление «{{title}}»",
+        "carouselRole": "карусель",
+        "prevAria": "Предыдущее объявление",
+        "nextAria": "Следующее объявление",
+        "position": "{{current}} / {{total}}"
       },
       "materials": {
         "title": "Материалы курса",

--- a/frontend/src/pages/Teacher/editor/AnnouncementPager.tsx
+++ b/frontend/src/pages/Teacher/editor/AnnouncementPager.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { ChevronLeft, ChevronRight, Megaphone, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { formatDateTime } from "@/i18n/format"
+import type { Announcement } from "@/types"
+
+interface AnnouncementPagerProps {
+  announcements: Announcement[]
+  onDelete: (id: string) => void
+}
+
+/**
+ * Step-through view over a list of announcements. Replaces the vertical
+ * stack so the modal stays one card tall regardless of how many posts
+ * the teacher has, with prev/next arrows and a position counter.
+ *
+ * Owns only the cursor index; the list, ordering, and the delete
+ * action all belong to the parent. The cursor clamps after deletes
+ * (so the card never blanks) and is *not* moved when a fresh
+ * announcement is posted — the teacher keeps reading what they
+ * were on instead of getting yanked to the new entry.
+ *
+ * Keyboard: ← / → step when focus is anywhere inside the pager. We do
+ * NOT install a window-level listener, so the keys never fight the
+ * post-form's title/content inputs sitting next to the pager.
+ */
+export function AnnouncementPager({ announcements, onDelete }: AnnouncementPagerProps) {
+  const { t } = useTranslation()
+  const [index, setIndex] = useState(0)
+  const total = announcements.length
+
+  // Clamp on shrink (after a delete drops the tail). One render with the
+  // ``!current`` early-return below covers the in-between tick.
+  useEffect(() => {
+    if (total > 0 && index > total - 1) setIndex(total - 1)
+  }, [index, total])
+
+  if (total === 0) return null
+  const current = announcements[index]
+  if (!current) return null
+
+  const step = (delta: number) => {
+    setIndex((i) => Math.min(Math.max(0, i + delta), total - 1))
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "ArrowLeft") {
+      e.preventDefault()
+      step(-1)
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault()
+      step(1)
+    }
+  }
+
+  return (
+    <div
+      role="region"
+      aria-roledescription={t("teacherEditor.modals.announcements.carouselRole")}
+      aria-label={t("teacherEditor.modals.announcements.title")}
+      onKeyDown={onKeyDown}
+      tabIndex={-1}
+      className="rounded-lg border bg-card"
+    >
+      <div className="flex items-start gap-3 p-3 sm:p-4">
+        <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-info" strokeWidth={1.75} aria-hidden />
+        <div className="min-w-0 flex-1">
+          {/* Polite live region announces the new title when the
+              teacher steps via arrows or buttons. ``aria-atomic`` so
+              the whole title is read each time, not just the diff. */}
+          <p
+            className="text-sm font-medium text-wrap-safe"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {current.title}
+          </p>
+          {current.content && (
+            <p className="mt-0.5 text-xs text-muted-foreground text-wrap-safe whitespace-pre-line">
+              {current.content}
+            </p>
+          )}
+          <time className="mt-1 block text-xs text-muted-foreground/60">
+            {formatDateTime(current.created_at)}
+          </time>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 shrink-0 p-0 text-destructive hover:text-destructive"
+          onClick={() => onDelete(current.id)}
+          aria-label={t("teacherEditor.modals.announcements.deleteAria", { title: current.title })}
+        >
+          <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />
+        </Button>
+      </div>
+      {total > 1 && (
+        <div className="flex items-center justify-between border-t bg-muted/40 px-2 py-1.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => step(-1)}
+            disabled={index === 0}
+            aria-label={t("teacherEditor.modals.announcements.prevAria")}
+          >
+            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+          <span className="text-xs tabular-nums text-muted-foreground" aria-hidden>
+            {t("teacherEditor.modals.announcements.position", {
+              current: index + 1,
+              total,
+            })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => step(1)}
+            disabled={index === total - 1}
+            aria-label={t("teacherEditor.modals.announcements.nextAria")}
+          >
+            <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { Megaphone, Trash2 } from "lucide-react"
+import { Megaphone } from "lucide-react"
 import { EmptyState, Modal } from "@/components/patterns"
 import type { Announcement } from "@/types"
-import { formatDateTime } from "@/i18n/format"
+import { AnnouncementPager } from "./AnnouncementPager"
 
 interface Props {
   open: boolean
@@ -62,33 +62,7 @@ export function AnnouncementsModal({
             title={t("teacherEditor.modals.announcements.empty")}
           />
         ) : (
-          <div className="space-y-2 max-h-60 overflow-y-auto">
-            {announcements.map((a) => (
-              <div key={a.id} className="flex items-start gap-3 p-3 border rounded-lg">
-                <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-info" strokeWidth={1.75} />
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-wrap-safe">{a.title}</p>
-                  {a.content && (
-                    <p className="mt-0.5 text-xs text-muted-foreground text-wrap-safe whitespace-pre-line">
-                      {a.content}
-                    </p>
-                  )}
-                  <time className="mt-1 block text-xs text-muted-foreground/60">
-                    {formatDateTime(a.created_at)}
-                  </time>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 w-7 p-0 text-destructive hover:text-destructive shrink-0"
-                  onClick={() => onDelete(a.id)}
-                  aria-label={t("teacherEditor.modals.announcements.deleteAria", { title: a.title })}
-                >
-                  <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />
-                </Button>
-              </div>
-            ))}
-          </div>
+          <AnnouncementPager announcements={announcements} onDelete={onDelete} />
         )}
       </div>
     </Modal>

--- a/frontend/src/pages/Teacher/editor/__tests__/AnnouncementPager.test.tsx
+++ b/frontend/src/pages/Teacher/editor/__tests__/AnnouncementPager.test.tsx
@@ -1,0 +1,151 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { I18nextProvider } from "react-i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import i18n from "@/i18n/config"
+import type { Announcement } from "@/types"
+import { AnnouncementPager } from "@/pages/Teacher/editor/AnnouncementPager"
+
+/**
+ * Contract of the pager:
+ *
+ *   1. Empty list → render nothing (parent shows its own empty state).
+ *   2. Single item → render the card without nav controls.
+ *   3. Many items → render nav controls; counter reads "1 / N" at start.
+ *   4. Next / Prev buttons step the cursor and disable at the ends.
+ *   5. ArrowLeft / ArrowRight keys step the cursor when focus is
+ *      inside the pager. Other keys are ignored.
+ *   6. When the list shrinks below the current cursor (e.g. delete),
+ *      the cursor clamps to the new last item rather than blanking
+ *      the card.
+ *   7. Delete button calls ``onDelete`` with the *current* item's id,
+ *      never a stale one — so a teacher deleting from the middle of
+ *      the list doesn't nuke a different post.
+ */
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+const make = (id: string, title: string, content = ""): Announcement => ({
+  id,
+  title,
+  content,
+  course_id: null,
+  created_by: "00000000-0000-0000-0000-000000000000",
+  created_at: "2026-05-18T12:00:00Z",
+  updated_at: "2026-05-18T12:00:00Z",
+})
+
+describe("AnnouncementPager", () => {
+  it("renders nothing when the list is empty", () => {
+    const { container } = render(<AnnouncementPager announcements={[]} onDelete={vi.fn()} />, {
+      wrapper: Wrapper,
+    })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("hides the nav row when there is only one item", () => {
+    render(<AnnouncementPager announcements={[make("a", "Only one")]} onDelete={vi.fn()} />, {
+      wrapper: Wrapper,
+    })
+    expect(screen.getByText("Only one")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /previous/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument()
+  })
+
+  it("shows the counter as '1 / N' on first render with many items", () => {
+    render(
+      <AnnouncementPager
+        announcements={[make("a", "First"), make("b", "Second"), make("c", "Third")]}
+        onDelete={vi.fn()}
+      />,
+      { wrapper: Wrapper },
+    )
+    expect(screen.getByText("1 / 3")).toBeInTheDocument()
+    expect(screen.getByText("First")).toBeInTheDocument()
+  })
+
+  it("steps with the Next button and disables it at the end", async () => {
+    const user = userEvent.setup()
+    render(
+      <AnnouncementPager
+        announcements={[make("a", "First"), make("b", "Second")]}
+        onDelete={vi.fn()}
+      />,
+      { wrapper: Wrapper },
+    )
+    const next = screen.getByRole("button", { name: /next/i })
+    await user.click(next)
+    expect(screen.getByText("Second")).toBeInTheDocument()
+    expect(screen.getByText("2 / 2")).toBeInTheDocument()
+    expect(next).toBeDisabled()
+  })
+
+  it("steps with the keyboard when focus is inside the pager", async () => {
+    const user = userEvent.setup()
+    render(
+      <AnnouncementPager
+        announcements={[make("a", "First"), make("b", "Second")]}
+        onDelete={vi.fn()}
+      />,
+      { wrapper: Wrapper },
+    )
+    // Focus the region itself (tabIndex=-1) so keyboard events land
+    // on the onKeyDown handler regardless of which control inside is
+    // currently focusable. Focusing a button instead would silently
+    // shift focus off when that button became disabled at the end.
+    const region = screen.getByRole("region")
+    ;(region as HTMLElement).focus()
+    await user.keyboard("{ArrowRight}")
+    expect(screen.getByText("Second")).toBeInTheDocument()
+    await user.keyboard("{ArrowLeft}")
+    expect(screen.getByText("First")).toBeInTheDocument()
+  })
+
+  it("clamps the cursor when the list shrinks below the current index", async () => {
+    const user = userEvent.setup()
+    const onDelete = vi.fn()
+    // Pass the bare component to ``rerender`` — RTL re-uses the
+    // wrapper from the initial ``render`` call. Wrapping again here
+    // would remount the pager and reset its index to 0.
+    const { rerender } = render(
+      <AnnouncementPager
+        announcements={[make("a", "First"), make("b", "Second"), make("c", "Third")]}
+        onDelete={onDelete}
+      />,
+      { wrapper: Wrapper },
+    )
+    await user.click(screen.getByRole("button", { name: /next/i }))
+    await user.click(screen.getByRole("button", { name: /next/i }))
+    expect(screen.getByText("Third")).toBeInTheDocument()
+    expect(screen.getByText("3 / 3")).toBeInTheDocument()
+
+    rerender(
+      <AnnouncementPager
+        announcements={[make("a", "First"), make("b", "Second")]}
+        onDelete={onDelete}
+      />,
+    )
+    expect(screen.getByText("Second")).toBeInTheDocument()
+    expect(screen.getByText("2 / 2")).toBeInTheDocument()
+  })
+
+  it("deletes the currently-displayed item, not a stale one", async () => {
+    const user = userEvent.setup()
+    const onDelete = vi.fn()
+    render(
+      <AnnouncementPager
+        announcements={[make("a", "First"), make("b", "Second"), make("c", "Third")]}
+        onDelete={onDelete}
+      />,
+      { wrapper: Wrapper },
+    )
+    await user.click(screen.getByRole("button", { name: /next/i }))
+    // Now on "Second" — clicking delete must report 'b', not 'a' or 'c'.
+    await user.click(screen.getByRole("button", { name: /delete announcement second/i }))
+    expect(onDelete).toHaveBeenCalledWith("b")
+  })
+})


### PR DESCRIPTION
## Why

The teacher's Announcements modal rendered every post as a stacked card in a 240 px scroll viewport. A course with two months of weekly posts turned the modal into a wall, and made the create-form at the top feel buried. Per Vadym's request: *«одно поле для анаунсментс и стрелочками их передвигать»*.

## What

New `AnnouncementPager` component owns *only* its cursor index. List, ordering, and the delete action stay with the parent hook (`useAnnouncementsSection`) so the existing confirm dialog and cache invalidation are reused unchanged.

**UX**
- One card view + prev/next chevrons + `N / M` counter
- Nav row hidden when only one announcement exists (no chrome you don't need)
- Cursor clamps after deletes so the card never blanks
- Cursor is *not* auto-moved when a new post arrives — teacher keeps reading what they were on

**Keyboard**
- ← / → step when focus is inside the pager
- Scoped via element-level `onKeyDown`, never a window listener — so the keys never fight the title/content inputs of the post-form sitting in the same modal

**Accessibility**
- `role="region"` + `aria-roledescription="carousel"` + `aria-label` from i18n
- Title is `aria-live="polite"` + `aria-atomic` so SRs announce the new card on each step
- Prev/next have explicit aria-labels; counter is `aria-hidden` (live region already conveys the change)

## Tests

7/7 vitest cases — empty list, single item, many items, button stepping with end-of-range disable, keyboard stepping, clamp-on-shrink (delete that lands while teacher is on the tail), and ID-correctness of delete (no stale-cursor bug).

## Not in scope

- No backend / DB / schema change
- No new dependencies
- Delete confirm dialog stays where it was (in the section hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)