### PR TITLE
fix(frontend): 4 hook fixes — CohortsTab dual-fetch, CourseDetail waterfall, useCountUp flash, logout race

### DIFF
--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -98,28 +98,21 @@ export function CohortsTab() {
     [setParams],
   )
 
-  // Effect-driven fetch with a request-id token. Without it, flipping
-  // the status filter quickly (All -> Upcoming -> Active) leaves three
-  // in-flight ``listCohorts`` calls; whichever resolves LAST writes
-  // its rows, so a slow "All" response can overwrite the freshly-
-  // loaded "Active" view. The token ensures only the latest request's
-  // result reaches state.
+  // Single effect-driven fetch with a per-render cancellation token.
+  // Without the token, flipping the status filter quickly
+  // (All → Upcoming → Active) leaves three in-flight ``listCohorts``
+  // calls; whichever resolves LAST writes its rows, so a slow "All"
+  // response can overwrite the freshly-loaded "Active" view. The
+  // token ensures only the latest request's result reaches state.
   //
-  // ``load`` stays exposed for the retry button below, but the
-  // primary path is the effect so the cancellation token lives at
-  // the effect's scope where it's needed.
-  const load = useCallback(async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const data = await cohortsService.listCohorts(statusFilter || undefined)
-      setCohorts(data)
-    } catch {
-      setError(t("admin.cohorts.loadError"))
-    } finally {
-      setLoading(false)
-    }
-  }, [statusFilter, t])
+  // ``reload`` increments ``reloadKey`` to re-trigger the effect for
+  // the retry button and post-create refresh. Previously there were
+  // TWO fetch paths (a ``load`` callback and a duplicate inline
+  // effect); the callback path lacked the cancellation token, so a
+  // retry mid-filter-flip could overwrite the latest result. One
+  // path means one set of semantics.
+  const [reloadKey, setReloadKey] = useState(0)
+  const reload = useCallback(() => setReloadKey((k) => k + 1), [])
 
   useEffect(() => {
     let cancelled = false
@@ -142,7 +135,7 @@ export function CohortsTab() {
     return () => {
       cancelled = true
     }
-  }, [statusFilter, t])
+  }, [statusFilter, t, reloadKey])
 
   // Client-side filter + paginate over the per-status fetch. Cohort
   // counts in production stay in the dozens, so we don't need a
@@ -272,7 +265,7 @@ export function CohortsTab() {
           <ErrorState
             title={error}
             action={
-              <Button size="sm" variant="outline" onClick={() => void load()}>
+              <Button size="sm" variant="outline" onClick={() => reload()}>
                 {t("common.tryAgain")}
               </Button>
             }
@@ -342,7 +335,7 @@ export function CohortsTab() {
         onClose={() => setCreateOpen(false)}
         onCreated={() => {
           setCreateOpen(false)
-          void load()
+          reload()
         }}
       />
     </Card>

--- a/frontend/src/pages/Course/CourseDetail.tsx
+++ b/frontend/src/pages/Course/CourseDetail.tsx
@@ -52,14 +52,43 @@ export default function CourseDetail() {
       setCalendarEvents([])
       setCohorts([])
       try {
-        const [courseData, enrollmentStatus, cohortsData] = await Promise.all([
+        // Speculatively kick off the enrollment-dependent fetches
+        // alongside the first batch when ``user`` is present, so the
+        // request round-trip only happens once. Previously this code
+        // awaited the enrollment-check result, THEN issued the second
+        // batch — a sequential waterfall that doubled the latency for
+        // every enrolled student loading a course page. The
+        // speculative calls cost 4 cheap GETs per non-enrolled
+        // logged-in user (still a single round-trip), but the
+        // enrolled-student path saves an entire RTT. Anonymous users
+        // pay nothing — the user-gated promises short-circuit to
+        // their empty defaults.
+        const enrolled = user
+          ? coursesService
+              .getEnrollmentStatus(id)
+              .catch(() => ({ enrolled: false, enrollment: null as Enrollment | null }))
+          : Promise.resolve({ enrolled: false, enrollment: null as Enrollment | null })
+        const certP = user
+          ? coursesService.getCourseCertificate(id).catch(() => null)
+          : Promise.resolve(null)
+        const progressP = user
+          ? coursesService.getMyChapterProgress(id).catch(() => [] as string[])
+          : Promise.resolve([] as string[])
+        const matsP = user
+          ? storageService.listCourseMaterials(id).catch(() => [] as CourseMaterial[])
+          : Promise.resolve([] as CourseMaterial[])
+        const evtsP = user
+          ? coursesService.getCalendarEvents(id).catch(() => [] as CalendarEvent[])
+          : Promise.resolve([] as CalendarEvent[])
+
+        const [courseData, enrollmentStatus, cohortsData, cert, progress, mats, evts] = await Promise.all([
           coursesService.getCourse(id),
-          user
-            ? coursesService
-                .getEnrollmentStatus(id)
-                .catch(() => ({ enrolled: false, enrollment: null as Enrollment | null }))
-            : Promise.resolve({ enrolled: false, enrollment: null as Enrollment | null }),
+          enrolled,
           coursesService.getCourseCohorts(id).catch(() => [] as Cohort[]),
+          certP,
+          progressP,
+          matsP,
+          evtsP,
         ])
         if (cancelled) return
         setCourse(courseData)
@@ -67,13 +96,6 @@ export default function CourseDetail() {
         const match = enrollmentStatus.enrolled ? enrollmentStatus.enrollment : null
         if (match) {
           setEnrollment(match)
-          const [cert, progress, mats, evts] = await Promise.all([
-            coursesService.getCourseCertificate(id).catch(() => null),
-            coursesService.getMyChapterProgress(id).catch(() => [] as string[]),
-            storageService.listCourseMaterials(id).catch(() => [] as CourseMaterial[]),
-            coursesService.getCalendarEvents(id).catch(() => [] as CalendarEvent[]),
-          ])
-          if (cancelled) return
           setCertificate(cert)
           setCompletedChapterIds(new Set(progress))
           setMaterials(mats)

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -28,22 +28,39 @@ import { initialsOf } from "@/lib/names"
 
 function useCountUp(target: number, durationMs = 800) {
   const prefersReducedMotion = useReducedMotion()
-  const [displayed, setDisplayed] = useState(0)
+  // Initialize to ``target`` (not 0) so the first render — and StrictMode's
+  // double-mount — never flashes through the animation. The effect only
+  // fires the count-up when the target genuinely changes from the last
+  // animated value, animating from the current display rather than from
+  // zero so a stat going 5→7 doesn't snap back to 0 first.
+  const [displayed, setDisplayed] = useState(target)
+  const lastAnimatedRef = useRef(target)
+
   useEffect(() => {
+    if (lastAnimatedRef.current === target) return
     if (prefersReducedMotion || target <= 0) {
       setDisplayed(target)
+      lastAnimatedRef.current = target
       return
     }
-    const steps = Math.min(24, Math.max(target, 6))
-    const stepMs = durationMs / steps
-    let i = 0
-    setDisplayed(0)
-    const id = window.setInterval(() => {
-      i++
-      setDisplayed(Math.min(target, Math.round((target * i) / steps)))
-      if (i >= steps) window.clearInterval(id)
-    }, stepMs)
-    return () => window.clearInterval(id)
+    // Animate from the previously-animated value (not from current
+    // ``displayed``, which would require a render-time ref read that
+    // the react-hooks/refs lint rule rightly forbids). On first
+    // genuine change ``lastAnimatedRef.current`` is the initial
+    // ``target`` the hook was mounted with (typically 0), so the
+    // animation behaves the same as the original interval-based
+    // implementation without any 0-flash on remount.
+    const from = lastAnimatedRef.current
+    lastAnimatedRef.current = target
+    let raf = 0
+    const startTime = performance.now()
+    const step = (now: number) => {
+      const progress = Math.min(1, (now - startTime) / durationMs)
+      setDisplayed(Math.round(from + (target - from) * progress))
+      if (progress < 1) raf = requestAnimationFrame(step)
+    }
+    raf = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(raf)
   }, [target, durationMs, prefersReducedMotion])
   return displayed
 }
@@ -108,8 +125,13 @@ export default function ProfilePage() {
     }
   }
 
-  const handleLogout = () => {
-    logout()
+  const handleLogout = async () => {
+    // ``logout`` is async (it round-trips through supabase.auth.signOut);
+    // navigating before it resolves leaves a window where AuthContext
+    // still has the old user but the redirect has already fired,
+    // letting a stale "loading" flash through the login screen. Await
+    // the signOut explicitly.
+    await logout()
     navigate("/login", { replace: true })
   }
 

--- a/frontend/src/services/storage.ts
+++ b/frontend/src/services/storage.ts
@@ -182,7 +182,14 @@ export const storageService = {
 
   async uploadContentImage(file: File): Promise<string> {
     const ext = fileExtension(file.name)
-    const random = Math.random().toString(36).slice(2, 10)
+    // ``Math.random()`` is non-cryptographic and worse:
+    // ``toString(36).slice(2, 10)`` shortens it to ~8 base-36 chars,
+    // so two simultaneous uploads in the same ms can collide. The
+    // bucket uses ``upsert: false`` so the second upload errors —
+    // visible as a confusing "upload failed" toast for the user.
+    // ``crypto.randomUUID().slice(0, 8)`` is the same byte budget,
+    // collision-resistant.
+    const random = crypto.randomUUID().slice(0, 8)
     const path = `content-images/${Date.now()}-${random}.${ext}`
 
     // Content images use upsert: false so the random suffix prevents


### PR DESCRIPTION
## Summary

Four CRITICAL+HIGH frontend hook fixes from the 2026-05-21 audit.

**`CohortsTab.tsx`** — two paths to the same cohort fetch (`load` callback + duplicate inline effect). The callback path lacked the cancellation token, so a retry mid-filter-flip could overwrite the latest result. Collapsed to one effect-driven path with a `reloadKey` that retry/post-create handlers increment.

**`CourseDetail.tsx`** — sequential second `await` for cert+progress+materials+events after the first `Promise.all` resolved. Doubled load latency for every enrolled student. Now speculatively kicks off user-gated fetches alongside the first batch — one RTT for enrolled students, one RTT for non-enrolled logged-in users (4 wasted cheap GETs), nothing for anonymous.

**`ProfilePage.useCountUp`** — initial state was 0; the effect always reset to 0 then ramped to target. StrictMode double-mount flashed 0→N→0→N. Initialize state to `target` and use a ref to skip re-animation when target hasn't actually changed. Switched the interval to `requestAnimationFrame` for monotonic timing.

**`ProfilePage.handleLogout`** — `logout()` is async; calling `navigate` synchronously left a window where AuthContext still had the old user but the redirect fired. Stale-loading flash through the login screen. Await the signOut.

**`storage.uploadContentImage`** — `Math.random().toString(36).slice(2, 10)` is non-cryptographic and only 8 base-36 chars; two simultaneous uploads in the same ms can collide. Bucket uses `upsert: false` so collision surfaces as confusing 'upload failed' toast. Switched to `crypto.randomUUID().slice(0, 8)`.

## Test plan

- [x] `npm run lint` clean (one react-hooks/refs catch fixed before push)
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 295 passed
- [ ] CI + Vercel frontend preview