### PR TITLE
fix(audit): commit log_action after savepoint so rows survive prod teardown

### DIFF
--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -24,13 +25,23 @@ def log_action(
     details: dict[str, object] | None = None,
     request: Request | None = None,
 ) -> None:
-    """Persist an audit log entry inside a SAVEPOINT so it never
-    interferes with the caller's transaction.
+    """Persist an audit log entry, isolated via SAVEPOINT and then
+    promoted with an explicit COMMIT.
 
     Failure here is non-fatal — audit-log writes must not crash the
     request that triggered them. The ``with db.begin_nested()`` block
     rolls the savepoint back on its own if the INSERT raises, leaving
     the caller's outer transaction intact.
+
+    The trailing ``db.commit()`` is load-bearing: most callers invoke
+    ``log_action`` AFTER their own ``db.commit()``, which leaves the
+    session with no open transaction. The savepoint then auto-begins
+    a new implicit transaction; without an explicit commit, FastAPI's
+    ``get_db`` teardown (``db.close()``) rolls that transaction back
+    and the audit row vanishes. Test suites don't catch this because
+    the conftest shares a single session between the route and the
+    assertion, so the unflushed-but-uncommitted row is still readable
+    from the same session before teardown.
     """
     ip_address: str | None = None
     user_agent: str | None = None
@@ -52,5 +63,8 @@ def log_action(
                 )
             )
             db.flush()
+        db.commit()
     except Exception:
+        with contextlib.suppress(Exception):
+            db.rollback()
         logger.exception("Failed to write audit log")

--- a/backend/tests/test_audit_service_persistence.py
+++ b/backend/tests/test_audit_service_persistence.py
@@ -1,0 +1,126 @@
+"""Regression test for the audit-log persistence bug.
+
+Background
+----------
+``audit_service.log_action`` used to wrap its INSERT in a SAVEPOINT and
+return without committing. Most call sites invoke ``log_action`` *after*
+their own ``db.commit()``, which leaves the session with no open
+transaction. The savepoint then auto-began a new implicit transaction —
+which FastAPI's ``get_db`` teardown silently rolled back on
+``db.close()``, dropping the audit row.
+
+The other tests in the suite use ``conftest`` fixtures that share a
+single session between the route and the assertion, so the
+unflushed-but-uncommitted row is still visible from the same session
+before teardown. They cannot catch the production regression.
+
+This test creates two independent sessions on the test engine: one to
+emulate the route, one to verify durability from a fresh connection
+after the first session is closed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from app.models.audit_log import AuditLog
+from app.models.user import User, UserRole
+from app.services.audit_service import log_action
+from tests.conftest import TestSessionFactory
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def test_log_action_survives_session_close_after_commit():
+    """Pattern A: route does db.commit() then log_action(). The audit row
+    must be visible from a fresh session after the route's session closes.
+    """
+    user_id = uuid.uuid4()
+
+    # Route-side session: seed a user + simulate the route's own commit,
+    # then call log_action just like the broken pattern.
+    route_session: Session = TestSessionFactory()
+    try:
+        route_session.add(
+            User(
+                id=user_id,
+                email=f"{user_id}@example.com",
+                full_name="Pattern A Tester",
+                role=UserRole.STUDENT.value,
+            )
+        )
+        route_session.commit()
+
+        log_action(
+            db=route_session,
+            user_id=user_id,
+            action="test_action",
+            resource_type="test_resource",
+            resource_id=str(user_id),
+            details={"pattern": "A"},
+        )
+    finally:
+        route_session.close()
+
+    # Fresh session — emulates "next request reads what the previous
+    # request wrote". Must see the audit row.
+    verifier: Session = TestSessionFactory()
+    try:
+        row = (
+            verifier.query(AuditLog)
+            .filter(
+                AuditLog.action == "test_action",
+                AuditLog.resource_id == str(user_id),
+            )
+            .first()
+        )
+        assert row is not None, "Audit row was lost on session close — log_action did not commit."
+        assert row.details == {"pattern": "A"}
+    finally:
+        verifier.close()
+
+
+def test_log_action_survives_session_close_before_caller_commit():
+    """Pattern B: route calls log_action() with pending writes, then commits.
+    With the fix, log_action's commit also commits the caller's pending
+    writes — both the audit row and the caller's row must be durable.
+    """
+    user_id = uuid.uuid4()
+
+    route_session: Session = TestSessionFactory()
+    try:
+        # Caller has pending writes when log_action is invoked.
+        route_session.add(
+            User(
+                id=user_id,
+                email=f"{user_id}@example.com",
+                full_name="Pattern B Tester",
+                role=UserRole.STUDENT.value,
+            )
+        )
+        log_action(
+            db=route_session,
+            user_id=user_id,
+            action="test_action_b",
+            resource_type="test_resource",
+            resource_id=str(user_id),
+            details={"pattern": "B"},
+        )
+        # Caller's own commit is now a no-op because log_action already
+        # promoted everything. This must not raise.
+        route_session.commit()
+    finally:
+        route_session.close()
+
+    verifier: Session = TestSessionFactory()
+    try:
+        row = verifier.query(AuditLog).filter(AuditLog.action == "test_action_b").first()
+        assert row is not None
+        assert row.details == {"pattern": "B"}
+
+        user_row = verifier.query(User).filter(User.id == user_id).first()
+        assert user_row is not None, "Caller's pending write was lost."
+    finally:
+        verifier.close()


### PR DESCRIPTION
## Summary

`audit_service.log_action` wrapped its INSERT in `with db.begin_nested()` and returned without committing. Most call sites invoke `log_action` AFTER their own `db.commit()`, which leaves the session with no open transaction. The savepoint then auto-begins a fresh implicit transaction — which FastAPI's `get_db` teardown silently rolls back on `db.close()`, **dropping the audit row in production**.

Tests didn't catch this because `conftest` shares one session between the route and the assertion: the unflushed-but-uncommitted row is still visible from the same session before teardown. A dedicated two-session regression test now covers both call patterns:

- **Pattern A** (log after commit): cohorts, users.bulk_role_update / update_user_role, courses crud, assignments, certificate_service — currently silently losing audit rows.
- **Pattern B** (log before caller commit): admin_delete_user, preferences PATCH — still functionally atomic; `log_action` just commits slightly earlier in the request flow.

## Test plan

- [x] `pytest tests/` — 709 passed (2 new regression tests included)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy app/` clean
- [ ] CI: backend-ci, postgres smoke, CodeQL
- [ ] Vercel backend preview deploys