### PR TITLE
chore(layout): re-indent header tooltip blocks left over from #195

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -11,7 +11,7 @@ import { User as UserIcon, Menu } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import { cn } from "@/lib/utils"
 import { EDITORIAL_EASE } from "@/lib/motion"
-import { Tooltip, TooltipContent,TooltipTrigger } from "@/components/ui/tooltip"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
 const UNDERLINE_LAYOUT_ID = "header-active-underline"
 
@@ -144,41 +144,40 @@ export default function Header() {
                   <Suspense fallback={<div className="h-7 w-7 shrink-0" aria-hidden />}>
                     <NotificationBell />
                   </Suspense>
-<Tooltip>
-  <TooltipTrigger asChild>
-    <Link to="/profile" className="inline-flex">
-      <PressFeedback className="inline-flex">
-        <Button
-          variant={isActive("/profile") ? "secondary" : "ghost"}
-          size="sm"
-          className="h-7 w-7 shrink-0 rounded-full p-0"
-          aria-label={t("header.profile")}
-        >
-          {user.avatar_url ? (
-            <img
-              src={toProxyImage(user.avatar_url)}
-              alt=""
-              className="h-6 w-6 rounded-full object-cover"
-              onError={(e) => {
-                e.currentTarget.style.display = "none"
-              }}
-            />
-          ) : (
-            <UserIcon
-              className="h-3.5 w-3.5"
-              strokeWidth={ICON_STROKE}
-              aria-hidden="true"
-            />
-          )}
-        </Button>
-      </PressFeedback>
-    </Link>
-  </TooltipTrigger>
-
-  <TooltipContent side="bottom" sideOffset={8}>
-   <p>{t("header.profile")}</p>
-  </TooltipContent>
-</Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Link to="/profile" className="inline-flex">
+                        <PressFeedback className="inline-flex">
+                          <Button
+                            variant={isActive("/profile") ? "secondary" : "ghost"}
+                            size="sm"
+                            className="h-7 w-7 shrink-0 rounded-full p-0"
+                            aria-label={t("header.profile")}
+                          >
+                            {user.avatar_url ? (
+                              <img
+                                src={toProxyImage(user.avatar_url)}
+                                alt=""
+                                className="h-6 w-6 rounded-full object-cover"
+                                onError={(e) => {
+                                  e.currentTarget.style.display = "none"
+                                }}
+                              />
+                            ) : (
+                              <UserIcon
+                                className="h-3.5 w-3.5"
+                                strokeWidth={ICON_STROKE}
+                                aria-hidden="true"
+                              />
+                            )}
+                          </Button>
+                        </PressFeedback>
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" sideOffset={8}>
+                      <p>{t("header.profile")}</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </>
               ) : (
                 <>

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -80,53 +80,52 @@ export default function NotificationBell({
   return (
     <div className={cn("relative", isSheet && "w-full")}>
       <Tooltip>
-  <TooltipTrigger asChild>
-      <Button
-        ref={buttonRef}
-        variant="ghost"
-        size="sm"
-        className={cn(
-          "relative shadow-none ring-offset-background focus-visible:ring-1",
-          isNavRow
-            ? "flex h-auto min-h-10 w-full flex-row items-center justify-between rounded-md px-3 py-2 text-left text-sm font-normal hover:bg-muted"
-            : "p-0",
-          !isNavRow && isSheet && "h-10 min-h-10 w-10 min-w-10",
-          !isNavRow && !isSheet && "h-7 w-7",
-          isNavRow && open && "bg-muted/80",
-        )}
-        onClick={() => setOpen((prev) => !prev)}
-        aria-label={isNavRow ? undefined : t("notifications.menuAriaLabel")}
-        aria-expanded={open}
-        aria-haspopup="true"
-      >
-        {isNavRow ? (
-          <>
-            <span className="text-sm font-medium text-foreground">{t("notifications.title")}</span>
-            <span className="flex min-w-[1.25rem] items-center justify-end">
-              {unreadCount > 0 ? (
-                <span className="rounded-full bg-destructive px-2 py-0.5 text-xs font-semibold tabular-nums text-destructive-foreground">
-                  {unreadCount > 99 ? "99+" : unreadCount}
-                </span>
-              ) : null}
-            </span>
-          </>
-        ) : (
-          <>
-            <Bell className="h-3.5 w-3.5" strokeWidth={1.75} />
-            {unreadCount > 0 && (
-              <span className="absolute -right-0.5 -top-0.5 flex min-h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-xs font-bold leading-none text-destructive-foreground">
-                {unreadCount > 99 ? "99+" : unreadCount}
-              </span>
+        <TooltipTrigger asChild>
+          <Button
+            ref={buttonRef}
+            variant="ghost"
+            size="sm"
+            className={cn(
+              "relative shadow-none ring-offset-background focus-visible:ring-1",
+              isNavRow
+                ? "flex h-auto min-h-10 w-full flex-row items-center justify-between rounded-md px-3 py-2 text-left text-sm font-normal hover:bg-muted"
+                : "p-0",
+              !isNavRow && isSheet && "h-10 min-h-10 w-10 min-w-10",
+              !isNavRow && !isSheet && "h-7 w-7",
+              isNavRow && open && "bg-muted/80",
             )}
-          </>
-        )}
-      </Button>
+            onClick={() => setOpen((prev) => !prev)}
+            aria-label={isNavRow ? undefined : t("notifications.menuAriaLabel")}
+            aria-expanded={open}
+            aria-haspopup="true"
+          >
+            {isNavRow ? (
+              <>
+                <span className="text-sm font-medium text-foreground">{t("notifications.title")}</span>
+                <span className="flex min-w-[1.25rem] items-center justify-end">
+                  {unreadCount > 0 ? (
+                    <span className="rounded-full bg-destructive px-2 py-0.5 text-xs font-semibold tabular-nums text-destructive-foreground">
+                      {unreadCount > 99 ? "99+" : unreadCount}
+                    </span>
+                  ) : null}
+                </span>
+              </>
+            ) : (
+              <>
+                <Bell className="h-3.5 w-3.5" strokeWidth={1.75} />
+                {unreadCount > 0 && (
+                  <span className="absolute -right-0.5 -top-0.5 flex min-h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-xs font-bold leading-none text-destructive-foreground">
+                    {unreadCount > 99 ? "99+" : unreadCount}
+                  </span>
+                )}
+              </>
+            )}
+          </Button>
         </TooltipTrigger>
-
-  <TooltipContent side="bottom">
-    <p>{t("header.notifications")}</p>
-  </TooltipContent>
-</Tooltip>
+        <TooltipContent side="bottom">
+          <p>{t("header.notifications")}</p>
+        </TooltipContent>
+      </Tooltip>
 
       {open && (
         <NotificationPanel


### PR DESCRIPTION
## Summary

Pure formatting cleanup of leftovers from #195 — no behavior change, no markup change, no a11y change.

- `Header.tsx`: the `<Tooltip>` wrapping the profile button was flush-left while surrounding JSX sat at 18 spaces. Re-indented in place. Also fixed `TooltipContent,TooltipTrigger` → `TooltipContent, TooltipTrigger` in the import (missing space).
- `NotificationBell.tsx`: same story — `<Tooltip>` block was a mix of 2-, 6-, and 8-space indents inside a 4-space-base component. Re-indented to match the rest of the file.

The originally-introduced regressions from #195 (double `<TooltipProvider>` wrap, missing i18n keys, dead `Tooltip` import in `ScrollToTop`, `z-50 → z-40` header stacking) were all already cleaned up in follow-up commits between then and now. This PR is what's still left visible in `git blame`.

## Test plan

- [x] `npm run lint` — zero warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm run i18n:check` — bundles in parity
- [x] `npx vitest run src/components/layout` — 13/13 passing
- [ ] Smoke: hover profile + bell in desktop header, hover mobile menu trigger — tooltip text matches the i18n strings