### PR TITLE
refactor(frontend): migrate ModuleView/CoursesPage/TodayCard to useAsyncData

### DIFF
--- a/frontend/src/components/dashboard/TodayCard.tsx
+++ b/frontend/src/components/dashboard/TodayCard.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react"
+import { useMemo } from "react"
+import { useAsyncData } from "@/hooks/useAsyncData"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { ArrowRight, CalendarDays } from "lucide-react"
@@ -31,39 +32,25 @@ function ymdKey(d: Date): string {
 export function TodayCard() {
   const { t, i18n } = useTranslation()
   const { user } = useAuth()
-  const [events, setEvents] = useState<CalendarEvent[]>([])
-  const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    if (!user) {
-      setLoading(false)
-      return
-    }
-    let cancelled = false
-    setLoading(true)
-    coursesService
-      .getCalendarEvents()
-      .then((evts) => {
-        if (cancelled) return
-        setEvents(evts)
-      })
-      .catch(() => {
-        // Silent: the dashboard is more important than this card. The
-        // empty state below covers both "no events today" and "fetch
-        // failed" — both surface as "nothing to do, open the full
-        // calendar to look further".
-        if (!cancelled) setEvents([])
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
+  // Silent on error: the dashboard is more important than this card.
+  // The empty state below covers both "no events today" and "fetch
+  // failed" — both surface as "nothing to do, open the full calendar
+  // to look further". We catch inside the fetcher so useAsyncData's
+  // error stays null and never reaches the render branch.
+  const { data: events = [], loading } = useAsyncData<CalendarEvent[]>(
+    async () => {
+      if (!user) return []
+      try {
+        return await coursesService.getCalendarEvents()
+      } catch {
+        return []
+      }
+    },
     // user object identity changes on unrelated context refreshes, so
-    // we key the dep on ``id`` to avoid spurious re-fetches.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.id, i18n.language])
+    // key the dep on ``id`` to avoid spurious re-fetches.
+    [user?.id, i18n.language],
+  )
 
   const today = useMemo(() => new Date(), [])
   const todayKey = ymdKey(today)

--- a/frontend/src/pages/Course/ModuleView.tsx
+++ b/frontend/src/pages/Course/ModuleView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react"
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useParams, Link } from "react-router-dom"
 import { formatDateLong } from "@/i18n/format"
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
 import { useAuth } from "@/context/useAuth"
+import { useAsyncData } from "@/hooks/useAsyncData"
 import type { Module } from "@/types"
 import {
   ArrowLeft,
@@ -22,46 +23,49 @@ import ChapterTypeBadge from "@/components/course/ChapterTypeBadge"
 import { ErrorState } from "@/components/patterns"
 import { Skeleton } from "@/components/ui/skeleton"
 
+// Module ID + course ID come from the route, locale from i18n; bundle the
+// fetcher's deps in one tuple so useAsyncData re-runs at the right edges.
+interface ModuleFetchResult {
+  module: Module | null
+  completedIds: Set<string>
+  invalidLink: boolean
+}
+
 export default function ModuleView() {
   const { t, i18n } = useTranslation()
   const { courseId, moduleId } = useParams<{ courseId: string; moduleId: string }>()
   const { user } = useAuth()
-  const [module, setModule] = useState<Module | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [completedIds, setCompletedIds] = useState<Set<string>>(new Set())
 
-  useEffect(() => {
-    let cancelled = false
-    const load = async () => {
+  const { data, loading, error: fetchError } = useAsyncData<ModuleFetchResult>(
+    async (isCancelled) => {
       if (!courseId || !moduleId) {
-        setLoading(false)
-        setError(t("errors.invalidCourseLink"))
-        return
+        return { module: null, completedIds: new Set(), invalidLink: true }
       }
-      setLoading(true)
-      setError(null)
-      try {
-        const [mod, completedChapterIds] = await Promise.all([
-          coursesService.getModule(courseId, moduleId),
-          coursesService.getMyChapterProgress(courseId).catch(() => [] as string[]),
-        ])
-        if (cancelled) return
-        setModule(mod)
-        setCompletedIds(new Set(completedChapterIds))
-      } catch {
-        if (!cancelled) setError(t("errors.loadModuleFailed"))
-      } finally {
-        if (!cancelled) setLoading(false)
+      const [mod, completedChapterIds] = await Promise.all([
+        coursesService.getModule(courseId, moduleId),
+        coursesService.getMyChapterProgress(courseId).catch(() => [] as string[]),
+      ])
+      if (isCancelled()) {
+        return { module: null, completedIds: new Set(), invalidLink: false }
       }
-    }
-    load()
-    return () => { cancelled = true }
+      return { module: mod, completedIds: new Set(completedChapterIds), invalidLink: false }
+    },
     // ``i18n.language`` so a locale flip re-pulls the localised module
-    // title / chapter list. ``t`` is intentionally not a dep — its
-    // reference-change behaviour is implementation-defined.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [courseId, moduleId, user?.id, i18n.language])
+    // title / chapter list. ``user?.id`` so a sign-in/sign-out re-pulls
+    // the progress overlay.
+    [courseId, moduleId, user?.id, i18n.language],
+  )
+
+  // Localised error string resolved at render time — using a token key
+  // instead of storing the localised text means a locale flip while an
+  // error is on screen updates the message without a refetch.
+  const error: string | null = data?.invalidLink
+    ? t("errors.invalidCourseLink")
+    : fetchError
+      ? t("errors.loadModuleFailed")
+      : null
+  const module = data?.module ?? null
+  const completedIds = data?.completedIds ?? new Set<string>()
 
   const sortedChapters = useMemo(
     () => [...(module?.chapters ?? [])].sort((a, b) => a.order_index - b.order_index),

--- a/frontend/src/pages/Courses/CoursesPage.tsx
+++ b/frontend/src/pages/Courses/CoursesPage.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
 import type { Course } from "@/types"
 import { useAuth } from "@/context/useAuth"
+import { useAsyncData } from "@/hooks/useAsyncData"
 import { useDebouncedSearchParam } from "@/hooks/useDebouncedSearchParam"
 import CourseCard from "@/components/course/CourseCard"
 import CourseCardSkeleton from "@/components/skeletons/CourseCardSkeleton"
@@ -32,34 +33,29 @@ export default function CoursesPage() {
   const { user } = useAuth()
   const { input, setInput, value: query, maxLength } = useDebouncedSearchParam()
   const [courses, setCourses] = useState<Course[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
+  const { data: fetchedCourses, loading, error: fetchError } = useAsyncData(
+    async () => coursesService.getCourses(query || undefined),
+    // ``i18n.language`` triggers a refetch on locale flip so localised
+    // titles/descriptions re-pull. ``t`` is intentionally not a dep —
+    // its reference-change behaviour is implementation-defined.
+    [query, reloadKey, i18n.language],
+  )
+  // Token-key error so a locale flip while the error is on screen
+  // updates the message without a refetch.
+  const error: string | null = fetchError ? t("courses.loadFailed") : null
   useUserTour({
     tourId: "courses-catalog-v1",
     steps: coursesCatalogSteps(t),
     ready: !loading && !error,
   })
 
+  // Sync the useAsyncData result into the existing courses state so the
+  // (search/filter) downstream logic can continue to read from a single
+  // source of truth without restructuring the rest of the file.
   useEffect(() => {
-    const signal = { cancelled: false }
-    setLoading(true)
-    setError(null)
-    coursesService
-      .getCourses(query || undefined)
-      .then((data) => {
-        if (!signal.cancelled) setCourses(data)
-      })
-      .catch(() => {
-        if (!signal.cancelled) setError(t("courses.loadFailed"))
-      })
-      .finally(() => {
-        if (!signal.cancelled) setLoading(false)
-      })
-    return () => {
-      signal.cancelled = true
-    }
-  }, [query, reloadKey, t, i18n.language])
+    if (fetchedCourses !== undefined) setCourses(fetchedCourses)
+  }, [fetchedCourses])
 
   return (
     <div className="container mx-auto px-4 py-6 sm:py-10">


### PR DESCRIPTION
## Summary

Three pages were each open-coding the same cancel-token-plus-Promise effect that `hooks/useAsyncData` already implements. Audit flagged this pattern across 10+ pages; this PR migrates the three simplest as a wedge — bigger ones (ChapterView, CohortDetailPage) need their own splits first.

Each migration also fixes the audit MEDIUM **stale-localized-error-string after locale flip** bug: error state is now a token key resolved at render time instead of a pre-localised string baked in during the effect, so flipping the language while an error is on screen updates the message immediately.

- **TodayCard**: single fetch with user-gating; silent-on-error stays — caught inside the fetcher so useAsyncData's `error` never trips the dashboard render branch.
- **ModuleView**: pair-fetch (module + chapter progress) bundled into one return value; invalid-link path returns a discriminator the render uses to pick the right error key.
- **CoursesPage**: single fetch keyed on query + locale; `reloadKey` survives because the search-and-filter logic downstream still mutates `courses`. Synced via a one-line useEffect that mirrors data into state.

**Net diff:** -84 +71 lines across the three files; -3 effect bodies.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 295 passed
- [ ] CI