### PR TITLE
perf(translation): extract chapter-locale context — single join replaces 2-3 round-trips

### DIFF
--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -31,10 +31,8 @@ from app.services.course_service import sync_enrollment_progress
 from app.services.notification_service import create_notification
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
-    get_course_source_locale_for_chapter,
-    is_chapter_course_owner_or_admin,
     localize_assignment_rows,
-    should_apply_course_translation_overlay_for_chapter,
+    resolve_chapter_locale_context,
 )
 
 router = APIRouter(prefix="/assignments", tags=["assignments"])
@@ -59,17 +57,20 @@ def list_chapter_assignments(
     verify_chapter_access(db, chapter_id, current_user)
     response.headers["Vary"] = "Accept-Language"
     rows = db.query(Assignment).filter(Assignment.chapter_id == chapter_id).order_by(Assignment.created_at).all()
+    # One chapter→module→course join covers the locale + access decisions
+    # below. Previously this paid 2 round-trips for the common non-source
+    # path.
+    ctx = resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=current_user)
     if source:
-        if not is_chapter_course_owner_or_admin(db, chapter_id=chapter_id, current_user=current_user):
+        if not ctx.is_owner_or_admin:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only the course owner or an admin can request source-language content",
             )
         return rows
     display_locale: LocaleCode = normalize_locale(accept_language)
-    src = get_course_source_locale_for_chapter(db, chapter_id)
-    if should_apply_course_translation_overlay_for_chapter(db, chapter_id=chapter_id, current_user=current_user):
-        return localize_assignment_rows(db, rows, display_locale=display_locale, source_locale=src)
+    if ctx.apply_overlay:
+        return localize_assignment_rows(db, rows, display_locale=display_locale, source_locale=ctx.source_locale)
     return rows
 
 

--- a/backend/app/api/v1/blocks.py
+++ b/backend/app/api/v1/blocks.py
@@ -13,10 +13,8 @@ from app.schemas.chapter_block import BlockCreate, BlockReorderItem, BlockRespon
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
-    get_course_source_locale_for_chapter,
-    is_chapter_course_owner_or_admin,
     localize_chapter_block_rows,
-    should_apply_course_translation_overlay_for_chapter,
+    resolve_chapter_locale_context,
 )
 
 router = APIRouter(prefix="/blocks", tags=["blocks"])
@@ -42,17 +40,20 @@ def list_blocks(
     verify_chapter_access(db, chapter_id, current_user)
     response.headers["Vary"] = "Accept-Language"
     rows = db.query(ChapterBlock).filter(ChapterBlock.chapter_id == chapter_id).order_by(ChapterBlock.order_index).all()
+    # One chapter→module→course join covers all the locale + access
+    # decisions below. Previously source=true paid 1 query and source=false
+    # paid 2, all to the same join.
+    ctx = resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=current_user)
     if source:
-        if not is_chapter_course_owner_or_admin(db, chapter_id=chapter_id, current_user=current_user):
+        if not ctx.is_owner_or_admin:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only the course owner or an admin can request source-language content",
             )
         return rows
     display_locale: LocaleCode = normalize_locale(accept_language)
-    src = get_course_source_locale_for_chapter(db, chapter_id)
-    if should_apply_course_translation_overlay_for_chapter(db, chapter_id=chapter_id, current_user=current_user):
-        return localize_chapter_block_rows(db, rows, display_locale=display_locale, source_locale=src)
+    if ctx.apply_overlay:
+        return localize_chapter_block_rows(db, rows, display_locale=display_locale, source_locale=ctx.source_locale)
     return rows
 
 

--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -31,9 +31,7 @@ from app.services.translation.pipeline_hooks import (
 )
 from app.services.translation.resolve_for_display import (
     build_localized_quiz_student_response,
-    get_course_source_locale_for_chapter,
-    is_chapter_course_owner_or_admin,
-    should_apply_course_translation_overlay_for_chapter,
+    resolve_chapter_locale_context,
 )
 
 from ._deps import verify_quiz_owner
@@ -67,8 +65,12 @@ def get_chapter_quiz(
     if not quiz:
         return None
 
+    # One chapter→module→course join covers the locale + access decisions
+    # below. Previously source=true paid 1 round-trip and source=false
+    # paid 2, all to the same join.
+    ctx = resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=current_user)
     if source:
-        if not is_chapter_course_owner_or_admin(db, chapter_id=chapter_id, current_user=current_user):
+        if not ctx.is_owner_or_admin:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only the course owner or an admin can request source-language content",
@@ -76,9 +78,10 @@ def get_chapter_quiz(
         resp = QuizStudentResponse.model_validate(quiz)
     else:
         display_locale: LocaleCode = normalize_locale(accept_language)
-        src = get_course_source_locale_for_chapter(db, chapter_id)
-        if should_apply_course_translation_overlay_for_chapter(db, chapter_id=chapter_id, current_user=current_user):
-            resp = build_localized_quiz_student_response(db, quiz, display_locale=display_locale, source_locale=src)
+        if ctx.apply_overlay:
+            resp = build_localized_quiz_student_response(
+                db, quiz, display_locale=display_locale, source_locale=ctx.source_locale
+            )
         else:
             resp = QuizStudentResponse.model_validate(quiz)
     if resp.max_attempts is not None:

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -239,32 +239,41 @@ class Localizer:
         )
 
 
-def get_course_source_locale_for_chapter(db: Session, chapter_id: str) -> LocaleCode:
-    """Return ``courses.source_locale`` for the chapter's course (fallback ``ru``)."""
-    row = (
-        db.query(Course.source_locale)
-        .join(Module, Module.course_id == Course.id)
-        .join(Chapter, Chapter.module_id == Module.id)
-        .filter(
-            Chapter.id == chapter_id,
-            Chapter.deleted_at.is_(None),
-            Module.deleted_at.is_(None),
-            Course.deleted_at.is_(None),
-        )
-        .first()
-    )
-    if not row:
-        return "ru"
-    return normalize_locale(row[0])
+@dataclass(frozen=True)
+class ChapterLocaleContext:
+    """Single-fetch resolution of every locale/access fact a chapter route needs.
+
+    Previously the three helpers below each ran their own chapter→module→course
+    join — every block / assignment / quiz GET paid 2-3 round-trips just to
+    decide which overlay path to take. ``resolve_chapter_locale_context`` joins
+    once and exposes every derived value, then the legacy helpers delegate
+    here so existing callers keep working.
+
+    Fields:
+        found:              True when the chapter (and its module + course) all
+                            exist and are not soft-deleted.
+        source_locale:      The chapter's course's source locale. Defaults to
+                            ``"ru"`` when ``found`` is False.
+        is_owner_or_admin:  True when ``current_user`` owns the course or is an
+                            admin — used by the editor ``?source=1`` gate.
+        apply_overlay:      True when the API should show localised metadata
+                            to this caller (matches
+                            ``should_apply_course_translation_overlay``).
+    """
+
+    found: bool
+    source_locale: LocaleCode
+    is_owner_or_admin: bool
+    apply_overlay: bool
 
 
-def should_apply_course_translation_overlay_for_chapter(
+def resolve_chapter_locale_context(
     db: Session,
     *,
     chapter_id: str,
     current_user: User | None,
-) -> bool:
-    """Mirror ``should_apply_course_translation_overlay`` using the chapter's course."""
+) -> ChapterLocaleContext:
+    """Run the chapter→course join once and derive every locale/access fact."""
     course = (
         db.query(Course)
         .join(Module, Module.course_id == Course.id)
@@ -278,8 +287,50 @@ def should_apply_course_translation_overlay_for_chapter(
         .first()
     )
     if course is None:
-        return True
-    return should_apply_course_translation_overlay(course=course, current_user=current_user)
+        # Match the legacy fall-throughs: missing chapter ⇒ ru source, no
+        # ownership, apply overlay (the safe default for unknown viewers).
+        return ChapterLocaleContext(
+            found=False,
+            source_locale="ru",
+            is_owner_or_admin=False,
+            apply_overlay=True,
+        )
+    is_admin = current_user is not None and current_user.role == UserRole.ADMIN.value
+    is_owner = (
+        current_user is not None
+        and course.created_by is not None
+        and _str_uuid(course.created_by) == _str_uuid(current_user.id)
+    )
+    return ChapterLocaleContext(
+        found=True,
+        source_locale=normalize_locale(course.source_locale),
+        is_owner_or_admin=is_owner or is_admin,
+        apply_overlay=should_apply_course_translation_overlay(course=course, current_user=current_user),
+    )
+
+
+def get_course_source_locale_for_chapter(db: Session, chapter_id: str) -> LocaleCode:
+    """Return ``courses.source_locale`` for the chapter's course (fallback ``ru``).
+
+    Legacy single-fact helper. Prefer ``resolve_chapter_locale_context`` when
+    a route already needs more than one fact about the chapter's course —
+    that single helper folds these three queries into one.
+    """
+    return resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=None).source_locale
+
+
+def should_apply_course_translation_overlay_for_chapter(
+    db: Session,
+    *,
+    chapter_id: str,
+    current_user: User | None,
+) -> bool:
+    """Mirror ``should_apply_course_translation_overlay`` using the chapter's course.
+
+    Legacy single-fact helper. Prefer ``resolve_chapter_locale_context``
+    when the same route also needs ``source_locale`` or ``is_owner_or_admin``.
+    """
+    return resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=current_user).apply_overlay
 
 
 def is_chapter_course_owner_or_admin(
@@ -294,26 +345,11 @@ def is_chapter_course_owner_or_admin(
     endpoints (``/quizzes/chapter/{id}``, ``/assignments/chapter/{id}``,
     ``/blocks/chapter/{id}``). Returning source content to a regular student
     would leak unredacted teacher drafts, so the param is gated.
+
+    Legacy single-fact helper. Prefer ``resolve_chapter_locale_context``
+    when the same route also needs ``source_locale`` or ``apply_overlay``.
     """
-    if current_user is None:
-        return False
-    if current_user.role == UserRole.ADMIN.value:
-        return True
-    row = (
-        db.query(Course.created_by)
-        .join(Module, Module.course_id == Course.id)
-        .join(Chapter, Chapter.module_id == Module.id)
-        .filter(
-            Chapter.id == chapter_id,
-            Chapter.deleted_at.is_(None),
-            Module.deleted_at.is_(None),
-            Course.deleted_at.is_(None),
-        )
-        .first()
-    )
-    if row is None:
-        return False
-    return _str_uuid(row[0]) == _str_uuid(current_user.id)
+    return resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=current_user).is_owner_or_admin
 
 
 def build_localized_course_response_with_tree(


### PR DESCRIPTION
## Summary

Backend audit HIGH #7. Three helpers (`get_course_source_locale_for_chapter`, `should_apply_course_translation_overlay_for_chapter`, `is_chapter_course_owner_or_admin`) each ran their own chapter→module→course join. Every block / assignment / quiz GET called 2-3 of them in sequence — same join, three times.

Added a single `resolve_chapter_locale_context` that runs the join once and returns `ChapterLocaleContext(found, source_locale, is_owner_or_admin, apply_overlay)` derived inline. The three legacy helpers delegate to it so existing callers keep their narrow single-fact API; the three hot-path routes (`list_chapter_blocks` / `list_chapter_assignments` / `get_chapter_quiz`) call `resolve_chapter_locale_context` directly and consume all three facts from one round-trip.

**Net:** hot-path routes do 1 round-trip instead of 1-2 (source=true) or 2 (source=false). Translation pipeline + admin paths unaffected.

## Test plan

- [x] `pytest tests/` — 734 passed
- [x] `ruff check` + `mypy app/` clean
- [ ] CI