### PR TITLE
fix(teacher): CreateCourseForm input length + ModuleList H2 + ChapterEditor H1 tracking

### DIFF
--- a/frontend/src/pages/Course/detail/ModuleList.tsx
+++ b/frontend/src/pages/Course/detail/ModuleList.tsx
@@ -31,7 +31,7 @@ export function ModuleList({ courseId, modules, completedChapterIds }: Props) {
   const { t } = useTranslation()
   return (
     <div>
-      <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+      <h2 className="mb-3 flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
         <BookOpen className="h-4 w-4" strokeWidth={1.75} aria-hidden />
         {t("courseDetail.modulesHeading")}
         <span className="text-sm font-normal text-muted-foreground">({modules.length})</span>

--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -304,7 +304,7 @@ export default function ChapterEditor() {
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             aria-label={t("chapterEditor.editTitleAria")}
-            className="font-serif text-2xl font-bold border-none shadow-none hover:border-border/50 hover:shadow-sm focus-visible:ring-1 h-auto py-1 px-2 w-full"
+            className="h-auto w-full border-none px-2 py-1 font-serif text-2xl font-bold tracking-tight shadow-none hover:border-border hover:shadow-sm focus-visible:ring-1"
             placeholder={t("chapterEditor.titlePlaceholder")}
           />
         </h1>

--- a/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import type { CourseFormData } from "@/lib/validations/course"
 
 interface Props {
@@ -46,9 +47,16 @@ export function CreateCourseForm({
             <Input
               id="title"
               autoFocus
+              maxLength={200}
               value={form.title}
               onChange={(e) => {
-                setForm((p) => ({ ...p, title: e.target.value }))
+                // Cap at 200 chars to match the server-side schema
+                // (``makeCourseSchema`` already enforces this, and so
+                // does CourseEditor's title field). Without ``maxLength``
+                // a paste of a 5000-char string was POSTed and rejected
+                // with a generic 400, costing one network round-trip
+                // and an opaque error.
+                setForm((p) => ({ ...p, title: e.target.value.slice(0, 200) }))
                 setErrors((p) => ({ ...p, title: undefined }))
               }}
               placeholder={t("teacherDashboard.createForm.titlePlaceholder")}
@@ -62,11 +70,15 @@ export function CreateCourseForm({
                 {t("teacherDashboard.createForm.optional")}
               </span>
             </Label>
-            <textarea
+            <Textarea
               id="desc"
-              className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              fieldSize="default"
+              maxLength={2000}
+              className="min-h-[80px]"
               value={form.description}
-              onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
+              onChange={(e) =>
+                setForm((p) => ({ ...p, description: e.target.value.slice(0, 2000) }))
+              }
               placeholder={t("teacherDashboard.createForm.descriptionPlaceholder")}
             />
           </div>


### PR DESCRIPTION
CreateCourseForm: title maxLength=200 + slice (no more 5000-char paste → 400 rejection); desc moved from hand-rolled textarea to shadcn Textarea + maxLength=2000. ModuleList H2 → font-serif tracking-tight. ChapterEditor H1 input gained tracking-tight + border-border (was /50 opacity). lint+tsc+288 tests pass.