### PR TITLE
fix(security): tighten profiles + enrollments RLS — self-only reads, server-only enrollment writes

### DIFF
--- a/supabase/migrations/20260521230719_rls_profiles_self_and_enrollments_server_only.sql
+++ b/supabase/migrations/20260521230719_rls_profiles_self_and_enrollments_server_only.sql
@@ -1,0 +1,38 @@
+-- Two RLS hardenings flagged by the 2026-05-21 security audit:
+--
+-- 1. ``profiles_select_authenticated`` exposed every user's email + role
+--    to ANY authenticated user via PostgREST. A student could enumerate
+--    admin emails for spear-phishing or scrape the whole member list.
+--    Restrict to self only. Backend service-role reads still work
+--    (service-role bypasses RLS); the three frontend PostgREST
+--    consumers (AuthContext.enrichProfile, usersService.updateProfile,
+--    and the implicit SELECT after UPDATE) all already key on
+--    ``id = auth.uid()`` and continue to work.
+--
+-- 2. ``enrollments_insert_own`` let a student self-enroll into ANY
+--    course via PostgREST, bypassing the publish / access_mode /
+--    cohort / enrollment-window gates in the backend's
+--    ``POST /api/v1/courses/{id}/enroll`` route. Drop the policy and
+--    REVOKE INSERT — server is the only legitimate writer.
+--
+-- 3. Drop the legacy ``Allow full access for postgres role`` policies
+--    on chapters / courses / enrollments / modules. The ``postgres``
+--    superuser bypasses RLS anyway; these policies are dead weight
+--    from the initial ``enable_rls_all_tables`` migration.
+
+DROP POLICY IF EXISTS profiles_select_authenticated ON public.profiles;
+
+CREATE POLICY profiles_select_self
+    ON public.profiles
+    FOR SELECT
+    TO authenticated
+    USING (id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS enrollments_insert_own ON public.enrollments;
+
+REVOKE INSERT ON public.enrollments FROM authenticated, anon;
+
+DROP POLICY IF EXISTS "Allow full access for postgres role" ON public.chapters;
+DROP POLICY IF EXISTS "Allow full access for postgres role" ON public.courses;
+DROP POLICY IF EXISTS "Allow full access for postgres role" ON public.enrollments;
+DROP POLICY IF EXISTS "Allow full access for postgres role" ON public.modules;


### PR DESCRIPTION
## Summary

Two HIGH-severity gaps from the 2026-05-21 security audit, both exploitable via direct PostgREST regardless of the backend's authorization.

**`profiles_select_authenticated`** — `USING ((SELECT auth.uid()) IS NOT NULL)` let any logged-in user enumerate every user's email + role via `supabase.from('profiles').select('*')`. Replaced with `profiles_select_self` (`id = auth.uid()`). The three frontend PostgREST consumers (AuthContext.enrichProfile, usersService.updateProfile, the implicit SELECT after UPDATE) all already key on the authed user's own id and continue to work. Backend reads go through service_role and bypass RLS.

**`enrollments_insert_own`** — `WITH CHECK (user_id = auth.uid())` let a student bypass publish / access_mode / cohort / enrollment-window gates via direct `supabase.from('enrollments').insert`. Policy dropped + `REVOKE INSERT ... FROM authenticated, anon`. Server is the only legitimate writer (`POST /api/v1/courses/{id}/enroll`). SELECT + DELETE policies kept.

**Legacy cleanup** — dropped four `Allow full access for postgres role` policies on chapters / courses / enrollments / modules. `postgres` superuser bypasses RLS anyway.

## Prod state

**Migration already applied to prod via MCP** (pre-release risk window, no real users yet). Repo file timestamp matches the DB-stamped version, so `supabase db push --linked` is a no-op.

## Test plan

- [x] `pytest tests/` — 734 passed (RLS lives in DB; unit tests use SQLite which ignores policies)
- [x] Verified post-migration policy state via MCP — only `profiles_select_self` remains for read on profiles
- [x] Three frontend PostgREST sites confirmed to key on self-only id
- [ ] CI

## Follow-up (PR9)

The `*_insert_teacher` / `*_update_teacher` policies on announcements / assignments / blocks / chapters / modules / quiz_* / student_grades only check role, not course ownership. Same pattern as this fix but needs case-by-case ownership joins. Will ship next.