### PR TITLE
fix(teacher): CardTitle font-serif + hover/rounded normalization

### DIFF
--- a/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
@@ -33,7 +33,7 @@ export function CreateCourseForm({
   return (
     <Card className="mb-8 border-dashed">
       <CardHeader>
-        <CardTitle className="text-lg">
+        <CardTitle className="font-serif text-lg font-semibold tracking-tight">
           {t("teacherDashboard.createForm.title")}
         </CardTitle>
       </CardHeader>

--- a/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
@@ -19,8 +19,8 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
   return (
     <Card data-tour="pending-certs" className="mb-8 border-l-stripe border-l-warning">
       <CardHeader>
-        <CardTitle className="text-xl flex items-center gap-2">
-          <Award className="h-5 w-5 text-warning" strokeWidth={1.75} />
+        <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
+          <Award className="h-5 w-5 text-warning" strokeWidth={1.75} aria-hidden />
           {t("teacherDashboard.pendingCerts.title")}
           <Badge variant="warning" className="font-normal">
             {certs.length}

--- a/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/AnnouncementsModal.tsx
@@ -36,7 +36,7 @@ export function AnnouncementsModal({
   return (
     <Modal open={open} onClose={onClose} title={t("teacherEditor.modals.announcements.title")}>
       <div className="space-y-4">
-        <div className="space-y-3 border rounded-lg p-3 bg-muted/30">
+        <div className="space-y-3 rounded-md border bg-muted/30 p-3">
           <Input
             value={title}
             onChange={(e) => onTitleChange(e.target.value)}

--- a/frontend/src/pages/Teacher/editor/EventsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/EventsModal.tsx
@@ -54,7 +54,7 @@ export function EventsModal({
   return (
     <Modal open={open} onClose={onClose} title={t("teacherEditor.modals.events.title")}>
       <div className="space-y-4">
-        <div className="space-y-3 border rounded-lg p-3 bg-muted/30">
+        <div className="space-y-3 rounded-md border bg-muted/30 p-3">
           <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
             {editingId
               ? t("teacherEditor.modals.events.editEvent")

--- a/frontend/src/pages/Teacher/editor/LoadingSkeleton.tsx
+++ b/frontend/src/pages/Teacher/editor/LoadingSkeleton.tsx
@@ -19,7 +19,7 @@ export function CourseEditorSkeleton() {
       </div>
       <div className="space-y-3">
         {[1, 2, 3].map((i) => (
-          <Skeleton key={i} className="h-16 rounded-lg border bg-muted/30" />
+          <Skeleton key={i} className="h-16 rounded-md border bg-muted/30" />
         ))}
       </div>
     </div>

--- a/frontend/src/pages/Teacher/editor/MaterialsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/MaterialsModal.tsx
@@ -85,7 +85,7 @@ export function MaterialsModal({
             {materials.map((m) => (
               <div
                 key={m.path}
-                className="flex items-center gap-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors"
+                className="flex items-center gap-3 rounded-md border p-3 transition-colors hover:bg-muted/40"
               >
                 <Paperclip className="h-4 w-4 text-muted-foreground shrink-0" strokeWidth={1.75} />
                 <span className="text-sm flex-1 truncate">{m.name}</span>

--- a/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
@@ -90,7 +90,7 @@ export function GradeTableTab({
     <div className="space-y-4">
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">{t("gradebook.table.title")}</CardTitle>
+          <CardTitle className="font-serif text-lg font-semibold tracking-tight">{t("gradebook.table.title")}</CardTitle>
           <CardDescription className="text-xs">{t("gradebook.table.description")}</CardDescription>
         </CardHeader>
         <CardContent>
@@ -231,7 +231,7 @@ const GradeTableRow = memo(function GradeTableRow({
   return (
     <Fragment>
       <tr
-        className="group hover:bg-muted/20 cursor-pointer transition-colors"
+        className="group cursor-pointer transition-colors hover:bg-muted/40"
         onClick={() => onToggleExpand(student.id)}
       >
         <td

--- a/frontend/src/pages/Teacher/gradebook/GradingConfigCard.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradingConfigCard.tsx
@@ -54,7 +54,7 @@ export function GradingConfigCard({
         <div className="flex items-center gap-2">
           <Settings2 className="h-5 w-5 text-muted-foreground" strokeWidth={1.75} aria-hidden />
           <div>
-            <CardTitle className="text-base">{t("gradebook.config.title")}</CardTitle>
+            <CardTitle className="font-serif text-lg font-semibold tracking-tight">{t("gradebook.config.title")}</CardTitle>
             <CardDescription className="text-xs">
               {t("gradebook.config.description")}
             </CardDescription>

--- a/frontend/src/pages/Teacher/gradebook/SummaryTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/SummaryTab.tsx
@@ -227,7 +227,7 @@ const StudentSummaryRow = memo(function StudentSummaryRow({
   return (
     <div>
       <div
-        className="grid grid-cols-[1fr_80px_80px_90px_80px_70px_70px] gap-3 px-4 py-3 cursor-pointer hover:bg-muted/30 transition-colors items-center"
+        className="grid cursor-pointer grid-cols-[1fr_80px_80px_90px_80px_70px_70px] items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
         onClick={() => onToggleExpand(student.student_id)}
       >
         <div className="flex items-center gap-2 min-w-0">

--- a/frontend/src/pages/Teacher/progress/StudentRow.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentRow.tsx
@@ -112,7 +112,7 @@ export function StudentRow({
   return (
     <>
       <tr
-        className="border-b last:border-0 cursor-pointer hover:bg-muted/50 transition-colors"
+        className="cursor-pointer border-b transition-colors last:border-0 hover:bg-muted/40"
         onClick={onToggle}
       >
         <td className="py-3 pr-2">

--- a/frontend/src/pages/Teacher/progress/StudentTable.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentTable.tsx
@@ -50,8 +50,8 @@ export function StudentTable({
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-lg flex items-center gap-2">
-          <Users className="h-5 w-5" strokeWidth={1.75} />
+        <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
+          <Users className="h-5 w-5" strokeWidth={1.75} aria-hidden />
           {t("studentProgress.table.heading")}
           <span className="text-sm font-normal text-muted-foreground">
             ({students.length})


### PR DESCRIPTION
Editorial baseline: 5 teacher CardTitles → font-serif text-lg font-semibold tracking-tight (matches admin sweep). Hover bg drift: StudentRow /50, GradeTableTab /20, SummaryTab /30, MaterialsModal /50 → unified /40 (standard). rounded-lg → rounded-md in MaterialsModal, AnnouncementsModal, EventsModal panels + LoadingSkeleton. lint+tsc+288 tests pass.