### PR TITLE
fix(security): validate file_url scheme and file_bucket allowlist

### DIFF
--- a/backend/app/schemas/assignment.py
+++ b/backend/app/schemas/assignment.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from typing import Literal
+from urllib.parse import urlparse
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class AssignmentCreate(BaseModel):
@@ -36,6 +37,28 @@ class AssignmentResponse(BaseModel):
 class SubmissionCreate(BaseModel):
     content: str | None = Field(None, max_length=50_000)
     file_url: str | None = Field(None, max_length=2048)
+
+    @field_validator("file_url")
+    @classmethod
+    def _enforce_https_scheme(cls, value: str | None) -> str | None:
+        """Reject anything but a fully-qualified ``https://`` URL.
+
+        A student-supplied URL is rendered by the teacher as
+        ``<a href={file_url} target="_blank">`` in the grader UI.
+        Allowing ``javascript:`` / ``data:`` / ``vbscript:`` would
+        execute attacker-controlled code in the teacher's session the
+        moment they click; ``rel=noopener`` does not defuse
+        ``javascript:``. We also reject bare ``http://`` because
+        every legitimate storage origin in this stack is HTTPS, and
+        accepting mixed-content links would surface a browser warning
+        more often than it would help.
+        """
+        if value is None or not value.strip():
+            return None
+        parsed = urlparse(value.strip())
+        if parsed.scheme.lower() != "https" or not parsed.netloc:
+            raise ValueError("file_url must be an https:// URL")
+        return value
 
 
 class SubmissionResponse(BaseModel):

--- a/backend/app/schemas/chapter_block.py
+++ b/backend/app/schemas/chapter_block.py
@@ -2,12 +2,49 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # ``video`` / ``audio`` block types were collapsed into ``text`` by migration
 # 025 — the rich text editor embeds them via its toolbar so the separate block
 # kinds were pure duplication.
 BLOCK_TYPES = Literal["text", "quiz", "assignment", "file"]
+
+# File-bucket allowlist. The signed-URL fetch trusts whatever bucket name the
+# block row carries, so without this gate a teacher could plant a block with
+# ``file_bucket='avatars'`` and mint signed URLs against another tenant's
+# objects. ``course-materials`` is the only bucket the upload path actually
+# writes to.
+_ALLOWED_FILE_BUCKETS = frozenset({"course-materials"})
+
+
+def _validate_file_bucket(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if value not in _ALLOWED_FILE_BUCKETS:
+        raise ValueError(f"file_bucket must be one of: {sorted(_ALLOWED_FILE_BUCKETS)}")
+    return value
+
+
+def _validate_file_path(value: str | None) -> str | None:
+    """Reject path-traversal attempts and absolute paths.
+
+    Per-chapter scope is enforced at the route layer (the upload sets
+    the path to ``{chapter_id}/{ts}-{name}``), but defense-in-depth at
+    the schema rejects any ``..`` segment and any leading ``/``
+    regardless of how the path was obtained.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("/") or stripped.startswith("\\"):
+        raise ValueError("file_path must be relative (no leading slash)")
+    # Split on both unix + windows separators and check each segment.
+    segments = stripped.replace("\\", "/").split("/")
+    if any(segment in ("..", ".") for segment in segments):
+        raise ValueError("file_path must not contain '..' or '.' segments")
+    return value
 
 
 class BlockCreate(BaseModel):
@@ -20,6 +57,16 @@ class BlockCreate(BaseModel):
     file_path: str | None = Field(None, max_length=2048)
     file_name: str | None = Field(None, max_length=255)
 
+    @field_validator("file_bucket")
+    @classmethod
+    def _check_bucket(cls, v: str | None) -> str | None:
+        return _validate_file_bucket(v)
+
+    @field_validator("file_path")
+    @classmethod
+    def _check_path(cls, v: str | None) -> str | None:
+        return _validate_file_path(v)
+
 
 class BlockUpdate(BaseModel):
     block_type: BLOCK_TYPES | None = None
@@ -30,6 +77,16 @@ class BlockUpdate(BaseModel):
     file_bucket: str | None = Field(None, max_length=50)
     file_path: str | None = Field(None, max_length=2048)
     file_name: str | None = Field(None, max_length=255)
+
+    @field_validator("file_bucket")
+    @classmethod
+    def _check_bucket(cls, v: str | None) -> str | None:
+        return _validate_file_bucket(v)
+
+    @field_validator("file_path")
+    @classmethod
+    def _check_path(cls, v: str | None) -> str | None:
+        return _validate_file_path(v)
 
 
 class BlockResponse(BaseModel):

--- a/backend/tests/test_file_url_and_bucket_validation.py
+++ b/backend/tests/test_file_url_and_bucket_validation.py
@@ -1,0 +1,100 @@
+"""Schema-level validation for the file_url + file_bucket attack surfaces.
+
+A teacher viewing a student submission opens ``file_url`` via
+``<a target="_blank">``. Accepting ``javascript:`` / ``data:`` schemes
+turns student input into stored XSS against the grader.
+
+A chapter block carries ``{file_bucket, file_path}`` that the frontend
+later signs into a download URL. Without an allowlist on ``file_bucket``,
+a teacher could plant a block pointing at the ``avatars`` bucket and
+mint signed URLs against another tenant's objects. Path-traversal
+segments in ``file_path`` are similarly defense-in-depth.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.assignment import SubmissionCreate
+from app.schemas.chapter_block import BlockCreate, BlockUpdate
+
+
+class TestSubmissionFileUrl:
+    def test_https_url_is_accepted(self):
+        SubmissionCreate(file_url="https://example.com/work.pdf")
+
+    def test_none_is_accepted(self):
+        SubmissionCreate(file_url=None)
+
+    def test_empty_string_normalizes_to_none(self):
+        result = SubmissionCreate(file_url="")
+        assert result.file_url is None
+
+    def test_javascript_scheme_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SubmissionCreate(file_url="javascript:alert(document.cookie)")
+
+    def test_data_scheme_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SubmissionCreate(file_url="data:text/html,<script>alert(1)</script>")
+
+    def test_http_is_rejected_no_mixed_content(self):
+        with pytest.raises(ValidationError):
+            SubmissionCreate(file_url="http://example.com/insecure.pdf")
+
+    def test_scheme_relative_url_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SubmissionCreate(file_url="//evil.example/x")
+
+    def test_vbscript_scheme_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SubmissionCreate(file_url="vbscript:msgbox(1)")
+
+
+class TestBlockFileBucket:
+    def test_course_materials_is_accepted(self):
+        BlockCreate(block_type="file", file_bucket="course-materials", file_path="chapter/x.pdf")
+
+    def test_none_is_accepted(self):
+        BlockCreate(block_type="text", file_bucket=None)
+
+    def test_avatars_bucket_rejected(self):
+        with pytest.raises(ValidationError):
+            BlockCreate(block_type="file", file_bucket="avatars", file_path="chapter/x.png")
+
+    def test_arbitrary_bucket_name_rejected(self):
+        with pytest.raises(ValidationError):
+            BlockCreate(block_type="file", file_bucket="course-assets", file_path="chapter/x.png")
+
+    def test_update_validates_too(self):
+        with pytest.raises(ValidationError):
+            BlockUpdate(file_bucket="avatars")
+
+
+class TestBlockFilePath:
+    def test_relative_path_is_accepted(self):
+        BlockCreate(block_type="file", file_bucket="course-materials", file_path="chapter-id/123-name.pdf")
+
+    def test_none_is_accepted(self):
+        BlockCreate(block_type="text", file_path=None)
+
+    def test_parent_segment_rejected(self):
+        with pytest.raises(ValidationError):
+            BlockCreate(block_type="file", file_bucket="course-materials", file_path="../etc/passwd")
+
+    def test_parent_segment_anywhere_rejected(self):
+        with pytest.raises(ValidationError):
+            BlockCreate(
+                block_type="file",
+                file_bucket="course-materials",
+                file_path="chapter/../../etc/passwd",
+            )
+
+    def test_leading_slash_rejected(self):
+        with pytest.raises(ValidationError):
+            BlockCreate(block_type="file", file_bucket="course-materials", file_path="/abs/path.pdf")
+
+    def test_backslash_traversal_rejected(self):
+        with pytest.raises(ValidationError):
+            BlockCreate(block_type="file", file_bucket="course-materials", file_path="chapter\\..\\evil.pdf")


### PR DESCRIPTION
## Summary

Two stored-input → render-as-link sinks were taking arbitrary strings:

**`SubmissionCreate.file_url`** — student-supplied URL rendered by the teacher as `<a href={file_url} target="_blank">`. `javascript:`, `data:`, `vbscript:` schemes become stored XSS against the grader's session (`rel=noopener` doesn't defuse `javascript:`). Now rejects anything but `https://` with a netloc.

**`BlockCreate/BlockUpdate.file_bucket`** + **`file_path`** — frontend signs `{bucket, path}` into a download URL. Without an allowlist on `file_bucket`, a teacher could plant a block pointing at `avatars` (or any tenant's bucket) and mint signed URLs against another tenant's objects.
- bucket allowlist: `{course-materials}` — the only bucket the upload path actually writes to
- path-traversal guard: rejects `..`/`.` segments and leading `/` or `\`

## Test plan

- [x] 19 new schema-level tests cover javascript/data/http/scheme-relative/vbscript schemes; avatars+arbitrary bucket names; .. / leading-slash / backslash traversal
- [x] `pytest tests/` — 734 passed
- [x] `ruff check` + `mypy app/` clean
- [ ] CI