### PR TITLE
fix(tour): seven audit findings — dark-mode overlay, double-fire, clipped outline, mobile width, perf, motion, active-interaction

### DIFF
--- a/frontend/src/hooks/useUserTour.ts
+++ b/frontend/src/hooks/useUserTour.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { Driver } from "driver.js"
 import { createEditorialTour, type TourStep } from "@/lib/tour"
@@ -85,7 +85,9 @@ function writeSeen(userId: string | undefined, tourId: string): void {
  * "user has been exposed to this once, don't pester them again". A
  * manual ``start()`` call from a "Take a tour" trigger always opens
  * the tour regardless of the flag, so the user can re-watch on
- * demand.
+ * demand. Manual start also cancels any pending auto-start timer so
+ * the user doesn't see a brief double-fire if they click within the
+ * autoStartDelayMs window.
  */
 export function useUserTour({
   tourId,
@@ -99,6 +101,7 @@ export function useUserTour({
   const { t } = useTranslation()
   const driverRef = useRef<Driver | null>(null)
   const firedRef = useRef(false)
+  const timerRef = useRef<number | null>(null)
   const stepsRef = useRef(steps)
   useEffect(() => {
     stepsRef.current = steps
@@ -106,7 +109,16 @@ export function useUserTour({
 
   const userId = user?.id
   const userRole = user?.role
-  const alreadySeen = readSeen(userId, tourId)
+  // ``alreadySeen`` is read once into state on mount instead of every
+  // render. Without this, every keystroke / sort change on a
+  // tour-hosting page (gradebook, etc.) would hit
+  // ``window.localStorage.getItem`` synchronously on the render path.
+  // The ``userId`` change re-reads (different account, possibly
+  // different flag) via the effect below.
+  const [alreadySeen, setAlreadySeen] = useState(() => readSeen(userId, tourId))
+  useEffect(() => {
+    setAlreadySeen(readSeen(userId, tourId))
+  }, [userId, tourId])
 
   const buildDriver = useCallback((): Driver => {
     return createEditorialTour({
@@ -128,6 +140,14 @@ export function useUserTour({
   }, [t, tourId, userId])
 
   const start = useCallback(() => {
+    // Manual start counts as "fired" — block any pending auto-start
+    // timer AND mark the surface as fired so the auto effect can't
+    // re-trigger after the user has already opened the tour by hand.
+    firedRef.current = true
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
     // Always rebuild — labels depend on the active i18n language, and
     // a stale Driver from a previous locale would render English
     // buttons on a Russian session (or vice versa).
@@ -148,19 +168,27 @@ export function useUserTour({
     if (ready === false) return
 
     firedRef.current = true
-    const timer = window.setTimeout(start, autoStartDelayMs)
-    return () => window.clearTimeout(timer)
-    // ``alreadySeen`` is a snapshot read at mount; deliberately not in
-    // deps so a mid-tour localStorage write doesn't re-fire. ``ready``
-    // IS in deps so data-dependent pages can flip from false → true
-    // after their fetch lands.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoStart, autoStartDelayMs, userId, userRole, ready, steps.length, start])
+    timerRef.current = window.setTimeout(start, autoStartDelayMs)
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+    // ``alreadySeen`` IS in deps (unlike before) because we now keep
+    // it in state — a flag write from another tab via storage event
+    // would still not invalidate, but the in-tab user-id swap that
+    // also re-reads the flag now properly re-evaluates.
+  }, [autoStart, autoStartDelayMs, userId, userRole, ready, steps.length, alreadySeen, skipRoles, start])
 
   useEffect(() => {
     return () => {
       driverRef.current?.destroy()
       driverRef.current = null
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
     }
   }, [])
 

--- a/frontend/src/lib/tour.ts
+++ b/frontend/src/lib/tour.ts
@@ -28,6 +28,26 @@ interface CreateTourOpts {
 }
 
 /**
+ * Read the current ``prefers-reduced-motion`` setting at call time.
+ *
+ * Honest fallback: ``window.matchMedia`` is missing in non-DOM
+ * environments (SSR, vitest jsdom without the polyfill), so we treat
+ * absence as "no preference" and let motion play. We re-read on every
+ * tour construction rather than caching, so the OS-level setting
+ * change reaches the next tour without a page reload.
+ */
+function reducedMotionPreferred(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false
+  }
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  } catch {
+    return false
+  }
+}
+
+/**
  * Build a driver.js tour with the editorial CSS class wired in and
  * localised navigation buttons.
  *
@@ -50,13 +70,22 @@ export function createEditorialTour({
   // which callback to fire. driver.js's own state.activeIndex isn't
   // reliable on the destroy hook — it gets reset before we see it.
   let reachedEnd = false
+  const animate = !reducedMotionPreferred()
 
   const config: Config = {
     steps: steps as DriveStep[],
-    animate: true,
+    // Both the SVG stage morph and the popover fade are gated on this
+    // single flag — driver.js doesn't expose them separately, and the
+    // CSS media query catches the popover fade as a defense in depth.
+    animate,
     smoothScroll: true,
     allowClose: true,
-    overlayColor: "hsl(var(--foreground))",
+    // The spotlit element should READ as the subject of the popover,
+    // not be a click-trap that scrolls the page underneath while the
+    // user is reading. Without this, the catalog-search step would
+    // accept keystrokes and reposition the spotlight on every char.
+    disableActiveInteraction: true,
+    overlayColor: "hsl(265 28% 13%)",
     overlayOpacity: 0.55,
     stagePadding: 6,
     stageRadius: 8,
@@ -67,6 +96,10 @@ export function createEditorialTour({
     doneBtnText: labels.done,
     popoverClass: "editorial-tour-popover",
     onNextClick: (_el, _step, { state, driver: d }) => {
+      // Last step's Next button doubles as Done — driver.js relabels
+      // it via ``doneBtnText`` but still fires the same onNextClick.
+      // Flag reachedEnd here so onDestroyed can distinguish a true
+      // completion from an Esc/X/overlay dismissal.
       if (state.activeIndex !== undefined && state.activeIndex + 1 >= steps.length) {
         reachedEnd = true
       }

--- a/frontend/src/styles/editorial-tour.css
+++ b/frontend/src/styles/editorial-tour.css
@@ -22,7 +22,11 @@
   border-radius: 0.5rem;
   padding: 1.125rem 1.25rem;
   box-shadow: 0 12px 32px hsl(var(--foreground) / 0.18);
-  min-width: 280px;
+  /* ``min-width`` was a hard 280px which overflowed the 320px iPhone
+     SE viewport once the container's safe-area gutter was applied.
+     ``clamp`` keeps the desktop minimum but lets mobile shrink to fit
+     the actual viewport minus a small breathing gutter. */
+  min-width: clamp(240px, calc(100vw - 2rem), 280px);
   max-width: 360px;
 }
 
@@ -159,18 +163,22 @@
 }
 
 /* Calm the overlay — driver's default 70% black sucks the warmth out
-   of the page. We use the project's foreground token at lower alpha
-   so the spotlit element still reads as part of the same surface. */
+   of the page. We use a fixed dark token (not ``--foreground``) so
+   the scrim stays dark in BOTH themes. The earlier
+   ``hsl(var(--foreground))`` resolved to a *light* cream on dark
+   mode and inverted the overlay into a white wash. */
 .driver-overlay {
-  fill: hsl(var(--foreground)) !important;
+  fill: hsl(265 28% 13%) !important;
   opacity: 0.55 !important;
 }
 
 /* Stage outline (the rounded rectangle around the highlighted element)
-   in the sage accent so it shares the popover's left-stripe colour. */
-.driver-active-element {
-  box-shadow: 0 0 0 4px hsl(var(--accent) / 0.25);
-}
+   was previously a 4px box-shadow on ``.driver-active-element``. Box
+   shadows get clipped by any ancestor with ``overflow:hidden`` — a
+   common pattern in dashboard cards — so the accent ring was being
+   shaved off on multiple surfaces. We rely on driver.js's own
+   ``stagePadding`` cutout to delineate the spotlit element instead;
+   no extra outline that can be clipped. */
 
 /* Respect the user's reduced-motion preference: kill the popover fade
    so nothing animates. driver.js's animate=false skips the SVG


### PR DESCRIPTION
## Summary

Strict pre-launch audit of the tour feature (#444 / #447 / #448) turned up seven real issues. All fixed in one PR; user is about to test live on prod.

### Critical

1. **Dark-mode overlay was inverted.** `.driver-overlay { fill: hsl(var(--foreground)) }` resolved to near-white on dark mode — the dim-the-page scrim turned into a *light wash*, spotlight read as a dark hole on a bright surround. Switched to a fixed `hsl(265 28% 13%)` so the scrim stays dark in both themes.

2. **Manual + auto double-fire.** Clicking "Take a tour" on the WelcomeCard within the `autoStartDelayMs` (350 ms) window triggered the click + then the queued auto-start, both calling `start()` → visible flicker as the driver destroyed mid-render and rebuilt from step 0. Added `timerRef` to the hook; `start()` now sets `firedRef` AND clears the pending timer.

3. **Stage outline was clipped.** The 4px `box-shadow` accent ring on `.driver-active-element` got shaved by every ancestor with `overflow:hidden` — common on dashboard cards. Dropped the custom outline; rely on driver.js's own `stagePadding` cutout for the visual delineation.

### High

4. **`readSeen` ran on every render.** Synchronous `localStorage.getItem` on the render path, called on every keystroke on tour-hosting pages (gradebook, student progress). Moved to `useState` initialiser + effect that re-reads on `userId` change.

### Medium

5. **Mobile popover overflowed 320 px viewports.** `min-width: 280px` + viewport + padding + safe-area pushed it past the edge. Switched to `min-width: clamp(240px, calc(100vw - 2rem), 280px)`.

6. **`disableActiveInteraction` was off.** Typing into the spotlit `catalog-search` field scrolled the catalog under the popover, repositioning the spotlight on every keystroke. Enabled globally — during a tour the user is reading, not interacting.

7. **`prefers-reduced-motion` only killed the popover fade.** The SVG stage morph between targets still animated. `animate` in driver.js's config gates both; now wired to `window.matchMedia("(prefers-reduced-motion: reduce)").matches` at tour-construction time. CSS media query stays as defense-in-depth.

### What's NOT fixed (deferred / acceptable)

- **Locale change mid-tour**: open tour keeps its build-time labels. Rebuild-on-start handles the next tour; mid-tour stale labels are an edge case.
- **Focus trap / aria-modal**: a11y improvement. driver.js doesn't ship it; non-trivial to wire correctly. Tracked separately.
- **Onclose-on-last-step distinction**: `onSkipped` fires if user presses Esc on the last step instead of clicking "Done". Both still write the seen flag — only the analytics signal differs.
- **Navigation-mid-tour writes seen flag**: unmount cleanup destroys driver, which fires `onSkipped → writeSeen`. Acceptable per the "one exposure is enough" rule in the hook docstring.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run i18n:check` — bundles in parity
- [x] `npm run build` — clean (driver.js still ~5KB in config chunk)
- [x] Full test suite — 278/278
- [ ] Preview smoke (dark theme): tour overlay reads as dim, not bright
- [ ] Preview smoke (mobile): popover fits the iPhone-SE viewport without horizontal scroll
- [ ] Preview smoke (catalog search step): typing in the search field is suppressed; popover doesn't reposition jitterily
- [ ] Preview smoke (WelcomeCard "Take a tour"): clicking within 350ms of mount does NOT show flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)