### PR TITLE
fix(certificates): drop issued_at server_default so pending certs don't show fake date

### DIFF
--- a/backend/app/models/certificate.py
+++ b/backend/app/models/certificate.py
@@ -43,7 +43,12 @@ class Certificate(Base):
     # ``20260516020225_certificates_course_set_null_with_archive.sql``.
     course_id: Mapped[str | None] = mapped_column(ForeignKey("courses.id", ondelete="SET NULL"), nullable=True)
     archived_course_title: Mapped[str | None] = mapped_column(Text, nullable=True)
-    issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    # No server_default: the previous ``func.now()`` populated this column
+    # on certificate REQUEST (status='pending'), exposing a fake "issued"
+    # datetime months before ``admin_approve`` actually issues the cert.
+    # ``admin_approve`` is the only writer now; the column stays NULL for
+    # pending / teacher_approved / rejected rows.
+    issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     certificate_number: Mapped[str | None] = mapped_column(String(50), unique=True)
     status: Mapped[str] = mapped_column(String(20), default="pending")
     requested_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/supabase/migrations/20260521210000_certificates_drop_issued_at_default.sql
+++ b/supabase/migrations/20260521210000_certificates_drop_issued_at_default.sql
@@ -1,0 +1,18 @@
+-- Drop the server-side default on ``certificates.issued_at``.
+--
+-- ``func.now()`` was populating the column at certificate REQUEST time
+-- (status='pending'), giving the API a fake "issued" datetime months
+-- before ``admin_approve`` actually issues the credential. The frontend
+-- displays that field in cert lists and on the verify page, so users
+-- have been seeing a misleading "Issued: <request date>" for every
+-- pending / teacher_approved / rejected certificate.
+--
+-- After this migration only ``admin_approve`` writes ``issued_at``.
+
+ALTER TABLE certificates ALTER COLUMN issued_at DROP DEFAULT;
+
+-- Clear the stale fake-issued dates on historical rows that are not in
+-- 'approved' status so the API stops returning misleading datetimes.
+UPDATE certificates
+SET issued_at = NULL
+WHERE status <> 'approved';


### PR DESCRIPTION
## Summary

The `func.now()` server_default on `certificates.issued_at` was populating the column at **certificate REQUEST** time (status='pending'). `admin_approve` overwrites it on actual issuance, but every pending / teacher_approved / rejected cert exposed a fake "Issued: <request date>" through the API — visible in cert lists + verify page.

## Changes

- **Model:** drop `server_default=func.now()`; column stays nullable; `admin_approve` is the only writer.
- **Migration:** `ALTER COLUMN issued_at DROP DEFAULT` + `UPDATE certificates SET issued_at = NULL WHERE status <> 'approved'` to clear stale fake dates on historical rows.

Frontend already handles `issued_at: null` via guarded ternaries in `CertificatesPage` + `CertificateCard`; type is already `string | null`. No frontend change needed.

## Test plan

- [x] `pytest tests/` — 707 passed
- [x] `ruff check` clean, `mypy app/` clean
- [ ] CI: backend-ci, postgres smoke
- [ ] **Apply migration on prod via Supabase MCP after merge** — separate step, not auto-applied