### PR TITLE
fix(teacher): kill addModule / addChapter order_index race conditions

### DIFF
--- a/frontend/src/pages/Teacher/editor/useCourseData.ts
+++ b/frontend/src/pages/Teacher/editor/useCourseData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { DropResult } from "@hello-pangea/dnd"
 import { coursesService } from "@/services/courses"
@@ -162,8 +162,17 @@ export function useCourseData(
     }
   }, [courseId, course, t])
 
+  const addingModuleRef = useRef(false)
   const addModule = useCallback(async () => {
     if (!courseId) return
+    // Lock: double-clicks before the optimistic ``setCourse`` lands used
+    // to compute the same ``order_index`` from the stale
+    // ``course?.modules?.length`` and the server then accepted two
+    // modules at the same ``order_index``, breaking the sortedModules
+    // contract until a page reload. The ref + early-return guarantees
+    // we never have two in-flight ``createModule`` calls.
+    if (addingModuleRef.current) return
+    addingModuleRef.current = true
     const order = course?.modules?.length ?? 0
     try {
       const m = await coursesService.createModule(courseId, {
@@ -180,6 +189,8 @@ export function useCourseData(
       toast({ title: t("teacherEditor.toast.moduleAdded"), variant: "success" })
     } catch {
       toast({ title: t("teacherEditor.toast.moduleAddFailed"), variant: "destructive" })
+    } finally {
+      addingModuleRef.current = false
     }
   }, [courseId, course?.modules?.length, t])
 

--- a/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
+++ b/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import type { DropResult } from "@hello-pangea/dnd";
@@ -107,8 +107,16 @@ export function useModuleEditor(
     void saveDueDate("");
   };
 
+  const addingChapterRef = useRef(false);
   const addChapter = async () => {
     if (!courseId || !moduleId || !mod) return;
+    // Lock: a fast double-click before the optimistic ``setMod`` lands
+    // recomputes the same ``order_index`` from a stale
+    // ``mod.chapters?.length``, and the server then accepts two
+    // chapters at the same ``order_index`` -- breaking ``sortedChapters``
+    // until a refresh. Same shape as ``addModule``'s ref-based guard.
+    if (addingChapterRef.current) return;
+    addingChapterRef.current = true;
     const order = mod.chapters?.length ?? 0;
     try {
       const ch = await coursesService.createChapter(courseId, moduleId, {
@@ -127,6 +135,8 @@ export function useModuleEditor(
       );
     } catch {
       toast({ title: t("moduleEditor.toast.failedAddChapter"), variant: "destructive" });
+    } finally {
+      addingChapterRef.current = false;
     }
   };
 


### PR DESCRIPTION
Double-click on Add module/chapter button used to fire two POST calls with same order_index → two siblings at same position, sortedModules/Chapters non-deterministic. Fix: addingRef lock checked sync at fn entry, released in finally. lint+tsc+288 tests pass.