### PR TITLE
fix: case-insensitive cohort email lookup + preserve extension on long filenames

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -519,7 +519,12 @@ def add_student(
     if body.user_id:
         user = db.query(User).filter(User.id == body.user_id).first()
     else:
-        user = db.query(User).filter(User.email == body.email).first()
+        # Email lookup must be case-insensitive. ``profiles.email`` is a plain
+        # ``text`` column with no normalization, so an admin who types
+        # ``Alice@Example.com`` when the stored row is ``alice@example.com``
+        # otherwise gets a 404. Lower-case both sides for the comparison.
+        email_lower = (body.email or "").lower()
+        user = db.query(User).filter(func.lower(User.email) == email_lower).first()
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -871,6 +871,44 @@ class TestCohortWriteActionsAreAudited:
         assert row is not None
 
 
+class TestAddStudentByEmail:
+    """``POST /cohorts/{id}/students`` accepts either user_id or email.
+    Email matching must be case-insensitive — ``profiles.email`` is plain
+    ``text``, so an admin who types ``Alice@Example.com`` against a row
+    stored as ``alice@example.com`` was getting a 404 before the fix."""
+
+    def test_add_by_email_case_insensitive(self, admin_client: TestClient, db: Session):
+        from app.models.user import User
+
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db, name="EmailCase")
+        student_id = uuid.uuid4()
+        db.add(
+            User(
+                id=student_id,
+                email="alice@example.com",
+                full_name="Alice",
+                role="student",
+            )
+        )
+        db.commit()
+
+        resp = admin_client.post(
+            f"{COHORT_PREFIX}/{cohort.id}/students",
+            json={"email": "Alice@Example.com"},
+        )
+        assert resp.status_code == 201, resp.text
+
+    def test_add_by_email_unknown_returns_404(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db, name="UnknownEmail")
+        resp = admin_client.post(
+            f"{COHORT_PREFIX}/{cohort.id}/students",
+            json={"email": "noone@example.com"},
+        )
+        assert resp.status_code == 404
+
+
 class TestSoloEnrollmentAccessMode:
     """ADR-010 §1: ``access_mode='institute'`` blocks the solo-enroll
     path (no cohort_id in the request body). Cohort-route enrollment

--- a/frontend/src/services/__tests__/sanitizeFileName.test.ts
+++ b/frontend/src/services/__tests__/sanitizeFileName.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import { sanitizeFileName } from "../storage"
+
+describe("sanitizeFileName", () => {
+  it("returns short filenames unchanged", () => {
+    expect(sanitizeFileName("notes.pdf")).toBe("notes.pdf")
+  })
+
+  it("replaces path-illegal characters with underscores", () => {
+    expect(sanitizeFileName('what:is/this\\file*.txt')).toBe("what_is_this_file_.txt")
+  })
+
+  it("collapses whitespace runs into single underscores", () => {
+    expect(sanitizeFileName("two   spaces.pdf")).toBe("two_spaces.pdf")
+  })
+
+  it("preserves the extension when the name exceeds the length cap", () => {
+    // Regression: the previous implementation sliced to 100 chars AFTER
+    // the special-char replace and dropped the extension. Result was a
+    // path like ``${chapterId}/${ts}-very-long-...na`` with no .pdf,
+    // breaking download MIME sniffing.
+    const stem = "a".repeat(200)
+    const result = sanitizeFileName(`${stem}.pdf`)
+    expect(result.endsWith(".pdf")).toBe(true)
+    expect(result.length).toBeLessThanOrEqual(100)
+  })
+
+  it("hard-truncates names that have no extension", () => {
+    const result = sanitizeFileName("x".repeat(150))
+    expect(result.length).toBe(100)
+    expect(result).toBe("x".repeat(100))
+  })
+
+  it("hard-truncates when the extension itself is pathologically long", () => {
+    // ``.${'y'.repeat(120)}`` is itself longer than the cap. Falling
+    // back to a hard truncate beats emitting a zero-length stem.
+    const result = sanitizeFileName("z" + "." + "y".repeat(120))
+    expect(result.length).toBe(100)
+  })
+
+  it("treats a trailing dot as no extension", () => {
+    const result = sanitizeFileName("name." + "a".repeat(150))
+    expect(result.length).toBeLessThanOrEqual(100)
+  })
+})

--- a/frontend/src/services/storage.ts
+++ b/frontend/src/services/storage.ts
@@ -11,8 +11,35 @@ const COURSE_MATERIALS_BUCKET = "course-materials"
 // breaking anything in the DB.
 const SIGNED_URL_TTL_SECONDS = 60 * 60
 
-function sanitizeFileName(name: string): string {
-  return name.replace(/[/\\:*?"<>|]/g, "_").replace(/\s+/g, "_").slice(0, 100)
+const MAX_SAFE_NAME_LEN = 100
+
+/**
+ * Strip path-illegal characters and collapse whitespace, then cap the
+ * result without losing the file extension. The previous version sliced
+ * to 100 chars *after* the special-char replacement, which silently
+ * dropped the trailing ``.pdf`` / ``.png`` on any name longer than 100
+ * chars and produced extensionless object keys (broken MIME sniffing /
+ * download UX). Truncate the stem, then re-append the extension.
+ *
+ * Exported only so the unit test can exercise the boundary case
+ * directly — runtime callers should use the upload functions below.
+ */
+export function sanitizeFileName(name: string): string {
+  const cleaned = name.replace(/[/\\:*?"<>|]/g, "_").replace(/\s+/g, "_")
+  if (cleaned.length <= MAX_SAFE_NAME_LEN) return cleaned
+
+  const dotIdx = cleaned.lastIndexOf(".")
+  // No extension to preserve (or trailing dot) → hard truncate.
+  if (dotIdx <= 0 || dotIdx === cleaned.length - 1) {
+    return cleaned.slice(0, MAX_SAFE_NAME_LEN)
+  }
+  const ext = cleaned.slice(dotIdx)
+  // Pathological case: extension itself is longer than the cap. Drop the
+  // extension rather than emit a zero-length stem.
+  if (ext.length >= MAX_SAFE_NAME_LEN) {
+    return cleaned.slice(0, MAX_SAFE_NAME_LEN)
+  }
+  return cleaned.slice(0, MAX_SAFE_NAME_LEN - ext.length) + ext
 }
 
 function fileExtension(name: string, fallback: string = "jpg"): string {


### PR DESCRIPTION
## Summary

Two small latent bugs surfaced by the bug-hunt audit.

**`cohorts.add_student` email lookup was case-sensitive** — `profiles.email` is plain `text` with no normalization, so an admin typing `Alice@Example.com` against a stored `alice@example.com` got a misleading "User not found — ask them to sign up first" 404 instead of a successful add.

**`storage.sanitizeFileName` was dropping the file extension** on names longer than 100 chars. It sliced to 100 chars *after* the special-char replace, so the trailing `.pdf` / `.png` was silently cut → object keys without extensions → broken MIME sniffing on download. Now truncates the stem and re-appends the extension. Exported the function so the boundary case is unit-testable.

## Test plan

- [x] `pytest tests/` — 709 passed (2 new email-case tests)
- [x] `vitest run sanitizeFileName.test.ts` — 7 passed
- [x] `ruff check` + `mypy app/` clean
- [x] `npm run lint` + `tsc --noEmit` clean
- [ ] CI: backend-ci, frontend-ci, Vercel preview deploys