### PR TITLE
fix(tour): kill the 'another 5 steps' trailer after grand-tour ends

### DIFF
--- a/frontend/src/hooks/__tests__/useUserTour.test.tsx
+++ b/frontend/src/hooks/__tests__/useUserTour.test.tsx
@@ -141,6 +141,46 @@ describe("useUserTour", () => {
     expect(createTourMock).toHaveBeenCalledTimes(1)
   })
 
+  it("bails when the grand tour writes its suppression flag mid-mount (no 'another 5 steps' after grand-tour end)", async () => {
+    // Regression for the per-page-after-grand-tour bug: per-page
+    // hook for ``student-dashboard-v1`` mounts before grand tour
+    // ends. Grand tour's ``onDone`` writes the per-page seen flag
+    // to localStorage and flips ``grandTourActive`` false. Before
+    // this fix, the per-page hook kept its mount-time
+    // ``alreadySeen=false`` state and fired its own 5-step dashboard
+    // tour 350 ms after grand tour ended.
+    const { setGrandTourActive } = await import("@/lib/tourState")
+    vi.useFakeTimers()
+    try {
+      // 1. Grand tour starts → signal flips true
+      act(() => {
+        setGrandTourActive(true)
+      })
+      // 2. Per-page hook mounts during grand tour (alreadySeen=false
+      //    at this moment, no flag in localStorage yet)
+      renderWithUser("user-a", "student-dashboard-v1")
+      // 3. Grand tour ends: suppression flag IS written
+      //    BEFORE the signal flip — same order as in useGrandTour
+      window.localStorage.setItem(
+        "equip.tour.seen.user-a.student-dashboard-v1",
+        "1",
+      )
+      act(() => {
+        setGrandTourActive(false)
+      })
+      // 4. Advance past the auto-start delay
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500)
+      })
+      // Per-page tour MUST NOT fire — alreadySeen got resynced from
+      // the freshly-written flag when grandTourActive flipped.
+      expect(driveMock).toHaveBeenCalledTimes(0)
+    } finally {
+      setGrandTourActive(false)
+      vi.useRealTimers()
+    }
+  })
+
   it("fires the auto-tour AFTER first-run flow closes (no firedRef poisoning)", async () => {
     // Regression for the firedRef bug: on initial mount,
     // firstRunActive=false (FirstRunFlow's effect hasn't run yet) so

--- a/frontend/src/hooks/useUserTour.ts
+++ b/frontend/src/hooks/useUserTour.ts
@@ -116,29 +116,33 @@ export function useUserTour({
 
   const userId = user?.id
   const userRole = user?.role
-  // ``alreadySeen`` is read once into state on mount instead of every
-  // render. Without this, every keystroke / sort change on a
-  // tour-hosting page (gradebook, etc.) would hit
-  // ``window.localStorage.getItem`` synchronously on the render path.
-  // The ``userId`` change re-reads (different account, possibly
-  // different flag) via the effect below.
-  const [alreadySeen, setAlreadySeen] = useState(() => readSeen(userId, tourId))
-  useEffect(() => {
-    setAlreadySeen(readSeen(userId, tourId))
-  }, [userId, tourId])
-
-  // Reactive grand-tour signal: when the orchestrator decides to fire
-  // (or is already firing), per-page tours that the grand tour covers
-  // must bail their own auto-start so the user doesn't see two
-  // overlapping spotlights. Useful even after the grand tour has
-  // finished because the seen flag may not have been written yet
-  // when this hook's useState init ran on the same mount tick.
+  // Reactive grand-tour signal — declared first so it can feed the
+  // ``alreadySeen`` resync effect below.
   const grandTourActive = useSyncExternalStore(
     subscribeGrandTour,
     getGrandTourActive,
     () => false,
   )
   const isCovered = isCoveredByGrandTour(tourId)
+  // ``alreadySeen`` is read once into state on mount instead of every
+  // render. Without this, every keystroke / sort change on a
+  // tour-hosting page (gradebook, etc.) would hit
+  // ``window.localStorage.getItem`` synchronously on the render path.
+  // The ``userId``/``tourId`` change re-reads via the effect below.
+  const [alreadySeen, setAlreadySeen] = useState(() => readSeen(userId, tourId))
+  useEffect(() => {
+    setAlreadySeen(readSeen(userId, tourId))
+    // ``grandTourActive`` IS in the deps too: when the grand tour
+    // finishes (flips the signal false), its ``onDone``/``onSkipped``
+    // also writes per-page seen flags via
+    // ``suppressCoveredPerPageTours``. Without this resync, a
+    // dashboard hook that has been mounted through the whole grand
+    // tour keeps its stale ``alreadySeen=false`` state and fires its
+    // own 5-step tour 350 ms after the grand tour ends — which is
+    // exactly the "another 5 steps after 10" symptom the user
+    // reported. Re-reading on the signal flip picks up the fresh
+    // suppression flag.
+  }, [userId, tourId, grandTourActive])
 
   // Reactive first-run signal: while the Privacy Policy + Quick Setup
   // screens are up, EVERY per-page tour bails (covered or not). The


### PR DESCRIPTION
## Why

User report: «Почему после десяти шагов начинаются ещё пять шагов?» — why does another 5-step tour start after the 10 grand-tour steps end? Reproduced via code trace + regression test.

## Root cause

\`useUserTour\` reads \`alreadySeen\` ONCE via \`useState(() => readSeen(userId, tourId))\`. The follow-up effect only re-reads when \`userId\` or \`tourId\` change.

Grand tour's \`onDone\`/\`onSkipped\`:
1. Writes per-page seen flags via \`suppressCoveredPerPageTours\`
2. Flips \`grandTourActive\` to false

DashboardPage's per-page hook is mounted through the entire grand tour (the dashboard is rendered under the tour's overlay). When the signal flips, its autostart effect re-runs — but \`alreadySeen\` state still reflects the mount-time read (\`false\`). Conditions pass → 350ms timer fires → dashboard's own 5-step per-page tour drives on top of the just-closed grand tour. **Exactly the symptom Vadym described.**

Catalog/calendar/certificates/profile don't trip the same bug because the user only visits them transiently during the grand tour — their pages unmount on each step, and on any subsequent mount the \`useState\` initialiser reads the suppression flag fresh.

## Fix

Add \`grandTourActive\` to the deps of the \`alreadySeen\` resync effect:

\`\`\`ts
useEffect(() => {
  setAlreadySeen(readSeen(userId, tourId))
}, [userId, tourId, grandTourActive])
\`\`\`

When grand tour ends and flips the signal, every per-page hook subscribed re-reads its own localStorage flag. The dashboard hook picks up the suppression flag and bails.

Side benefit: per-page hooks are now resilient to any future out-of-band seen-flag writes.

## Regression test

\`useUserTour.test.tsx\` new case **\"bails when the grand tour writes its suppression flag mid-mount\"**. Drives the exact failure sequence — mount per-page hook with grand tour already active, write the suppression flag, flip the signal false, advance fake timers past the auto-start delay — and asserts the per-page \`drive\` mock was never called. **Fails against the pre-fix code.**

## What's NOT in this PR — step 6 bug

User also mentioned «на шаге 6 есть баг какой-то». Step 6 of the grand tour is the catalog-grid spotlight on \`/courses\`. Without a screen recording it's a guess between several candidates:

- \`stagger-fade-in\` animation on the grid racing the popover position calculation
- Popover \`side=\"top\"\` pushed off-screen on certain viewports when grid is tall
- Spotlight bounds wrong on an empty catalog
- Something else entirely

Asked for specifics in chat. This PR doesn't touch that path — will follow up once we have repro.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run i18n:check\` — bundles in parity (1479 / 1533)
- [x] \`npm run build\` — clean
- [x] Full test suite — **299/299** (1 new regression)
- [ ] **Preview smoke (fresh student)**: grand tour fires + completes → NO additional 5-step dashboard tour follows
- [ ] **Preview smoke (skip mid-tour)**: dismiss grand tour mid-way → covered surfaces still suppressed → no second wave
- [ ] **Preview smoke (uncovered routes)**: visit /courses/:id, /courses/:cid/modules/:mid/chapters/:chid after grand tour → contextual per-page tours STILL fire on first visit (course-detail, chapter-view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)