### PR TITLE
fix(admin): audit-log date range was silently losing the 'from' bound

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -138,8 +138,7 @@ export default function AdminDashboard() {
             dateTo={audit.dateTo}
             onAction={audit.setAction}
             onResource={audit.setResource}
-            onDateFrom={audit.setDateFrom}
-            onDateTo={audit.setDateTo}
+            onDateRange={audit.setDateRange}
             onReset={audit.resetFilters}
             onPageChange={audit.setPage}
             onPageSizeChange={audit.setPageSize}

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -40,8 +40,10 @@ interface Props {
   dateTo: string
   onAction: (next: string) => void
   onResource: (next: string) => void
-  onDateFrom: (next: string) => void
-  onDateTo: (next: string) => void
+  /** Single atomic setter for both date bounds — the date-range picker
+   *  emits both at once, so writing them through two separate setters
+   *  raced and dropped the ``from`` bound. */
+  onDateRange: (from: string, to: string) => void
   onReset: () => void
   onPageChange: (nextPage: number) => void
   onPageSizeChange: (next: AuditPageSize) => void
@@ -78,8 +80,7 @@ export function AuditLogTab({
   dateTo,
   onAction,
   onResource,
-  onDateFrom,
-  onDateTo,
+  onDateRange,
   onReset,
   onPageChange,
   onPageSizeChange,
@@ -157,10 +158,7 @@ export function AuditLogTab({
             {() => (
               <DateRangePicker
                 value={{ from: dateFrom, to: dateTo }}
-                onChange={({ from, to }) => {
-                  onDateFrom(from)
-                  onDateTo(to)
-                }}
+                onChange={({ from, to }) => onDateRange(from, to)}
                 active={Boolean(dateFrom || dateTo)}
               />
             )}

--- a/frontend/src/pages/Admin/dashboard/useAdminAudit.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminAudit.ts
@@ -138,8 +138,15 @@ export function useAdminAudit({ enabled }: UseAdminAuditArgs) {
     dateTo,
     setAction: (v: string) => updateAudit({ ax: v || null }, { resetPage: true }),
     setResource: (v: string) => updateAudit({ ar: v || null }, { resetPage: true }),
-    setDateFrom: (v: string) => updateAudit({ af: v || null }, { resetPage: true }),
-    setDateTo: (v: string) => updateAudit({ at: v || null }, { resetPage: true }),
+    // Atomic two-key write. The DateRangePicker fires both bounds in
+    // one handler; calling ``setDateFrom`` then ``setDateTo`` back-to-
+    // back used to lose the first one — both call ``setSearchParams``,
+    // and within a single event the second invocation reads the same
+    // ``prev`` URLSearchParams snapshot as the first, so the second
+    // write overwrites the first. Folding the two keys into one
+    // ``updateAudit`` call is the fix.
+    setDateRange: (from: string, to: string) =>
+      updateAudit({ af: from || null, at: to || null }, { resetPage: true }),
     setPage: (next: number) => updateAudit({ ap: next <= 1 ? null : String(next) }),
     // Setting page size resets to page 1: the offset that was valid
     // for the old size is meaningless under the new one.


### PR DESCRIPTION
## The bug Vadym hit

"В вкладке логов date picker не работает и date range не работает."

Tracing the wiring:

1. `DateRangePicker.onChange({from, to})` fires **both** bounds in one handler
2. The handler did `onDateFrom(from)` then `onDateTo(to)`
3. Each setter calls `setSearchParams((prev) => ...)`
4. **Within a single event, React Router's `setSearchParams` does NOT batch like `useState`.** The second invocation reads the same `prev` URLSearchParams snapshot the first did — so it writes `at=...` over a base that's still missing `af=...`
5. Net effect: only `at` lands, `af` is dropped
6. Query reads `dateFrom` from `af` → empty string → no lower bound applied. Filter looks broken.

## Fix

Collapse the two setters into a single `setDateRange(from, to)` that writes both keys in one `updateAudit` call (one `setSearchParams` call). Same shape `CohortsTab.setStartRange` already uses correctly for the same reason.

`setDateFrom` / `setDateTo` removed from the hook's public surface — no callers outside the range picker had ever used them.

## Verification

- 261/261 frontend tests pass
- `tsc` + `eslint` clean
- The audit-log filter now actually narrows by date range when the picker fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)