### PR TITLE
fix(teacher): guard chapter-editor breadcrumb against silent unsaved-work loss

### DIFF
--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -167,6 +167,39 @@ export default function ChapterEditor() {
     return () => document.removeEventListener("keydown", handleKeyDown)
   }, [save])
 
+  // Shared dirty-check used by the Back button and every breadcrumb
+  // link. Pre-fix, only the Back button asked before discarding work;
+  // a click on any breadcrumb crumb silently navigated away. Three of
+  // them — easy to miss when you've just typed two paragraphs.
+  const guardedNavigate = useCallback(
+    async (to: string) => {
+      if (isDirty) {
+        const ok = await confirm({
+          title: t("chapterEditor.leaveConfirm.title"),
+          description: t("chapterEditor.leaveConfirm.description"),
+          confirmLabel: t("chapterEditor.leaveConfirm.confirm"),
+          tone: "destructive",
+        })
+        if (!ok) return
+      }
+      navigate(to)
+    },
+    [confirm, isDirty, navigate, t],
+  )
+
+  // Click interceptor for breadcrumb ``<Link>`` elements. Only swallows
+  // the plain left-click; Ctrl/Cmd/Shift/middle-click pass through to
+  // the browser default so open-in-new-tab still works without a
+  // confirm prompt (a new tab doesn't lose the editor's draft).
+  const handleNavClick = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    to: string,
+  ) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
+    e.preventDefault()
+    void guardedNavigate(to)
+  }
+
   if (loading) {
     return (
       <div className="container mx-auto px-4 py-8 max-w-4xl">
@@ -202,14 +235,23 @@ export default function ChapterEditor() {
 
   return (
     <div className="container mx-auto max-w-4xl px-4 py-6 sm:py-8">
-      {/* Breadcrumb — earlier crumbs hide on mobile to keep one line. */}
+      {/* Breadcrumb — earlier crumbs hide on mobile to keep one line.
+          Each link intercepts normal-button clicks so the dirty-check
+          confirm fires before navigation; Ctrl/Cmd/Shift/middle-click
+          fall through to the browser default (open-in-new-tab etc.)
+          unchanged. */}
       <div className="mb-6 flex items-center gap-2 text-sm text-muted-foreground">
-        <Link to="/teacher" className="hidden transition-colors hover:text-foreground sm:inline">
+        <Link
+          to="/teacher"
+          onClick={(e) => handleNavClick(e, "/teacher")}
+          className="hidden transition-colors hover:text-foreground sm:inline"
+        >
           {t("chapterEditor.breadcrumb.myCourses")}
         </Link>
         <ChevronRight className="hidden h-3.5 w-3.5 sm:inline-block" strokeWidth={1.75} />
         <Link
           to={`/teacher/courses/${courseId}`}
+          onClick={(e) => handleNavClick(e, `/teacher/courses/${courseId}`)}
           className="hidden transition-colors hover:text-foreground sm:inline"
         >
           {t("chapterEditor.breadcrumb.course")}
@@ -217,6 +259,9 @@ export default function ChapterEditor() {
         <ChevronRight className="hidden h-3.5 w-3.5 sm:inline-block" strokeWidth={1.75} />
         <Link
           to={`/teacher/courses/${courseId}/modules/${moduleId}/edit`}
+          onClick={(e) =>
+            handleNavClick(e, `/teacher/courses/${courseId}/modules/${moduleId}/edit`)
+          }
           className="min-w-0 truncate transition-colors hover:text-foreground"
         >
           {moduleName}
@@ -233,18 +278,11 @@ export default function ChapterEditor() {
           variant="ghost"
           size="sm"
           className="shrink-0"
-          onClick={async () => {
-            if (isDirty) {
-              const ok = await confirm({
-                title: t("chapterEditor.leaveConfirm.title"),
-                description: t("chapterEditor.leaveConfirm.description"),
-                confirmLabel: t("chapterEditor.leaveConfirm.confirm"),
-                tone: "destructive",
-              })
-              if (!ok) return
-            }
-            navigate(`/teacher/courses/${courseId}/modules/${moduleId}/edit`)
-          }}
+          onClick={() =>
+            void guardedNavigate(
+              `/teacher/courses/${courseId}/modules/${moduleId}/edit`,
+            )
+          }
         >
           <ArrowLeft className="h-4 w-4 mr-1" strokeWidth={1.75} />
           {t("chapterEditor.back")}


### PR DESCRIPTION
## What was wrong

The chapter editor's Back button asked `Leave without saving?` when the editor was dirty, but the breadcrumb crumbs sitting **right above it** (My Courses › Course › Module name) were plain `<Link>`s — a click on any of them silently discarded the teacher's draft.

Three exits visible, three different behaviours, and the two unsafe ones look identical to the safe one. *«Чище и логичнее»* — same exit, same prompt.

## Fix

All four exits now go through one `guardedNavigate(to)` helper:

- **Back button**: `onClick={() => guardedNavigate(...)}`. Old inline body merged into the helper.
- **Breadcrumb crumbs**: keep `<Link to=...>` so Ctrl/Cmd/Shift/middle-click still open in a new tab unchanged (a new tab doesn't lose the editor's draft → no prompt needed). Plain left-click is intercepted via `handleNavClick` which calls `preventDefault()` and routes through the same dirty-check.

Helper memoised via `useCallback(deps=[confirm, isDirty, navigate, t])` so click handlers re-bind only when the dirty state actually flips.

## Not in scope

- No behavioural change for the happy path (clean editor still navigates instantly)
- No new dependency (didn't pull in `useBlocker` — would have required migrating the whole app from BrowserRouter to data router)
- No backend / DB / schema change

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean
- Existing editor vitest suite — 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)