### PR TITLE
fix(certificates): bound the public /verify/{certificate_number} path param

### DIFF
--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -310,7 +310,11 @@ def reject_certificate(
     },
 )
 def verify_certificate(
-    certificate_number: str,
+    # Real certificate numbers are ~17 chars (``CERT-`` + 12 hex). The
+    # column is ``String(50)``; cap the path param at 50 so a crafted
+    # multi-KB URL is rejected by FastAPI before the public unauth
+    # rate-limit bucket and the DB scan run.
+    certificate_number: str = Path(..., max_length=50),
     db: Session = Depends(get_db),
 ) -> CertificateVerifyResponse:
     """Unauthenticated certificate verification.


### PR DESCRIPTION
## Why

The public unauthenticated certificate-verify endpoint accepted an unbounded path parameter, then ran a Postgres SELECT against `certificate_number == <whatever>` (column type `String(50)`). A crafted multi-KB URL still gets one bucket per IP at the rate limiter (since #409), but every request still parses the URL, runs an index lookup, and returns empty.

## Fix

Cap the path param at 50 chars via `Path(..., max_length=50)`. Real certificate numbers are 17 chars (`CERT-` + 12 hex), so 50 is generous headroom for any future format tweak without rejecting legit values. FastAPI now 422s the long URL before the route runs — strictly less work per request, never blocks a real verification.

## Verification

- 86/86 certificate tests pass
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)