### PR TITLE
perf: paginate /quizzes/{id}/pending-answers and /cohorts/{id}/students

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -449,6 +449,13 @@ def detach_course(
 @router.get("/{cohort_id}/students")
 def list_cohort_students(
     cohort_id: UUID,
+    skip: int = Query(0, ge=0, description="Pagination offset (student-level)."),
+    limit: int = Query(
+        100,
+        ge=1,
+        le=500,
+        description="Max students per page (default 100, max 500).",
+    ),
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> list[dict]:
@@ -457,12 +464,36 @@ def list_cohort_students(
     course_id so the cohort overview can show a matrix.
 
     Includes ``full_name`` + ``email`` from ``profiles`` so the admin
-    table renders identity without an N+1 follow-up fetch per row."""
+    table renders identity without an N+1 follow-up fetch per row.
+
+    Paginates at the **student** level (not the row level) so each page
+    returns whole student blocks — a 200-student cohort attached to 20
+    courses was previously emitting 4000 rows in a single unbounded
+    response. The default page returns 100 students; clients that need
+    more can request via ``?limit=500``.
+    """
     cohort = _get_or_404(db, cohort_id)
+    # Paginate user_ids first so the row-fetch never crosses page
+    # boundaries (a single student's enrollments stay together).
+    user_id_page = (
+        db.query(Enrollment.user_id)
+        .filter(Enrollment.cohort_id == cohort.id)
+        .distinct()
+        .order_by(Enrollment.user_id)
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    page_user_ids = [row[0] for row in user_id_page]
+    if not page_user_ids:
+        return []
     rows = (
         db.query(Enrollment, User.full_name, User.email)
         .join(User, Enrollment.user_id == User.id)
-        .filter(Enrollment.cohort_id == cohort.id)
+        .filter(
+            Enrollment.cohort_id == cohort.id,
+            Enrollment.user_id.in_(page_user_ids),
+        )
         .order_by(Enrollment.user_id, Enrollment.course_id)
         .all()
     )

--- a/backend/app/api/v1/quizzes/grading.py
+++ b/backend/app/api/v1/quizzes/grading.py
@@ -28,15 +28,25 @@ def list_pending_answers(
         False,
         description="If true, return already-graded open-ended answers too.",
     ),
+    skip: int = Query(0, ge=0, description="Pagination offset."),
+    limit: int = Query(
+        200,
+        ge=1,
+        le=500,
+        description="Max rows per page (caps response size; default 200, max 500).",
+    ),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ):
     """Flat list of open-ended answers for the teacher's grading queue.
 
-    An answer is considered *pending* when it carries text but still
-    has ``points_earned == 0`` AND no ``grader_comment`` — that's our
-    proxy for "not graded yet", since a legitimate 0-point grade with
-    a comment is distinguishable from the untouched default.
+    Pagination is bounded — an essay-heavy course over a busy semester
+    can accumulate thousands of pending answers, and the previous
+    unbounded ``query.all()`` was an OOM hazard on a serverless worker.
+    Defaults preserve the unpaginated shape for any existing client that
+    omits the params.
+
+    An answer is considered *pending* when ``graded_at IS NULL``.
     """
     quiz = db.query(Quiz).filter(Quiz.id == quiz_id).first()
     if not quiz:
@@ -65,7 +75,7 @@ def list_pending_answers(
         query = query.filter(QuizAnswer.graded_at.is_(None))
 
     results: list[PendingAnswerInfo] = []
-    for answer, question, attempt, student in query.all():
+    for answer, question, attempt, student in query.offset(skip).limit(limit).all():
         results.append(
             PendingAnswerInfo(
                 answer_id=answer.id,

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -871,6 +871,91 @@ class TestCohortWriteActionsAreAudited:
         assert row is not None
 
 
+class TestListCohortStudentsPagination:
+    """``GET /cohorts/{id}/students`` paginates at the student level so
+    each page returns whole student blocks (a student's enrollments
+    never split across pages). Defaults (skip=0, limit=100) preserve
+    the pre-pagination shape for any existing caller."""
+
+    @staticmethod
+    def _seed_users_in_cohort(db: Session, cohort, n: int) -> list:
+        from app.models.user import User
+
+        users = []
+        for i in range(n):
+            uid = uuid.UUID(int=0x10000000_0000_0000_0000_000000000000 + i)
+            db.add(
+                User(
+                    id=uid,
+                    email=f"student-{i:02d}@example.com",
+                    full_name=f"Student {i:02d}",
+                    role="student",
+                )
+            )
+            users.append(uid)
+        db.commit()
+        course_ids = [
+            row[0] for row in db.query(CohortCourse.course_id).filter(CohortCourse.cohort_id == cohort.id).all()
+        ]
+        for uid in users:
+            for cid in course_ids:
+                db.add(
+                    Enrollment(
+                        id=str(uuid.uuid4()),
+                        user_id=uid,
+                        course_id=cid,
+                        cohort_id=cohort.id,
+                        progress=0,
+                    )
+                )
+        db.commit()
+        return users
+
+    def test_default_returns_all_students_when_under_limit(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        self._seed_users_in_cohort(db, cohort, 5)
+
+        resp = admin_client.get(f"{COHORT_PREFIX}/{cohort.id}/students")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 5
+
+    def test_limit_bounds_response_at_student_level(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        self._seed_users_in_cohort(db, cohort, 7)
+
+        resp = admin_client.get(f"{COHORT_PREFIX}/{cohort.id}/students?limit=3")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 3
+        for student in data:
+            assert "per_course" in student
+            assert len(student["per_course"]) >= 1
+
+    def test_skip_advances_to_next_page(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        self._seed_users_in_cohort(db, cohort, 7)
+
+        page1 = admin_client.get(f"{COHORT_PREFIX}/{cohort.id}/students?limit=3").json()
+        page2 = admin_client.get(f"{COHORT_PREFIX}/{cohort.id}/students?skip=3&limit=3").json()
+        assert len(page1) == 3
+        assert len(page2) == 3
+        page1_ids = {s["user_id"] for s in page1}
+        page2_ids = {s["user_id"] for s in page2}
+        assert page1_ids.isdisjoint(page2_ids)
+
+    def test_empty_page_past_end(self, admin_client: TestClient, db: Session):
+        _seed_course(db)
+        cohort = _seed_cohort_with_course(db)
+        self._seed_users_in_cohort(db, cohort, 3)
+
+        resp = admin_client.get(f"{COHORT_PREFIX}/{cohort.id}/students?skip=10")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
 class TestAddStudentByEmail:
     """``POST /cohorts/{id}/students`` accepts either user_id or email.
     Email matching must be case-insensitive — ``profiles.email`` is plain


### PR DESCRIPTION
## Summary

Both routes previously returned the full result set via `.all()` with no bound. An essay-heavy course over a busy semester can stack thousands of pending answers; a 200-student cohort attached to 20 courses emits 4000+ enrollment rows in a single response. Both are OOM hazards on a serverless worker.

## Changes

- `GET /quizzes/{id}/pending-answers`: `skip` (default 0) + `limit` (default 200, max 500).
- `GET /cohorts/{id}/students`: `skip` (default 0) + `limit` (default 100, max 500). Paginates at the **student** level via a distinct `user_id` subquery — a student's enrollments never split across pages.

Defaults preserve the pre-pagination shape; no client changes needed.

## Test plan

- [x] 4 new cohort-pagination tests: default-under-limit, hard limit, skip advance with no overlap, empty page past end
- [x] `pytest tests/` — 715 passed
- [x] `ruff check` + `mypy app/` clean
- [ ] CI