### PR TITLE
feat(ui): migrate remaining native checkboxes to Radix Checkbox + indeterminate select-all

### DIFF
--- a/frontend/src/components/quiz/QuizSubmissionsReview.tsx
+++ b/frontend/src/components/quiz/QuizSubmissionsReview.tsx
@@ -5,6 +5,7 @@ import { toast } from "@/lib/toast"
 import { getErrorDetail } from "@/lib/errorDetail"
 import type { PendingAnswer } from "@/types"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { CheckCircle2, GraduationCap, Loader2, Save, Users } from "lucide-react"
 import { formatDateTime } from "@/i18n/format"
@@ -128,11 +129,9 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
             : t("quizEditor.review.openEndedCount", { count: items.length })}
         </div>
         <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer select-none">
-          <input
-            type="checkbox"
+          <Checkbox
             checked={showGraded}
-            onChange={(e) => setShowGraded(e.target.checked)}
-            className="accent-primary"
+            onCheckedChange={(v) => setShowGraded(v === true)}
           />
           {t("quizEditor.review.showAlreadyGraded")}
         </label>

--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -2,6 +2,7 @@ import { List, type RowComponentProps } from "react-window"
 import { useTranslation } from "react-i18next"
 import { Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { RoleSelector } from "@/components/admin/RoleSelector"
 import { toProxyImage } from "@/lib/images"
 import type { UserRole } from "@/types"
@@ -55,11 +56,9 @@ function UserRow({
       }`}
     >
       <div role="cell" className="flex items-center justify-center">
-        <input
-          type="checkbox"
+        <Checkbox
           checked={selected}
-          onChange={() => onToggleSelect(u.id)}
-          className="h-4 w-4 rounded border-input"
+          onCheckedChange={() => onToggleSelect(u.id)}
           aria-label={t("admin.users.selectAriaPrefix", { name: displayName })}
         />
       </div>

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react"
 import { useTranslation } from "react-i18next"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { NativeSelect } from "@/components/ui/native-select"
 import { Button } from "@/components/ui/button"
@@ -72,6 +73,14 @@ export function UsersCard({
   const { t } = useTranslation()
   const allFilteredSelected =
     filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
+  // Three-state select-all: ``true`` when every row in the current
+  // filtered view is selected, ``"indeterminate"`` when only some are
+  // (Checkbox renders the dash glyph), ``false`` when none.
+  const selectAllState: boolean | "indeterminate" = allFilteredSelected
+    ? true
+    : selectedIds.size > 0
+      ? "indeterminate"
+      : false
 
   return (
     <Card>
@@ -130,11 +139,9 @@ export function UsersCard({
         ) : filtered.length >= USERS_VIRTUAL_THRESHOLD ? (
           <>
             <div className="flex items-center gap-3 px-3 pb-2">
-              <input
-                type="checkbox"
-                checked={allFilteredSelected}
-                onChange={onToggleSelectAll}
-                className="h-4 w-4 rounded border-input"
+              <Checkbox
+                checked={selectAllState}
+                onCheckedChange={onToggleSelectAll}
                 aria-label={t("admin.users.selectAllAria")}
               />
               <span className="text-xs text-muted-foreground">
@@ -212,6 +219,11 @@ function UsersTable({
   const { t } = useTranslation()
   const allFilteredSelected =
     filtered.length > 0 && filtered.every((u) => selectedIds.has(u.id))
+  const selectAllState: boolean | "indeterminate" = allFilteredSelected
+    ? true
+    : selectedIds.size > 0
+      ? "indeterminate"
+      : false
 
   return (
     <>
@@ -219,11 +231,9 @@ function UsersTable({
           data, same controls, larger tap targets. */}
       <div className="-mx-3 space-y-2 sm:hidden">
         <label className="mx-3 flex min-h-[44px] items-center gap-2 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={allFilteredSelected}
-            onChange={onToggleSelectAll}
-            className="h-4 w-4 rounded border-input"
+          <Checkbox
+            checked={selectAllState}
+            onCheckedChange={onToggleSelectAll}
             aria-label={t("admin.users.selectAllAria")}
           />
           <span>{t("admin.users.selectAllN", { count: filtered.length })}</span>
@@ -253,11 +263,9 @@ function UsersTable({
           <thead className="sticky top-0 z-10 bg-card">
             <tr className="border-b text-left">
               <th className="w-10 px-3 py-3">
-                <input
-                  type="checkbox"
-                  checked={allFilteredSelected}
-                  onChange={onToggleSelectAll}
-                  className="h-4 w-4 rounded border-input"
+                <Checkbox
+                  checked={selectAllState}
+                  onCheckedChange={onToggleSelectAll}
                   aria-label={t("admin.users.selectAllAria")}
                 />
               </th>
@@ -306,11 +314,10 @@ function UserCard({
       }`}
     >
       <div className="flex items-start gap-3">
-        <input
-          type="checkbox"
+        <Checkbox
+          className="mt-1.5"
           checked={selected}
-          onChange={() => onToggleSelect(user.id)}
-          className="mt-1.5 h-4 w-4 shrink-0 rounded border-input"
+          onCheckedChange={() => onToggleSelect(user.id)}
           aria-label={t("admin.users.selectAriaPrefix", { name: displayName })}
         />
         {user.avatar_url ? (
@@ -385,11 +392,9 @@ function UserRow({
       }`}
     >
       <td className="px-3 py-3">
-        <input
-          type="checkbox"
+        <Checkbox
           checked={selected}
-          onChange={() => onToggleSelect(user.id)}
-          className="h-4 w-4 rounded border-input"
+          onCheckedChange={() => onToggleSelect(user.id)}
           aria-label={t("admin.users.selectAriaPrefix", { name: displayName })}
         />
       </td>


### PR DESCRIPTION
## Why

Seven `<input type="checkbox">` instances remained after the #433 primitive landed:

| Place | Count |
|---|---|
| UsersCard (select-all in 3 layouts + per-row in 2 layouts) | 5 |
| VirtualAdminUsers (per-row in windowed list) | 1 |
| QuizSubmissionsReview ("show graded" filter) | 1 |

All migrated to `Checkbox`. Same data contract via `checked + onCheckedChange`, branded appearance, OS-native look gone.

## Bonus polish

Every "select all" control now shows the **indeterminate** state. When some-but-not-all rows are selected, it renders the dash glyph instead of a misleading unchecked. One `selectAllState` computation drives all three select-all checkboxes (virtual / mobile / desktop) consistently.

## Verification

- 261/261 tests pass
- `tsc` + `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)