### PR TITLE
fix(admin): visual perfection sweep — kill 13 pixel/token bugs

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/context/useAuth"
 import { Button } from "@/components/ui/button"
 import { ErrorState } from "@/components/patterns"
 import PageSpinner from "@/components/ui/PageSpinner"
-import { ADMIN_TABS, type AdminTab } from "./dashboard/constants"
+import { ADMIN_TAB_PANEL_ID, ADMIN_TAB_TRIGGER_ID, ADMIN_TABS, type AdminTab } from "./dashboard/constants"
 import { AdminTabs } from "./dashboard/AdminTabs"
 import { OverviewStats } from "./dashboard/OverviewStats"
 import { PendingTeachersCard } from "./dashboard/PendingTeachersCard"
@@ -71,12 +71,12 @@ export default function AdminDashboard() {
   return (
     <div className="animate-fade-in container mx-auto max-w-6xl px-4 py-6 sm:py-8">
       <header className="mb-6 space-y-2">
-        <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
           {t("admin.eyebrow")}
         </p>
         <div className="flex items-center gap-3">
-          <div className="rounded-lg bg-primary/10 p-2">
-            <Shield className="h-6 w-6 text-primary" strokeWidth={1.75} />
+          <div className="rounded-md bg-primary/10 p-2">
+            <Shield className="h-6 w-6 text-primary" strokeWidth={1.75} aria-hidden />
           </div>
           <h1 className="font-serif text-2xl font-bold tracking-tight sm:text-3xl">
             {t("admin.title")}
@@ -100,7 +100,11 @@ export default function AdminDashboard() {
       )}
 
       {!overview.error && tab === "overview" && (
-        <>
+        <div
+          role="tabpanel"
+          id={ADMIN_TAB_PANEL_ID.overview}
+          aria-labelledby={ADMIN_TAB_TRIGGER_ID.overview}
+        >
           <OverviewStats
             stats={overview.stats}
             loading={overview.loading}
@@ -142,36 +146,48 @@ export default function AdminDashboard() {
             onRoleChange={overview.handleRoleChange}
             onDeleteUser={overview.handleDeleteUser}
           />
-        </>
+        </div>
       )}
 
       {tab === "cohorts" && (
-        <Suspense fallback={<PageSpinner />}>
-          <CohortsTab />
-        </Suspense>
+        <div
+          role="tabpanel"
+          id={ADMIN_TAB_PANEL_ID.cohorts}
+          aria-labelledby={ADMIN_TAB_TRIGGER_ID.cohorts}
+        >
+          <Suspense fallback={<PageSpinner />}>
+            <CohortsTab />
+          </Suspense>
+        </div>
       )}
 
       {!overview.error && tab === "audit" && (
-        <Suspense fallback={<PageSpinner />}>
-          <AuditLogTab
-            logs={audit.logs}
-            total={audit.total}
-            loading={audit.loading}
-            page={audit.page}
-            pageSize={audit.pageSize}
-            userMap={overview.userMap}
-            action={audit.action}
-            resource={audit.resource}
-            dateFrom={audit.dateFrom}
-            dateTo={audit.dateTo}
-            onAction={audit.setAction}
-            onResource={audit.setResource}
-            onDateRange={audit.setDateRange}
-            onReset={audit.resetFilters}
-            onPageChange={audit.setPage}
-            onPageSizeChange={audit.setPageSize}
-          />
-        </Suspense>
+        <div
+          role="tabpanel"
+          id={ADMIN_TAB_PANEL_ID.audit}
+          aria-labelledby={ADMIN_TAB_TRIGGER_ID.audit}
+        >
+          <Suspense fallback={<PageSpinner />}>
+            <AuditLogTab
+              logs={audit.logs}
+              total={audit.total}
+              loading={audit.loading}
+              page={audit.page}
+              pageSize={audit.pageSize}
+              userMap={overview.userMap}
+              action={audit.action}
+              resource={audit.resource}
+              dateFrom={audit.dateFrom}
+              dateTo={audit.dateTo}
+              onAction={audit.setAction}
+              onResource={audit.setResource}
+              onDateRange={audit.setDateRange}
+              onReset={audit.resetFilters}
+              onPageChange={audit.setPage}
+              onPageSizeChange={audit.setPageSize}
+            />
+          </Suspense>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -51,8 +51,8 @@ function UserRow({
     <div
       role="row"
       style={style}
-      className={`grid grid-cols-[40px_2fr_2fr_2fr_1fr_40px] items-center border-b px-3 text-sm hover:bg-muted/50 transition-colors ${
-        selected ? "bg-primary/[0.03]" : ""
+      className={`grid grid-cols-[40px_2fr_2fr_2fr_1fr_40px] items-center border-b px-3 text-sm transition-colors hover:bg-muted/40 ${
+        selected ? "border-primary/40 bg-primary/[0.08] dark:bg-primary/15" : ""
       }`}
     >
       <div role="cell" className="flex items-center justify-center">
@@ -62,22 +62,24 @@ function UserRow({
           aria-label={t("admin.users.selectAriaPrefix", { name: displayName })}
         />
       </div>
-      <div role="cell" className="flex items-center gap-3 px-3 min-w-0">
+      <div role="cell" className="flex min-w-0 items-center gap-3 px-3">
         {u.avatar_url ? (
           <img
             src={toProxyImage(u.avatar_url)}
             alt={t("admin.users.avatarAltPrefix", { name: u.full_name ?? u.email })}
-            className="h-8 w-8 rounded-full object-cover shrink-0"
+            className="h-8 w-8 shrink-0 rounded-full object-cover"
             loading="lazy"
           />
         ) : (
-          <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-muted-foreground shrink-0">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
             {(u.full_name?.[0] ?? u.email[0] ?? "?").toUpperCase()}
           </div>
         )}
-        <span className="font-medium truncate">{u.full_name || t("admin.users.missingName")}</span>
+        <span className="truncate font-medium" title={u.full_name ?? undefined}>
+          {u.full_name || t("admin.users.missingName")}
+        </span>
       </div>
-      <div role="cell" className="px-3 text-muted-foreground truncate">
+      <div role="cell" className="truncate px-3 text-muted-foreground" title={u.email}>
         {u.email}
       </div>
       <div role="cell" className="px-3 flex items-center gap-2">
@@ -101,7 +103,7 @@ function UserRow({
           aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
           title={u.id === currentUserId ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
         >
-          <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+          <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
         </Button>
       </div>
     </div>

--- a/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
@@ -239,7 +239,7 @@ export default function CohortDetailPage() {
         backLabel={t("admin.cohorts.backToList")}
         title={
           <div className="space-y-2">
-            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
               {t("admin.cohorts.eyebrow")}
             </p>
             <div className="flex flex-wrap items-center gap-3">
@@ -276,7 +276,7 @@ export default function CohortDetailPage() {
 
       <Card className="mb-6">
         <CardHeader className="pb-3">
-          <CardTitle className="flex items-center gap-2 text-lg">
+          <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
             <Calendar className="h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.detailsHeading")}
           </CardTitle>
@@ -337,7 +337,7 @@ export default function CohortDetailPage() {
 
       <Card className="mb-6">
         <CardHeader className="flex-row items-center justify-between space-y-0 pb-3">
-          <CardTitle className="text-lg">
+          <CardTitle className="font-serif text-lg font-semibold tracking-tight">
             {t("admin.cohorts.coursesHeading", { count: courses.length })}
           </CardTitle>
           <Button size="sm" className="h-9" onClick={() => setAttachOpen(true)}>
@@ -368,7 +368,7 @@ export default function CohortDetailPage() {
               {courses.map((c) => (
                 <li
                   key={c.id}
-                  className="flex items-center justify-between gap-3 rounded-md border border-border/80 bg-muted/10 px-3 py-2 transition-colors hover:border-primary/30 hover:bg-muted/25"
+                  className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/10 px-3 py-2 transition-colors hover:border-primary/30 hover:bg-muted/40"
                 >
                   <div className="flex min-w-0 items-center gap-2">
                     <Link
@@ -390,7 +390,7 @@ export default function CohortDetailPage() {
                     onClick={() => detachCourse(c.id)}
                     aria-label={t("admin.cohorts.detachAriaPrefix", { name: c.title })}
                   >
-                    <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+                    <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
                   </Button>
                 </li>
               ))}
@@ -600,7 +600,7 @@ function StudentsCard({
     <Card>
       <CardHeader className="gap-3 space-y-0">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <CardTitle className="flex items-center gap-2 text-lg">
+          <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
             <Users className="h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.studentsHeading", { count: students.length })}
           </CardTitle>
@@ -681,7 +681,7 @@ function StudentsCard({
                           name: s.full_name ?? s.email,
                         })}
                       >
-                        <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+                        <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
                       </Button>
                     </td>
                   </tr>

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -189,7 +189,7 @@ export function CohortsTab() {
     <Card className="flex max-h-[calc(100dvh-240px)] flex-col md:max-h-[calc(100dvh-200px)] md:min-h-[420px]">
       <CardHeader className="shrink-0 gap-3 space-y-0 border-b">
         <div className="flex items-center justify-between gap-3">
-          <CardTitle className="text-xl">{t("admin.cohorts.title")}</CardTitle>
+          <CardTitle className="font-serif text-xl font-semibold tracking-tight">{t("admin.cohorts.title")}</CardTitle>
           <Button size="sm" onClick={() => setCreateOpen(true)} className="h-9 shrink-0">
             <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.createButton")}
@@ -278,7 +278,7 @@ export function CohortsTab() {
             }
           />
         ) : filtered.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center px-6 py-10">
+          <div className="flex flex-1 items-center justify-center px-5 py-10">
             <EmptyCohorts hasQuery={filtersActive} onCreate={() => setCreateOpen(true)} />
           </div>
         ) : (

--- a/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
+++ b/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { Users, GraduationCap, FileText } from "lucide-react"
 import { cn } from "@/lib/utils"
-import type { AdminTab } from "./constants"
+import { ADMIN_TAB_PANEL_ID, ADMIN_TAB_TRIGGER_ID, type AdminTab } from "./constants"
 
 interface Props {
   active: AdminTab
@@ -21,18 +21,21 @@ export function AdminTabs({ active, onChange }: Props) {
   return (
     <div className="mb-6 flex gap-1 border-b border-border sm:mb-8" role="tablist">
       <TabButton
+        name="overview"
         active={active === "overview"}
         onClick={() => onChange("overview")}
         icon={<Users className="h-4 w-4" strokeWidth={1.75} aria-hidden />}
         label={t("admin.tabOverview")}
       />
       <TabButton
+        name="cohorts"
         active={active === "cohorts"}
         onClick={() => onChange("cohorts")}
         icon={<GraduationCap className="h-4 w-4" strokeWidth={1.75} aria-hidden />}
         label={t("admin.tabCohorts")}
       />
       <TabButton
+        name="audit"
         active={active === "audit"}
         onClick={() => onChange("audit")}
         icon={<FileText className="h-4 w-4" strokeWidth={1.75} aria-hidden />}
@@ -43,17 +46,20 @@ export function AdminTabs({ active, onChange }: Props) {
 }
 
 interface TabButtonProps {
+  name: AdminTab
   active: boolean
   onClick: () => void
   icon: React.ReactNode
   label: string
 }
 
-function TabButton({ active, onClick, icon, label }: TabButtonProps) {
+function TabButton({ name, active, onClick, icon, label }: TabButtonProps) {
   return (
     <button
       type="button"
       role="tab"
+      id={ADMIN_TAB_TRIGGER_ID[name]}
+      aria-controls={ADMIN_TAB_PANEL_ID[name]}
       aria-selected={active}
       onClick={onClick}
       className={cn(

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -92,7 +92,7 @@ export function AuditLogTab({
   return (
     <Card className="flex max-h-[calc(100dvh-240px)] flex-col md:max-h-[calc(100dvh-200px)] md:min-h-[420px]">
       <CardHeader className="shrink-0 gap-3 space-y-0 border-b">
-        <CardTitle className="flex items-center gap-2 text-xl">
+        <CardTitle className="flex items-center gap-2 font-serif text-xl font-semibold tracking-tight">
           <FileText className="h-5 w-5 shrink-0" strokeWidth={1.75} aria-hidden />
           {t("admin.audit.title")}
           <span className="ml-1.5 text-sm font-normal text-muted-foreground">
@@ -180,7 +180,7 @@ export function AuditLogTab({
         {loading ? (
           <AuditTableSkeleton />
         ) : logs.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center px-6 py-10">
+          <div className="flex flex-1 items-center justify-center px-5 py-10">
             <EmptyState
               variant="compact"
               icon={<FileText strokeWidth={1.75} aria-hidden />}

--- a/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
+++ b/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
@@ -108,7 +108,7 @@ export function OverviewStats({ stats, loading, pendingActions }: Props) {
           <CardContent className="flex items-start gap-4 p-5">
             <div
               className={cn(
-                "flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-border/80 bg-card",
+                "flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-border bg-card",
                 warningTint && "border-warning/40 bg-warning/10",
               )}
             >

--- a/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
@@ -23,7 +23,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
   return (
     <Card className="mb-6 border-l-stripe border-l-primary">
       <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-2 text-lg">
+        <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
           <Award className="h-4 w-4 text-primary" strokeWidth={1.75} aria-hidden />
           {t("admin.pendingCerts.title")}
           <Badge variant="default" className="font-normal">

--- a/frontend/src/pages/Admin/dashboard/PendingTeachersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingTeachersCard.tsx
@@ -60,7 +60,7 @@ export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: 
   return (
     <Card className="mb-6 border-l-stripe border-l-warning">
       <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-2 text-lg">
+        <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
           <Clock className="h-4 w-4 text-warning" strokeWidth={1.75} aria-hidden />
           {t("admin.pendingTeachers.title")}
           <Badge variant="warning" className="font-normal">
@@ -100,7 +100,7 @@ export function PendingTeachersCard({ pending, updatingId, onApprove, onDeny }: 
                       <span className="truncate">{u.email}</span>
                       {disposable && (
                         <Badge variant="destructive" className="ml-1 h-4 px-1 text-[10px] font-medium">
-                          <AlertTriangle className="mr-0.5 h-2.5 w-2.5" strokeWidth={2} aria-hidden />
+                          <AlertTriangle className="mr-0.5 h-3 w-3" strokeWidth={1.75} aria-hidden />
                           {t("admin.pendingTeachers.disposableEmail")}
                         </Badge>
                       )}

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -106,7 +106,7 @@ export function UsersCard({
             single flex-wrap row, and at laptop widths the chip strip
             below would wrap up under the search input creating an
             orphan visual that looked unfinished. */}
-        <CardTitle className="text-lg">{t("admin.users.title")}</CardTitle>
+        <CardTitle className="font-serif text-lg font-semibold tracking-tight">{t("admin.users.title")}</CardTitle>
 
         {/* Row 2: filter + search aligned right. ``items-center`` so
             the search h-9 input and select line up; ``ml-auto`` pushes
@@ -139,9 +139,9 @@ export function UsersCard({
           </Select>
           <div className="relative w-full sm:max-w-xs sm:flex-1">
             <Search
-              className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
               strokeWidth={1.75}
-              aria-hidden="true"
+              aria-hidden
             />
             <Input
               placeholder={t("admin.users.searchPlaceholder")}
@@ -193,7 +193,7 @@ export function UsersCard({
             selected. Full-width tinted card makes the "selection
             mode" state obvious. */}
         {selectedIds.size > 0 && (
-          <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2">
+          <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2">
             <span className="text-xs font-medium">
               {t("admin.users.selected", { count: selectedIds.size })}
             </span>
@@ -269,7 +269,7 @@ export function UsersCard({
           />
         )}
         {!loading && filtered.length > 0 && (
-          <p className="text-xs text-muted-foreground mt-4 px-6">
+          <p className="mt-4 text-xs text-muted-foreground">
             {t("admin.users.showing", { shown: filtered.length, total: users.length })}
           </p>
         )}
@@ -395,10 +395,10 @@ function UsersTable({
                   aria-label={t("admin.users.selectAllAria")}
                 />
               </th>
-              <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thName")}</th>
-              <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thEmail")}</th>
-              <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thRole")}</th>
-              <th className="px-6 py-3 font-medium text-muted-foreground">{t("admin.users.thJoined")}</th>
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.users.thName")}</th>
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.users.thEmail")}</th>
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.users.thRole")}</th>
+              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.users.thJoined")}</th>
               <th className="px-3 py-3" aria-label={t("admin.users.thActions")} />
             </tr>
           </thead>
@@ -436,7 +436,7 @@ function UserCard({
   return (
     <div
       className={`rounded-md border border-border bg-card p-3 transition-colors ${
-        selected ? "border-primary/40 bg-primary/[0.03]" : ""
+        selected ? "border-primary/40 bg-primary/[0.08] dark:bg-primary/15" : ""
       }`}
     >
       <div className="flex items-start gap-3">
@@ -475,7 +475,7 @@ function UserCard({
           aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
           title={isSelf ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
         >
-          <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+          <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
         </Button>
       </div>
       <div className="mt-3 pl-7">
@@ -513,8 +513,8 @@ function UserRow({
   const displayName = user.full_name || user.email
   return (
     <tr
-      className={`hover:bg-muted/50 transition-colors ${
-        selected ? "bg-primary/[0.03]" : ""
+      className={`transition-colors hover:bg-muted/40 ${
+        selected ? "bg-primary/[0.08] dark:bg-primary/15" : ""
       }`}
     >
       <td className="px-3 py-3">
@@ -524,7 +524,7 @@ function UserRow({
           aria-label={t("admin.users.selectAriaPrefix", { name: displayName })}
         />
       </td>
-      <td className="px-6 py-3">
+      <td className="px-5 py-3">
         <div className="flex min-w-0 items-center gap-3">
           {user.avatar_url ? (
             <img
@@ -542,10 +542,10 @@ function UserRow({
           </span>
         </div>
       </td>
-      <td className="px-6 py-3 text-muted-foreground">
+      <td className="px-5 py-3 text-muted-foreground">
         <span className="block truncate" title={user.email}>{user.email}</span>
       </td>
-      <td className="px-6 py-3">
+      <td className="px-5 py-3">
         <RoleSelector
           role={user.role}
           disabled={updating || isSelf}
@@ -553,7 +553,7 @@ function UserRow({
           ariaLabel={t("admin.users.changeRoleAria", { name: displayName })}
         />
       </td>
-      <td className="whitespace-nowrap px-6 py-3 text-xs text-muted-foreground tabular-nums">
+      <td className="whitespace-nowrap px-5 py-3 text-xs text-muted-foreground tabular-nums">
         {formatDate(user.created_at)}
       </td>
       <td className="px-3 py-3 text-right">
@@ -566,7 +566,7 @@ function UserRow({
           aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
           title={isSelf ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
         >
-          <Trash2 className="h-4 w-4" strokeWidth={1.75} />
+          <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
         </Button>
       </td>
     </tr>

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -7,6 +7,25 @@ export { ROLE_I18N_KEY } from "@/lib/roles"
 export type AdminTab = "overview" | "cohorts" | "audit"
 export const ADMIN_TABS: readonly AdminTab[] = ["overview", "cohorts", "audit"]
 
+/** Stable DOM ids for each admin tab's trigger button. Mirrors of these
+ *  live on the corresponding ``role="tabpanel"`` wrappers in
+ *  ``AdminDashboard.tsx`` via ``aria-labelledby``, so screen readers
+ *  hear "Cohorts, tab, selected" and the panel reads as belonging to
+ *  that tab. Kept in the constants module so AdminTabs.tsx stays a
+ *  pure component file (no shared constants → no Fast Refresh
+ *  invalidation when only the component changes). */
+export const ADMIN_TAB_TRIGGER_ID = {
+  overview: "admin-tab-overview",
+  cohorts: "admin-tab-cohorts",
+  audit: "admin-tab-audit",
+} as const
+
+export const ADMIN_TAB_PANEL_ID = {
+  overview: "admin-tabpanel-overview",
+  cohorts: "admin-tabpanel-cohorts",
+  audit: "admin-tabpanel-audit",
+} as const
+
 export const ACTION_OPTIONS = [
   "create",
   "update",


### PR DESCRIPTION
## Summary

Vadym called out that the 6-minute pass on the Users table was lazy. I ran 4 parallel forensic audits (visual, cross-file consistency, edge-cases/responsive, backend) on the entire admin section. This PR ships the visual + token + a11y items; UX-bug and backend-correctness PRs follow.

### Pixel / token fixes

- **UsersCard** — th/td cells stayed on `px-6` after the `-mx-5` wrapper landed in PR #463; the cells were 4 px to the right of where the wrapper put the table edge. Migrated all 6 body cells + 4 header cells + the \"showing N of M\" footer to `px-5`. Matches AuditLogTab / CohortsTab / StudentsCard which already use `px-5` uniformly.
- **AuditLogTab + CohortsTab** — empty-state wrappers had `px-6 py-10` inside a CardContent that uses the `p-5` token; aligned both to `px-5 py-10` so the empty/populated boundary stops jogging by 4 px.
- **PendingTeachersCard** — AlertTriangle had `strokeWidth={2}` and `h-2.5 w-2.5` — only stroke-width-2 in the entire admin tree and smallest icon by a wide margin. Bumped to `h-3 w-3` + `1.75`.

### Dark-mode invisibility

- `bg-primary/[0.03]` selected-row tint was effectively invisible on dark cards (3 locations: VirtualAdminUsers, UsersCard desktop row, UsersCard mobile card). Migrated to `bg-primary/[0.08]` + `dark:bg-primary/15` so the selection actually reads in both themes.

### Tone unification

- Row-hover bg drift `muted/40` vs `muted/50` vs non-standard `muted/25` → unified to `bg-muted/40` in UsersCard, VirtualAdminUsers, and CohortDetailPage course chips.
- Border-tone drift: OverviewStats stat-icon tile had `border-border/80` (only opacity step in admin); UsersCard selection bar had `border-primary/20` (only `/20` in admin). Both moved to standard tokens.

### Editorial typography

- Admin CardTitles were all sans-serif (`text-lg`/`text-xl` with no `font-serif`), while Profile/Dashboard CardTitles are `font-serif text-lg font-semibold tracking-tight`. Added `font-serif font-semibold tracking-tight` to every admin CardTitle (8 locations) so admin reads as one app with the rest of the editorial surface.
- Eyebrow size split `text-xs` (12 px) vs `text-[11px]` (11 px): FilterField's own docstring claims `[11px]` is the DESIGN.md recipe. Migrated the two page-header eyebrows (AdminDashboard, CohortDetailPage) to `text-[11px]` so every admin eyebrow is the same 11 px now.

### A11y

- Trash icons across UsersCard / VirtualAdminUsers / CohortDetailPage gained `aria-hidden` (PendingTeachers/Certs already had it).
- AdminDashboard Shield gained `aria-hidden` + `rounded-md` (was `rounded-lg`, the only such radius for admin icon tiles).
- UsersCard search icon gained `pointer-events-none` so clicks fall through to the input cleanly.
- VirtualAdminUsers name + email cells gained `title=` attributes so truncated content has a hover/AT escape hatch (matches UsersTable parity).
- AdminTabs + AdminDashboard wired `aria-controls` / `aria-labelledby` / `role=\"tabpanel\"` so screen readers hear the tab→panel relationship. IDs moved to `constants.ts` to keep AdminTabs.tsx a pure Fast-Refresh-friendly component file.

## Test plan

- [x] Frontend: lint + tsc + 288/288 tests + build all clean
- [ ] Manually: Users table cells line up flush with header chip strip (no 4px shift)
- [ ] Manually: select a user row in dark mode — selection visible
- [ ] Manually: hover rows in Users table — matches hover in Cohorts table
- [ ] Manually: admin CardTitles read serif (not sans), matching Profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)