### PR TITLE
fix(backend): 2 bug-hunt MEDIUM fixes — sanitized title in fan-out, localized prereq response

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -202,7 +202,12 @@ def create_announcement(
             recipients,
             type="new_announcement",
             title="New Announcement",
-            message=f'{data.title} — in "{course_title}"',
+            # Defence-in-depth: use the sanitised title in the fanned-out
+            # notification message too. The notification UI today renders
+            # the message as plain text (safe), but a future "render
+            # markdown in notifications" feature would silently inherit
+            # any unsanitised payload that lived in the message column.
+            message=f'{safe_title} — in "{course_title}"',
             link=f"/courses/{data.course_id}",
             metadata={"course_id": data.course_id, "announcement_id": str(announcement.id)},
         )

--- a/backend/app/api/v1/prerequisites.py
+++ b/backend/app/api/v1/prerequisites.py
@@ -105,6 +105,8 @@ def get_prerequisites(
 def set_prerequisites(
     course_id: str,
     data: PrerequisiteSetRequest,
+    response: Response,
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ):
@@ -183,9 +185,16 @@ def set_prerequisites(
 
     db.commit()
 
+    # Route the post-save title hydration through the same locale-aware
+    # overlay helper the GET handler uses. Previously we returned raw
+    # ``c.title`` here, so a teacher editing prereqs in EN UI on a RU
+    # course saw RU titles in the immediate save response (until the
+    # next GET refreshed). The header-driven locale matches what the
+    # client expects to render.
+    response.headers["Vary"] = "Accept-Language"
+    display_locale: LocaleCode = normalize_locale(accept_language)
     prereq_ids = [p.prerequisite_course_id for p in new_prereqs]
-    prereq_courses = db.query(Course).filter(Course.id.in_(prereq_ids)).all() if prereq_ids else []
-    title_map = {str(c.id): c.title for c in prereq_courses}
+    title_map = _localized_title_map(db, prereq_ids, display_locale=display_locale)
 
     return [
         PrerequisiteResponse(


### PR DESCRIPTION
## Summary

Two MEDIUM-severity items from the 2026-05-21 bug-hunt audit.

**`announcements.create`** — the announcement record uses `safe_title` from `sanitize_string(data.title)`, but the notification fan-out (`create_notifications_bulk` `message` column) was using `data.title` raw. Notification UI renders message as plain text today so it isn't an active XSS, but a future 'render markdown in notifications' feature would silently inherit any unsanitised payload. Use `safe_title` in the fan-out too.

**`prerequisites.set_prerequisites`** — built `title_map` from raw `c.title`, while the GET handler routes through `_localized_title_map` with Accept-Language. A teacher editing prereqs in EN UI on a RU course saw RU titles flash in the immediate save response. Added the same header + localizer to keep PUT in sync with GET.

## Test plan

- [x] `pytest tests/` — 734 passed
- [x] `ruff check` + `mypy app/` clean
- [ ] CI