### PR TITLE
fix(api): bound query-parameter string lengths at the FastAPI layer

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -38,7 +38,8 @@ def _course_source_locale_map(db: Session, course_ids: list[str]) -> dict[str, L
 @router.get("", response_model=list[AnnouncementResponse])
 def list_announcements(
     response: Response,
-    course_id: str | None = Query(None),
+    # 36 = UUID length; matches the bound on every Create schema id.
+    course_id: str | None = Query(None, max_length=36),
     global_only: bool = Query(False),
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),

--- a/backend/app/api/v1/audit.py
+++ b/backend/app/api/v1/audit.py
@@ -47,9 +47,13 @@ class AuditLogPage(BaseModel):
 def list_audit_logs(
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=200),
-    user_id: str | None = Query(None),
-    resource_type: str | None = Query(None),
-    action: str | None = Query(None),
+    # ``user_id`` is parsed as a UUID below, so 36 chars is the legitimate cap.
+    user_id: str | None = Query(None, max_length=36),
+    # ``resource_type`` / ``action`` map to ``String(50)`` columns; a longer
+    # query string can never match any row but would still run a wasted
+    # ``EXPLAIN`` + index lookup before returning empty. Bound at parse.
+    resource_type: str | None = Query(None, max_length=50),
+    action: str | None = Query(None, max_length=50),
     date_from: datetime | None = Query(None),
     date_to: datetime | None = Query(None),
     admin: User = Depends(require_admin),

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -29,7 +29,8 @@ router = APIRouter(prefix="/calendar", tags=["calendar"])
 @router.get("/events", response_model=list[CalendarEvent])
 def get_calendar_events(
     response: Response,
-    course_id: str | None = Query(None),
+    # 36 = UUID length; matches the bound on every Create schema id.
+    course_id: str | None = Query(None, max_length=36),
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/grades.py
+++ b/backend/app/api/v1/grades.py
@@ -256,7 +256,7 @@ def get_my_grade_for_course(
 @router.get("/course/{course_id}", response_model=list[GradeResponse])
 def list_course_grades(
     course_id: str,
-    cohort_id: str | None = Query(None),
+    cohort_id: str | None = Query(None, max_length=36),
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=500),
     teacher: User = Depends(require_teacher),
@@ -273,7 +273,7 @@ def list_course_grades(
 def get_student_grade(
     course_id: str,
     student_id: str,
-    cohort_id: str | None = Query(None),
+    cohort_id: str | None = Query(None, max_length=36),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> StudentGrade:
@@ -298,7 +298,7 @@ def upsert_student_grade(
     course_id: str,
     student_id: str,
     data: GradeUpsert,
-    cohort_id: str | None = Query(None),
+    cohort_id: str | None = Query(None, max_length=36),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> StudentGrade:

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -243,7 +243,9 @@ def bulk_update_user_roles(
 def update_user_role(
     user_id: str,
     request: Request,
-    role: str = Query(...),
+    # Validated against ``VALID_ROLES`` below; cap keeps Pydantic from
+    # parsing a multi-MB role string before that allow-list check runs.
+    role: str = Query(..., max_length=32),
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> dict:


### PR DESCRIPTION
## Why

Several routes accepted **unbounded** string query parameters that were then compared against UUID-shaped FK columns or short `String(50)` columns:

| Route | Param | Real shape |
|---|---|---|
| /audit | `user_id` | parsed as UUID |
| /audit | `resource_type`, `action` | String(50) indexed columns |
| /announcements | `course_id` | UUID FK |
| /calendar/events | `course_id` | UUID FK |
| /grades/course/* (×3) | `cohort_id` | UUID FK |
| /admin/users/{id}/role | `role` | allow-listed against `VALID_ROLES` (≤15 chars) |

A 1 MB query string in any of those landed in Pydantic, parsed fine, then wasted a Postgres round trip (index lookup against the literal returns empty) before the route ran.

## Fix

Same fail-fast pattern as the recent `QuizCreate.chapter_id` schema bound (#424). Cap at the `Query()` boundary so FastAPI's request validation rejects oversized values before the route function executes.

Bounds chosen to match the underlying column / value semantics:
- UUID FK fields → `max_length=36`
- `audit.resource_type` / `audit.action` → `max_length=50` (matches the column type)
- `role` → `max_length=32` (longest legal value `pending_teacher` is 15)

## Verification

- `pytest -k 'audit or announcement or calendar or grade or users'` → **316/316** pass
- `ruff check` + `ruff format --check` — clean
- No behaviour change for the happy path (all bounds are well above any legitimate value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)