### PR TITLE
feat(pager): vertical right-rail nav with dot indicators

### DIFF
--- a/frontend/src/components/announcements/AnnouncementPager.tsx
+++ b/frontend/src/components/announcements/AnnouncementPager.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { ChevronLeft, ChevronRight, Megaphone, Trash2 } from "lucide-react"
+import { ChevronDown, ChevronUp, Megaphone, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 import { formatDateTime } from "@/i18n/format"
 import type { Announcement } from "@/types"
 
@@ -13,11 +14,22 @@ interface AnnouncementPagerProps {
   onDelete?: (id: string) => void
 }
 
+// At more than this many entries the dot column reads as clutter; we
+// swap to a compact "current / total" counter instead so the rail
+// stays the same height regardless of how many posts the teacher has.
+const DOTS_CAP = 7
+
 /**
- * Step-through view over a list of announcements. Replaces the vertical
- * stack so the host (teacher modal or student course page) stays one
- * card tall regardless of how many posts exist, with prev/next arrows
- * and a position counter.
+ * Step-through view over a list of announcements. The host (teacher
+ * modal or student course page) stays one card tall regardless of
+ * how many posts exist.
+ *
+ * Layout: the announcement body fills the card; a slim vertical rail
+ * on the right of the card holds the navigation (↑ at top, ↓ at
+ * bottom, dot indicators or a counter between them). The rail spans
+ * the full card height so the affordance is always visible without
+ * scrolling. The trash button (when allowed) lives in the content
+ * area's top-right corner, separate from the nav rail.
  *
  * Owns only the cursor index; the list, ordering, and the delete
  * action all belong to the parent. The cursor clamps after deletes
@@ -25,10 +37,10 @@ interface AnnouncementPagerProps {
  * announcement is posted — the reader keeps reading what they were
  * on instead of getting yanked to the new entry.
  *
- * Keyboard: ← / → step when focus is anywhere inside the pager. We do
- * NOT install a window-level listener, so the keys never fight any
- * surrounding form inputs (e.g. the post-form sitting next to the
- * pager in the teacher modal).
+ * Keyboard: ↑ / ↓ step when focus is inside the pager. ← / → also
+ * step (kept for parity with the previous horizontal layout). The
+ * listener is element-scoped, never window-level, so the keys never
+ * fight surrounding form inputs.
  */
 export function AnnouncementPager({ announcements, onDelete }: AnnouncementPagerProps) {
   const { t } = useTranslation()
@@ -50,14 +62,17 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
   }
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "ArrowLeft") {
+    if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
       e.preventDefault()
       step(-1)
-    } else if (e.key === "ArrowRight") {
+    } else if (e.key === "ArrowDown" || e.key === "ArrowRight") {
       e.preventDefault()
       step(1)
     }
   }
+
+  const hasNav = total > 1
+  const showDots = hasNav && total <= DOTS_CAP
 
   return (
     <div
@@ -66,9 +81,9 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
       aria-label={t("teacherEditor.modals.announcements.title")}
       onKeyDown={onKeyDown}
       tabIndex={-1}
-      className="rounded-lg border bg-card"
+      className="flex overflow-hidden rounded-lg border bg-card"
     >
-      <div className="flex items-start gap-3 p-3 sm:p-4">
+      <div className="flex min-w-0 flex-1 items-start gap-3 p-3 sm:p-4">
         <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-info" strokeWidth={1.75} aria-hidden />
         <div className="min-w-0 flex-1">
           {/* Polite live region announces the new title when the
@@ -102,8 +117,8 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
           </Button>
         )}
       </div>
-      {total > 1 && (
-        <div className="flex items-center justify-between border-t bg-muted/40 px-2 py-1.5">
+      {hasNav && (
+        <div className="flex shrink-0 flex-col items-center justify-between gap-2 border-l bg-muted/40 px-1.5 py-2">
           <Button
             variant="ghost"
             size="sm"
@@ -112,14 +127,31 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
             disabled={index === 0}
             aria-label={t("teacherEditor.modals.announcements.prevAria")}
           >
-            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+            <ChevronUp className="h-4 w-4" strokeWidth={1.75} aria-hidden />
           </Button>
-          <span className="text-xs tabular-nums text-muted-foreground" aria-hidden>
-            {t("teacherEditor.modals.announcements.position", {
-              current: index + 1,
-              total,
-            })}
-          </span>
+          {showDots ? (
+            <div className="flex flex-col items-center gap-1.5" aria-hidden>
+              {announcements.map((a, i) => (
+                <span
+                  key={a.id}
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full transition-colors duration-150",
+                    i === index ? "bg-primary" : "bg-muted-foreground/30",
+                  )}
+                />
+              ))}
+            </div>
+          ) : (
+            <span
+              className="text-[10px] leading-none tabular-nums text-muted-foreground"
+              aria-hidden
+            >
+              {t("teacherEditor.modals.announcements.position", {
+                current: index + 1,
+                total,
+              })}
+            </span>
+          )}
           <Button
             variant="ghost"
             size="sm"
@@ -128,7 +160,7 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
             disabled={index === total - 1}
             aria-label={t("teacherEditor.modals.announcements.nextAria")}
           >
-            <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+            <ChevronDown className="h-4 w-4" strokeWidth={1.75} aria-hidden />
           </Button>
         </div>
       )}

--- a/frontend/src/components/announcements/__tests__/AnnouncementPager.test.tsx
+++ b/frontend/src/components/announcements/__tests__/AnnouncementPager.test.tsx
@@ -69,7 +69,7 @@ describe("AnnouncementPager", () => {
     expect(screen.queryByRole("button", { name: /delete announcement/i })).not.toBeInTheDocument()
   })
 
-  it("shows the counter as '1 / N' on first render with many items", () => {
+  it("renders the first item as current on initial render with many items", () => {
     render(
       <AnnouncementPager
         announcements={[make("a", "First"), make("b", "Second"), make("c", "Third")]}
@@ -77,8 +77,20 @@ describe("AnnouncementPager", () => {
       />,
       { wrapper: Wrapper },
     )
-    expect(screen.getByText("1 / 3")).toBeInTheDocument()
     expect(screen.getByText("First")).toBeInTheDocument()
+    // Other items are not rendered — pager shows only the current one.
+    expect(screen.queryByText("Second")).not.toBeInTheDocument()
+    expect(screen.queryByText("Third")).not.toBeInTheDocument()
+    // Prev disabled at the start, next enabled.
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /next/i })).not.toBeDisabled()
+  })
+
+  it("switches to a compact counter when more than 7 items are present", () => {
+    const many = Array.from({ length: 9 }, (_, i) => make(`id${i}`, `Item ${i + 1}`))
+    render(<AnnouncementPager announcements={many} onDelete={vi.fn()} />, { wrapper: Wrapper })
+    // 9 dots would clutter the rail — counter renders instead.
+    expect(screen.getByText("1 / 9")).toBeInTheDocument()
   })
 
   it("steps with the Next button and disables it at the end", async () => {
@@ -93,8 +105,8 @@ describe("AnnouncementPager", () => {
     const next = screen.getByRole("button", { name: /next/i })
     await user.click(next)
     expect(screen.getByText("Second")).toBeInTheDocument()
-    expect(screen.getByText("2 / 2")).toBeInTheDocument()
     expect(next).toBeDisabled()
+    expect(screen.getByRole("button", { name: /previous/i })).not.toBeDisabled()
   })
 
   it("steps with the keyboard when focus is inside the pager", async () => {
@@ -134,7 +146,8 @@ describe("AnnouncementPager", () => {
     await user.click(screen.getByRole("button", { name: /next/i }))
     await user.click(screen.getByRole("button", { name: /next/i }))
     expect(screen.getByText("Third")).toBeInTheDocument()
-    expect(screen.getByText("3 / 3")).toBeInTheDocument()
+    // Reached the tail.
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled()
 
     rerender(
       <AnnouncementPager
@@ -142,8 +155,9 @@ describe("AnnouncementPager", () => {
         onDelete={onDelete}
       />,
     )
+    // Cursor clamps to the new last item ("Second"), card never blanks.
     expect(screen.getByText("Second")).toBeInTheDocument()
-    expect(screen.getByText("2 / 2")).toBeInTheDocument()
+    expect(screen.queryByText("Third")).not.toBeInTheDocument()
   })
 
   it("deletes the currently-displayed item, not a stale one", async () => {


### PR DESCRIPTION
## Why

The horizontal nav row below each card felt heavy — extra band of chrome on every card. Vadym's feedback: *«стрелка вверх и стрелка вниз и между ними точка или несколько точек, на всю высоту прямоугольника»*.

## What

```
Before                          After
┌──────────────────┐            ┌──────────────────┬───┐
│ Title         🗑 │            │ Title         🗑 │ ↑ │
│ content          │            │ content          │ • │
│ time             │            │ time             │ • │
├──────────────────┤            │                  │ ↓ │
│  ←   1 / 2   →   │            └──────────────────┴───┘
└──────────────────┘
```

- Slim rail (~28-32 px wide) on the right of the card, full height
- ↑ at top, ↓ at bottom — direction matches *«flip to next»* on a vertical card
- Between the arrows: one dot per item, current = `bg-primary`, others = `bg-muted-foreground/30`. 6 px, quiet, animated colour transition
- **Above 7 items** the dots would clutter — rail swaps to a compact `N / M` counter at the same visual weight
- Trash button stays in the content area's top-right corner, separate from the nav rail

## Keyboard

- ↑ / ↓ added (the natural pair for vertical nav)
- ← / → kept for parity (muscle memory)
- All four step. Element-scoped `onKeyDown` — never fights surrounding form inputs.

## Tests

8 → **9 cases**, all pass:
- Dot mode (≤7 items): assertions on disabled state of prev/next + current title
- Counter mode (≥8 items, new): asserts compact `N / M` text
- Read-only mode, single item, empty list, clamp on shrink, delete-id correctness, keyboard step — unchanged

## Not in scope

- No backend / DB / schema / network change
- Same i18n keys as before
- ✅ Both surfaces (teacher modal + student course page) automatically pick up the new layout — single component, two callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)