### PR TITLE
chore(deps): bump brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3611,9 +3611,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

`npm audit` flagged a **moderate DoS** in `brace-expansion@5.0.0–5.0.5` — large numeric range defeats the documented `max` cap (GHSA-jxxr-4gwj-5jf2 / CWE-400 / CVSS 6.5). We pull it transitively.

Pure patch bump 5.0.5 → 5.0.6, lockfile only.

## Before / after

```
$ npm audit
1 moderate severity vulnerability  →  found 0 vulnerabilities
```

## Verification

`npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)