### PR TITLE
fix(teacher): browser back + TeacherAnalytics CardTitle

### DIFF
--- a/frontend/src/pages/Teacher/TeacherAnalytics.tsx
+++ b/frontend/src/pages/Teacher/TeacherAnalytics.tsx
@@ -165,7 +165,9 @@ export default function TeacherAnalytics() {
 
       <Card>
         <CardHeader>
-          <CardTitle>{t("teacherAnalytics.enrollments.heading")}</CardTitle>
+          <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+            {t("teacherAnalytics.enrollments.heading")}
+          </CardTitle>
           <CardDescription>
             {t("teacherAnalytics.enrollments.subheadingCount", { count: analytics.totalStudents })}
           </CardDescription>

--- a/frontend/src/pages/Teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.tsx
@@ -215,7 +215,12 @@ export default function TeacherDashboard() {
     const next = new URLSearchParams(params)
     if (showTrash) next.delete("trash")
     else next.set("trash", "1")
-    setParams(next, { replace: true })
+    // PUSH (not replace) -- opening / closing the Trash drawer is a
+    // meaningful state change that the user can reasonably back-button
+    // out of. ``replace`` here used to drop the prior dashboard view
+    // from history; pressing back from the Trash drawer left the
+    // /teacher route entirely instead of just closing the drawer.
+    setParams(next)
   }
 
   return (

--- a/frontend/src/pages/Teacher/TeacherGradebook.tsx
+++ b/frontend/src/pages/Teacher/TeacherGradebook.tsx
@@ -47,15 +47,17 @@ export default function TeacherGradebook() {
   const sortDir: SortDir = params.get("dir") === "desc" ? "desc" : "asc"
 
   const setActiveTab = (next: ActiveTab) =>
-    setParams(
-      (p) => {
-        const n = new URLSearchParams(p)
-        if (next === "summary") n.delete("tab")
-        else n.set("tab", next)
-        return n
-      },
-      { replace: true },
-    )
+    // PUSH (not replace) -- summary ↔ table tab switching is primary
+    // navigation; back-button should undo it instead of dropping the
+    // user out of the gradebook entirely. Sort toggles below stay on
+    // ``replace`` since each column-click is a quick filter tweak,
+    // not a navigation step worth back-stop-ing.
+    setParams((p) => {
+      const n = new URLSearchParams(p)
+      if (next === "summary") n.delete("tab")
+      else n.set("tab", next)
+      return n
+    })
 
   const applySort = (field: SortField, dir: SortDir) =>
     setParams(


### PR DESCRIPTION
TeacherDashboard.toggleTrash + TeacherGradebook tab-switch now use push (not replace) so browser back works. TeacherAnalytics enrollments CardTitle migrated to font-serif baseline. lint+tsc+288 tests pass.