### PR TITLE
chore(ci): SHA-pin all GitHub Actions (closes 16 Scorecard alerts)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -33,7 +33,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -81,10 +81,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           cache: pip
@@ -131,7 +131,7 @@ jobs:
           --strict-markers
 
       - name: Upload coverage XML artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success() || failure()
         with:
           name: backend-coverage-xml
@@ -145,7 +145,7 @@ jobs:
       # gate stable if Codecov has an outage -- the artifact above is the
       # durable backup.
       - name: Upload coverage to Codecov (backend)
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./backend/coverage.xml
           flags: backend
@@ -193,10 +193,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -25,7 +25,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -70,10 +70,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           # jsdom@>=28 and vitest@>=4 declare engines ^20.19.0 || ^22.12.0 || >=24.0.0,
           # so we need 22.12+ specifically (not just "22" which resolves to 22.0.0).
@@ -121,7 +121,7 @@ jobs:
       # `CODECOV_TOKEN` repo secret. `fail_ci_if_error: false` keeps the
       # gate stable if Codecov has an outage.
       - name: Upload coverage to Codecov (frontend)
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./frontend/coverage/lcov.info
           flags: frontend

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply path-based labels
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,12 +40,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -56,13 +56,13 @@ jobs:
       # Keep the raw SARIF as an artifact for one PR cycle so a contributor
       # can grab it and see exactly which check moved without re-running.
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Greet first-time contributor
-        uses: actions/first-interaction@v3
+        uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

OpenSSF Scorecard's `PinnedDependenciesID` lint has been firing for months — every action `uses: foo/bar@vN` is a mutable tag the upstream owner can rewrite. SHA-pinning makes the workflow deterministic and Scorecard happy in one stroke.

## Actions pinned (10 unique repos, ~16 callsites)

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | v6 | `de0fac2e...` |
| `actions/setup-python` | v6 | `a309ff8b...` |
| `actions/setup-node` | v6 | `48b55a01...` |
| `actions/upload-artifact` | v7 | `043fb46d...` |
| `actions/labeler` | v5 | `8558fd74...` |
| `actions/first-interaction` | v3 | `1c468894...` |
| `codecov/codecov-action` | v6 | `e79a6962...` |
| `ossf/scorecard-action` | v2.4.3 | `4eaacf05...` |
| `github/codeql-action/upload-sarif` | v3 | `458d36d7...` |
| `dependabot/fetch-metadata` | v2 | `21025c70...` |

Each pin keeps the readable `# vN` comment so Dependabot's existing `github-actions` ecosystem watcher will see the version label and propose SHA-only bumps weekly. No `dependabot.yml` change needed.

## Test plan

- [x] `grep "uses:.*@v[0-9]" .github/workflows/ | grep -v "# v"` returns empty
- [ ] CI re-runs all workflows on the SHA pins
- [ ] Scorecard re-scan should dismiss all 16 `PinnedDependenciesID` alerts
