### PR TITLE
refactor(onboarding): central storage-key registry + XSS hardening + audit-found bug fixes

### DIFF
--- a/frontend/src/components/firstRun/CoursePickerStep.tsx
+++ b/frontend/src/components/firstRun/CoursePickerStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { ArrowRight, BookOpen, Check, Loader2, RefreshCw } from "lucide-react"
@@ -59,8 +59,12 @@ export function CoursePickerStep({ firstName, onEnrolled, onBrowse, onSkip }: Pr
   // Keep an indexed map so ``handleEnroll`` can hand the
   // orchestrator the actual ``Course`` object (title + cover) and
   // not just the id — needed for the EnrollSplash that bridges the
-  // picker click and the navigation.
-  const coursesById = new Map(courses.map((c) => [c.id, c]))
+  // picker click and the navigation. Memoised on ``courses`` so we
+  // don't allocate a new Map on every keystroke / parent re-render.
+  const coursesById = useMemo(
+    () => new Map(courses.map((c) => [c.id, c])),
+    [courses],
+  )
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set())

--- a/frontend/src/components/firstRun/FirstRunFlow.tsx
+++ b/frontend/src/components/firstRun/FirstRunFlow.tsx
@@ -18,34 +18,12 @@ const EDITORIAL_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1]
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
 
-const STORAGE_PREFIX_PRIVACY = "equip.privacy.accepted"
-const STORAGE_PREFIX_SETUP = "equip.first-run.setup"
-// The picker flag CLOSES the first-run flow. Re-using the legacy
-// ``equip.first-run.completed`` key so users who already cleared
-// the pre-picker flow on prod don't see the picker pop up out of
-// nowhere on their next visit — they're past the first-run gate.
-const STORAGE_PREFIX_PICKER = "equip.first-run.completed"
-// The grand tour's seen-flag — we set it when the picker finishes
-// (or is skipped) so the cross-page tour doesn't auto-fire on top
-// of the user's brand-new enrollment. Manual "Take a tour" still
-// works via the WelcomeCard link.
-const STORAGE_PREFIX_GRAND_TOUR_SEEN = "equip.grand-tour.seen"
-
-function privacyKey(userId: string): string {
-  return `${STORAGE_PREFIX_PRIVACY}.${userId}`
-}
-
-function setupKey(userId: string): string {
-  return `${STORAGE_PREFIX_SETUP}.${userId}`
-}
-
-function pickerKey(userId: string): string {
-  return `${STORAGE_PREFIX_PICKER}.${userId}`
-}
-
-function grandTourSeenKey(userId: string): string {
-  return `${STORAGE_PREFIX_GRAND_TOUR_SEEN}.${userId}`
-}
+import {
+  firstRunPickerKey,
+  firstRunSetupKey,
+  grandTourSeenKey,
+  privacyAcceptedKey,
+} from "@/lib/storageKeys"
 
 function readFlag(key: string): boolean {
   if (typeof window === "undefined") return false
@@ -69,9 +47,9 @@ type Step = "privacy" | "setup" | "picker" | "splash" | "done"
 
 function decideInitialStep(userId: string | undefined): Step {
   if (!userId) return "done"
-  if (!readFlag(privacyKey(userId))) return "privacy"
-  if (!readFlag(setupKey(userId))) return "setup"
-  if (!readFlag(pickerKey(userId))) return "picker"
+  if (!readFlag(privacyAcceptedKey(userId))) return "privacy"
+  if (!readFlag(firstRunSetupKey(userId))) return "setup"
+  if (!readFlag(firstRunPickerKey(userId))) return "picker"
   return "done"
 }
 
@@ -183,25 +161,25 @@ export function FirstRunFlow() {
   }, [step])
 
   const handlePrivacyAccept = useCallback(() => {
-    if (userId) writeFlag(privacyKey(userId))
+    if (userId) writeFlag(privacyAcceptedKey(userId))
     setStep("setup")
   }, [userId])
 
   const handleSetupComplete = useCallback(() => {
-    if (userId) writeFlag(setupKey(userId))
+    if (userId) writeFlag(firstRunSetupKey(userId))
     setStep("picker")
   }, [userId])
 
   const handleSetupSkip = useCallback(() => {
     // Skip writes the flag too — the user has made the choice to
     // bypass setup; pestering them again next visit is wrong.
-    if (userId) writeFlag(setupKey(userId))
+    if (userId) writeFlag(firstRunSetupKey(userId))
     setStep("picker")
   }, [userId])
 
   const closePickerFlow = useCallback(() => {
     if (!userId) return
-    writeFlag(pickerKey(userId))
+    writeFlag(firstRunPickerKey(userId))
     // Also tick the grand-tour-seen flag so the cross-page
     // popover tour doesn't auto-fire on top of the user's brand-
     // new enrollment / dashboard. Manual replay via the

--- a/frontend/src/components/firstRun/SetupStep.tsx
+++ b/frontend/src/components/firstRun/SetupStep.tsx
@@ -99,12 +99,26 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
   // preview-clicks the user made. The theme and locale APIs apply
   // changes immediately so the user can see the preview; if they
   // skip without committing, the snapshots restore the prior state.
-  const initialLocale: SupportedLocale =
+  //
+  // ``initialLocale`` MUST be a ref, not a recomputed const — when
+  // an avatar upload triggers ``refreshUser`` mid-flow, the live
+  // ``user`` object updates and a plain ``const initialLocale =
+  // user.preferred_locale ?? ...`` would silently rebind to the
+  // refreshed value, defeating the snapshot semantics ``handleSkip``
+  // relies on.
+  const initialLocaleSnapshot: SupportedLocale =
     (user?.preferred_locale as SupportedLocale | undefined) ??
     (i18n.resolvedLanguage as SupportedLocale | undefined) ??
     "en"
+  // ``useRef(initialLocaleSnapshot)`` works because ``useRef``'s
+  // initial value is captured on first call only; subsequent renders
+  // ignore the argument. So even if ``user.preferred_locale``
+  // changes mid-flow (e.g. after an avatar ``refreshUser``), the ref
+  // keeps the mount-time value — that's the snapshot ``handleSkip``
+  // needs.
+  const initialLocaleRef = useRef<SupportedLocale>(initialLocaleSnapshot)
   const initialThemeRef = useRef<Theme>(theme)
-  const [locale, setLocale] = useState<SupportedLocale>(initialLocale)
+  const [locale, setLocale] = useState<SupportedLocale>(initialLocaleSnapshot)
   const [uploading, setUploading] = useState(false)
   const [saving, setSaving] = useState(false)
 
@@ -203,8 +217,8 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
     // Undo any preview-only changes the user made but didn't commit:
     // locale via i18n (theme was persisted immediately by the
     // ThemeProvider, so we reverse it here too if it drifted).
-    if (i18n.resolvedLanguage !== initialLocale) {
-      void i18n.changeLanguage(initialLocale)
+    if (i18n.resolvedLanguage !== initialLocaleRef.current) {
+      void i18n.changeLanguage(initialLocaleRef.current)
     }
     if (theme !== initialThemeRef.current) {
       toggleTheme()

--- a/frontend/src/hooks/useGrandTour.ts
+++ b/frontend/src/hooks/useGrandTour.ts
@@ -10,31 +10,23 @@ import {
   setGrandTourActive,
   subscribeFirstRun,
 } from "@/lib/tourState"
+import { grandTourSeenKey, perPageTourSeenKey } from "@/lib/storageKeys"
 
-const STORAGE_PREFIX_GRAND = "equip.grand-tour.seen"
-const STORAGE_PREFIX_PERPAGE = "equip.tour.seen"
 const AUTO_START_DELAY_MS = 500
 
-function grandFlagKey(userId: string | undefined): string | null {
-  if (!userId) return null
-  return `${STORAGE_PREFIX_GRAND}.${userId}`
-}
-
 function readGrandSeen(userId: string | undefined): boolean {
-  const key = grandFlagKey(userId)
-  if (!key || typeof window === "undefined") return false
+  if (!userId || typeof window === "undefined") return false
   try {
-    return window.localStorage.getItem(key) === "1"
+    return window.localStorage.getItem(grandTourSeenKey(userId)) === "1"
   } catch {
     return false
   }
 }
 
 function writeGrandSeen(userId: string | undefined): void {
-  const key = grandFlagKey(userId)
-  if (!key || typeof window === "undefined") return
+  if (!userId || typeof window === "undefined") return
   try {
-    window.localStorage.setItem(key, "1")
+    window.localStorage.setItem(grandTourSeenKey(userId), "1")
   } catch {
     /* private browsing */
   }
@@ -51,7 +43,7 @@ function suppressCoveredPerPageTours(userId: string | undefined): void {
   if (!userId || typeof window === "undefined") return
   for (const tourId of STUDENT_GRAND_TOUR_COVERS) {
     try {
-      window.localStorage.setItem(`${STORAGE_PREFIX_PERPAGE}.${userId}.${tourId}`, "1")
+      window.localStorage.setItem(perPageTourSeenKey(userId, tourId), "1")
     } catch {
       /* ignore */
     }
@@ -134,7 +126,12 @@ export function useGrandTour(): UseGrandTourReturn {
         progress: t("tour.progress", { current: "{{current}}", total: "{{total}}" }),
       },
       navigate,
-      initialPath: location.pathname,
+      // ``initialPath`` is captured at build time; reading
+      // ``window.location.pathname`` directly keeps ``buildAndDrive``
+      // out of ``location.pathname``'s dep chain, which used to
+      // trigger a callback re-bind on every internal tour navigation
+      // — visible as an unnecessary effect re-run on each step.
+      initialPath: typeof window !== "undefined" ? window.location.pathname : "/",
       reducedMotion: reducedMotionPreferred(),
       onDone: () => {
         writeGrandSeen(userId)
@@ -152,7 +149,7 @@ export function useGrandTour(): UseGrandTourReturn {
       },
     })
     driverRef.current.drive()
-  }, [t, userId, navigate, location.pathname])
+  }, [t, userId, navigate])
 
   const start = useCallback(() => {
     // Defensive: don't yank the user into a tour while the first-run
@@ -223,9 +220,14 @@ export function useGrandTour(): UseGrandTourReturn {
         window.clearTimeout(timerRef.current)
         timerRef.current = null
       }
-      // Reset shared signal on unmount so per-page tours can fire on
-      // the next mount cycle if the user signs back in.
-      setGrandTourActive(false)
+      // Only release the shared signal if THIS instance was the one
+      // that set it. Without the ``firedRef`` guard, a stray second
+      // mount (HMR, test, accidental double-mount) unmounting could
+      // clear the running instance's signal, letting per-page tours
+      // race a live grand tour.
+      if (firedRef.current) {
+        setGrandTourActive(false)
+      }
     }
   }, [])
 

--- a/frontend/src/hooks/useUserTour.ts
+++ b/frontend/src/hooks/useUserTour.ts
@@ -10,6 +10,7 @@ import {
   subscribeFirstRun,
   subscribeGrandTour,
 } from "@/lib/tourState"
+import { perPageTourSeenKey } from "@/lib/storageKeys"
 
 interface UseUserTourOpts {
   /** Stable identifier for this surface's tour. Combined with the
@@ -50,29 +51,21 @@ interface UseUserTourReturn {
   alreadySeen: boolean
 }
 
-const STORAGE_PREFIX = "equip.tour.seen"
 const DEFAULT_SKIP_ROLES: ReadonlyArray<string> = ["admin"]
 
-function flagKey(userId: string | undefined, tourId: string): string | null {
-  if (!userId) return null
-  return `${STORAGE_PREFIX}.${userId}.${tourId}`
-}
-
 function readSeen(userId: string | undefined, tourId: string): boolean {
-  const key = flagKey(userId, tourId)
-  if (!key || typeof window === "undefined") return false
+  if (!userId || typeof window === "undefined") return false
   try {
-    return window.localStorage.getItem(key) === "1"
+    return window.localStorage.getItem(perPageTourSeenKey(userId, tourId)) === "1"
   } catch {
     return false
   }
 }
 
 function writeSeen(userId: string | undefined, tourId: string): void {
-  const key = flagKey(userId, tourId)
-  if (!key || typeof window === "undefined") return
+  if (!userId || typeof window === "undefined") return
   try {
-    window.localStorage.setItem(key, "1")
+    window.localStorage.setItem(perPageTourSeenKey(userId, tourId), "1")
   } catch {
     // Private-browsing or quota — the tour will re-offer next visit.
   }

--- a/frontend/src/lib/grandTour.ts
+++ b/frontend/src/lib/grandTour.ts
@@ -1,6 +1,7 @@
 import { driver, type Config, type Driver, type DriveStep } from "driver.js"
 import "driver.js/dist/driver.css"
 import "@/styles/editorial-tour.css"
+import { sanitizeHtml } from "@/lib/sanitize"
 
 /**
  * A grand-tour step is a regular driver.js step plus an optional
@@ -103,10 +104,21 @@ export function createGrandTour({
 
   // Driver.js types want a mutable DriveStep[]; the route field is
   // ours and gets read separately from the array index inside the
-  // navigation hooks below.
+  // navigation hooks below. We also sanitise the popover text here
+  // for the same reason as ``createEditorialTour`` — driver.js
+  // renders title + description through ``innerHTML``, so any
+  // future user-interpolated tour copy could otherwise XSS.
   const baseSteps: DriveStep[] = steps.map((s) => ({
     element: s.element,
-    popover: s.popover,
+    popover: s.popover
+      ? {
+          ...s.popover,
+          title: s.popover.title ? sanitizeHtml(s.popover.title) : s.popover.title,
+          description: s.popover.description
+            ? sanitizeHtml(s.popover.description)
+            : s.popover.description,
+        }
+      : s.popover,
   }))
 
   // Pre-position on the first step's route so the very first

--- a/frontend/src/lib/storageKeys.ts
+++ b/frontend/src/lib/storageKeys.ts
@@ -1,0 +1,82 @@
+/**
+ * Single source of truth for every ``localStorage`` key used by the
+ * onboarding + tour stack. Centralising the prefixes here removes
+ * two real risks the audit caught:
+ *
+ *   1. Two modules independently writing the same logical flag with
+ *      string literals — ``equip.grand-tour.seen`` was hard-coded
+ *      in both ``FirstRunFlow.tsx`` and ``useGrandTour.ts``. A typo
+ *      in one place would silently desync the tour suppression.
+ *
+ *   2. The "suppress per-page tours that the grand tour covered"
+ *      helper inside ``useGrandTour`` knew the EXACT key format
+ *      used by ``useUserTour`` — string-formatted across modules,
+ *      undocumented coupling. Now both go through the same
+ *      ``perPageTourSeenKey`` builder.
+ *
+ * Every key follows the ``equip.<domain>.<aspect>`` shape with
+ * dot separators (no colons — except the legacy locale key, which
+ * the i18n bundle still reads at boot time and we don't want to
+ * migrate in flight). User-scoped keys append ``.<userId>`` so a
+ * shared device's second account starts with a clean slate.
+ */
+
+const PREFIX_PRIVACY = "equip.privacy.accepted"
+const PREFIX_FIRST_RUN_SETUP = "equip.first-run.setup"
+// Picker completion (== "first-run flow closed"). Reuses the legacy
+// "equip.first-run.completed" name so users who cleared the
+// pre-picker flow on prod don't see the picker pop up on next visit.
+const PREFIX_FIRST_RUN_PICKER = "equip.first-run.completed"
+const PREFIX_GRAND_TOUR_SEEN = "equip.grand-tour.seen"
+const PREFIX_PER_PAGE_TOUR_SEEN = "equip.tour.seen"
+const PREFIX_COMPLETION_CELEBRATED = "equip.celebrated"
+
+/** Privacy Policy acceptance flag — gates step 1 of the first-run flow. */
+export function privacyAcceptedKey(userId: string): string {
+  return `${PREFIX_PRIVACY}.${userId}`
+}
+
+/** Quick-Setup completion flag — gates step 2 (avatar / name / theme / locale). */
+export function firstRunSetupKey(userId: string): string {
+  return `${PREFIX_FIRST_RUN_SETUP}.${userId}`
+}
+
+/**
+ * Picker / first-run-overall completion flag — gates step 3 AND
+ * closes the gate. Once this is set, the modal stays closed
+ * regardless of the other two flags' state.
+ */
+export function firstRunPickerKey(userId: string): string {
+  return `${PREFIX_FIRST_RUN_PICKER}.${userId}`
+}
+
+/**
+ * Grand-tour seen flag — set by the cross-page tour itself when it
+ * completes/dismisses, AND by ``FirstRunFlow`` when the picker
+ * closes (so the cross-page tour doesn't auto-fire on top of a
+ * just-enrolled student).
+ */
+export function grandTourSeenKey(userId: string): string {
+  return `${PREFIX_GRAND_TOUR_SEEN}.${userId}`
+}
+
+/**
+ * Per-page tour seen flag — one per ``(userId, tourId)``. Written
+ * by ``useUserTour`` when the user dismisses or completes a
+ * single-page tour, AND by the grand tour's ``onDone``/``onSkipped``
+ * for every tour id in ``STUDENT_GRAND_TOUR_COVERS`` so revisits of
+ * those surfaces don't get a second wave of contextual tours.
+ */
+export function perPageTourSeenKey(userId: string, tourId: string): string {
+  return `${PREFIX_PER_PAGE_TOUR_SEEN}.${userId}.${tourId}`
+}
+
+/**
+ * Course-completion celebration flag — per ``(userId, courseId)``.
+ * Written by ``EnrolledView`` when the student closes the
+ * ``CompletionDialog`` for a course that just hit 100% progress,
+ * so the celebration doesn't re-fire on every revisit.
+ */
+export function completionCelebratedKey(userId: string, courseId: string): string {
+  return `${PREFIX_COMPLETION_CELEBRATED}.${userId}.${courseId}`
+}

--- a/frontend/src/lib/tour.ts
+++ b/frontend/src/lib/tour.ts
@@ -1,8 +1,47 @@
 import { driver, type Config, type DriveStep, type Driver } from "driver.js"
 import "driver.js/dist/driver.css"
 import "@/styles/editorial-tour.css"
+import { sanitizeHtml } from "@/lib/sanitize"
 
 export type TourStep = DriveStep
+
+/**
+ * driver.js writes ``popover.title`` and ``popover.description``
+ * directly via ``innerHTML`` — confirmed in
+ * ``node_modules/driver.js/dist/driver.js.iife.js``'s renderer.
+ *
+ * Today every tour string is a static translation with no user
+ * interpolation, so there's no live XSS vector. But the moment
+ * anyone adds ``t(KEY, { something: userInput })`` to a tour
+ * step (a course title surfaced in a tour popover, a user name in
+ * a header step, etc.), they'd silently open an XSS through the
+ * popover — and our ``i18n/config.ts`` sets
+ * ``interpolation.escapeValue = false`` which removes the only
+ * other layer of protection.
+ *
+ * Hardening: run every tour string through the project's existing
+ * DOMPurify config before driver.js gets to render it. This is the
+ * same sanitiser ``ChapterView``'s rich-text blocks already use, so
+ * a future tour string that legitimately needs ``<strong>`` or
+ * ``<em>`` keeps those tags while ``<script>``, ``<img onerror>``,
+ * ``href="javascript:..."`` etc. are stripped.
+ */
+function sanitiseStepTextInPlace(steps: readonly TourStep[]): TourStep[] {
+  return steps.map((step) => {
+    if (!step.popover) return step
+    const { popover, ...rest } = step
+    return {
+      ...rest,
+      popover: {
+        ...popover,
+        title: popover.title ? sanitizeHtml(popover.title) : popover.title,
+        description: popover.description
+          ? sanitizeHtml(popover.description)
+          : popover.description,
+      },
+    }
+  })
+}
 
 interface CreateTourOpts {
   steps: readonly TourStep[]
@@ -73,7 +112,7 @@ export function createEditorialTour({
   const animate = !reducedMotionPreferred()
 
   const config: Config = {
-    steps: steps as DriveStep[],
+    steps: sanitiseStepTextInPlace(steps) as DriveStep[],
     // Both the SVG stage morph and the popover fade are gated on this
     // single flag — driver.js doesn't expose them separately, and the
     // CSS media query catches the popover fade as a defense in depth.

--- a/frontend/src/pages/Course/detail/EnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/EnrolledView.tsx
@@ -11,6 +11,7 @@ import { useUserTour } from "@/hooks/useUserTour"
 import { courseDetailSteps } from "@/lib/tourSteps"
 import { storageService } from "@/services/storage"
 import { toast } from "@/lib/toast"
+import { completionCelebratedKey } from "@/lib/storageKeys"
 import type {
   CalendarEvent,
   Certificate,
@@ -71,7 +72,7 @@ export function EnrolledView({
   // course the first user already finished. The flag is written on
   // close (not on open) so a closed-before-render edge case doesn't
   // silently swallow the moment.
-  const celebrationFlagKey = `equip.celebrated.${enrollment.user_id}.${course.id}`
+  const celebrationFlagKey = completionCelebratedKey(enrollment.user_id, course.id)
 
   useEffect(() => {
     if (!(enrollment.progress >= 100)) return


### PR DESCRIPTION
## Why

Pre-launch strict audit of PRs #444–#457: **0 Critical**, 4 Medium across bugs / architecture / security. All fixed in one PR; no behaviour changes.

Audit also flagged a 1-WARN Supabase advisor (HaveIBeenPwned leaked-password protection disabled). That's a one-click toggle in the Supabase dashboard, not a code change.

## What's in

### Architecture — single source of truth for storage keys

New `src/lib/storageKeys.ts` owns every `equip.<domain>.<aspect>[.userId[.tourId]]` builder:

| Builder | Key shape |
|---|---|
| `privacyAcceptedKey(userId)` | `equip.privacy.accepted.{userId}` |
| `firstRunSetupKey(userId)` | `equip.first-run.setup.{userId}` |
| `firstRunPickerKey(userId)` | `equip.first-run.completed.{userId}` (legacy name preserved) |
| `grandTourSeenKey(userId)` | `equip.grand-tour.seen.{userId}` |
| `perPageTourSeenKey(userId, tourId)` | `equip.tour.seen.{userId}.{tourId}` |
| `completionCelebratedKey(userId, courseId)` | `equip.celebrated.{userId}.{courseId}` |

**Pre-fix:** `equip.grand-tour.seen` was hard-coded in both `FirstRunFlow.tsx` AND `useGrandTour.ts`. A typo in one would silently desync the tour suppression. `useGrandTour.suppressCoveredPerPageTours` knew `useUserTour`'s key format by string-formatting. Two undocumented coupling points.

**Post-fix:** one constant per concept, one place to edit. Migrated call sites: `FirstRunFlow`, `useGrandTour`, `useUserTour`, `EnrolledView`.

### Security — sanitise driver.js popover text

Verified: driver.js writes `popover.title` + `popover.description` via `innerHTML` (in `dist/driver.js.iife.js`'s renderer). Today every tour string is a static translation with no user interpolation — no live XSS — but `i18n/config.ts` sets `escapeValue: false`, so a future `t(KEY, { foo: userInput })` in a tour step would silently open XSS.

Hardening: both `createEditorialTour` and `createGrandTour` now route title + description through the project's existing `sanitizeHtml` (DOMPurify) before driver.js sees them. Same sanitiser `ChapterView`'s rich-text blocks already use.

### Bug — `SetupStep.initialLocale` drift mid-flow

`initialLocale` was a `const` recomputed every render. When `handleAvatarChange` triggered `refreshUser()`, the live `user` object updated and `handleSkip`'s "undo preview locale" used the refreshed value, not the mount-time snapshot.

Fix: `useRef` (`initialLocaleRef`) like the existing `initialThemeRef`. `useRef` ignores its init arg after first call, so the snapshot stays frozen.

### Bug — `useGrandTour` unmount could clear another instance's signal

Cleanup-only effect unconditionally called `setGrandTourActive(false)`. A stray double-mount (HMR, hypothetical test) unmounting would silently clear the running instance's signal, letting per-page tours race a live grand tour.

Fix: guard the cleanup on `firedRef.current` — only release the signal if THIS instance was the one that set it.

### Minor cleanups

- `CoursePickerStep.coursesById` now `useMemo([courses])` (was rebuilding the `Map` on every parent re-render)
- `useGrandTour.buildAndDrive` no longer depends on `location.pathname` (reads `window.location.pathname` at call time, drops unnecessary callback re-bind on every internal tour navigation)
- `lib/tour.ts` comment example tweaked from literal `t("...")` to `t(KEY, ...)` — the literal was tripping the `keyCoverage` test's regex into looking for a key named `...`

## What's NOT in this PR (audit Nitpicks, deferred)

- `equip:locale` (i18n bundle key) uses colon while every other key uses dots — cosmetic, migrating would orphan existing localStorage entries on all current users
- `FirstRunFlow`'s `setFirstRunActive(false)` cleanup runs on every step change — but `setFirstRunActive` short-circuits when value unchanged, so subscribers never observe a spurious flip
- Avatar 2MB limit is client-side only — server-side validation is the storage service's job, out of scope

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run i18n:check` — bundles in parity (1502 / 1557)
- [x] `npm run build` — clean
- [x] Full test suite — **299/299**
- [ ] **Preview smoke**: fresh signup → Privacy → Setup → Picker → Splash → course detail. Same UX as #457; this PR is purely structural.
- [ ] **Preview smoke (storage check)**: open DevTools → Application → localStorage. After completing the flow, see `equip.privacy.accepted.{uid}`, `equip.first-run.setup.{uid}`, `equip.first-run.completed.{uid}`, `equip.grand-tour.seen.{uid}` all set to `"1"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)