### PR TITLE
refactor(teacher): consolidate raw <select> usages onto the shared NativeSelect

### DIFF
--- a/frontend/src/components/assignment/editor/SubmissionGrader.tsx
+++ b/frontend/src/components/assignment/editor/SubmissionGrader.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { NativeSelect } from "@/components/ui/native-select"
 import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
 import { FileText, Loader2, MessageSquare, Save, Star, User } from "lucide-react"
@@ -98,14 +99,16 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
             />
             <span className="text-xs text-muted-foreground">/ {maxScore}</span>
           </div>
-          <select
+          <NativeSelect
+            fieldSize="xs"
             value={status}
+            aria-label={t("assignmentEditor.grader.statusAria")}
             onChange={(e) => setStatus(e.target.value as AssignmentSubmission["status"])}
-            className="h-7 rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="w-auto"
           >
             <option value="graded">{t("assignmentEditor.grader.statusGrade")}</option>
             <option value="returned">{t("assignmentEditor.grader.statusReturn")}</option>
-          </select>
+          </NativeSelect>
         </div>
 
         <div className="space-y-1">

--- a/frontend/src/components/quiz/editor/QuestionCard.tsx
+++ b/frontend/src/components/quiz/editor/QuestionCard.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { NativeSelect } from "@/components/ui/native-select"
 import { getTrueFalseLabel, type DraftOption, type DraftQuestion } from "./types"
 
 interface Props {
@@ -75,20 +76,22 @@ export function QuestionCard({
             </div>
 
             <div className="flex items-center gap-3">
-              <select
+              <NativeSelect
+                fieldSize="xs"
                 value={q.question_type}
+                aria-label={t("quizEditor.questions.questionTypeAria")}
                 onChange={(e) =>
                   onUpdate({
                     question_type: e.target.value as DraftQuestion["question_type"],
                   })
                 }
-                className="h-7 rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="w-auto"
               >
                 <option value="multiple_choice">{t("quizEditor.questions.types.multiple_choice")}</option>
                 <option value="true_false">{t("quizEditor.questions.types.true_false")}</option>
                 <option value="short_answer">{t("quizEditor.questions.types.short_answer")}</option>
                 <option value="essay">{t("quizEditor.questions.types.essay")}</option>
-              </select>
+              </NativeSelect>
               {q.question_type === "essay" && (
                 <div className="flex items-center gap-1">
                   <Label className="text-xs text-muted-foreground">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -438,6 +438,7 @@
       "essayHint": "Long-form written response. Graded manually from the Submissions tab.",
       "removeQuestionAria": "Remove question {{n}}",
       "removeOptionAria": "Remove option {{n}}",
+      "questionTypeAria": "Question type",
       "trueFalseOption": {
         "True": "True",
         "False": "False"
@@ -593,6 +594,7 @@
       "viewFile": "View attached file",
       "statusGrade": "Grade",
       "statusReturn": "Return for revision",
+      "statusAria": "Grading action",
       "feedback": "Feedback",
       "feedbackPlaceholder": "Optional feedback for the student...",
       "saving": "Saving...",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -403,6 +403,7 @@
       "essayHint": "Развёрнутый письменный ответ. Оценивается вручную во вкладке проверки.",
       "removeQuestionAria": "Удалить вопрос {{n}}",
       "removeOptionAria": "Удалить вариант {{n}}",
+      "questionTypeAria": "Тип вопроса",
       "trueFalseOption": {
         "True": "Истина",
         "False": "Ложь"
@@ -564,6 +565,7 @@
       "viewFile": "Открыть прикреплённый файл",
       "statusGrade": "Оценить",
       "statusReturn": "Вернуть на доработку",
+      "statusAria": "Действие проверки",
       "feedback": "Отзыв",
       "feedbackPlaceholder": "Необязательный отзыв студенту...",
       "saving": "Сохранение...",

--- a/frontend/src/pages/Teacher/editor/EventsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/EventsModal.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { NativeSelect } from "@/components/ui/native-select"
 import { Textarea } from "@/components/ui/textarea"
 import { CalendarDays, Pencil, Save, Trash2 } from "lucide-react"
 import { EmptyState, Modal } from "@/components/patterns"
@@ -66,17 +67,17 @@ export function EventsModal({
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1">
               <Label className="text-xs">{t("teacherEditor.modals.events.type")}</Label>
-              <select
+              <NativeSelect
+                fieldSize="sm"
                 value={form.event_type}
                 onChange={(e) => patch({ event_type: e.target.value })}
-                className="w-full text-sm border rounded-md px-2 py-1.5 bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
               >
                 {EVENT_TYPE_VALUES.map((value) => (
                   <option key={value} value={value}>
                     {t(`teacherEditor.modals.events.types.${value}`)}
                   </option>
                 ))}
-              </select>
+              </NativeSelect>
             </div>
             <div className="space-y-1">
               <Label className="text-xs">{t("teacherEditor.modals.events.dateTime")}</Label>


### PR DESCRIPTION
## Why

Three teacher-facing surfaces still wrote raw `<select>` elements with hand-rolled Tailwind that almost-but-not-quite matched the project's design tokens:

- `components/quiz/editor/QuestionCard.tsx` — question-type picker
- `components/assignment/editor/SubmissionGrader.tsx` — grade-status picker
- `pages/Teacher/editor/EventsModal.tsx` — event-type picker

Each re-implemented its own focus ring, border, padding, and text-size — close to but not identical to `inputVariants`. Three near-duplicate classNames meant any future design-token tweak had to be repeated three times *and* at least one would still drift.

## What

All three switched to `<NativeSelect fieldSize="xs"|"sm">`. Now they share:

- Same semantic tokens (`border-input`, `ring-ring`, `shadow-sm`)
- Same iOS-zoom-prevention behaviour on small screens
- Same disabled-state styling
- One source of truth for size/spacing

Two missing aria-labels added (`questions.questionTypeAria`, `grader.statusAria`) so the visually-unlabelled pickers have an accessible name. The Events picker already had a `<Label>` above it — no aria-label needed there.

## Not in scope

- No behavioural change — every callsite has equivalent visual size + matching variants
- No backend / DB / schema change
- Admin and Calendar pages were already on NativeSelect; nothing to migrate there

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean
- `npm run i18n:check` — 1299 en + 1353 ru, parity holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)