### PR TITLE
feat(admin): role filter + role-distribution chip strip on the users table

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1412,6 +1412,8 @@
       "deleteTooltip": "Delete user",
       "avatarAltPrefix": "{{name}} avatar",
       "searchPlaceholder": "Search by name or email…",
+      "roleFilterAria": "Filter by role",
+      "roleFilterAll": "All roles",
       "thName": "Name",
       "thEmail": "Email",
       "thRole": "Role",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1407,6 +1407,8 @@
       "deleteTooltip": "Удалить пользователя",
       "avatarAltPrefix": "Аватар {{name}}",
       "searchPlaceholder": "Поиск по имени или email…",
+      "roleFilterAria": "Фильтр по роли",
+      "roleFilterAll": "Все роли",
       "thName": "Имя",
       "thEmail": "Email",
       "thRole": "Роль",

--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -105,6 +105,9 @@ export default function AdminDashboard() {
             bulkUpdating={overview.bulkUpdating}
             updatingId={overview.updatingId}
             currentUserId={user?.id}
+            roleFilter={overview.roleFilter}
+            roleCounts={overview.roleCounts}
+            onRoleFilterChange={overview.setRoleFilter}
             onSearchInputChange={overview.setSearchInput}
             onBulkRoleChange={overview.setBulkRole}
             onApplyBulkRole={overview.handleBulkRoleChange}

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 import { Users, Search, Trash2 } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import PageSpinner from "@/components/ui/PageSpinner"
@@ -32,6 +33,9 @@ const VirtualAdminUsers = lazy(() => import("../VirtualAdminUsers"))
  */
 const USERS_VIRTUAL_THRESHOLD = 50
 
+/** Empty string = "all roles" (no filter). */
+export type RoleFilterValue = "" | "admin" | "teacher" | "pending_teacher" | "student"
+
 interface Props {
   users: ProfileRow[]
   filtered: ProfileRow[]
@@ -44,6 +48,9 @@ interface Props {
   bulkUpdating: boolean
   updatingId: string | null
   currentUserId: string | undefined
+  roleFilter: RoleFilterValue
+  roleCounts: Record<UserRole, number>
+  onRoleFilterChange: (next: RoleFilterValue) => void
   onSearchInputChange: (next: string) => void
   onBulkRoleChange: (next: UserRole) => void
   onApplyBulkRole: () => void
@@ -67,6 +74,9 @@ export function UsersCard({
   bulkUpdating,
   updatingId,
   currentUserId,
+  roleFilter,
+  roleCounts,
+  onRoleFilterChange,
   onSearchInputChange,
   onBulkRoleChange,
   onApplyBulkRole,
@@ -128,16 +138,76 @@ export function UsersCard({
               </Button>
             </div>
           )}
-          <div className="relative w-full max-w-xs">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
-            <Input
-              placeholder={t("admin.users.searchPlaceholder")}
-              value={searchInput}
-              onChange={(e) => onSearchInputChange(e.target.value.slice(0, searchMaxLength))}
-              maxLength={searchMaxLength}
-              className="pl-9"
-            />
+          <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+            {/* Role filter — narrows the table to a single role.
+                ``"all"`` ↔ empty string in the URL; same wrapper trick
+                the cohort / audit Selects use. */}
+            <Select
+              value={roleFilter || "all"}
+              onValueChange={(v) =>
+                onRoleFilterChange((v === "all" ? "" : v) as RoleFilterValue)
+              }
+            >
+              <SelectTrigger
+                size="sm"
+                aria-label={t("admin.users.roleFilterAria")}
+                className={cn(
+                  "h-9 w-full sm:w-44",
+                  roleFilter && "border-primary/40 ring-1 ring-primary/40",
+                )}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t("admin.users.roleFilterAll")}</SelectItem>
+                <SelectItem value="admin">{t("roles.admin")}</SelectItem>
+                <SelectItem value="teacher">{t("roles.teacher")}</SelectItem>
+                <SelectItem value="pending_teacher">{t("roles.pendingTeacher")}</SelectItem>
+                <SelectItem value="student">{t("roles.student")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <div className="relative w-full max-w-xs">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
+              <Input
+                placeholder={t("admin.users.searchPlaceholder")}
+                value={searchInput}
+                onChange={(e) => onSearchInputChange(e.target.value.slice(0, searchMaxLength))}
+                maxLength={searchMaxLength}
+                className="pl-9"
+              />
+            </div>
           </div>
+        </div>
+        {/* Role distribution chip strip — clickable shortcuts for the
+            filter that double as a tenant-shape snapshot. Hides
+            zero-count roles so the strip stays meaningful on small
+            tenants. Active filter gets the primary fill. */}
+        <div className="flex flex-wrap items-center gap-1.5 text-xs">
+          {(["admin", "teacher", "pending_teacher", "student"] as const).map((role) => {
+            if (roleCounts[role] === 0) return null
+            const active = roleFilter === role
+            return (
+              <button
+                key={role}
+                type="button"
+                onClick={() => onRoleFilterChange(active ? "" : role)}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 transition-colors",
+                  active
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border hover:border-primary/40 hover:bg-muted",
+                )}
+              >
+                <span>{t(`roles.${role === "pending_teacher" ? "pendingTeacher" : role}`)}</span>
+                <span className={cn(
+                  "tabular-nums",
+                  active ? "opacity-90" : "text-muted-foreground"
+                )}>
+                  {roleCounts[role]}
+                </span>
+              </button>
+            )
+          })}
         </div>
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { useSearchParams } from "react-router-dom"
 import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
 import { useAsyncData } from "@/hooks/useAsyncData"
 import { coursesService } from "@/services/courses"
@@ -10,6 +11,13 @@ import { useConfirm } from "@/components/ui/alert-dialog"
 import { ROLES, type UserRole } from "@/types"
 import type { AdminCert } from "./PendingCertsCard"
 import { ROLE_I18N_KEY, type AdminStats, type ProfileRow } from "./constants"
+
+const ROLE_FILTER_VALUES = ["admin", "teacher", "pending_teacher", "student"] as const
+type RoleFilter = (typeof ROLE_FILTER_VALUES)[number] | ""
+
+function isRoleFilter(v: string): v is (typeof ROLE_FILTER_VALUES)[number] {
+  return (ROLE_FILTER_VALUES as readonly string[]).includes(v)
+}
 
 interface UseAdminOverviewArgs {
   /** Current signed-in user id — excluded from bulk operations and delete confirmations. */
@@ -26,6 +34,7 @@ interface UseAdminOverviewArgs {
 export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
   const confirm = useConfirm()
   const { t } = useTranslation()
+  const [params, setParams] = useSearchParams()
 
   const {
     input: searchInput,
@@ -33,6 +42,25 @@ export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
     value: urlQuery,
     maxLength: searchMaxLength,
   } = useDebouncedSearchParam()
+
+  // URL-state role filter so a bookmarked admin link round-trips with
+  // its filter. Reject any value not in the allow-list (defaults to "").
+  const rawRoleFilter = params.get("role") ?? ""
+  const roleFilter: RoleFilter = isRoleFilter(rawRoleFilter) ? rawRoleFilter : ""
+  const setRoleFilter = useCallback(
+    (next: RoleFilter) => {
+      setParams(
+        (prev) => {
+          const n = new URLSearchParams(prev)
+          if (next) n.set("role", next)
+          else n.delete("role")
+          return n
+        },
+        { replace: true },
+      )
+    },
+    [setParams],
+  )
 
   const [users, setUsers] = useState<ProfileRow[]>([])
   const [stats, setStats] = useState<AdminStats>({ users: 0, courses: 0, enrollments: 0 })
@@ -89,11 +117,33 @@ export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
 
   const filtered = useMemo(() => {
     const q = urlQuery.trim().toLowerCase()
-    if (!q) return users
-    return users.filter(
-      (u) => u.full_name?.toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
-    )
-  }, [users, urlQuery])
+    return users.filter((u) => {
+      if (roleFilter && u.role !== roleFilter) return false
+      if (q && !u.full_name?.toLowerCase().includes(q) && !u.email.toLowerCase().includes(q)) {
+        return false
+      }
+      return true
+    })
+  }, [users, urlQuery, roleFilter])
+
+  /**
+   * Per-role counts across the whole user list (NOT filtered) — drives
+   * the chip strip above the search input so the admin sees the
+   * tenant's role distribution at a glance without flipping the
+   * filter through every value.
+   */
+  const roleCounts = useMemo(() => {
+    const counts: Record<UserRole, number> = {
+      admin: 0,
+      teacher: 0,
+      pending_teacher: 0,
+      student: 0,
+    }
+    for (const u of users) {
+      if (u.role in counts) counts[u.role as UserRole] += 1
+    }
+    return counts
+  }, [users])
 
   const userMap = useMemo(() => {
     const map: Record<string, string> = {}
@@ -318,6 +368,9 @@ export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
     setSearchInput,
     urlQuery,
     searchMaxLength,
+    roleFilter,
+    setRoleFilter,
+    roleCounts,
     reload,
     setBulkRole,
     handleRoleChange,


### PR DESCRIPTION
## Why

Admin overview let you search users by name/email but couldn't narrow to a single role — Vadym asked for *«ещё какие-то фильтры»* as part of the full admin panel push.

## What

Two coordinated additions:

### 1. URL-state `?role=` filter

`admin` / `teacher` / `pending_teacher` / `student`, validated against the allow-list so a crafted value lands on "all roles" instead of breaking the query. New Select in the card header (matches the cohort / audit filter Selects).

### 2. Role-distribution chip strip above the search input

Each chip = role name + per-tenant count, computed against the **full user list** (not the filtered slice — the chips are the snapshot that lets the admin see the tenant's shape at a glance).

- Click a chip to apply that role as the active filter
- Click the same chip again to clear
- Zero-count roles hidden so the strip stays meaningful on small tenants

Both controls feed the same `roleFilter` URL param, so an admin can bookmark `?role=pending_teacher` to land directly on the queue of people waiting for teacher approval.

The existing `selectedIds` narrowing effect already drops hidden rows from the selection set, so flipping the filter resets bulk operations to only-visible rows automatically.

## Verification

- 261/261 tests pass
- `tsc` + `eslint` clean
- i18n parity: 1341 en / 1395 ru

🤖 Generated with [Claude Code](https://claude.com/claude-code)