### PR TITLE
fix(cohort): type the cohort-list status filter as a Literal

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -21,6 +21,7 @@ is intentionally removed. Frontend that called it is being migrated to
 the top-level admin UI.
 """
 
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
@@ -122,7 +123,10 @@ def _course_or_404(db: Session, course_id: str) -> Course:
 
 @router.get("", response_model=list[CohortResponse])
 def list_cohorts(
-    status_filter: str | None = Query(None, alias="status"),
+    # Typed as a Literal so FastAPI rejects any value outside the three
+    # legal cohort statuses before the query runs. Matches the constraint
+    # already on ``CohortUpdate.status`` and the DB ``CHECK``.
+    status_filter: Literal["upcoming", "active", "completed"] | None = Query(None, alias="status"),
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> list[CohortResponse]:


### PR DESCRIPTION
## Why

Admin cohort-list endpoint accepted `status` as unbounded `str | None` then ran `Cohort.status == status_filter` against a `String(20)` column. Malformed or oversized values returned empty — wasted btree index lookup before parse-time rejection.

`Cohort.status` has exactly three legal values, the DB has a CHECK constraint to prove it, and `CohortUpdate.status` is **already** typed as `Literal['upcoming', 'active', 'completed']`. Apply the same typing at the route parameter.

## Effect

- Invalid status → 422 from FastAPI's validator (instead of empty result list)
- Oversized payload → 422 (instead of wasted DB round-trip)
- Consistency with the Update schema's typing

## Verification

- 148/148 cohort tests pass
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)