### PR TITLE
feat(course): same step-through pager on the student-facing course page

### DIFF
--- a/frontend/src/components/announcements/AnnouncementPager.tsx
+++ b/frontend/src/components/announcements/AnnouncementPager.tsx
@@ -7,23 +7,28 @@ import type { Announcement } from "@/types"
 
 interface AnnouncementPagerProps {
   announcements: Announcement[]
-  onDelete: (id: string) => void
+  /** Required only on surfaces where the viewer may delete entries
+   *  (i.e. the teacher's editor modal). Omitted on read-only feeds
+   *  (course detail page, banner, public surfaces). */
+  onDelete?: (id: string) => void
 }
 
 /**
  * Step-through view over a list of announcements. Replaces the vertical
- * stack so the modal stays one card tall regardless of how many posts
- * the teacher has, with prev/next arrows and a position counter.
+ * stack so the host (teacher modal or student course page) stays one
+ * card tall regardless of how many posts exist, with prev/next arrows
+ * and a position counter.
  *
  * Owns only the cursor index; the list, ordering, and the delete
  * action all belong to the parent. The cursor clamps after deletes
  * (so the card never blanks) and is *not* moved when a fresh
- * announcement is posted — the teacher keeps reading what they
- * were on instead of getting yanked to the new entry.
+ * announcement is posted — the reader keeps reading what they were
+ * on instead of getting yanked to the new entry.
  *
  * Keyboard: ← / → step when focus is anywhere inside the pager. We do
- * NOT install a window-level listener, so the keys never fight the
- * post-form's title/content inputs sitting next to the pager.
+ * NOT install a window-level listener, so the keys never fight any
+ * surrounding form inputs (e.g. the post-form sitting next to the
+ * pager in the teacher modal).
  */
 export function AnnouncementPager({ announcements, onDelete }: AnnouncementPagerProps) {
   const { t } = useTranslation()
@@ -85,15 +90,17 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
             {formatDateTime(current.created_at)}
           </time>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 w-7 shrink-0 p-0 text-destructive hover:text-destructive"
-          onClick={() => onDelete(current.id)}
-          aria-label={t("teacherEditor.modals.announcements.deleteAria", { title: current.title })}
-        >
-          <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />
-        </Button>
+        {onDelete && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 shrink-0 p-0 text-destructive hover:text-destructive"
+            onClick={() => onDelete(current.id)}
+            aria-label={t("teacherEditor.modals.announcements.deleteAria", { title: current.title })}
+          >
+            <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />
+          </Button>
+        )}
       </div>
       {total > 1 && (
         <div className="flex items-center justify-between border-t bg-muted/40 px-2 py-1.5">

--- a/frontend/src/components/announcements/CourseAnnouncements.tsx
+++ b/frontend/src/components/announcements/CourseAnnouncements.tsx
@@ -1,13 +1,19 @@
 import { useState, useEffect } from "react"
 import { coursesService } from "@/services/courses"
 import type { Announcement } from "@/types"
-import { Megaphone } from "lucide-react"
-import { formatDate } from "@/i18n/format"
+import { AnnouncementPager } from "./AnnouncementPager"
 
 interface Props {
   courseId: string
 }
 
+/**
+ * Student-facing list of course announcements rendered above the
+ * chapter list. Uses the shared ``AnnouncementPager`` so a course
+ * with months of weekly posts collapses to a single card the student
+ * can step through with arrows or keyboard — same UX as the teacher
+ * editor's announcement panel, just read-only (``onDelete`` omitted).
+ */
 export default function CourseAnnouncements({ courseId }: Props) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [loaded, setLoaded] = useState(false)
@@ -15,32 +21,27 @@ export default function CourseAnnouncements({ courseId }: Props) {
   useEffect(() => {
     let cancelled = false
     setLoaded(false)
-    coursesService.getAnnouncements(courseId).then((data) => {
-      if (!cancelled) setAnnouncements(data)
-    }).catch(() => {
-      if (!cancelled) setAnnouncements([])
-    }).finally(() => {
-      if (!cancelled) setLoaded(true)
-    })
-    return () => { cancelled = true }
+    coursesService
+      .getAnnouncements(courseId)
+      .then((data) => {
+        if (!cancelled) setAnnouncements(data)
+      })
+      .catch(() => {
+        if (!cancelled) setAnnouncements([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [courseId])
 
   if (!loaded || announcements.length === 0) return null
 
   return (
-    <div className="space-y-3 mb-6">
-      {announcements.map((a) => (
-        <div key={a.id} className="flex gap-3 rounded-md border border-border border-l-stripe border-l-info bg-info/5 p-4">
-          <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-info" strokeWidth={1.75} />
-          <div className="min-w-0 flex-1 text-wrap-safe">
-            <h4 className="text-sm font-medium">{a.title}</h4>
-            <p className="mt-1 text-xs text-muted-foreground whitespace-pre-line">{a.content}</p>
-            <time className="mt-1 block text-xs text-muted-foreground/60">
-              {formatDate(a.created_at)}
-            </time>
-          </div>
-        </div>
-      ))}
+    <div className="mb-6">
+      <AnnouncementPager announcements={announcements} />
     </div>
   )
 }

--- a/frontend/src/components/announcements/__tests__/AnnouncementPager.test.tsx
+++ b/frontend/src/components/announcements/__tests__/AnnouncementPager.test.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import i18n from "@/i18n/config"
 import type { Announcement } from "@/types"
-import { AnnouncementPager } from "@/pages/Teacher/editor/AnnouncementPager"
+import { AnnouncementPager } from "@/components/announcements/AnnouncementPager"
 
 /**
  * Contract of the pager:
@@ -54,6 +54,19 @@ describe("AnnouncementPager", () => {
     expect(screen.getByText("Only one")).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /previous/i })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument()
+  })
+
+  it("hides the delete button when no onDelete is provided (read-only mode)", () => {
+    render(
+      <AnnouncementPager
+        announcements={[make("a", "First"), make("b", "Second")]}
+      />,
+      { wrapper: Wrapper },
+    )
+    // Nav still works in read-only mode.
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument()
+    // But there's no delete affordance.
+    expect(screen.queryByRole("button", { name: /delete announcement/i })).not.toBeInTheDocument()
   })
 
   it("shows the counter as '1 / N' on first render with many items", () => {

--- a/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
@@ -5,7 +5,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Megaphone } from "lucide-react"
 import { EmptyState, Modal } from "@/components/patterns"
 import type { Announcement } from "@/types"
-import { AnnouncementPager } from "./AnnouncementPager"
+import { AnnouncementPager } from "@/components/announcements/AnnouncementPager"
 
 interface Props {
   open: boolean


### PR DESCRIPTION
## Why

The pager I shipped in #416 only lived in the **teacher's edit modal** (`AnnouncementsModal`). The **student-facing course page** uses a different component, `CourseAnnouncements`, which still rendered announcements as a vertical stack. Vadym opened a course with two posts and rightly asked: *«всё ещё вижу 2 объяснения вместо одного с возможностью свайпать его или каруселить»*.

So: same UX everywhere announcements are displayed.

## What

- **Moved** `AnnouncementPager` from `pages/Teacher/editor/` to `components/announcements/`. Both surfaces now import from the same place, and the import direction (page → component) stays right-way-up.
- **`onDelete` is now optional.** When omitted, the trash button is not rendered. Teacher modal still passes its handler; the student-facing course page omits it and gets read-only navigation.
- **`CourseAnnouncements` rewritten** to use the pager (~25 LOC → ~10 LOC).

## Result

- Teacher: edit modal → ⋯ → Announcements → one card + arrows (unchanged, still has trash button)
- Student / anyone on a course page: course overview → announcements section → one card + arrows (NEW, read-only)

## Tests

8/8 vitest cases pass (was 7/7). New case covers read-only mode: nav buttons present, delete button absent.

## Not in scope

- No backend / DB / schema / network change
- i18n keys still live under `teacherEditor.modals.announcements.*` — functionally fine cross-context, but a future PR could migrate the pager-specific subset to a shared `announcements.pager.*` namespace for cleaner naming. Not load-bearing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)