### PR TITLE
fix(student): ChapterView eyebrows + ModuleView typography → editorial baseline

### DIFF
--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -130,7 +130,7 @@ function FileBlockLink({
         )}
       </div>
       <div className="min-w-0 flex-1">
-        <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
           {t("chapter.attachmentEyebrow")}
         </p>
         <p className="mt-0.5 truncate text-sm font-medium text-foreground">{label}</p>
@@ -234,7 +234,7 @@ function ChapterNavLink({
   if (!chapter) {
     return (
       <div className={`${disabledClass} ${alignment}`} aria-hidden="true">
-        <span className={`flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground ${justify}`}>
+        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground ${justify}`}>
           {side === "prev" && <ArrowLeft className="h-3.5 w-3.5" strokeWidth={1.75} />}
           {eyebrow}
           {side === "next" && <ArrowRight className="h-3.5 w-3.5" strokeWidth={1.75} />}
@@ -249,7 +249,7 @@ function ChapterNavLink({
   if (locked) {
     return (
       <div className={`${disabledClass} ${alignment}`} aria-label={fallbackLabel}>
-        <span className={`flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground ${justify}`}>
+        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground ${justify}`}>
           <Lock className="h-3.5 w-3.5" strokeWidth={1.75} />
           {eyebrow}
         </span>
@@ -270,7 +270,7 @@ function ChapterNavLink({
         className={`${enabledClass} ${alignment}`}
         aria-label={`${eyebrow}: ${chapter.title}`}
       >
-        <span className={`flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground transition-colors group-hover:text-primary ${justify}`}>
+        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground transition-colors group-hover:text-primary ${justify}`}>
           {side === "prev" && <ArrowLeft className="h-3.5 w-3.5" strokeWidth={1.75} />}
           {eyebrow}
           {side === "next" && <ArrowRight className="h-3.5 w-3.5" strokeWidth={1.75} />}
@@ -307,7 +307,7 @@ function ChapterNav({
       aria-label={t("chapter.navAriaLabel")}
       className="mt-10 border-t border-border pt-6"
     >
-      <p className="mb-3 text-center text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground tabular-nums">
+      <p className="mb-3 text-center text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground tabular-nums">
         {t("chapter.positionEyebrow", { current: currentIdx + 1, total })}
       </p>
       <div className="flex items-stretch gap-2 sm:gap-3">
@@ -533,7 +533,7 @@ export default function ChapterView() {
       </Link>
 
       <header data-tour="chapter-header" className="mb-10">
-        <p className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <p className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
           <span className="inline-flex items-center gap-1.5">
             <ChapterTypeIcon className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
             {t(`chapterTypes.${chapterType}.label`)}

--- a/frontend/src/pages/Course/ModuleView.tsx
+++ b/frontend/src/pages/Course/ModuleView.tsx
@@ -118,7 +118,7 @@ export default function ModuleView() {
       </Link>
 
       <div className="mb-4">
-        <h1 className="mb-1 text-2xl font-bold tracking-tight text-wrap-safe">{module.title}</h1>
+        <h1 className="mb-1 font-serif text-2xl font-bold tracking-tight text-wrap-safe">{module.title}</h1>
         {module.description && (
           <p className="text-sm leading-relaxed text-muted-foreground text-wrap-safe whitespace-pre-line">
             {module.description}
@@ -184,7 +184,7 @@ export default function ModuleView() {
       )}
 
       <div>
-        <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+        <h2 className="mb-3 flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
           <Book className="h-4 w-4" strokeWidth={1.75} aria-hidden />
           {t("module.chaptersHeading")}
           <span className="text-sm font-normal text-muted-foreground">
@@ -210,7 +210,7 @@ export default function ModuleView() {
                     style={{ animationDelay: `${idx * 50}ms` }}
                   >
                     <CardHeader className="pb-2">
-                      <CardTitle className="flex min-w-0 items-center gap-2 text-base">
+                      <CardTitle className="flex min-w-0 items-center gap-2 font-serif text-base font-semibold tracking-tight">
                         <Lock className="h-5 w-5 text-muted-foreground/50 shrink-0" strokeWidth={1.75} aria-hidden />
                         <span className="min-w-0 flex-1 truncate text-muted-foreground">
                           {chapter.title}
@@ -236,7 +236,7 @@ export default function ModuleView() {
                     style={{ animationDelay: `${idx * 50}ms` }}
                   >
                     <CardHeader className="pb-2">
-                      <CardTitle className="flex min-w-0 items-center gap-2 text-base">
+                      <CardTitle className="flex min-w-0 items-center gap-2 font-serif text-base font-semibold tracking-tight">
                         {isGradable ? (
                           isCompleted ? (
                             <CheckCircle className="h-5 w-5 shrink-0 text-success" strokeWidth={1.75} aria-hidden />


### PR DESCRIPTION
6 ChapterView eyebrows text-xs (12px) → text-[11px] canonical. ModuleView H1+H2+2 CardTitles gained font-serif tracking-tight matching every other editorial surface in the app. lint+tsc+288 tests pass.