### PR TITLE
fix(numeric-inputs): guard NaN on the passing-score + grade fields

### DIFF
--- a/frontend/src/components/assignment/editor/SubmissionGrader.tsx
+++ b/frontend/src/components/assignment/editor/SubmissionGrader.tsx
@@ -93,7 +93,13 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
               min={0}
               max={maxScore}
               value={grade}
-              onChange={(e) => setGrade(Number(e.target.value))}
+              // Clamp into [0..maxScore] and fall back to 0 on empty/NaN.
+              // Without this the teacher clearing the field lands NaN in
+              // state, which JSON-serialises to ``null`` and trips the
+              // backend's ``grade: int`` validation on save.
+              onChange={(e) =>
+                setGrade(Math.min(maxScore, Math.max(0, Number(e.target.value) || 0)))
+              }
               fieldSize="sm"
               className="w-20"
             />

--- a/frontend/src/components/quiz/editor/QuizHeaderFields.tsx
+++ b/frontend/src/components/quiz/editor/QuizHeaderFields.tsx
@@ -56,7 +56,13 @@ export function QuizHeaderFields({
           min={0}
           max={100}
           value={passingScore}
-          onChange={(e) => setPassingScore(Number(e.target.value))}
+          // Clamp to [0..100] and fall back to 0 on empty/NaN. Without
+          // this the field could land on NaN when the teacher clears it,
+          // which JSON-serialises to ``null`` and trips the backend's
+          // ``int`` schema on save.
+          onChange={(e) =>
+            setPassingScore(Math.min(100, Math.max(0, Number(e.target.value) || 0)))
+          }
           fieldSize="sm"
           className="w-28 text-sm"
         />


### PR DESCRIPTION
## Bug

Two number inputs assigned `Number(e.target.value)` straight to state with **no fallback**. When the user cleared the field, the empty string became `NaN`:

1. Displays as a blank input — user thinks nothing's wrong
2. JSON-serialises to `null` on save
3. Backend's `int` schema rejects with a generic 422

## Affected

- **`QuizHeaderFields.passingScore`** — teacher editing quiz passing threshold could ship `NaN` if they Cmd-A + Delete the value
- **`SubmissionGrader.grade`** — teacher grading an assignment could do the same; failed grade saves on `NaN` were the visible symptom

## Fix

Clamp into the field's documented range on every keystroke:

```tsx
Math.min(max, Math.max(0, Number(value) || 0))
```

Empty / NaN → floor; out-of-range → clamp. Matches the existing pattern already used in `QuizHeaderFields.maxAttempts`.

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)