### PR TITLE
fix(security): resolve CodeQL ReDoS + incomplete-sanitization alerts (#1, #2)

### DIFF
--- a/backend/app/core/sanitize.py
+++ b/backend/app/core/sanitize.py
@@ -86,7 +86,13 @@ _ALLOWED_ATTRIBUTES: dict[str, list[str]] = {
 
 _ALLOWED_PROTOCOLS = frozenset({"http", "https", "mailto", "tel"})
 
-_TAG_RE = re.compile(r"<\s*/?\s*(script|object|embed|form|style|link|meta)[^>]*>", re.IGNORECASE)
+# CodeQL flagged the previous pattern ``<\s*/?\s*(...)[^>]*>`` as
+# polynomial-redos: the two ``\s*`` flanking ``/?`` can partition any
+# leading whitespace run in O(n) ways, triggering quadratic backtracking
+# on attacker-shaped input. Drop both — real HTML doesn't allow
+# whitespace between ``<`` / ``</`` and the tag name; bleach (the
+# primary path) handles the obfuscation cases properly anyway.
+_TAG_RE = re.compile(r"</?(?:script|object|embed|form|style|link|meta)\b[^>]*>", re.IGNORECASE)
 _EVENT_ATTR_RE = re.compile(r"\bon\w+\s*=", re.IGNORECASE)
 _JS_PROTO_RE = re.compile(r"javascript\s*:", re.IGNORECASE)
 

--- a/frontend/scripts/contrast-audit.mjs
+++ b/frontend/scripts/contrast-audit.mjs
@@ -15,8 +15,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const cssPath = resolve(__dirname, "../src/index.css")
 const css = readFileSync(cssPath, "utf8")
 
+function escapeRegExp(s) {
+  // CodeQL flagged the previous in-place ``.replace(/\./g, "\\.")`` as
+  // incomplete sanitization: it only escaped ``.`` and left other regex
+  // metacharacters (notably ``\``) live. Escape every special character
+  // so any blockName value is treated as literal.
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
 function parseBlock(blockName) {
-  const re = new RegExp(`${blockName.replace(/\./g, "\\.")}\\s*\\{([\\s\\S]*?)\\n\\s*\\}`, "m")
+  const re = new RegExp(`${escapeRegExp(blockName)}\\s*\\{([\\s\\S]*?)\\n\\s*\\}`, "m")
   const match = re.exec(css)
   if (!match) throw new Error(`Could not find block ${blockName}`)
   const body = match[1]


### PR DESCRIPTION
## Summary

Closes the two HIGH-severity CodeQL alerts that have been open since 2026-05-16.

**Alert #1 `py/polynomial-redos`** in `backend/app/core/sanitize.py`. Previous pattern `<\s*/?\s*(...)[^>]*>` had two `\s*` flanking `/?` — they partition any leading whitespace run in O(n) ways, so attacker-shaped input (`<      script>`) triggers quadratic backtracking. This regex only runs in the fallback path when `bleach` isn't installed (prod always has bleach), but it's still blast surface for ad-hoc scripts. Fix: drop both `\s*` and anchor with `\b` after the tag-name alternation.

**Alert #2 `js/incomplete-sanitization`** in `frontend/scripts/contrast-audit.mjs`. In-place `.replace(/\./g, '\.')` only escaped `.` and left every other regex metacharacter live (notably `\`). Replaced with a proper `escapeRegExp` helper escaping the full set. Dev-only script, hardcoded callers, no real exploit — but the gap is real and the fix is one line.

## Test plan

- [x] `pytest tests/` — 734 passed
- [x] `node scripts/contrast-audit.mjs` still emits identical report
- [x] `ruff check` + `npm run lint` clean
- [ ] CI + CodeQL re-scan should dismiss both alerts