### PR TITLE
fix(student): hover-bg drift → bg-muted/40 + CohortSelectModal dark-mode tint

### DIFF
--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -229,7 +229,7 @@ function ChapterNavLink({
   const disabledClass =
     "flex min-w-0 flex-1 cursor-not-allowed flex-col rounded-md border border-border bg-muted/20 px-3 py-2 opacity-60"
   const enabledClass =
-    "group flex min-w-0 flex-1 flex-col rounded-md border border-border bg-card px-3 py-2 transition-colors hover:border-primary/40 hover:bg-muted/30"
+    "group flex min-w-0 flex-1 flex-col rounded-md border border-border bg-card px-3 py-2 transition-colors hover:border-primary/40 hover:bg-muted/40"
 
   if (!chapter) {
     return (

--- a/frontend/src/pages/Course/detail/CohortSelectModal.tsx
+++ b/frontend/src/pages/Course/detail/CohortSelectModal.tsx
@@ -33,10 +33,10 @@ export function CohortSelectModal({
         {cohorts.map((cohort) => (
           <label
             key={cohort.id}
-            className={`flex items-center gap-3 p-3 border rounded-lg cursor-pointer transition-colors ${
+            className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
               selectedCohortId === cohort.id
-                ? "border-primary bg-primary/5"
-                : "hover:bg-muted/50"
+                ? "border-primary bg-primary/[0.08] dark:bg-primary/15"
+                : "hover:bg-muted/40"
             }`}
           >
             <input

--- a/frontend/src/pages/Course/detail/MaterialsModal.tsx
+++ b/frontend/src/pages/Course/detail/MaterialsModal.tsx
@@ -33,7 +33,7 @@ export function MaterialsModal({
           {materials.map((file) => (
             <div
               key={file.path}
-              className="flex items-center justify-between px-3 py-2 hover:bg-muted/50 transition-colors"
+              className="flex items-center justify-between px-3 py-2 transition-colors hover:bg-muted/40"
             >
               <span className="truncate mr-2">{file.name}</span>
               <Button

--- a/frontend/src/pages/Course/detail/UpcomingEvents.tsx
+++ b/frontend/src/pages/Course/detail/UpcomingEvents.tsx
@@ -38,7 +38,7 @@ export function UpcomingEvents({ events }: Props) {
               className={`flex items-center gap-2 px-3 py-2 rounded-md border text-sm ${
                 overdue
                   ? "border-l-stripe border-l-destructive border-border bg-destructive/5"
-                  : "border-border hover:bg-muted/50"
+                  : "border-border hover:bg-muted/40"
               }`}
             >
               {overdue ? (

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -189,7 +189,7 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
               key={enrollment.id}
               to={`/courses/${courseId}`}
               style={{ "--stagger-index": index } as React.CSSProperties}
-              className="group block rounded-md border border-border/80 bg-muted/10 px-3 py-2.5 transition-colors hover:border-primary/30 hover:bg-muted/25"
+              className="group block rounded-md border border-border bg-muted/10 px-3 py-2.5 transition-colors hover:border-primary/30 hover:bg-muted/40"
             >
               <div className="flex items-center gap-3">
                 <div className="min-w-0 flex-1">


### PR DESCRIPTION
Student surfaces drifted across 5 hover tones (/25 /30 /50) for one affordance. Unified to /40 in ChapterView, Dashboard, UpcomingEvents, MaterialsModal, CohortSelectModal. CohortSelectModal selected state bg-primary/5 (invisible in dark) → /[0.08] dark:/15, rounded-lg → rounded-md. lint+tsc+288 tests pass.