### PR TITLE
fix(teacher): CRIT token + numeric validation fixes

### DIFF
--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -327,7 +327,7 @@ export default function ChapterEditor() {
                 aria-pressed={selected}
                 className={`flex items-start gap-3 rounded-md border p-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                   selected
-                    ? "border-primary bg-primary/[0.04] ring-1 ring-primary/40"
+                    ? "border-primary bg-primary/[0.08] ring-1 ring-primary/40 dark:bg-primary/15"
                     : "border-border hover:border-primary/30 hover:bg-muted/40"
                 }`}
               >
@@ -358,7 +358,7 @@ export default function ChapterEditor() {
 
       {/* Type-specific editor */}
       <Card data-tour="chapter-editor-blocks" className="mb-6">
-        <CardContent className="p-6 space-y-4">
+        <CardContent className="space-y-4 p-5">
           {chapterType === "reading" && (
             <ChapterBlockEditor chapterId={chapter.id} />
           )}

--- a/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
@@ -54,7 +54,7 @@ export function CourseCard({
 
   return (
     <Card className="group transition-colors hover:border-primary/30">
-      <div className="flex items-start gap-3 p-4 sm:gap-4 sm:p-6">
+      <div className="flex items-start gap-3 p-4 sm:gap-4 sm:p-5">
         {course.image_url ? (
           <img
             src={toProxyImage(course.image_url)}

--- a/frontend/src/pages/Teacher/dashboard/TeacherDashboardSkeleton.tsx
+++ b/frontend/src/pages/Teacher/dashboard/TeacherDashboardSkeleton.tsx
@@ -11,7 +11,7 @@ export function TeacherDashboardSkeleton() {
     <div className="space-y-4" aria-hidden="true">
       {[0, 1, 2].map((i) => (
         <Card key={i}>
-          <div className="flex items-start gap-4 p-6">
+          <div className="flex items-start gap-4 p-5">
             <Skeleton className="h-20 w-20 shrink-0 rounded-lg" />
             <div className="flex-1 min-w-0 space-y-3">
               <div className="flex items-center gap-2">

--- a/frontend/src/pages/Teacher/editor/AccessModeModal.tsx
+++ b/frontend/src/pages/Teacher/editor/AccessModeModal.tsx
@@ -81,7 +81,7 @@ function Option({ checked, onSelect, icon, label, description }: OptionProps) {
       aria-pressed={checked}
       className={`w-full text-left rounded-md border p-3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
         checked
-          ? "border-primary bg-primary/5"
+          ? "border-primary bg-primary/[0.08] dark:bg-primary/15"
           : "border-border hover:border-primary/40"
       }`}
     >

--- a/frontend/src/pages/Teacher/editor/LoadingSkeleton.tsx
+++ b/frontend/src/pages/Teacher/editor/LoadingSkeleton.tsx
@@ -5,9 +5,9 @@ export function CourseEditorSkeleton() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <Skeleton className="h-8 w-32 mb-6" />
-      <div className="rounded-lg border overflow-hidden mb-8">
+      <div className="mb-8 overflow-hidden rounded-md border">
         <Skeleton className="h-48 w-full rounded-none" />
-        <div className="p-6 space-y-3">
+        <div className="space-y-3 p-5">
           <Skeleton className="h-6 w-2/3" />
           <Skeleton className="h-4 w-1/2" />
           <div className="flex gap-2 mt-4">

--- a/frontend/src/pages/Teacher/gradebook/GradingConfigCard.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradingConfigCard.tsx
@@ -49,7 +49,7 @@ export function GradingConfigCard({
         onClick={onToggle}
         aria-expanded={open}
         aria-controls={panelId}
-        className="flex w-full select-none items-center justify-between rounded-t-md px-6 py-4 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        className="flex w-full select-none items-center justify-between rounded-t-md p-5 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       >
         <div className="flex items-center gap-2">
           <Settings2 className="h-5 w-5 text-muted-foreground" strokeWidth={1.75} aria-hidden />
@@ -124,7 +124,21 @@ function WeightField({ label, value, onChange }: WeightFieldProps) {
         min={0}
         max={100}
         value={value}
-        onChange={(e) => onChange(Number(e.target.value) || 0)}
+        onChange={(e) => {
+          // ``Number(e.target.value) || 0`` masked invalid input by
+          // silently coercing -50, 1e10, NaN, "abc" to 0 or to garbage.
+          // ``min``/``max`` are HTML hints only -- the browser accepts
+          // any number-shaped string. Clamp into [0, 100] and floor to
+          // an int so a teacher pasting "-50" or "1e9" can't poison
+          // the weights and force a "must sum to 100" trap they can't
+          // see why.
+          const raw = Number(e.target.value)
+          if (!Number.isFinite(raw)) {
+            onChange(0)
+            return
+          }
+          onChange(Math.max(0, Math.min(100, Math.floor(raw))))
+        }}
         fieldSize="md"
       />
     </div>


### PR DESCRIPTION
**Token violations:** ChapterEditor CardContent p-6→p-5, CourseCard sm:p-6→sm:p-5, GradingConfigCard toggle px-6→p-5, LoadingSkeleton rounded-lg+p-6→rounded-md+p-5, TeacherDashboardSkeleton p-6→p-5. **Dark-mode tints:** ChapterEditor + AccessModeModal selected-card bg-primary/[0.04]→/[0.08] + dark:/15. **Numeric validation:** GradingConfigCard accepted -50, 1e10, NaN, 'abc'—now clamps [0,100] + floor. lint+tsc+288 tests pass.