### PR TITLE
fix(admin-backend): cert two-eyes + reject-stage gate + silent IntegrityError + audit + rate limits

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -187,6 +187,7 @@ def get_cohort(
 def update_cohort(
     cohort_id: UUID,
     data: CohortUpdate,
+    request: Request,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> CohortResponse:
@@ -203,13 +204,32 @@ def update_cohort(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot reopen a completed cohort",
         )
+    # Snapshot the fields the admin is actually changing for the audit
+    # row. Comparing pre/post values means a no-op PATCH (same fields,
+    # same values) doesn't generate a noisy audit entry, and a status
+    # flip like ``upcoming -> active`` is fully traceable: the row holds
+    # both ends of the transition.
+    changes: dict[str, dict[str, object]] = {}
     for field, value in patch.items():
+        before = getattr(cohort, field)
+        if before != value:
+            changes[field] = {"from": before, "to": value}
         setattr(cohort, field, value)
     db.commit()
     db.refresh(cohort)
     # Translation reconcile reads the attached-course set internally and
     # is idempotent — call once per cohort, not once per attached course.
     reconcile_entity_if_course_published(db, "cohort", cohort)
+    if changes:
+        log_action(
+            db,
+            admin.id,
+            "update",
+            "cohort",
+            str(cohort.id),
+            details={"changes": changes, "name": cohort.name},
+            request=request,
+        )
     return _serialize(db, cohort)
 
 
@@ -354,8 +374,24 @@ def attach_course(
     try:
         db.commit()
     except IntegrityError:
-        # A concurrent attach raced us; safe to roll back and re-read.
+        # Two paths can land here:
+        #   1. A concurrent attach raced us. After rollback the link
+        #      already exists, so the desired state is satisfied and
+        #      we treat it as idempotent success.
+        #   2. A different constraint actually fired (FK violation,
+        #      etc.) -- the link is missing post-rollback and we
+        #      surface a 409 instead of silently 201'ing.
         db.rollback()
+        still_linked = (
+            db.query(CohortCourse)
+            .filter(CohortCourse.cohort_id == cohort.id, CohortCourse.course_id == course.id)
+            .first()
+        )
+        if still_linked is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Could not attach course due to a conflict; please retry.",
+            ) from None
     db.refresh(cohort)
     log_action(
         db,
@@ -547,7 +583,21 @@ def add_student(
     try:
         db.commit()
     except IntegrityError:
+        # Same idempotency check as ``attach_course``: if a concurrent
+        # add_student already landed the enrollments for this (user,
+        # cohort), the desired state is satisfied -- 201. Otherwise
+        # we surface a 409 instead of silently lying about success.
         db.rollback()
+        landed = (
+            db.query(Enrollment.course_id)
+            .filter(Enrollment.cohort_id == cohort.id, Enrollment.user_id == user.id)
+            .first()
+        )
+        if landed is None and missing_course_ids:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Could not add student due to a conflict; please retry.",
+            ) from None
     log_action(
         db,
         admin.id,

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -63,6 +63,15 @@ ENDPOINT_LIMITS: dict[str, tuple[int, int]] = {
     # case and prevents trivial cost-amplification attacks against the
     # upstream quota.
     "/api/v1/verse-of-the-day": (60, 60),
+    # Admin-mutation buckets. A compromised admin token falls under the
+    # global 100/60s default otherwise, which is enough for an attacker
+    # to script delete-100-users-per-minute. These per-prefix ceilings
+    # are still generous for legitimate admin use (typing through 30
+    # role changes a minute is unusual; deleting 30 users a minute is
+    # very unusual). Reads on these prefixes also share the bucket --
+    # that's a small UX cost for the safety net.
+    "/api/v1/users/admin/": (30, 60),
+    "/api/v1/cohorts": (60, 60),
 }
 
 MAX_BUCKETS = 10_000

--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -27,6 +27,7 @@ from fastapi import HTTPException, Request, status
 from app.api.dependencies import assert_course_owner
 from app.models.certificate import Certificate
 from app.models.course import Course
+from app.models.user import UserRole
 from app.services.audit_service import log_action
 from app.services.notification_service import create_notification
 
@@ -156,6 +157,21 @@ def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> 
     _assert_status(cert, "teacher_approved")
     _assert_not_self_approval(cert, admin)
 
+    # Two-eyes guard. An admin who is ALSO the course's teacher can land on
+    # the cert at the ``teacher_approved`` stage (they signed it themselves
+    # via ``teacher_approve``) and then immediately admin-approve it,
+    # collapsing the two-step review into one human. Refuse when the
+    # admin's id matches the teacher-approver's so issuance always involves
+    # two distinct accounts.
+    if cert.teacher_approved_by is not None and str(cert.teacher_approved_by) == str(admin.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "You can't admin-approve a certificate you teacher-approved yourself. "
+                "Another admin needs to sign off on this issuance."
+            ),
+        )
+
     cert.status = "approved"
     cert.certificate_number = generate_certificate_number()
     now = datetime.now(UTC)
@@ -198,6 +214,21 @@ def reject(db: Session, cert_id: UUID, user: User, request: Request) -> Certific
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Certificate cannot be rejected (current status: {cert.status})",
+        )
+
+    # Stage-gated authorisation:
+    #   pending           -> teacher (course owner) or admin
+    #   teacher_approved  -> admin only (the cert is at the admin desk;
+    #                        the original teacher already signed off and
+    #                        shouldn't be able to walk it back without
+    #                        a second pair of eyes)
+    # Without this gate, a course-owning teacher could teacher-approve a
+    # cert, change their mind, and reject it after it reached the admin
+    # queue -- effectively a one-person veto of their own prior approval.
+    if cert.status == "teacher_approved" and user.role != UserRole.ADMIN.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=("Only an administrator can reject a certificate that has already passed teacher approval."),
         )
 
     ownership_detail = "You can only reject certificates for your own courses"

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -16,7 +16,7 @@ from app.models.enrollment import Enrollment
 from app.models.quiz import Quiz, QuizAttempt
 from app.models.student_grade import StudentGrade
 from app.models.user import User, UserRole
-from tests.conftest import STUDENT_ID, TEACHER_ID
+from tests.conftest import ADMIN_ID, STUDENT_ID, TEACHER_ID
 
 # SQLite does not auto-cast str → UUID for bind parameters.  The grade
 # endpoints receive ``student_id`` as a plain ``str`` from the URL and
@@ -492,10 +492,20 @@ class TestRejectCertificate:
         assert r.status_code == 200
         assert r.json()["status"] == "rejected"
 
-    def test_reject_teacher_approved(self, client: TestClient, db: Session):
+    def test_teacher_cannot_reject_teacher_approved(self, client: TestClient, db: Session):
+        # New stage-gated policy: once a cert is teacher-approved it sits
+        # at the admin desk, and the original teacher cannot walk back
+        # their own prior approval without a second pair of eyes.
         _seed_enrolled_course(db, progress=100)
         cert = _seed_certificate(db, "course-1", cert_status="teacher_approved")
         r = client.put(f"/api/v1/certificates/{cert.id}/reject")
+        assert r.status_code == 403
+
+    def test_admin_can_reject_teacher_approved(self, admin_client: TestClient, db: Session):
+        # Admin reject is the legitimate path at the teacher-approved stage.
+        _seed_enrolled_course(db, progress=100)
+        cert = _seed_certificate(db, "course-1", cert_status="teacher_approved")
+        r = admin_client.put(f"/api/v1/certificates/{cert.id}/reject")
         assert r.status_code == 200
         assert r.json()["status"] == "rejected"
 
@@ -618,19 +628,47 @@ class TestCertificateSurvivesCourseDeletion:
 
 
 class TestFullCertificateLifecycle:
-    """Integration: seed → teacher-approve → admin-approve → verify."""
+    """Integration: seed → teacher-approve → admin-approve → verify.
+
+    Two-eyes policy means teacher and admin MUST be distinct user
+    accounts. We use the dedicated ``admin_client`` fixture (a separate
+    seeded user) for the admin-approve step, instead of promoting the
+    same user mid-test like the old version did.
+    """
 
     def test_lifecycle(self, client: TestClient, db: Session):
+        from app.api.dependencies import get_current_user
+        from app.main import app
+
         _seed_enrolled_course(db, progress=100)
         cert = _seed_certificate(db, "course-1")
 
+        # Step 1: course-owning teacher signs off
         r = client.put(f"/api/v1/certificates/{cert.id}/teacher-approve")
         assert r.status_code == 200
         assert r.json()["status"] == "teacher_approved"
 
-        _make_admin(db)
-
-        r = client.put(f"/api/v1/certificates/{cert.id}/admin-approve")
+        # Step 2: swap auth to a DIFFERENT user (the admin fixture seeds
+        # ADMIN_ID) so the two-eyes policy is satisfied. The dependency
+        # override only persists inside the ``with`` block, so the
+        # subsequent verify call falls back to the teacher-authed client.
+        admin = User(
+            id=ADMIN_ID,
+            email="admin@example.com",
+            full_name="Test Admin",
+            role=UserRole.ADMIN.value,
+        )
+        db.add(admin)
+        db.commit()
+        prev_override = app.dependency_overrides.get(get_current_user)
+        app.dependency_overrides[get_current_user] = lambda: admin
+        try:
+            r = client.put(f"/api/v1/certificates/{cert.id}/admin-approve")
+        finally:
+            if prev_override is None:
+                app.dependency_overrides.pop(get_current_user, None)
+            else:
+                app.dependency_overrides[get_current_user] = prev_override
         assert r.status_code == 200
         cert_number = r.json()["certificate_number"]
         assert cert_number.startswith("CERT-")
@@ -638,6 +676,23 @@ class TestFullCertificateLifecycle:
         r = client.get(f"/api/v1/certificates/verify/{cert_number}")
         assert r.status_code == 200
         assert r.json()["valid"] is True
+
+    def test_admin_cannot_complete_own_teacher_approval(self, client: TestClient, db: Session):
+        """Regression for the two-eyes loophole: a teacher who's later
+        promoted to admin (or is admin from the start with course-owner
+        rights) cannot complete both approval stages single-handedly.
+        """
+        _seed_enrolled_course(db, progress=100)
+        cert = _seed_certificate(db, "course-1")
+
+        # Step 1: teacher_approve as TEACHER_ID
+        r = client.put(f"/api/v1/certificates/{cert.id}/teacher-approve")
+        assert r.status_code == 200
+
+        # Step 2: promote SAME user to admin and try to admin-approve
+        _make_admin(db)
+        r = client.put(f"/api/v1/certificates/{cert.id}/admin-approve")
+        assert r.status_code == 403
 
 
 # =====================================================================


### PR DESCRIPTION
**Cert two-eyes:** admin_approve refuses when cert.teacher_approved_by == admin.id. Reject is stage-gated: at teacher_approved stage only admin can reject. **attach_course/add_student:** silent IntegrityError swallow → re-read post-rollback, raise 409 if state not satisfied. **update_cohort:** added audit log with per-field diff. **Rate limits:** added /users/admin/ (30/60s) + /cohorts (60/60s) buckets. **Tests:** 3 cert tests rewritten/added including regression for the two-eyes loophole. 707/707 tests pass, ruff+mypy clean.