### PR TITLE
fix(quiz): bound QuizCreate.chapter_id length at the schema layer

### DIFF
--- a/backend/app/schemas/quiz.py
+++ b/backend/app/schemas/quiz.py
@@ -71,7 +71,11 @@ class QuizQuestionStudentResponse(BaseModel):
 
 
 class QuizCreate(BaseModel):
-    chapter_id: str
+    # Chapter ids are UUIDs (36 chars). Cap at the schema layer so a crafted
+    # 1 MB string is rejected by Pydantic before the route runs ``verify_chapter_owner``
+    # against it. Matches the bounds already on ``AssignmentCreate.chapter_id``
+    # and ``CohortCourseAttach.course_id``.
+    chapter_id: str = Field(..., min_length=1, max_length=36)
     title: str = Field(..., min_length=1, max_length=300)
     description: str | None = Field(None, max_length=5000)
     quiz_type: Literal["quiz", "exam"] = "quiz"


### PR DESCRIPTION
## Why

Every other Create schema with a UUID-shaped FK string id already caps it at 36 chars:

| Schema | Bound |
|---|---|
| `AssignmentCreate.chapter_id` | `max_length=36` ✓ |
| `CohortCourseAttach.course_id` | `max_length=36` ✓ |
| `BlockCreate.quiz_id / assignment_id / file_*` | bounded ✓ |
| **`QuizCreate.chapter_id`** | ❌ unbounded |

A crafted 1 MB `chapter_id` body would parse fine through Pydantic, then waste a round trip through `verify_chapter_owner` doing a Postgres SELECT against the giant string before the FK check returns NULL and the route 404s.

## Fix

Cap at `max_length=36` (UUID length). Fail-fast at parse time before the DB sees anything.

## Verification

- 106/106 quiz tests pass
- `ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)