### PR TITLE
refactor(i18n): replace 11 template-literal t() callsites with static Record lookups

### DIFF
--- a/frontend/src/components/course/ChapterTypeBadge.tsx
+++ b/frontend/src/components/course/ChapterTypeBadge.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { getChapterTypeMeta, normalizeChapterType } from "@/lib/chapterTypes"
+import { CHAPTER_TYPE_LABEL_KEYS, getChapterTypeMeta, normalizeChapterType } from "@/lib/chapterTypes"
 
 interface Props {
   type: string
@@ -19,7 +19,7 @@ export default function ChapterTypeBadge({ type, size = "md" }: Props) {
   return (
     <span className={`inline-flex items-center rounded-full font-medium ${sizing} ${meta.color}`}>
       <Icon className={iconSize} strokeWidth={1.75} aria-hidden />
-      {t(`chapterTypes.${normalized}.label`)}
+      {t(CHAPTER_TYPE_LABEL_KEYS[normalized])}
     </span>
   )
 }

--- a/frontend/src/components/editor/CalloutDropdown.tsx
+++ b/frontend/src/components/editor/CalloutDropdown.tsx
@@ -25,6 +25,15 @@ const CALLOUT_VARIANTS: CalloutChoice[] = [
   { value: "warning", icon: AlertTriangle, color: "text-warning" },
 ];
 
+// Static i18n key lookup — exposes each literal to the keyCoverage
+// static check that template-literal callsites silently bypass.
+const CALLOUT_LABEL_KEYS: Record<CalloutVariant, string> = {
+  info: "blockEditor.callout.info",
+  verse: "blockEditor.callout.verse",
+  takeaway: "blockEditor.callout.takeaway",
+  warning: "blockEditor.callout.warning",
+};
+
 /**
  * Dropdown menu for inserting or removing a Callout block. Lives next
  * to the formatting toolbar but owns its own open/close state and
@@ -107,7 +116,7 @@ export function CalloutDropdown({
                 className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
               >
                 <Icon size={16} className={v.color} aria-hidden="true" />
-                {t(`blockEditor.callout.${v.value}`)}
+                {t(CALLOUT_LABEL_KEYS[v.value])}
               </button>
             );
           })}

--- a/frontend/src/components/editor/ChapterBlockEditor.tsx
+++ b/frontend/src/components/editor/ChapterBlockEditor.tsx
@@ -8,6 +8,7 @@ import { toast } from "@/lib/toast"
 import type { ChapterBlock } from "@/types"
 import { useConfirm } from "@/components/ui/alert-dialog"
 import { AddBlockMenu, BlockRow, type BlockType } from "./blocks"
+import { BLOCK_TYPE_LABEL_KEYS } from "./blocks/types"
 
 interface Props {
   chapterId: string
@@ -74,7 +75,7 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
       setBlocks((prev) => [...prev, newBlock])
       setExpandedId(newBlock.id)
       toast({
-        title: t("blockEditor.addedSuccess", { type: t(`blockEditor.types.${type}`) }),
+        title: t("blockEditor.addedSuccess", { type: t(BLOCK_TYPE_LABEL_KEYS[type]) }),
         variant: "success",
       })
     } catch (error: unknown) {

--- a/frontend/src/components/editor/blocks/AddBlockMenu.tsx
+++ b/frontend/src/components/editor/blocks/AddBlockMenu.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Loader2, Plus } from "lucide-react"
-import { BLOCK_TYPES, type BlockType } from "./types"
+import { BLOCK_TYPE_LABEL_KEYS, BLOCK_TYPES, type BlockType } from "./types"
 
 interface Props {
   onAdd: (type: BlockType) => void
@@ -49,7 +49,7 @@ export function AddBlockMenu({ onAdd, adding }: Props) {
                 className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-muted transition-colors text-left"
               >
                 <Icon className="h-4 w-4 text-muted-foreground" />
-                {t(`blockEditor.types.${bt.value}`)}
+                {t(BLOCK_TYPE_LABEL_KEYS[bt.value])}
               </button>
             )
           })}

--- a/frontend/src/components/editor/blocks/types.ts
+++ b/frontend/src/components/editor/blocks/types.ts
@@ -26,3 +26,13 @@ export type BlockType = (typeof BLOCK_TYPES)[number]["value"]
 export function blockIcon(type: string): LucideIcon {
   return BLOCK_TYPES.find((bt) => bt.value === type)?.icon ?? FileText
 }
+
+// Static i18n key lookup so callers ``t(BLOCK_TYPE_LABEL_KEYS[type])``
+// instead of ``t(`blockEditor.types.${type}`)`` — keeps the keys
+// visible to the i18n keyCoverage static check.
+export const BLOCK_TYPE_LABEL_KEYS: Record<BlockType, string> = {
+  text: "blockEditor.types.text",
+  quiz: "blockEditor.types.quiz",
+  assignment: "blockEditor.types.assignment",
+  file: "blockEditor.types.file",
+}

--- a/frontend/src/lib/chapterTypes.ts
+++ b/frontend/src/lib/chapterTypes.ts
@@ -85,3 +85,21 @@ export function getChapterTypeMeta(raw: string | null | undefined): ChapterTypeM
 export function isGradableChapterType(raw: string | null | undefined): boolean {
   return GRADABLE_CHAPTER_TYPES.has(normalizeChapterType(raw))
 }
+
+// Static i18n key lookups so callers ``t(CHAPTER_TYPE_LABEL_KEYS[type])`` —
+// instead of ``t(`chapterTypes.${type}.label`)`` — and the keyCoverage
+// test can see every key as a literal at scan time. Per docs/I18N.md:
+// "Resist the temptation to write t(`prefix.${variable}`)".
+export const CHAPTER_TYPE_LABEL_KEYS: Record<ChapterType, string> = {
+  reading: "chapterTypes.reading.label",
+  quiz: "chapterTypes.quiz.label",
+  exam: "chapterTypes.exam.label",
+  assignment: "chapterTypes.assignment.label",
+}
+
+export const CHAPTER_TYPE_DESCRIPTION_KEYS: Record<ChapterType, string> = {
+  reading: "chapterTypes.reading.description",
+  quiz: "chapterTypes.quiz.description",
+  exam: "chapterTypes.exam.description",
+  assignment: "chapterTypes.assignment.description",
+}

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -29,6 +29,15 @@ const STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
   completed: "muted",
 }
 
+// Static i18n key lookup so the keyCoverage check sees each literal;
+// the previous ``t(`admin.cohorts.status${capitalize(c.status)}`)``
+// hid the key from the static scan.
+const STATUS_LABEL_KEYS: Record<Cohort["status"], string> = {
+  upcoming: "admin.cohorts.statusUpcoming",
+  active: "admin.cohorts.statusActive",
+  completed: "admin.cohorts.statusCompleted",
+}
+
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const
 type PageSize = (typeof PAGE_SIZE_OPTIONS)[number]
 const DEFAULT_PAGE_SIZE: PageSize = 25
@@ -364,7 +373,7 @@ function CohortsTable({ items }: { items: Cohort[] }) {
                 </p>
               </div>
               <Badge variant={STATUS_BADGE[c.status]} className="shrink-0 capitalize">
-                {t(`admin.cohorts.status${capitalize(c.status)}`)}
+                {t(STATUS_LABEL_KEYS[c.status])}
               </Badge>
             </div>
             <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
@@ -423,7 +432,7 @@ function CohortsTable({ items }: { items: Cohort[] }) {
                 </td>
                 <td className="px-5 py-3">
                   <Badge variant={STATUS_BADGE[c.status]} className="capitalize">
-                    {t(`admin.cohorts.status${capitalize(c.status)}`)}
+                    {t(STATUS_LABEL_KEYS[c.status])}
                   </Badge>
                 </td>
                 <td className="px-5 py-3 text-xs text-muted-foreground">
@@ -441,10 +450,6 @@ function CohortsTable({ items }: { items: Cohort[] }) {
       </div>
     </>
   )
-}
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 function EmptyCohorts({ hasQuery, onCreate }: { hasQuery: boolean; onCreate: () => void }) {

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -17,9 +17,11 @@ import { EmptyState } from "@/components/patterns/EmptyState"
 import { FileText, ChevronLeft, ChevronRight, X } from "lucide-react"
 import type { AuditLogEntry } from "@/types"
 import {
-  ACTION_OPTIONS,
-  RESOURCE_OPTIONS,
   ACTION_BADGE_VARIANT,
+  ACTION_LABEL_KEYS,
+  ACTION_OPTIONS,
+  RESOURCE_LABEL_KEYS,
+  RESOURCE_OPTIONS,
 } from "./constants"
 import { AUDIT_PAGE_SIZE_OPTIONS, type AuditPageSize } from "./useAdminAudit"
 import { AuditDetailsCell } from "./AuditDetailsCell"
@@ -120,7 +122,7 @@ export function AuditLogTab({
                   <SelectItem value="all">{t("admin.audit.filterAllActions")}</SelectItem>
                   {ACTION_OPTIONS.map((o) => (
                     <SelectItem key={o} value={o}>
-                      {t(`admin.audit.actionValue.${o}`)}
+                      {t(ACTION_LABEL_KEYS[o])}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -147,7 +149,7 @@ export function AuditLogTab({
                   <SelectItem value="all">{t("admin.audit.filterAllResources")}</SelectItem>
                   {RESOURCE_OPTIONS.map((o) => (
                     <SelectItem key={o} value={o}>
-                      {t(`admin.audit.resourceValue.${o}`)}
+                      {t(RESOURCE_LABEL_KEYS[o])}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -18,6 +18,7 @@ import { EmptyState } from "@/components/patterns/EmptyState"
 import { RoleSelector } from "@/components/admin/RoleSelector"
 import { UserAvatar } from "@/components/admin/UserAvatar"
 import { displayNameOf } from "@/lib/userDisplay"
+import { ROLE_I18N_KEY } from "@/lib/roles"
 import type { UserRole } from "@/types"
 import { formatDate } from "@/i18n/format"
 import { type ProfileRow } from "./constants"
@@ -174,7 +175,7 @@ export function UsersCard({
                     : "border-border hover:border-primary/40 hover:bg-muted",
                 )}
               >
-                <span>{t(`roles.${role === "pending_teacher" ? "pendingTeacher" : role}`)}</span>
+                <span>{t(ROLE_I18N_KEY[role])}</span>
                 <span
                   className={cn(
                     "tabular-nums",

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -68,6 +68,30 @@ export const ACTION_BADGE_VARIANT: Record<
   grade: "warningSubtle",
 }
 
+// Static i18n key lookups — callers use ``t(ACTION_LABEL_KEYS[o])``
+// instead of ``t(`admin.audit.actionValue.${o}`)`` so the keyCoverage
+// test can see each literal at scan time. Per docs/I18N.md.
+export const ACTION_LABEL_KEYS: Record<(typeof ACTION_OPTIONS)[number], string> = {
+  create: "admin.audit.actionValue.create",
+  update: "admin.audit.actionValue.update",
+  delete: "admin.audit.actionValue.delete",
+  publish: "admin.audit.actionValue.publish",
+  enroll: "admin.audit.actionValue.enroll",
+  approve: "admin.audit.actionValue.approve",
+  reject: "admin.audit.actionValue.reject",
+  grade: "admin.audit.actionValue.grade",
+}
+
+export const RESOURCE_LABEL_KEYS: Record<(typeof RESOURCE_OPTIONS)[number], string> = {
+  course: "admin.audit.resourceValue.course",
+  module: "admin.audit.resourceValue.module",
+  chapter: "admin.audit.resourceValue.chapter",
+  enrollment: "admin.audit.resourceValue.enrollment",
+  certificate: "admin.audit.resourceValue.certificate",
+  assignment_submission: "admin.audit.resourceValue.assignment_submission",
+  user: "admin.audit.resourceValue.user",
+}
+
 export interface ProfileRow {
   id: string
   email: string

--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -25,6 +25,7 @@ import QuizTaker from "@/components/quiz/QuizTaker"
 import AssignmentPanel from "@/components/assignment/AssignmentPanel"
 import { PressFeedback } from "@/components/motion"
 import {
+  CHAPTER_TYPE_LABEL_KEYS,
   getChapterTypeMeta,
   isGradableChapterType,
   normalizeChapterType,
@@ -536,7 +537,7 @@ export default function ChapterView() {
         <p className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
           <span className="inline-flex items-center gap-1.5">
             <ChapterTypeIcon className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
-            {t(`chapterTypes.${chapterType}.label`)}
+            {t(CHAPTER_TYPE_LABEL_KEYS[chapterType])}
           </span>
           <span aria-hidden className="text-muted-foreground/40">·</span>
           <span className="tabular-nums">

--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -19,6 +19,8 @@ import {
 } from "lucide-react"
 import {
   CHAPTER_TYPES,
+  CHAPTER_TYPE_DESCRIPTION_KEYS,
+  CHAPTER_TYPE_LABEL_KEYS,
   CHAPTER_TYPE_META,
   normalizeChapterType,
   type ChapterType,
@@ -344,10 +346,10 @@ export default function ChapterEditor() {
                       selected ? "text-primary" : ""
                     }`}
                   >
-                    {t(`chapterTypes.${ct.value}.label`)}
+                    {t(CHAPTER_TYPE_LABEL_KEYS[ct.value])}
                   </div>
                   <div className="text-xs text-muted-foreground mt-0.5">
-                    {t(`chapterTypes.${ct.value}.description`)}
+                    {t(CHAPTER_TYPE_DESCRIPTION_KEYS[ct.value])}
                   </div>
                 </div>
               </button>

--- a/frontend/src/pages/Teacher/editor/EventsModal.tsx
+++ b/frontend/src/pages/Teacher/editor/EventsModal.tsx
@@ -32,6 +32,8 @@ interface Props {
   onDelete: (id: string) => void
 }
 
+import { EVENT_TYPE_LABEL_KEYS } from "./eventTypes"
+
 const EVENT_TYPE_VALUES = ["deadline", "live_session", "exam", "other"] as const
 
 export function EventsModal({
@@ -84,7 +86,7 @@ export function EventsModal({
                 <SelectContent>
                   {EVENT_TYPE_VALUES.map((value) => (
                     <SelectItem key={value} value={value}>
-                      {t(`teacherEditor.modals.events.types.${value}`)}
+                      {t(EVENT_TYPE_LABEL_KEYS[value])}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/pages/Teacher/editor/badges.tsx
+++ b/frontend/src/pages/Teacher/editor/badges.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { Badge } from "@/components/ui/badge"
+import { EVENT_TYPE_LABEL_KEYS, type EventType } from "./eventTypes"
 
 /** Enrollment-window state derived from (start, end) strings. */
 export function EnrollmentStatusBadge({ start, end }: { start: string; end: string }) {
@@ -26,16 +27,14 @@ const EVENT_BADGE_VARIANT: Record<string, EventVariant> = {
   other: "muted",
 }
 
-const KNOWN_EVENT_TYPES = new Set(["deadline", "live_session", "exam", "other"])
-
 export function EventTypeBadge({ type }: { type: string }) {
   const { t } = useTranslation()
   // Fall back to "other" for unknown types so we still render a sensible
   // localized label (the i18n keys cover the four supported types).
-  const key = KNOWN_EVENT_TYPES.has(type) ? type : "other"
+  const key: EventType = (type in EVENT_TYPE_LABEL_KEYS ? type : "other") as EventType
   return (
     <Badge variant={EVENT_BADGE_VARIANT[type] ?? "muted"}>
-      {t(`teacherEditor.modals.events.types.${key}`)}
+      {t(EVENT_TYPE_LABEL_KEYS[key])}
     </Badge>
   )
 }

--- a/frontend/src/pages/Teacher/editor/eventTypes.ts
+++ b/frontend/src/pages/Teacher/editor/eventTypes.ts
@@ -1,0 +1,13 @@
+// Shared event-type constants extracted from badges.tsx so consumers can
+// import the i18n key map without dragging the React component module
+// (which trips the react-refresh/only-export-components lint rule when
+// the .tsx file exports both components and constants).
+
+export const EVENT_TYPE_LABEL_KEYS = {
+  deadline: "teacherEditor.modals.events.types.deadline",
+  live_session: "teacherEditor.modals.events.types.live_session",
+  exam: "teacherEditor.modals.events.types.exam",
+  other: "teacherEditor.modals.events.types.other",
+} as const
+
+export type EventType = keyof typeof EVENT_TYPE_LABEL_KEYS

--- a/frontend/src/pages/Teacher/moduleEditor/ChapterRow.tsx
+++ b/frontend/src/pages/Teacher/moduleEditor/ChapterRow.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { normalizeChapterType } from "@/lib/chapterTypes";
+import { CHAPTER_TYPE_LABEL_KEYS, normalizeChapterType } from "@/lib/chapterTypes";
 import type { Chapter } from "@/types";
 
 interface ChapterRowProps {
@@ -85,7 +85,7 @@ export function ChapterRow({
             {/* Row 2 on mobile (badge + actions). Inline on sm+. */}
             <div className="flex items-center justify-end gap-1 sm:gap-2">
               <Badge variant="muted" className="mr-auto shrink-0 sm:mr-0">
-                {t(`chapterTypes.${type}.label`)}
+                {t(CHAPTER_TYPE_LABEL_KEYS[type])}
               </Badge>
 
               <Button


### PR DESCRIPTION
## Summary

`docs/I18N.md`: "Resist the temptation to write `t(\`prefix.${variable}\`)` — a template literal makes the key invisible to the keyCoverage static check." The audit flagged 11 violations across 10 files; each was a key the keyCoverage test silently could not verify.

Pattern per fix: define `export const FOO_LABEL_KEYS: Record<Enum, string> = { ... }` next to the enum/option set, then `t(FOO_LABEL_KEYS[value])` at the site. Every literal is now visible to the static scan.

**Files touched** (16): chapterTypes lookups, audit Action/Resource lookups, cohort Status lookups, block-type lookups, callout lookups, event-type lookups (extracted to new `eventTypes.ts` to keep `badges.tsx` from tripping `react-refresh/only-export-components`). `UsersCard` switched to the existing `ROLE_I18N_KEY` helper. Dead `capitalize` helper in `CohortsTab` removed.

The defaultValue-equipped callsites (ChapterBreakdownRow, AuditSummaryRow#288, MonthGrid, SelectedDayPanel, BlockRow, SubmissionGrader) are intentionally left as-is — they have a runtime fallback so the keyCoverage gap is benign.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 295 passed
- [ ] CI
