### PR TITLE
fix(admin): editorial header + per-field saving + N+1 + layout + i18n

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1615,6 +1615,7 @@
   },
   "admin": {
     "title": "Admin Dashboard",
+    "eyebrow": "Administration",
     "subtitle": "Manage users, roles, and monitor platform activity",
     "tabOverview": "Overview",
     "tabCohorts": "Cohorts",
@@ -1674,8 +1675,12 @@
       "adding": "Adding…",
       "errorUserNotFound": "No Equip user with that email — ask them to sign up first.",
       "errorCohortFull": "Cohort has reached its maximum capacity.",
-      "noCoursesAttached": "No courses attached. Click \"Attach course\" to add one.",
-      "noStudents": "No students yet. Click \"Add student\" to enroll one.",
+      "eyebrow": "Cohort",
+      "noCoursesAttachedTitle": "No courses attached yet",
+      "noCoursesAttached": "Attach a course to make it available to the students in this cohort.",
+      "noStudentsTitle": "No students yet",
+      "noStudents": "Add students by email to enroll them in every attached course.",
+      "studentSearchNoMatchHint": "Try a different name or email.",
       "deleteButton": "Delete cohort",
       "completeConfirmTitle": "Mark this cohort as completed?",
       "completeConfirmDescription": "Students keep their enrollments and grades; the cohort just stops being editable.",
@@ -1814,6 +1819,13 @@
       "usersLast7Days_one": "+{{count}} this week",
       "usersLast7Days_other": "+{{count}} this week",
       "usersLast7Days_zero": "No new signups this week"
+    },
+    "pagination": {
+      "pageSizeLabel": "Rows per page",
+      "page": "Page {{page}} of {{total}}",
+      "prevPageAria": "Previous page",
+      "nextPageAria": "Next page",
+      "filterClear": "Clear filters"
     },
     "audit": {
       "filterAction": "Action",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1294,6 +1294,7 @@
   },
   "admin": {
     "title": "Админ-панель",
+    "eyebrow": "Администрирование",
     "subtitle": "Пользователи, роли и активность платформы",
     "tabOverview": "Обзор",
     "tabCohorts": "Когорты",
@@ -1353,8 +1354,12 @@
       "adding": "Добавляем…",
       "errorUserNotFound": "Пользователя с таким email нет — попросите его зарегистрироваться.",
       "errorCohortFull": "Когорта достигла максимума мест.",
-      "noCoursesAttached": "Курсов пока нет. Нажмите «Добавить курс», чтобы привязать первый.",
-      "noStudents": "Студентов пока нет. Нажмите «Добавить студента», чтобы зачислить первого.",
+      "eyebrow": "Когорта",
+      "noCoursesAttachedTitle": "Курсы ещё не привязаны",
+      "noCoursesAttached": "Привяжите курс, чтобы он стал доступен студентам этой когорты.",
+      "noStudentsTitle": "Пока нет студентов",
+      "noStudents": "Добавьте студентов по email — они автоматически зачислятся на все привязанные курсы.",
+      "studentSearchNoMatchHint": "Попробуйте другое имя или email.",
       "deleteButton": "Удалить когорту",
       "completeConfirmTitle": "Отметить когорту как завершённую?",
       "completeConfirmDescription": "Зачисления и оценки сохранятся; когорта просто перестанет быть редактируемой.",
@@ -1495,6 +1500,13 @@
       "usersLast7Days_many": "+{{count}} за неделю",
       "usersLast7Days_other": "+{{count}} за неделю",
       "usersLast7Days_zero": "Новых регистраций нет"
+    },
+    "pagination": {
+      "pageSizeLabel": "Строк на странице",
+      "page": "Страница {{page}} из {{total}}",
+      "prevPageAria": "Предыдущая страница",
+      "nextPageAria": "Следующая страница",
+      "filterClear": "Сбросить фильтры"
     },
     "audit": {
       "filterAction": "Действие",

--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -42,7 +42,15 @@ export default function AdminDashboard() {
     ? (rawTab as AdminTab)
     : "overview"
 
-  const overview = useAdminOverview({ currentUserId: user?.id })
+  // Overview data is needed by the overview tab itself AND by the audit
+  // tab (audit rows show the user's name via ``userMap``, which is
+  // derived from the same users list). The cohorts tab needs neither,
+  // so we skip the whole overview fetch when the user opens that tab
+  // directly via ``?tab=cohorts``. Saves four service round-trips
+  // (users, courses count, enrollments count, pending certs) on every
+  // cold visit to the cohorts surface.
+  const overviewEnabled = tab === "overview" || tab === "audit"
+  const overview = useAdminOverview({ currentUserId: user?.id, enabled: overviewEnabled })
   const audit = useAdminAudit({ enabled: tab === "audit" })
 
   if (user?.role !== "admin") return <Navigate to="/" replace />
@@ -56,12 +64,19 @@ export default function AdminDashboard() {
 
   return (
     <div className="animate-fade-in container mx-auto max-w-6xl px-4 py-6 sm:py-8">
-      <div className="mb-6 flex items-center gap-3">
-        <div className="rounded-lg bg-primary/10 p-2">
-          <Shield className="h-6 w-6 text-primary" strokeWidth={1.75} />
+      <header className="mb-6 space-y-2">
+        <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          {t("admin.eyebrow")}
+        </p>
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-primary/10 p-2">
+            <Shield className="h-6 w-6 text-primary" strokeWidth={1.75} />
+          </div>
+          <h1 className="font-serif text-2xl font-bold tracking-tight sm:text-3xl">
+            {t("admin.title")}
+          </h1>
         </div>
-        <h1 className="font-serif text-2xl font-bold tracking-tight sm:text-3xl">{t("admin.title")}</h1>
-      </div>
+      </header>
 
       <AdminTabs active={tab} onChange={setTab} />
 

--- a/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import {
-  ArrowLeft,
+  BookOpen,
   Calendar,
   Plus,
   Search,
@@ -18,7 +18,7 @@ import { Label } from "@/components/ui/label"
 import { useConfirm } from "@/components/ui/alert-dialog"
 import { useAuth } from "@/context/useAuth"
 import PageSpinner from "@/components/ui/PageSpinner"
-import { ErrorState } from "@/components/patterns"
+import { EmptyState, ErrorState, PageHeader } from "@/components/patterns"
 import { cohortsService, type CohortStudent } from "@/services/cohorts"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
@@ -43,7 +43,11 @@ export default function CohortDetailPage() {
   const [notFound, setNotFound] = useState(false)
   const [attachOpen, setAttachOpen] = useState(false)
   const [addOpen, setAddOpen] = useState(false)
-  const [savingField, setSavingField] = useState(false)
+  // Track which specific field is in-flight so saving "name" doesn't
+  // also disable the date pickers and capacity input. Previously a
+  // single boolean froze the whole Details card on each save which
+  // looked broken on slow networks. ``null`` = nothing saving.
+  const [savingField, setSavingField] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     if (!cohortId) return
@@ -56,9 +60,18 @@ export default function CohortDetailPage() {
       setCohort(c)
       setStudents(s)
       if (c.course_ids.length) {
-        const all = await coursesService.getCourses()
-        const attached = all.filter((co) => c.course_ids.includes(co.id))
-        setCourses(attached)
+        // Fetch only the cohort's attached courses instead of the
+        // whole catalog. ``getCourse`` is cached for 3 minutes per
+        // id, so revisiting the same cohort or visiting overlapping
+        // cohorts is largely free; a single cold cohort with N
+        // courses costs N parallel requests instead of 1 request
+        // returning the entire tenant catalog.
+        const attached = await Promise.all(
+          c.course_ids.map((id) =>
+            coursesService.getCourse(id).catch(() => null),
+          ),
+        )
+        setCourses(attached.filter((co): co is Course => co !== null))
       } else {
         setCourses([])
       }
@@ -75,9 +88,12 @@ export default function CohortDetailPage() {
     void load()
   }, [load])
 
-  const patch = async (body: Parameters<typeof cohortsService.updateCohort>[1]) => {
+  const patch = async (
+    fieldName: string,
+    body: Parameters<typeof cohortsService.updateCohort>[1],
+  ) => {
     if (!cohortId) return
-    setSavingField(true)
+    setSavingField(fieldName)
     try {
       const updated = await cohortsService.updateCohort(cohortId, body)
       setCohort(updated)
@@ -85,7 +101,7 @@ export default function CohortDetailPage() {
     } catch {
       toast({ title: t("admin.cohorts.toast.saveFailed"), variant: "destructive" })
     } finally {
-      setSavingField(false)
+      setSavingField(null)
     }
   }
 
@@ -109,7 +125,7 @@ export default function CohortDetailPage() {
       })
       if (!ok) return
     }
-    await patch({ status: next })
+    await patch("status", { status: next })
   }
 
   const handleDelete = async () => {
@@ -190,39 +206,35 @@ export default function CohortDetailPage() {
   }
 
   return (
-    <div className="animate-fade-in container mx-auto px-4 py-8 max-w-5xl">
-      <Link to="/admin?tab=cohorts">
-        <Button variant="ghost" size="sm" className="mb-4 h-8 text-xs">
-          <ArrowLeft className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
-          {t("admin.cohorts.backToList")}
-        </Button>
-      </Link>
-
-      <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <div className="mb-2 flex flex-wrap items-center gap-3">
-            <h1 className="font-serif text-3xl font-bold tracking-tight text-wrap-safe">
-              {cohort.name}
-            </h1>
-            <CohortStatusPicker
-              status={cohort.status}
-              disabled={savingField}
-              onChange={(next) => void handleStatusChange(next)}
-              ariaLabel={t("admin.cohorts.fieldStatus")}
-            />
+    <div className="animate-fade-in container mx-auto px-4 py-8 max-w-6xl">
+      <PageHeader
+        backTo="/admin?tab=cohorts"
+        backLabel={t("admin.cohorts.backToList")}
+        title={
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              {t("admin.cohorts.eyebrow")}
+            </p>
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="font-serif text-3xl font-bold tracking-tight text-wrap-safe">
+                {cohort.name}
+              </h1>
+              <CohortStatusPicker
+                status={cohort.status}
+                disabled={savingField === "status"}
+                onChange={(next) => void handleStatusChange(next)}
+                ariaLabel={t("admin.cohorts.fieldStatus")}
+              />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {formatDate(cohort.start_date)} &mdash; {formatDate(cohort.end_date)}
+            </p>
+            {cohort.max_students != null && (
+              <CapacityMeter current={cohort.student_count} cap={cohort.max_students} />
+            )}
           </div>
-          <p className="text-sm text-muted-foreground">
-            {formatDate(cohort.start_date)} &mdash; {formatDate(cohort.end_date)}
-          </p>
-          {/* Capacity meter — gives the admin an at-a-glance read of
-              how full the cohort is. Hidden when ``max_students`` is
-              null (unlimited) since the "X of unlimited" bar has no
-              meaningful fill state. */}
-          {cohort.max_students != null && (
-            <CapacityMeter current={cohort.student_count} cap={cohort.max_students} />
-          )}
-        </div>
-        <div className="flex items-center gap-2">
+        }
+        actions={
           <Button
             variant="outline"
             size="sm"
@@ -232,8 +244,8 @@ export default function CohortDetailPage() {
             <Trash2 className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.deleteButton")}
           </Button>
-        </div>
-      </div>
+        }
+      />
 
       <Card className="mb-6">
         <CardHeader className="pb-3">
@@ -246,18 +258,18 @@ export default function CohortDetailPage() {
           <Field
             label={t("admin.cohorts.fieldName")}
             value={cohort.name}
-            onBlurSave={(v) => v !== cohort.name && patch({ name: v })}
-            disabled={savingField}
+            onBlurSave={(v) => v !== cohort.name && patch("name", { name: v })}
+            disabled={savingField === "name"}
           />
           <Field
             label={t("admin.cohorts.fieldMaxStudents")}
             value={cohort.max_students == null ? "" : String(cohort.max_students)}
             placeholder={t("admin.cohorts.unlimited")}
-            disabled={savingField}
+            disabled={savingField === "max_students"}
             onBlurSave={(v) => {
               const n = v ? Number(v) : null
               if (n === cohort.max_students) return
-              void patch({ max_students: n })
+              void patch("max_students", { max_students: n })
             }}
             inputType="number"
           />
@@ -265,30 +277,30 @@ export default function CohortDetailPage() {
             label={t("admin.cohorts.fieldStart")}
             value={cohort.start_date}
             onSave={(iso) => {
-              if (iso) void patch({ start_date: iso })
+              if (iso) void patch("start_date", { start_date: iso })
             }}
-            disabled={savingField}
+            disabled={savingField === "start_date"}
           />
           <DateField
             label={t("admin.cohorts.fieldEnd")}
             value={cohort.end_date}
             onSave={(iso) => {
-              if (iso) void patch({ end_date: iso })
+              if (iso) void patch("end_date", { end_date: iso })
             }}
-            disabled={savingField}
+            disabled={savingField === "end_date"}
           />
           <DateField
             label={t("admin.cohorts.fieldEnrollStart")}
             value={cohort.enrollment_start}
-            onSave={(iso) => patch({ enrollment_start: iso })}
-            disabled={savingField}
+            onSave={(iso) => patch("enrollment_start", { enrollment_start: iso })}
+            disabled={savingField === "enrollment_start"}
             nullable
           />
           <DateField
             label={t("admin.cohorts.fieldEnrollEnd")}
             value={cohort.enrollment_end}
-            onSave={(iso) => patch({ enrollment_end: iso })}
-            disabled={savingField}
+            onSave={(iso) => patch("enrollment_end", { enrollment_end: iso })}
+            disabled={savingField === "enrollment_end"}
             nullable
           />
         </CardContent>
@@ -306,9 +318,17 @@ export default function CohortDetailPage() {
         </CardHeader>
         <CardContent className="pt-0">
           {courses.length === 0 ? (
-            <p className="py-4 text-sm text-muted-foreground">
-              {t("admin.cohorts.noCoursesAttached")}
-            </p>
+            <EmptyState
+              icon={<BookOpen strokeWidth={1.75} aria-hidden />}
+              title={t("admin.cohorts.noCoursesAttachedTitle")}
+              description={t("admin.cohorts.noCoursesAttached")}
+              action={
+                <Button size="sm" variant="outline" onClick={() => setAttachOpen(true)}>
+                  <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
+                  {t("admin.cohorts.attachCourseButton")}
+                </Button>
+              }
+            />
           ) : (
             // Inline list of course chips — dense, visually consistent
             // with the rest of the admin row vocabulary (Vercel-style
@@ -527,13 +547,23 @@ function StudentsCard({
       </CardHeader>
       <CardContent className="p-0">
         {students.length === 0 ? (
-          <p className="px-6 py-6 text-sm text-muted-foreground">
-            {t("admin.cohorts.noStudents")}
-          </p>
+          <EmptyState
+            icon={<Users strokeWidth={1.75} aria-hidden />}
+            title={t("admin.cohorts.noStudentsTitle")}
+            description={t("admin.cohorts.noStudents")}
+            action={
+              <Button size="sm" variant="outline" onClick={onAdd}>
+                <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
+                {t("admin.cohorts.addStudentButton")}
+              </Button>
+            }
+          />
         ) : filtered.length === 0 ? (
-          <p className="px-6 py-6 text-sm text-muted-foreground">
-            {t("admin.cohorts.studentSearchNoMatch")}
-          </p>
+          <EmptyState
+            icon={<Search strokeWidth={1.75} aria-hidden />}
+            title={t("admin.cohorts.studentSearchNoMatch")}
+            description={t("admin.cohorts.studentSearchNoMatchHint")}
+          />
         ) : (
           <div className="max-h-[55vh] overflow-y-auto">
             <table className="w-full text-sm">

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DateRangePicker } from "@/components/ui/date-range-picker"
-import { EmptyState } from "@/components/patterns/EmptyState"
+import { EmptyState, ErrorState } from "@/components/patterns"
 import { cohortsService } from "@/services/cohorts"
 import { formatDate } from "@/i18n/format"
 import type { Cohort } from "@/types"
@@ -226,7 +226,7 @@ export function CohortsTab() {
               className="h-9 self-end text-muted-foreground hover:text-foreground"
             >
               <X className="mr-1 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
-              {t("admin.audit.filterClear")}
+              {t("admin.pagination.filterClear")}
             </Button>
           )}
         </div>
@@ -235,14 +235,14 @@ export function CohortsTab() {
         {loading ? (
           <CohortsTableSkeleton />
         ) : error ? (
-          <div className="flex flex-1 items-center justify-center px-6 py-10">
-            <div className="text-center">
-              <p className="text-sm text-destructive">{error}</p>
-              <Button size="sm" variant="outline" className="mt-3" onClick={() => void load()}>
+          <ErrorState
+            title={error}
+            action={
+              <Button size="sm" variant="outline" onClick={() => void load()}>
                 {t("common.tryAgain")}
               </Button>
-            </div>
-          </div>
+            }
+          />
         ) : filtered.length === 0 ? (
           <div className="flex flex-1 items-center justify-center px-6 py-10">
             <EmptyCohorts hasQuery={filtersActive} onCreate={() => setCreateOpen(true)} />
@@ -253,7 +253,7 @@ export function CohortsTab() {
 
         <div className="flex shrink-0 flex-col items-stretch gap-2 border-t border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <label htmlFor="cohort-page-size">{t("admin.audit.pageSizeLabel")}</label>
+            <label htmlFor="cohort-page-size">{t("admin.pagination.pageSizeLabel")}</label>
             <Select
               value={String(pageSize)}
               onValueChange={(v) => setPageSize(Number(v) as PageSize)}
@@ -275,7 +275,7 @@ export function CohortsTab() {
           </div>
           <div className="flex items-center justify-between gap-3 sm:justify-end">
             <p className="text-xs text-muted-foreground">
-              {t("admin.audit.page", { page: safePage, total: totalPages })}
+              {t("admin.pagination.page", { page: safePage, total: totalPages })}
             </p>
             <div className="flex items-center gap-1.5">
               <Button
@@ -284,7 +284,7 @@ export function CohortsTab() {
                 disabled={safePage <= 1}
                 onClick={() => setPage(safePage - 1)}
                 className="h-9 w-9 p-0"
-                aria-label={t("admin.audit.prevPageAria")}
+                aria-label={t("admin.pagination.prevPageAria")}
               >
                 <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
               </Button>
@@ -294,7 +294,7 @@ export function CohortsTab() {
                 disabled={safePage >= totalPages}
                 onClick={() => setPage(safePage + 1)}
                 className="h-9 w-9 p-0"
-                aria-label={t("admin.audit.nextPageAria")}
+                aria-label={t("admin.pagination.nextPageAria")}
               >
                 <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
               </Button>

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -281,7 +281,7 @@ function AuditTable({
                 {formatRelative(log.created_at)}
               </td>
               <td className="max-w-[160px] truncate px-5 py-3 text-xs" title={log.user_id ?? ""}>
-                {log.user_id ? userMap[log.user_id] || `${log.user_id.slice(0, 8)}…` : "—"}
+                {log.user_id ? (userMap[log.user_id] ?? `${log.user_id.slice(0, 8)}…`) : "—"}
               </td>
               <td className="px-5 py-3">
                 <Badge variant={ACTION_BADGE_VARIANT[log.action] ?? "muted"}>

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -100,88 +100,63 @@ export function UsersCard({
 
   return (
     <Card>
-      <CardHeader className="flex-row items-center justify-between gap-4 space-y-0 flex-wrap">
-        <CardTitle className="text-xl">{t("admin.users.title")}</CardTitle>
-        <div className="flex items-center gap-3 flex-wrap">
-          {selectedIds.size > 0 && (
-            <div className="flex w-full flex-wrap items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-1.5 sm:w-auto">
-              <span className="text-xs font-medium">{t("admin.users.selected", { count: selectedIds.size })}</span>
-              <Select
-                value={bulkRole}
-                onValueChange={(v) => onBulkRoleChange(v as UserRole)}
-              >
-                <SelectTrigger size="sm" className="w-auto">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="student">{t("roles.student")}</SelectItem>
-                  <SelectItem value="pending_teacher">{t("roles.pendingTeacher")}</SelectItem>
-                  <SelectItem value="teacher">{t("roles.teacher")}</SelectItem>
-                  <SelectItem value="admin">{t("roles.admin")}</SelectItem>
-                </SelectContent>
-              </Select>
-              <Button
-                size="sm"
-                className="h-9 text-xs sm:h-7"
-                onClick={onApplyBulkRole}
-                disabled={bulkUpdating}
-              >
-                {bulkUpdating ? t("admin.users.bulkUpdating") : t("admin.users.bulkApply")}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-9 text-xs sm:h-7"
-                onClick={onClearSelection}
-              >
-                {t("admin.users.bulkClear")}
-              </Button>
-            </div>
-          )}
-          <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-            {/* Role filter — narrows the table to a single role.
-                ``"all"`` ↔ empty string in the URL; same wrapper trick
-                the cohort / audit Selects use. */}
-            <Select
-              value={roleFilter || "all"}
-              onValueChange={(v) =>
-                onRoleFilterChange((v === "all" ? "" : v) as RoleFilterValue)
-              }
+      <CardHeader className="space-y-4">
+        {/* Row 1: title only. Keeps the visual hierarchy honest --
+            previously the title competed with three controls in a
+            single flex-wrap row, and at laptop widths the chip strip
+            below would wrap up under the search input creating an
+            orphan visual that looked unfinished. */}
+        <CardTitle className="text-lg">{t("admin.users.title")}</CardTitle>
+
+        {/* Row 2: filter + search aligned right. ``items-center`` so
+            the search h-9 input and select line up; ``ml-auto`` pushes
+            the controls to the trailing edge on wide widths but stays
+            stackable on mobile via ``flex-wrap``. */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Select
+            value={roleFilter || "all"}
+            onValueChange={(v) =>
+              onRoleFilterChange((v === "all" ? "" : v) as RoleFilterValue)
+            }
+          >
+            <SelectTrigger
+              size="sm"
+              aria-label={t("admin.users.roleFilterAria")}
+              className={cn(
+                "h-9 w-full sm:w-44",
+                roleFilter && "border-primary/40 ring-1 ring-primary/40",
+              )}
             >
-              <SelectTrigger
-                size="sm"
-                aria-label={t("admin.users.roleFilterAria")}
-                className={cn(
-                  "h-9 w-full sm:w-44",
-                  roleFilter && "border-primary/40 ring-1 ring-primary/40",
-                )}
-              >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">{t("admin.users.roleFilterAll")}</SelectItem>
-                <SelectItem value="admin">{t("roles.admin")}</SelectItem>
-                <SelectItem value="teacher">{t("roles.teacher")}</SelectItem>
-                <SelectItem value="pending_teacher">{t("roles.pendingTeacher")}</SelectItem>
-                <SelectItem value="student">{t("roles.student")}</SelectItem>
-              </SelectContent>
-            </Select>
-            <div className="relative w-full max-w-xs">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
-              <Input
-                placeholder={t("admin.users.searchPlaceholder")}
-                value={searchInput}
-                onChange={(e) => onSearchInputChange(e.target.value.slice(0, searchMaxLength))}
-                maxLength={searchMaxLength}
-                className="pl-9"
-              />
-            </div>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("admin.users.roleFilterAll")}</SelectItem>
+              <SelectItem value="admin">{t("roles.admin")}</SelectItem>
+              <SelectItem value="teacher">{t("roles.teacher")}</SelectItem>
+              <SelectItem value="pending_teacher">{t("roles.pendingTeacher")}</SelectItem>
+              <SelectItem value="student">{t("roles.student")}</SelectItem>
+            </SelectContent>
+          </Select>
+          <div className="relative w-full sm:max-w-xs sm:flex-1">
+            <Search
+              className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+              strokeWidth={1.75}
+              aria-hidden="true"
+            />
+            <Input
+              placeholder={t("admin.users.searchPlaceholder")}
+              value={searchInput}
+              onChange={(e) => onSearchInputChange(e.target.value.slice(0, searchMaxLength))}
+              maxLength={searchMaxLength}
+              className="pl-9"
+            />
           </div>
         </div>
-        {/* Role distribution chip strip — clickable shortcuts for the
-            filter that double as a tenant-shape snapshot. Hides
-            zero-count roles so the strip stays meaningful on small
-            tenants. Active filter gets the primary fill. */}
+
+        {/* Row 3: role distribution chip strip — clickable shortcuts
+            for the filter that double as a tenant-shape snapshot.
+            Hides zero-count roles so the strip stays meaningful on
+            small tenants. Active filter gets the primary fill. */}
         <div className="flex flex-wrap items-center gap-1.5 text-xs">
           {(["admin", "teacher", "pending_teacher", "student"] as const).map((role) => {
             if (roleCounts[role] === 0) return null
@@ -199,16 +174,58 @@ export function UsersCard({
                 )}
               >
                 <span>{t(`roles.${role === "pending_teacher" ? "pendingTeacher" : role}`)}</span>
-                <span className={cn(
-                  "tabular-nums",
-                  active ? "opacity-90" : "text-muted-foreground"
-                )}>
+                <span
+                  className={cn(
+                    "tabular-nums",
+                    active ? "opacity-90" : "text-muted-foreground",
+                  )}
+                >
                   {roleCounts[role]}
                 </span>
               </button>
             )
           })}
         </div>
+
+        {/* Row 4 (conditional): bulk-action bar. Lives below the
+            distribution strip rather than competing with title +
+            filters above; appears only when at least one row is
+            selected. Full-width tinted card makes the "selection
+            mode" state obvious. */}
+        {selectedIds.size > 0 && (
+          <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2">
+            <span className="text-xs font-medium">
+              {t("admin.users.selected", { count: selectedIds.size })}
+            </span>
+            <Select value={bulkRole} onValueChange={(v) => onBulkRoleChange(v as UserRole)}>
+              <SelectTrigger size="sm" className="w-auto">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="student">{t("roles.student")}</SelectItem>
+                <SelectItem value="pending_teacher">{t("roles.pendingTeacher")}</SelectItem>
+                <SelectItem value="teacher">{t("roles.teacher")}</SelectItem>
+                <SelectItem value="admin">{t("roles.admin")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              size="sm"
+              className="h-9 text-xs sm:h-7"
+              onClick={onApplyBulkRole}
+              disabled={bulkUpdating}
+            >
+              {bulkUpdating ? t("admin.users.bulkUpdating") : t("admin.users.bulkApply")}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-9 text-xs sm:h-7"
+              onClick={onClearSelection}
+            >
+              {t("admin.users.bulkClear")}
+            </Button>
+          </div>
+        )}
       </CardHeader>
       <CardContent>
         {loading ? (

--- a/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
@@ -22,6 +22,11 @@ function isRoleFilter(v: string): v is (typeof ROLE_FILTER_VALUES)[number] {
 interface UseAdminOverviewArgs {
   /** Current signed-in user id — excluded from bulk operations and delete confirmations. */
   currentUserId: string | undefined
+  /** When false, the hook skips the data fetch entirely. Used by the
+   *  AdminDashboard to avoid pulling users / courses / enrollments
+   *  counts when the user opens a tab (cohorts) that needs none of
+   *  them. Defaults to true so existing callers don't change shape. */
+  enabled?: boolean
 }
 
 /**
@@ -31,7 +36,7 @@ interface UseAdminOverviewArgs {
  * handlers. Split out of `AdminDashboard` so the page component stays
  * focused on layout and tab routing.
  */
-export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
+export function useAdminOverview({ currentUserId, enabled = true }: UseAdminOverviewArgs) {
   const confirm = useConfirm()
   const { t } = useTranslation()
   const [params, setParams] = useSearchParams()
@@ -76,6 +81,10 @@ export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
 
   const { data: fetchedData, loading, error: fetchError } = useAsyncData(
     async (isCancelled) => {
+      // Hook is reused across tabs that don't all need this data; the
+      // ``enabled`` arg lets the parent skip the fetch (and the loading
+      // state) without unmounting the hook.
+      if (!enabled) return undefined
       const [allUsers, coursesCount, enrollmentsCount, certs] = await Promise.all([
         coursesService.getAllUsers(),
         supabase.from("courses").select("id", { count: "exact", head: true }),
@@ -85,7 +94,7 @@ export function useAdminOverview({ currentUserId }: UseAdminOverviewArgs) {
       if (isCancelled()) return undefined
       return { allUsers, coursesCount, enrollmentsCount, certs }
     },
-    [reloadKey],
+    [reloadKey, enabled],
   )
 
   // Sync fetched data into individual state (handlers still need setUsers/setAdminCerts)


### PR DESCRIPTION
## Summary

End-to-end audit of the Admin section after Vadym reported visible styling artifacts and misplaced elements. Each item below is a distinct improvement; nothing is speculative.

### Visible UX

- **AdminDashboard:** header now carries the editorial eyebrow (\"Administration\"/\"Администрирование\") above the page title — matching Profile/Dashboard.
- **CohortDetailPage:** replaced the ad-hoc header+back-link block with the shared `PageHeader`. Back link, eyebrow, title, status picker, capacity meter, and Delete action now sit in a coherent shell instead of a wrap-prone floated div. Container max-width aligned to `max-w-6xl` (was `max-w-5xl`) — kills the visible width jump on navigation from the cohort list.
- **CohortDetailPage:** per-field saving. Single `savingField: boolean` became `savingField: string | null` so saving the name no longer freezes the date pickers and capacity input. Each field disables only itself.
- **CohortDetailPage:** bare `<p>` placeholders for \"no courses\" and \"no students\" replaced with `EmptyState`. Both empty surfaces now carry an action button straight to the matching dialog.
- **UsersCard:** rebuilt the CardHeader as four stacked rows (title / filters / chip strip / optional bulk action bar) instead of one wrap-prone flex row. The chip strip no longer orphans below the search input at laptop widths.

### Architecture

- `useAdminOverview` accepts `enabled`; `AdminDashboard` sets it only when the active tab is `overview` or `audit`. Opening `?tab=cohorts` cold no longer fires the users / courses count / enrollments count / pending certs fetch the cohorts surface doesn't read.
- `CohortDetailPage` stopped pulling the entire course catalog to show 1-5 attached courses. Switched to `Promise.all(course_ids.map(getCourse))`; the per-id endpoint is cached for 3 minutes so a warm revisit is free. On a tenant with N total courses and M attached, cost drops from O(N) to O(M) network bytes.

### i18n

- Cohorts tab was reusing `admin.audit.*` keys for pagination and \"Clear filters\". Moved to a shared `admin.pagination.*` namespace (both locales) so audit copy can be retuned without silently changing cohorts.

### Bugs

- `AuditLogTab` user-id stump fallback used `||` so a user with an empty-string name fell through to the 8-char id stump even though the lookup succeeded. Switched to `??`.

## Test plan

- [x] Frontend: lint + tsc + 288/288 tests + vite build all clean
- [ ] Manually: open ?tab=cohorts cold → users fetch does NOT fire (devtools network)
- [ ] Manually: cohort detail page width matches cohort list page width
- [ ] Manually: edit cohort name → date pickers stay enabled (don't dim)
- [ ] Manually: cohort with 0 courses → click Attach button from the empty state, not a separate header CTA
- [ ] Manually: UsersCard at 1280×800 → chip strip stays under filters row, no orphan
- [ ] Manually: audit user with no name fallback → reads id stump rather than rendering empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)