### PR TITLE
fix(backend): 4 latent bug-hunt fixes — rate-limit race, XFF trust, grade clamp, quiz lock ordering

### DIFF
--- a/backend/app/api/v1/quizzes/attempts.py
+++ b/backend/app/api/v1/quizzes/attempts.py
@@ -61,17 +61,15 @@ def submit_quiz(
     ``passing_score``. Exam attempts deliberately don't leak the
     ``correct_option_id`` back to the student.
     """
-    quiz = (
-        db.query(Quiz)
-        .options(selectinload(Quiz.questions).selectinload(QuizQuestion.options))
-        .filter(Quiz.id == quiz_id)
-        .with_for_update()
-        .first()
-    )
-    if not quiz:
+    # Cheap pre-check WITHOUT FOR UPDATE first — if the user isn't
+    # enrolled, we can 403 without serializing other students on the
+    # row lock. Holding the Quiz lock during the enrollment SELECT +
+    # 403-raise was making non-enrolled attempts contend with
+    # legitimate submitters under load.
+    pre_quiz = db.query(Quiz.chapter_id).filter(Quiz.id == quiz_id).first()
+    if not pre_quiz:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
-
-    course_id = resolve_chapter_course_id(db, quiz.chapter_id)
+    course_id = resolve_chapter_course_id(db, pre_quiz.chapter_id)
     enrolled = (
         db.query(Enrollment)
         .filter(
@@ -85,6 +83,18 @@ def submit_quiz(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You must be enrolled in this course to submit quizzes",
         )
+
+    quiz = (
+        db.query(Quiz)
+        .options(selectinload(Quiz.questions).selectinload(QuizQuestion.options))
+        .filter(Quiz.id == quiz_id)
+        .with_for_update()
+        .first()
+    )
+    if not quiz:
+        # Lost-race fallback: someone deleted the quiz between the
+        # pre-check and the lock. Same 404 the original flow returned.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
 
     quiz_service.ensure_attempts_available(db, quiz, current_user.id)
 

--- a/backend/app/core/http.py
+++ b/backend/app/core/http.py
@@ -6,34 +6,52 @@ and anything else that needs a reliable client IP share one implementation.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from fastapi import Request
 
 
+# ``X-Forwarded-For`` is only trustworthy when we're behind a proxy that
+# actively replaces it (Vercel does). On a bare deploy or local dev,
+# clients can set the header themselves and farm fresh rate-limit
+# buckets per spoofed IP. Gate the header on a trusted-proxy env signal
+# so the unsafe path is opt-in rather than the default.
+#
+# Vercel sets ``VERCEL=1`` in every function invocation, and we also
+# honour an explicit ``TRUST_FORWARDED_HEADERS=1`` for other reverse-
+# proxy deployments (Cloudflare, custom Caddy/nginx, etc).
+_TRUSTED_PROXY = bool(os.environ.get("VERCEL") or os.environ.get("TRUST_FORWARDED_HEADERS"))
+
+
 def get_client_ip(request: Request, fallback: str | None = None) -> str | None:
-    """Resolve the real client IP, honoring standard proxy-forwarding headers.
+    """Resolve the real client IP, honoring standard proxy-forwarding headers
+    only when a trusted reverse proxy is in front of us.
 
-    On Vercel (and any reverse-proxy deploy) ``request.client.host`` is the
-    proxy worker's IP, not the user's real IP. ``X-Forwarded-For`` is set by
-    the proxy to ``<client>, <proxy>, <proxy>...`` (left-to-right), so the
-    left-most entry is the original client; everything after is proxy chain.
+    On Vercel (and any other configured reverse-proxy deploy)
+    ``request.client.host`` is the proxy worker's IP, not the user's
+    real IP. ``X-Forwarded-For`` is set by the proxy to ``<client>,
+    <proxy>, <proxy>...`` (left-to-right), so the left-most entry is
+    the original client; everything after is proxy chain.
 
-    ``request.client.host`` is used as a last resort for local development,
-    where no proxy is in front. Returns ``fallback`` when we truly cannot
-    determine the IP (for the rate limiter, pass ``"unknown"``; for audit
-    logging, pass ``None`` so the DB column stays NULL).
+    Outside that trusted-proxy environment we ignore both forwarded
+    headers and use ``request.client.host`` directly — otherwise any
+    client can spoof their IP per request and defeat per-IP throttling.
+    Returns ``fallback`` when we truly cannot determine the IP (for the
+    rate limiter, pass ``"unknown"``; for audit logging, pass ``None``
+    so the DB column stays NULL).
     """
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        ip = forwarded.split(",")[0].strip()
-        if ip:
-            return ip
+    if _TRUSTED_PROXY:
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded:
+            ip = forwarded.split(",")[0].strip()
+            if ip:
+                return ip
 
-    real_ip = request.headers.get("x-real-ip")
-    if real_ip:
-        return real_ip.strip()
+        real_ip = request.headers.get("x-real-ip")
+        if real_ip:
+            return real_ip.strip()
 
     if request.client is not None and request.client.host:
         return request.client.host

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -32,6 +32,7 @@ IP, NOT the user's real IP — so every user shares one bucket per worker
 and the limiter is effectively disabled. We now read `X-Forwarded-For` first.
 """
 
+import asyncio
 import time
 from collections import defaultdict
 
@@ -87,6 +88,15 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self.window = window
         self._hits: dict[str, list[float]] = defaultdict(list)
         self._last_cleanup: float = time.time()
+        # Starlette BaseHTTPMiddleware runs ``dispatch`` concurrently for
+        # overlapping requests on the same worker. Without a lock, two
+        # requests can both read ``len(hits) < max_calls`` and both
+        # append, briefly exceeding the cap. The same window also makes
+        # ``X-RateLimit-Remaining`` racy. One asyncio.Lock around the
+        # read-prune-check-append section serializes the hot path while
+        # leaving the await on ``call_next`` outside the lock so
+        # downstream handlers stay fully concurrent.
+        self._lock = asyncio.Lock()
 
     def _resolve_limit(self, path: str) -> tuple[str | None, int, int]:
         """Return ``(matched_prefix, max_calls, window)``.
@@ -131,21 +141,26 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         now = time.time()
         cutoff = now - window
 
-        self._cleanup_stale_buckets(now)
+        async with self._lock:
+            self._cleanup_stale_buckets(now)
 
-        hits = self._hits[bucket_key]
-        self._hits[bucket_key] = [t for t in hits if t > cutoff]
+            pruned = [t for t in self._hits[bucket_key] if t > cutoff]
+            if len(pruned) >= max_calls:
+                # Reassign so the cleanup loop sees the pruned state too.
+                self._hits[bucket_key] = pruned
+                return Response(
+                    content='{"detail":"Too many requests"}',
+                    status_code=429,
+                    media_type="application/json",
+                    headers={"Retry-After": str(window)},
+                )
+            pruned.append(now)
+            self._hits[bucket_key] = pruned
+            # Capture the post-append count under the lock so the
+            # header value matches the same snapshot the gate used.
+            remaining = max(0, max_calls - len(pruned))
 
-        if len(self._hits[bucket_key]) >= max_calls:
-            return Response(
-                content='{"detail":"Too many requests"}',
-                status_code=429,
-                media_type="application/json",
-                headers={"Retry-After": str(window)},
-            )
-
-        self._hits[bucket_key].append(now)
         response = await call_next(request)
         response.headers["X-RateLimit-Limit"] = str(max_calls)
-        response.headers["X-RateLimit-Remaining"] = str(max(0, max_calls - len(self._hits[bucket_key])))
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
         return response

--- a/backend/app/services/grade_calculator.py
+++ b/backend/app/services/grade_calculator.py
@@ -149,8 +149,16 @@ def calculate_student_grade(
         )
         total_assignments = len(assignment_ids)
         if total_assignments > 0:
+            # Clamp at 100% defensively — assignment_submissions.grade
+            # is capped at ``assignment.max_score`` going forward (per the
+            # grade-submission route), but any pre-cap historical row
+            # with ``grade > max_score`` would inflate the average above
+            # 100% and distort the final course grade. ``min(100.0, ...)``
+            # is the cheap fix; the underlying CHECK constraint would be
+            # the durable one (separate PR).
             graded_pcts = [
-                (row.best_grade / row.max_score * 100.0) if row.max_score else 0.0 for row in best_per_assignment
+                min(100.0, row.best_grade / row.max_score * 100.0) if row.max_score else 0.0
+                for row in best_per_assignment
             ]
             assignment_avg = sum(graded_pcts) / total_assignments
 
@@ -236,7 +244,9 @@ def calculate_all_student_grades(db: Session, course: Course):
             .all()
         )
         for ar in asgn_rows:
-            pct = (float(ar.best_grade) / ar.max_score * 100.0) if ar.max_score else 0.0
+            # See same-named single-student site above — clamp at 100%
+            # so a historical over-cap grade doesn't distort the batch.
+            pct = min(100.0, float(ar.best_grade) / ar.max_score * 100.0) if ar.max_score else 0.0
             asgn_scores.setdefault(str(ar.student_id), []).append(pct)
 
     # Batch: chapter completion counts per student


### PR DESCRIPTION
## Summary

Four latent bugs from the 2026-05-21 bug-hunt audit, all surgical.

**`rate_limit.py`** — read-prune-check-append on `self._hits[bucket_key]` was not atomic across concurrent dispatches (BaseHTTPMiddleware runs `dispatch` concurrently). Two requests could both observe `len < max_calls` and both append. `X-RateLimit-Remaining` could lie. Added an `asyncio.Lock` around the hot section; `call_next` stays outside the lock so downstream handlers remain fully concurrent.

**`core/http.py`** — `X-Forwarded-For` was trusted unconditionally. On non-Vercel deploys (local dev, custom proxy, preview tunnels) clients can set the header themselves and farm fresh rate-limit buckets per spoofed IP. Now gated on `VERCEL=1` or explicit `TRUST_FORWARDED_HEADERS=1`. Falls back to `request.client.host` in untrusted environments.

**`grade_calculator.py`** — `best_grade / max_score * 100.0` had no upper bound. Pre-cap historical rows where `grade > max_score` push the assignment average above 100% and distort the final course grade. `min(100.0, ...)` clamp at both call sites (single-student + batch). Durable fix is a DB CHECK in a later migration.

**`quizzes/attempts.py`** — `with_for_update` on `Quiz` was acquired BEFORE the enrollment check, so non-enrolled submitters serialized every legitimate submitter on that quiz while we computed their 403. Cheap pre-SELECT on `Quiz.chapter_id` (no lock) + enrollment check first; FOR UPDATE only happens once the user is allowed to submit.

## Test plan

- [x] `pytest tests/` — 734 passed
- [x] `ruff check` + `mypy app/` clean
- [ ] CI