### PR TITLE
fix(completion): scope celebration localStorage flag by user_id

### DIFF
--- a/frontend/src/pages/Course/detail/EnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/EnrolledView.tsx
@@ -58,28 +58,31 @@ export function EnrolledView({
 
   // Course-completion celebration: when a student lands on this view
   // with progress at 100% for the first time on this device, open the
-  // celebration dialog. We guard with a per-course localStorage flag
-  // so the moment doesn't re-fire on every revisit, and we set the
-  // flag on close (not on open) so a closed-before-render edge case
-  // doesn't silently swallow the moment.
+  // celebration dialog. We guard with a per-user-per-course
+  // localStorage flag — scoped by ``user_id`` so a second account on
+  // a shared device still gets its own celebration moment for a
+  // course the first user already finished. The flag is written on
+  // close (not on open) so a closed-before-render edge case doesn't
+  // silently swallow the moment.
+  const celebrationFlagKey = `equip.celebrated.${enrollment.user_id}.${course.id}`
+
   useEffect(() => {
-    if (enrollment.progress < 100) return
+    if (!(enrollment.progress >= 100)) return
     if (typeof window === "undefined") return
-    const flagKey = `equip.celebrated.${course.id}`
-    if (window.localStorage.getItem(flagKey) === "1") return
+    if (window.localStorage.getItem(celebrationFlagKey) === "1") return
     setShowCompletion(true)
-  }, [enrollment.progress, course.id])
+  }, [enrollment.progress, celebrationFlagKey])
 
   const handleCloseCompletion = useCallback(() => {
     setShowCompletion(false)
     if (typeof window === "undefined") return
     try {
-      window.localStorage.setItem(`equip.celebrated.${course.id}`, "1")
+      window.localStorage.setItem(celebrationFlagKey, "1")
     } catch {
       // localStorage can be denied in some private-browsing contexts;
       // in that case the dialog will re-show on next visit. Acceptable.
     }
-  }, [course.id])
+  }, [celebrationFlagKey])
 
   const handleDownload = useCallback(async (path: string) => {
     setDownloadingPath(path)


### PR DESCRIPTION
## Summary

Follow-up to #445.

The localStorage flag used the bare `equip.celebrated.{courseId}` key, which meant a second account on a shared device would have its celebration silently suppressed by the first account's flag. Example: sibling on a shared laptop finishes the same course — never sees the dialog.

Scope the key by `enrollment.user_id` so each account gets its own celebration per course:

```diff
- const flagKey = `equip.celebrated.${course.id}`
+ const flagKey = `equip.celebrated.${enrollment.user_id}.${course.id}`
```

Also tightens the threshold check from `progress < 100` → `progress >= 100` so a NaN payload from a broken server response can't bypass the early-return and open the dialog with garbage state.

Old keys remain in localStorage as harmless dead weight under the unscoped name; no migration needed since the new key namespace is disjoint.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/components/course` — 14/14
- [ ] Smoke (preview): account A finishes course, dismisses dialog. Sign out, sign in as account B, enroll + finish same course — dialog opens for B

🤖 Generated with [Claude Code](https://claude.com/claude-code)