### PR TITLE
fix(admin): kill Users-table edge bleed (-mx-6 vs CardContent p-5)

### DIFF
--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -123,7 +123,12 @@ export default function VirtualAdminUsers({
   const height = Math.min(users.length * ROW_HEIGHT, 640)
 
   return (
-    <div role="table" aria-rowcount={users.length} className="-mx-6">
+    // ``-mx-5`` matches ``CardContent``'s ``p-5`` padding -- previously
+    // ``-mx-6`` against ``p-5`` left this virtualised list bleeding
+    // 4 px past the Card border on each side, so the header row's
+    // ``border-b`` showed up as visible stripes outside the rounded
+    // corners. Same bug + same fix as the non-virtual ``UsersTable``.
+    <div role="table" aria-rowcount={users.length} className="-mx-5">
       <div
         role="row"
         className="grid grid-cols-[40px_2fr_2fr_2fr_1fr_40px] items-center border-b px-3 py-3 text-xs font-medium text-muted-foreground"

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -324,9 +324,12 @@ function UsersTable({
   return (
     <>
       {/* Mobile: stacked card list — the table doesn't fit a phone. Same
-          data, same controls, larger tap targets. */}
-      <div className="-mx-3 space-y-2 sm:hidden">
-        <label className="mx-3 flex min-h-[44px] items-center gap-2 text-xs text-muted-foreground">
+          data, same controls, larger tap targets. No negative margins
+          here -- the previous ``-mx-3``/``mx-3`` pair on the outer and
+          inner divs cancelled out (net 0) and just made the layout
+          harder to read. */}
+      <div className="space-y-2 sm:hidden">
+        <label className="flex min-h-[44px] items-center gap-2 text-xs text-muted-foreground">
           <Checkbox
             checked={selectAllState}
             onCheckedChange={onToggleSelectAll}
@@ -334,7 +337,7 @@ function UsersTable({
           />
           <span>{t("admin.users.selectAllN", { count: filtered.length })}</span>
         </label>
-        <div className="mx-3 space-y-2">
+        <div className="space-y-2">
           {filtered.map((u) => (
             <UserCard
               key={u.id}
@@ -356,8 +359,17 @@ function UsersTable({
           can't push the actions column off-screen. ``max-h-[60vh]``
           matches the audit log so the users panel doesn't push the
           admin overview off-screen when the tenant grows past 20-30
-          rows. */}
-      <div className="-mx-6 hidden max-h-[60vh] overflow-y-auto sm:block">
+          rows.
+
+          ``-mx-5`` MUST match ``CardContent``'s ``p-5`` padding token
+          exactly. The previous ``-mx-6`` (-24 px) against ``p-5``
+          (20 px) left the table jutting 4 px past the Card's
+          rounded border on each side -- the thead ``border-b`` and
+          tbody ``divide-y`` rules then visibly bled out under the
+          rounded corners as little stripes on the left + right
+          edges. This is the cleanest fix: zero math, zero risk of
+          drift if the Card token changes. */}
+      <div className="-mx-5 hidden max-h-[60vh] overflow-y-auto sm:block">
         <table className="w-full table-fixed text-sm">
           <colgroup>
             <col className="w-10" />


### PR DESCRIPTION
## Summary

Vadym reported that the Users table looked \"a bit crooked\" with stripes sticking out from the left side. He was right and I had missed it on the prior pass. Diagnosis below.

### The bug

The scroll wrapper around the desktop Users table used \`-mx-6\` (-24 px) to pull the table edge-to-edge. In this codebase the shadcn \`CardContent\` token is \`p-5\` (20 px), not \`p-6\`. The 4 px difference put the table **outside** the Card's border on each side. Then:

- thead's \`border-b\` and tbody's \`divide-y\` rules followed the table to its (now overshooting) left and right edges
- those 1 px lines crossed under the Card's rounded corners
- visually: a stripe on the left + right edge of every row separator

Same bug in \`VirtualAdminUsers\` (used for tenants over 50 users) — same \`-mx-6\` on the virtual-list wrapper.

### The fix

Match the padding exactly. \`-mx-5\` against \`p-5\` puts the table flush with the Card's inner border with zero overshoot. Zero math, zero drift if the token ever changes. Applied to both \`UsersCard\` and \`VirtualAdminUsers\`.

Also cleaned up a no-op margin pair on the mobile branch — \`-mx-3\` on the outer div + \`mx-3\` on the label and inner card list cancelled out to net zero and added nothing but reader friction.

## Test plan

- [x] Frontend: lint + tsc + 288/288 tests clean
- [ ] Manually: open Admin → Overview, scroll Users list — no stripes outside the rounded card border
- [ ] Manually: as an admin in a tenant with 50+ users, confirm the virtual list also sits flush (no bleed)
- [ ] Manually: phone width — mobile card list still has the correct edge-to-edge layout (no negative-margin drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)