### PR TITLE
perf(auth): skip redundant /profiles refetch on tab focus + token refresh

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -143,10 +143,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // ``user_metadata`` which is unreliable (often stale or missing, so
         // teachers/admins get demoted to student for one render). The
         // authoritative role lives in the ``profiles`` row that
-        // ``enrichProfile`` loads. Tab refocus triggers SIGNED_IN with the
-        // same user — if we already have them loaded we refresh silently
-        // without toggling ``loading``, which avoids both a spinner flash
-        // and a brief <Gate> redirect to "/".
+        // ``enrichProfile`` loads.
+        //
+        // Supabase fires SIGNED_IN every tab focus and TOKEN_REFRESHED every
+        // ~1h, both with the *same* user. Pre-fix we re-ran ``enrichProfile``
+        // for every one of them, so the production /rest/v1/profiles logs
+        // showed duplicate GETs in the same millisecond on every tab focus.
+        // The profile row barely changes (full_name / avatar / role mutate
+        // on admin action, not on JWT refresh), so we only re-fetch when
+        // the user id actually changes — i.e. a real sign-in by a new
+        // account. Same-user events become a no-op.
         if (event === "INITIAL_SESSION") {
           if (session?.user) {
             enrichProfile(session.user.id, session.user.email ?? "")
@@ -157,14 +163,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         if (event === "SIGNED_IN" && session?.user) {
-          if (activeUserId.current !== session.user.id) {
-            setLoading(true)
+          if (activeUserId.current === session.user.id) {
+            // Tab refocus or auto-refresh with the same account — we
+            // already have the authoritative profile loaded.
+            return
           }
+          setLoading(true)
           enrichProfile(session.user.id, session.user.email ?? "")
           return
         }
 
         if (event === "TOKEN_REFRESHED" && session?.user) {
+          // Pure JWT refresh — no profile change implied. The
+          // ``services/api.ts`` token cache picks the new JWT up on its
+          // own ``onAuthStateChange`` subscription, so we don't need
+          // to do anything here.
+          if (activeUserId.current === session.user.id) return
           enrichProfile(session.user.id, session.user.email ?? "")
           return
         }


### PR DESCRIPTION
## Where this came from

Audited production Supabase API logs and found a striking pattern: every signed-in session was hitting `GET /rest/v1/profiles?id=eq.<uid>` in **pairs within the same millisecond** on every tab focus and every hourly token refresh. Same user id, same payload, dropped on the floor.

```
1779139587252 GET /profiles
1779139587251 GET /profiles   ← duplicate, 1ms apart
1779139587138 OPTIONS /profiles
1779139587137 OPTIONS /profiles ← duplicate
```

## Root cause

`AuthContext` re-ran `enrichProfile` on every:
- `SIGNED_IN` (which Supabase fires on tab refocus)
- `TOKEN_REFRESHED` (every ~1h)

…even when `activeUserId.current` already matched `session.user.id`. The pre-existing comment said *"refresh silently"* — but silent or not, it was still a duplicate network + DB round trip per session per focus event.

## Fix

Same-user `SIGNED_IN` / `TOKEN_REFRESHED` is now a no-op. Real events still flow:

| Event | Before | After |
|---|---|---|
| `INITIAL_SESSION` | enrich | enrich (unchanged) |
| `SIGNED_IN`, different user | enrich + spinner | enrich + spinner (unchanged) |
| `SIGNED_IN`, same user | enrich (silent) | **no-op** |
| `TOKEN_REFRESHED` | enrich | **no-op** |
| `SIGNED_OUT` | clear | clear (unchanged) |

The `services/api.ts` token cache has its own `onAuthStateChange` listener that updates the bearer token, so HTTP requests keep working through TOKEN_REFRESHED without anything in this layer.

## Trade-off accepted

Profile-mutating admin actions (role change, full-name edit by admin) are rare and are followed by a manual reload anyway. Losing the auto-refetch in that one edge case is acceptable for removing the per-focus DB hit pattern that appears in every single production log.

## Verification

- 12/12 AuthContext tests pass
- `tsc --noEmit` + `eslint --max-warnings 0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)