### PR TITLE
fix(student): CRIT calendar i18n + selectedDay sync + empty-state padding + aria-hidden

### DIFF
--- a/frontend/src/pages/Calendar/MonthGrid.tsx
+++ b/frontend/src/pages/Calendar/MonthGrid.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import type { CalendarEvent } from "@/types";
-import { DAY_NAMES, EVENT_COLORS, MONTH_NAMES, getEventColor } from "./constants";
+import { EVENT_COLORS, getDayShortName, getEventColor, getMonthName } from "./constants";
 import { calendarDayKey, isSameDay } from "./utils";
 
 interface MonthGridProps {
@@ -36,17 +36,23 @@ export function MonthGrid({
   onNextMonth,
   onGoToday,
 }: MonthGridProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.resolvedLanguage ?? i18n.language ?? "en";
+  // ``getMonthName`` / ``getDayShortName`` are locale-aware via Intl;
+  // previously this file read hard-coded English ``MONTH_NAMES`` /
+  // ``DAY_NAMES`` arrays, so the calendar grid rendered "January Sun
+  // Mon Tue" regardless of the user's language.
+  const dayLabels = Array.from({ length: 7 }, (_, i) => getDayShortName(i, locale));
   return (
     <Card>
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between gap-3">
           <div>
-            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground tabular-nums">
+            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground tabular-nums">
               {year}
             </p>
-            <CardTitle className="font-serif text-xl font-semibold tracking-tight">
-              {MONTH_NAMES[month]}
+            <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+              {getMonthName(month, locale)}
             </CardTitle>
           </div>
           <div className="flex items-center gap-1">
@@ -76,12 +82,12 @@ export function MonthGrid({
       </CardHeader>
       <CardContent className="pt-2">
         <div className="mb-1 grid grid-cols-7">
-          {DAY_NAMES.map((d, i) => {
+          {dayLabels.map((d, i) => {
             const isWeekend = i === 0 || i === 6;
             return (
               <div
-                key={d}
-                className={`py-1.5 text-center text-xs font-medium uppercase tracking-[0.18em] ${
+                key={i}
+                className={`py-1.5 text-center text-[11px] font-medium uppercase tracking-[0.18em] ${
                   isWeekend ? "text-muted-foreground/60" : "text-muted-foreground"
                 }`}
               >

--- a/frontend/src/pages/Calendar/constants.ts
+++ b/frontend/src/pages/Calendar/constants.ts
@@ -43,19 +43,33 @@ export function getEventColor(type: string): EventColorPalette {
   return EVENT_COLORS[type] ?? FALLBACK_EVENT_COLOR;
 }
 
-export const MONTH_NAMES = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-];
+/**
+ * Locale-aware month name for the calendar header. Previously this was
+ * a hard-coded English array (``"January", "February", ...``) -- a real
+ * i18n regression in a Russian-first bilingual app where the calendar
+ * grid would read English regardless of the user's language. ``Intl``
+ * gets us the localized full name without bundling per-language tables,
+ * and BCP-47 ``ru-RU`` / ``en-US`` are the only locales the app
+ * supports today.
+ */
+export function getMonthName(monthIndex: number, locale: string): string {
+  const bcp47 = locale.toLowerCase().startsWith("ru") ? "ru-RU" : "en-US";
+  // Day 15 avoids any timezone-edge surprise; any day inside the month works.
+  const ref = new Date(2000, monthIndex, 15);
+  return new Intl.DateTimeFormat(bcp47, { month: "long" }).format(ref);
+}
 
-export const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+/**
+ * Locale-aware short weekday name (``Sun..Sat`` / ``Вс..Сб``). Same
+ * reasoning as ``getMonthName`` -- hard-coded English would only
+ * render correctly for half the user base.
+ *
+ * Indices are Sun=0..Sat=6 to match ``Date.prototype.getDay`` so the
+ * caller can pass values from the existing day-of-week math directly.
+ */
+export function getDayShortName(dayIndex: number, locale: string): string {
+  const bcp47 = locale.toLowerCase().startsWith("ru") ? "ru-RU" : "en-US";
+  // 2000-01-02 was a Sunday in every timezone, so add (dayIndex) days.
+  const ref = new Date(2000, 0, 2 + dayIndex);
+  return new Intl.DateTimeFormat(bcp47, { weekday: "short" }).format(ref);
+}

--- a/frontend/src/pages/Calendar/useMonthGrid.ts
+++ b/frontend/src/pages/Calendar/useMonthGrid.ts
@@ -84,8 +84,27 @@ export function useMonthGrid(events: CalendarEvent[]) {
     setSelectedDay,
     selectedDayEvents,
     upcomingEvents,
-    prevMonth: () => setCurrentDate(new Date(year, month - 1, 1)),
-    nextMonth: () => setCurrentDate(new Date(year, month + 1, 1)),
-    goToday: () => setCurrentDate(new Date()),
+    // ``selectedDay`` needs to follow the visible month -- otherwise
+    // navigating May -> June while May-15 was selected leaves the
+    // right-side panel claiming "events for May 15" while rendering
+    // an empty June grid. Anchor selectedDay to the 1st of the
+    // destination month so the panel reads the new month's data on
+    // navigation; ``goToday`` snaps both the grid AND selection back
+    // to today.
+    prevMonth: () => {
+      const nextMonthStart = new Date(year, month - 1, 1)
+      setCurrentDate(nextMonthStart)
+      setSelectedDay(nextMonthStart)
+    },
+    nextMonth: () => {
+      const nextMonthStart = new Date(year, month + 1, 1)
+      setCurrentDate(nextMonthStart)
+      setSelectedDay(nextMonthStart)
+    },
+    goToday: () => {
+      const today = new Date()
+      setCurrentDate(today)
+      setSelectedDay(today)
+    },
   };
 }

--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -181,7 +181,7 @@ function ChapterBodyBlocks({
   }
   if (blocks.length === 0) {
     return (
-      <div className="rounded-md border border-dashed border-border bg-muted/20 px-6 py-12 text-center">
+      <div className="rounded-md border border-dashed border-border bg-muted/20 px-5 py-12 text-center">
         <p className="text-sm text-muted-foreground">
           {t("chapter.emptyContent")}
         </p>

--- a/frontend/src/pages/Course/ModuleView.tsx
+++ b/frontend/src/pages/Course/ModuleView.tsx
@@ -93,7 +93,7 @@ export default function ModuleView() {
     return (
       <div className="container mx-auto px-4">
         <ErrorState
-          icon={<Book strokeWidth={1.75} />}
+          icon={<Book strokeWidth={1.75} aria-hidden />}
           title={error ?? t("toast.moduleNotFound")}
           action={
             <Link to={courseId ? `/courses/${courseId}` : "/"}>
@@ -112,7 +112,7 @@ export default function ModuleView() {
     <div className="container mx-auto px-4 py-6 max-w-3xl">
       <Link to={`/courses/${courseId}`}>
         <Button variant="ghost" size="sm" className="mb-4 h-8 text-xs">
-          <ArrowLeft className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.75} />
+          <ArrowLeft className="h-3.5 w-3.5 mr-1.5" strokeWidth={1.75} aria-hidden />
           {t("course.backToCourse")}
         </Button>
       </Link>
@@ -140,9 +140,9 @@ export default function ModuleView() {
                 : "border-border bg-muted/50"
           }`}>
             {isOverdue ? (
-              <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" strokeWidth={1.75} />
+              <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" strokeWidth={1.75} aria-hidden />
             ) : (
-              <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
+              <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
             )}
             <span className={`text-sm font-medium ${
               isOverdue ? "text-destructive" : isUpcoming ? "text-warning" : "text-foreground"
@@ -161,7 +161,7 @@ export default function ModuleView() {
 
       {allComplete && (
         <div className="mb-4 flex items-center gap-2 rounded-md border border-border border-l-stripe border-l-success bg-success/10 px-3 py-2">
-          <CheckCircle className="h-4 w-4 shrink-0 text-success" strokeWidth={1.75} />
+          <CheckCircle className="h-4 w-4 shrink-0 text-success" strokeWidth={1.75} aria-hidden />
           <span className="text-sm font-medium text-success">{t("module.moduleComplete")}</span>
         </div>
       )}
@@ -185,7 +185,7 @@ export default function ModuleView() {
 
       <div>
         <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
-          <Book className="h-4 w-4" strokeWidth={1.75} />
+          <Book className="h-4 w-4" strokeWidth={1.75} aria-hidden />
           {t("module.chaptersHeading")}
           <span className="text-sm font-normal text-muted-foreground">
             ({sortedChapters.length})
@@ -211,14 +211,14 @@ export default function ModuleView() {
                   >
                     <CardHeader className="pb-2">
                       <CardTitle className="flex min-w-0 items-center gap-2 text-base">
-                        <Lock className="h-5 w-5 text-muted-foreground/50 shrink-0" strokeWidth={1.75} />
+                        <Lock className="h-5 w-5 text-muted-foreground/50 shrink-0" strokeWidth={1.75} aria-hidden />
                         <span className="min-w-0 flex-1 truncate text-muted-foreground">
                           {chapter.title}
                         </span>
                         {chapter.chapter_type && (
                           <ChapterTypeBadge type={chapter.chapter_type} size="sm" />
                         )}
-                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/30" strokeWidth={1.75} />
+                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/30" strokeWidth={1.75} aria-hidden />
                       </CardTitle>
                     </CardHeader>
                   </Card>
@@ -239,11 +239,11 @@ export default function ModuleView() {
                       <CardTitle className="flex min-w-0 items-center gap-2 text-base">
                         {isGradable ? (
                           isCompleted ? (
-                            <CheckCircle className="h-5 w-5 shrink-0 text-success" strokeWidth={1.75} />
+                            <CheckCircle className="h-5 w-5 shrink-0 text-success" strokeWidth={1.75} aria-hidden />
                           ) : requiresTeacher ? (
-                            <Lock className="h-5 w-5 shrink-0 text-warning" strokeWidth={1.75} />
+                            <Lock className="h-5 w-5 shrink-0 text-warning" strokeWidth={1.75} aria-hidden />
                           ) : (
-                            <Circle className="h-5 w-5 shrink-0 text-muted-foreground/40" strokeWidth={1.75} />
+                            <Circle className="h-5 w-5 shrink-0 text-muted-foreground/40" strokeWidth={1.75} aria-hidden />
                           )
                         ) : null}
                         <span className={`min-w-0 flex-1 truncate ${isCompleted ? "text-muted-foreground" : ""}`}>
@@ -252,7 +252,7 @@ export default function ModuleView() {
                         {chapter.chapter_type && (
                           <ChapterTypeBadge type={chapter.chapter_type} size="sm" />
                         )}
-                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" strokeWidth={1.75} />
+                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" strokeWidth={1.75} aria-hidden />
                       </CardTitle>
                     </CardHeader>
                   </Card>

--- a/frontend/src/pages/Courses/CoursesPage.tsx
+++ b/frontend/src/pages/Courses/CoursesPage.tsx
@@ -121,7 +121,7 @@ export default function CoursesPage() {
         </div>
       ) : error ? (
         <ErrorState
-          icon={<BookOpen />}
+          icon={<BookOpen strokeWidth={1.75} aria-hidden />}
           description={error}
           action={
             <Button variant="ghost" size="sm" onClick={() => setReloadKey((k) => k + 1)}>
@@ -131,7 +131,7 @@ export default function CoursesPage() {
         />
       ) : courses.length === 0 ? (
         <EmptyState
-          icon={<BookOpen />}
+          icon={<BookOpen strokeWidth={1.75} aria-hidden />}
           title={query ? t("courses.noCoursesFound") : t("courses.noCoursesYet")}
           description={query ? t("courses.tryDifferentSearch") : t("courses.checkBackSoon")}
           className="border-none bg-transparent py-20"


### PR DESCRIPTION
**CRIT i18n:** Calendar MONTH_NAMES/DAY_NAMES were hard-coded English — calendar grid permanently read English in Russian-first bilingual app. Replaced with Intl.DateTimeFormat. **CRIT nav bug:** useMonthGrid prev/next/goToday now re-anchor selectedDay so the right panel always describes a visible day. **HIGH:** ChapterView empty px-6 → px-5, CoursesPage default-strokeWidth BookOpen → 1.75 + aria-hidden, ModuleView 12 icons gained aria-hidden. lint+tsc+288 tests pass.