### PR TITLE
fix(student): course-detail typography + Calendar formatTime locale

### DIFF
--- a/frontend/src/pages/Calendar/utils.ts
+++ b/frontend/src/pages/Calendar/utils.ts
@@ -1,3 +1,4 @@
+import i18n from "@/i18n/config";
 import { formatDateLong } from "@/i18n/format";
 
 export function isSameDay(a: Date, b: Date): boolean {
@@ -9,10 +10,15 @@ export function isSameDay(a: Date, b: Date): boolean {
 }
 
 export function formatTime(dateStr: string): string {
-  // Time-only display uses the OS locale; the only callsites are the
-  // calendar agenda where the row is already grouped by day, so the date
-  // separator is implicit. Keep this Intl-direct.
-  return new Date(dateStr).toLocaleTimeString(undefined, {
+  // Locale-aware time display. The previous ``toLocaleTimeString(
+  // undefined, ...)`` deferred to the OS locale, so a Russian-UI
+  // user on an en-US Windows install saw AM/PM in their agenda
+  // while every other timestamp in the app rendered as ru-RU. Wire
+  // through the same i18n language the rest of the format helpers
+  // already use so the calendar reads as one app.
+  const lang = (i18n.resolvedLanguage ?? i18n.language ?? "en").toLowerCase();
+  const locale = lang.startsWith("ru") ? "ru-RU" : "en-US";
+  return new Date(dateStr).toLocaleTimeString(locale, {
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/frontend/src/pages/Course/detail/EnrolledHeader.tsx
+++ b/frontend/src/pages/Course/detail/EnrolledHeader.tsx
@@ -51,7 +51,7 @@ export function EnrolledHeader({
           </div>
         )}
         <div className="flex-1 min-w-0">
-          <h1 className="mb-1 font-serif text-xl font-bold tracking-tight text-wrap-safe sm:text-2xl">
+          <h1 className="mb-1 font-serif text-xl font-semibold tracking-tight text-wrap-safe sm:text-2xl">
             {course.title}
           </h1>
           <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">

--- a/frontend/src/pages/Course/detail/ModuleList.tsx
+++ b/frontend/src/pages/Course/detail/ModuleList.tsx
@@ -102,7 +102,7 @@ function ModuleRow({
     <Card className={`group transition-colors ${isLocked ? "opacity-60" : "hover:border-primary/25"}`}>
       <CardHeader className="py-3 px-4">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="flex min-w-0 items-center gap-2 text-sm font-medium">
+          <CardTitle className="flex min-w-0 items-center gap-2 font-serif text-sm font-semibold tracking-tight">
             <span
               className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${
                 isLocked

--- a/frontend/src/pages/Course/detail/UpcomingEvents.tsx
+++ b/frontend/src/pages/Course/detail/UpcomingEvents.tsx
@@ -24,7 +24,7 @@ export function UpcomingEvents({ events }: Props) {
 
   return (
     <div className="mb-5">
-      <h2 className="mb-2 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+      <h2 className="mb-2 flex items-center gap-2 font-serif text-sm font-semibold tracking-tight text-muted-foreground">
         <CalendarDays className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
         {t("courseDetail.upcoming.heading")}
       </h2>


### PR DESCRIPTION
Calendar formatTime → uses i18n locale instead of OS locale (RU user on en-US Windows no longer sees AM/PM). UpcomingEvents H2, EnrolledHeader H1 (font-bold→font-semibold), ModuleList CardTitle → editorial font-serif baseline. lint+tsc+288 tests pass.