### PR TITLE
feat(editor): KaTeX math in chapters — inline + block, sanitiser, view-time render

### DIFF
--- a/backend/app/core/sanitize.py
+++ b/backend/app/core/sanitize.py
@@ -89,6 +89,21 @@ _ALLOWED_ATTRIBUTES: dict[str, list[str]] = {
     # round-tripping for the .prose-cascade CSS.
     "td": ["colspan", "rowspan", "class", "id"],
     "th": ["colspan", "rowspan", "scope", "class", "id"],
+    # Inline-math markers from ``@aarkue/tiptap-math-extension``. The
+    # extension stores math as ``<span data-type="inlineMath"
+    # data-latex="..." data-display="..." data-evaluate="...">$x^2$</span>``
+    # and the BlockRenderer renders KaTeX into the marker at view time.
+    # Same per-tag-overrides-wildcard rule as the table cells —
+    # ``class`` / ``id`` are repeated so highlight.js token spans and
+    # any other span use still keeps its class.
+    "span": [
+        "class",
+        "id",
+        "data-type",
+        "data-latex",
+        "data-display",
+        "data-evaluate",
+    ],
     "*": ["class", "id"],
 }
 

--- a/backend/tests/test_sanitize.py
+++ b/backend/tests/test_sanitize.py
@@ -105,3 +105,41 @@ class TestCodeBlockAllowlist:
         cleaned = sanitize_string(html)
         assert 'class="hljs-built_in"' in cleaned
         assert 'class="hljs-number"' in cleaned
+
+
+class TestMathMarkerAllowlist:
+    """The TipTap math extension stores math as
+    ``<span data-type="inlineMath" data-latex="..." data-display="..."
+    data-evaluate="...">$x^2$</span>``. The BlockRenderer re-runs
+    ``katex.render`` over each marker at view time, so the data-*
+    attributes must round-trip through bleach intact — otherwise the
+    chapter view shows the raw ``$x^2$`` delimiters instead of the
+    rendered formula.
+    """
+
+    def test_inline_math_marker_survives(self):
+        html = (
+            '<p>Theorem: <span data-type="inlineMath" data-latex="a^2+b^2=c^2" '
+            'data-display="no" data-evaluate="no">$a^2+b^2=c^2$</span>.</p>'
+        )
+        cleaned = sanitize_string(html)
+        assert 'data-type="inlineMath"' in cleaned
+        assert 'data-latex="a^2+b^2=c^2"' in cleaned
+        assert 'data-display="no"' in cleaned
+
+    def test_block_math_marker_survives(self):
+        html = (
+            '<p><span data-type="inlineMath" data-latex="\\sum_{i=0}^n i" '
+            'data-display="yes" data-evaluate="no">$$\\sum_{i=0}^n i$$</span></p>'
+        )
+        cleaned = sanitize_string(html)
+        assert 'data-display="yes"' in cleaned
+        assert "\\sum_{i=0}^n i" in cleaned
+
+    def test_other_span_attrs_still_stripped(self):
+        # Defence-in-depth: a malicious span carrying a non-allowlisted
+        # data-* attribute (or a real event handler) must still be
+        # scrubbed even after we widened the span allowlist for math.
+        cleaned = sanitize_string('<span data-evil="payload" onclick="x">x</span>')
+        assert "data-evil" not in cleaned
+        assert "onclick" not in cleaned

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "equip-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@aarkue/tiptap-math-extension": "^1.4.0",
         "@datadog/browser-rum": "^7.1.0",
         "@datadog/browser-rum-react": "^7.1.0",
         "@fontsource-variable/fraunces": "^5.2.9",
@@ -45,6 +46,7 @@
         "highlight.js": "^11.11.1",
         "i18next": "^26.0.10",
         "i18next-browser-languagedetector": "^8.2.1",
+        "katex": "^0.17.0",
         "lowlight": "^3.3.0",
         "lucide-react": "^1.14.0",
         "motion": "^12.38.0",
@@ -87,6 +89,45 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@aarkue/tiptap-math-extension": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@aarkue/tiptap-math-extension/-/tiptap-math-extension-1.4.0.tgz",
+      "integrity": "sha512-vCu/6WgO2yJ2cFnvsOL6kQCcWRWDm7OJ5I64KLyXIGGzIA2HuVhSyfuWeoNg51YVkEqlxZNTUgy0MXw6OTvrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "evaluatex": "^2.2.0",
+        "katex": "^0.16.7"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.0",
+        "@tiptap/pm": "^3.0.0"
+      }
+    },
+    "node_modules/@aarkue/tiptap-math-extension/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@aarkue/tiptap-math-extension/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4564,6 +4605,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/evaluatex": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/evaluatex/-/evaluatex-2.2.0.tgz",
+      "integrity": "sha512-QVtGvYTf9HvQyDjbBCwoDQPP9KMuVB56H8KalrkLsPPCQfngpVmkiIoxJ4FU/SVmlmhnbr/heOmP5VlbCTEJpg==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5335,6 +5382,31 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
+      "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@aarkue/tiptap-math-extension": "^1.4.0",
     "@datadog/browser-rum": "^7.1.0",
     "@datadog/browser-rum-react": "^7.1.0",
     "@fontsource-variable/fraunces": "^5.2.9",
@@ -54,6 +55,7 @@
     "highlight.js": "^11.11.1",
     "i18next": "^26.0.10",
     "i18next-browser-languagedetector": "^8.2.1",
+    "katex": "^0.17.0",
     "lowlight": "^3.3.0",
     "lucide-react": "^1.14.0",
     "motion": "^12.38.0",

--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -16,6 +16,7 @@ import {
   Video as Youtube,
   Headphones,
   Minus,
+  Sigma,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -76,6 +77,7 @@ interface EditorToolbarProps {
   onAddImage: () => void;
   onAddYoutube: () => void;
   onAddAudio: () => void;
+  onAddMath: () => void;
   onSetLink: () => void;
 }
 
@@ -91,6 +93,7 @@ export function EditorToolbar({
   onAddImage,
   onAddYoutube,
   onAddAudio,
+  onAddMath,
   onSetLink,
 }: EditorToolbarProps) {
   const { t } = useTranslation();
@@ -198,6 +201,10 @@ export function EditorToolbar({
 
       <ToolbarButton onClick={onAddAudio} title={t("blockEditor.toolbar.insertAudio")}>
         <Headphones size={TOOLBAR_ICON_SIZE} strokeWidth={1.75} aria-hidden="true" />
+      </ToolbarButton>
+
+      <ToolbarButton onClick={onAddMath} title={t("blockEditor.toolbar.insertMath")}>
+        <Sigma size={TOOLBAR_ICON_SIZE} strokeWidth={1.75} aria-hidden="true" />
       </ToolbarButton>
 
       <ToolbarButton

--- a/frontend/src/components/editor/RichTextEditor.tsx
+++ b/frontend/src/components/editor/RichTextEditor.tsx
@@ -11,6 +11,8 @@ import { TableHeader } from "@tiptap/extension-table-header";
 import { TableCell } from "@tiptap/extension-table-cell";
 import { CharacterCount } from "@tiptap/extension-character-count";
 import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
+import { MathExtension } from "@aarkue/tiptap-math-extension";
+import "katex/dist/katex.min.css";
 
 import { Callout } from "./CalloutExtension";
 import { YoutubeEmbed } from "./YoutubeExtension";
@@ -89,6 +91,18 @@ export default function RichTextEditor({
       // hard cap when ``characterLimit`` is set — passing ``null`` /
       // ``undefined`` keeps input unbounded.
       CharacterCount.configure({ limit: characterLimit ?? null }),
+      // ``MathExtension`` stores math as ``<span data-type="inlineMath"
+      // data-latex="x^2">...</span>`` markers — tiny, sanitizer-friendly,
+      // KaTeX renders them via NodeView at view time inside the editor.
+      // Outside the editor (``BlockRenderer``) we re-run ``katex.render``
+      // on each marker so the student sees the same math.
+      // ``evaluation: false`` disables the symbolic-math evaluator that
+      // ships with the extension — Bible-school context doesn't need
+      // "$1+2=$" auto-expanding to 3.
+      MathExtension.configure({
+        evaluation: false,
+        renderTextMode: "raw-latex",
+      }),
     ],
     content,
     editable,
@@ -120,7 +134,7 @@ export default function RichTextEditor({
     }
   }, [content, editor]);
 
-  const { setLink, addImage, addYoutube, addAudio } = useMediaPrompts(editor, imageUpload);
+  const { setLink, addImage, addYoutube, addAudio, addMath } = useMediaPrompts(editor, imageUpload);
 
   // TipTap mutates the editor in place; reading
   // ``editor.storage.characterCount.characters()`` only refreshes on a
@@ -154,6 +168,7 @@ export default function RichTextEditor({
           onAddImage={addImage}
           onAddYoutube={addYoutube}
           onAddAudio={addAudio}
+          onAddMath={addMath}
           onSetLink={setLink}
         />
       )}

--- a/frontend/src/components/editor/useMediaPrompts.ts
+++ b/frontend/src/components/editor/useMediaPrompts.ts
@@ -91,5 +91,30 @@ export function useMediaPrompts(
     if (!ok) toast({ title: t("editor.toast.audioUrlInvalid"), variant: "destructive" });
   }, [editor, prompt, t]);
 
-  return { setLink, addImage, addYoutube, addAudio };
+  const addMath = useCallback(async () => {
+    if (!editor) return;
+    // Teachers can also auto-trigger inline math by typing ``$x^2$``
+    // directly — this prompt is the discoverability path for users
+    // who don't know the shortcut. Stored shape:
+    //   <span data-type="inlineMath" data-latex="x^2"></span>
+    // KaTeX renders the latex via the extension's NodeView in-editor
+    // and via the post-render hook on the chapter view.
+    const latex = await prompt({
+      title: t("editor.prompt.mathTitle"),
+      description: t("editor.prompt.mathDescription"),
+      placeholder: t("editor.prompt.mathPlaceholder"),
+      confirmLabel: t("editor.prompt.mathConfirm"),
+    });
+    if (!latex) return;
+    editor
+      .chain()
+      .focus()
+      .insertContent({
+        type: "inlineMath",
+        attrs: { latex, evaluate: "no", display: "no" },
+      })
+      .run();
+  }, [editor, prompt, t]);
+
+  return { setLink, addImage, addYoutube, addAudio, addMath };
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -908,7 +908,8 @@
       "link": "Link",
       "undo": "Undo",
       "redo": "Redo",
-      "characters": "{{count}} / {{limit}} characters"
+      "characters": "{{count}} / {{limit}} characters",
+      "insertMath": "Insert math expression"
     },
     "callout": {
       "trigger": "Callout Block",
@@ -1968,6 +1969,10 @@
       "audioDescription": "Paste a direct https:// URL to an audio file (mp3, m4a, ogg).",
       "audioPlaceholder": "https://example.com/lesson.mp3",
       "audioConfirm": "Embed",
+      "mathTitle": "Insert math",
+      "mathDescription": "Type a LaTeX expression (no $ delimiters). Example: \\frac{1}{2}.",
+      "mathPlaceholder": "x^2 + y^2 = z^2",
+      "mathConfirm": "Insert",
       "imageUrlPlaceholder": "https://…"
     }
   },

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -563,7 +563,8 @@
       "link": "Ссылка",
       "undo": "Отменить",
       "redo": "Повторить",
-      "characters": "{{count}} / {{limit}} символов"
+      "characters": "{{count}} / {{limit}} символов",
+      "insertMath": "Вставить формулу"
     },
     "callout": {
       "trigger": "Блок-выноска",
@@ -1651,6 +1652,10 @@
       "audioDescription": "Вставьте прямой https://-URL к аудиофайлу (mp3, m4a, ogg).",
       "audioPlaceholder": "https://example.com/lesson.mp3",
       "audioConfirm": "Встроить",
+      "mathTitle": "Вставить формулу",
+      "mathDescription": "Введите LaTeX-выражение (без $-разделителей). Пример: \\frac{1}{2}.",
+      "mathPlaceholder": "x^2 + y^2 = z^2",
+      "mathConfirm": "Вставить",
       "imageUrlPlaceholder": "https://…"
     }
   },

--- a/frontend/src/lib/katex-render.ts
+++ b/frontend/src/lib/katex-render.ts
@@ -1,0 +1,54 @@
+import katex from "katex";
+
+/**
+ * Walks ``container`` for math markers emitted by
+ * ``@aarkue/tiptap-math-extension`` and replaces each marker's text
+ * content with the KaTeX-rendered HTML output.
+ *
+ * The TipTap extension only renders math via a NodeView inside the
+ * editor. For chapter pages (``BlockRenderer``) the stored HTML is
+ * piped through ``dangerouslySetInnerHTML`` — KaTeX never runs unless
+ * we call it explicitly, leaving the student staring at the raw
+ * ``$x^2$`` source.
+ *
+ * The extension stores math as:
+ *   ``<span data-type="inlineMath" data-latex="x^2" data-display="no">$x^2$</span>``
+ *
+ * We render LaTeX from ``data-latex`` (not the inner text, which has
+ * the delimiters baked in) and replace the span's children with the
+ * KaTeX output. Idempotent — markers that have already been rendered
+ * carry a ``data-katex-rendered`` flag we skip on the second pass.
+ *
+ * Throws are caught per-marker: a single malformed expression must
+ * never blank out the rest of the chapter.
+ */
+export function renderMathIn(container: HTMLElement | null): void {
+  if (!container) return;
+  const nodes = container.querySelectorAll<HTMLSpanElement>(
+    'span[data-type="inlineMath"]:not([data-katex-rendered])',
+  );
+  for (const node of nodes) {
+    const latex = node.getAttribute("data-latex") ?? "";
+    const displayMode = node.getAttribute("data-display") === "yes";
+    if (!latex) continue;
+    try {
+      katex.render(latex, node, {
+        displayMode,
+        throwOnError: false,
+        // Don't let KaTeX expand ``\href`` / ``\url`` / etc. — Bible-school
+        // teachers don't need them and they enlarge the attack surface.
+        trust: false,
+        // Suppress the red "ParseError" output element in favour of just
+        // showing the broken latex literal — looks much less alarming
+        // when a teacher fat-fingered a backslash.
+        strict: "ignore",
+      });
+      node.setAttribute("data-katex-rendered", "true");
+    } catch {
+      // ``throwOnError: false`` already swallows render errors and
+      // shows the source; this catch is the belt-and-braces guard
+      // against an unexpected katex bug.
+      continue;
+    }
+  }
+}

--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useCallback, useMemo, memo } from "react"
+import { useEffect, useRef, useState, useCallback, useMemo, memo } from "react"
 import { useTranslation } from "react-i18next"
 import { useParams, Link, useNavigate } from "react-router-dom"
 import { sanitizeHtml as sanitize } from "@/lib/sanitize"
+import { renderMathIn } from "@/lib/katex-render"
 import PageSpinner from "@/components/ui/PageSpinner"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
@@ -34,6 +35,27 @@ import { ErrorState } from "@/components/patterns"
 import { useUserTour } from "@/hooks/useUserTour"
 import { chapterViewSteps } from "@/lib/tourSteps"
 
+/**
+ * Renders a sanitised text-block via ``dangerouslySetInnerHTML`` and
+ * runs KaTeX over any ``<span data-type="inlineMath">`` markers the
+ * math extension stored in the source. Lives outside BlockRenderer so
+ * the ``useRef`` + ``useEffect`` for the post-render KaTeX pass have
+ * a stable host element to anchor against.
+ */
+function TextBlockRender({ html }: { html: string }) {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    renderMathIn(ref.current)
+  }, [html])
+  return (
+    <div
+      ref={ref}
+      className="prose max-w-none"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}
+
 const BlockRenderer = memo(function BlockRenderer({
   block,
   onProgressChanged,
@@ -52,10 +74,7 @@ const BlockRenderer = memo(function BlockRenderer({
   switch (block.block_type) {
     case "text":
       return sanitizedContent ? (
-        <div
-          className="prose max-w-none"
-          dangerouslySetInnerHTML={{ __html: sanitizedContent }}
-        />
+        <TextBlockRender html={sanitizedContent} />
       ) : null
 
     case "quiz":


### PR DESCRIPTION
## Summary

Adds `@aarkue/tiptap-math-extension` (MIT, v1.4.0) + `katex` (MIT, v0.17.0). Teachers drop LaTeX via:
- Toolbar Σ button → prompt → `insertContent({ type: 'inlineMath' })`
- Inline auto-trigger: typing `$x^2$` or `$$\sum_i i$$` converts on the fly via input rule.

## Architecture

The extension stores math as a tiny sanitiser-friendly marker:
```
<span data-type="inlineMath" data-latex="x^2" data-display="no" data-evaluate="no">$x^2$</span>
```
KaTeX never enters the persisted HTML. Two render surfaces:

- **In-editor**: NodeView renders the marker live (extension's job; we just import the CSS).
- **In chapter view** (BlockRenderer): sanitised HTML → `dangerouslySetInnerHTML` → `useEffect` calls new `renderMathIn(ref.current)` (`lib/katex-render.ts`) which walks `span[data-type="inlineMath"]` and renders KaTeX into each. Idempotent via `data-katex-rendered` flag; per-marker `try/catch` so a single bad expression doesn't blank the chapter.

KaTeX is configured `trust: false` (no `\href`/`\url`) + `strict: "ignore"` (broken LaTeX renders as source instead of red banner). `evaluation: false` disables the symbolic `1+2=` evaluator — not needed for Bible-school.

## Sanitiser

- **bleach**: widened `span` allowlist to include `data-type`/`data-latex`/`data-display`/`data-evaluate`. Per-tag overrides wildcard, so `class`/`id` repeated for highlight.js spans.
- **DOMPurify**: same four `data-*` attrs in `ADD_ATTR`.
- Other `data-*` + event handlers still stripped (regression test included).

## Tests

3 new `TestMathMarkerAllowlist` cases pin inline + block + defence-in-depth shapes. 17 sanitiser tests total; **751 backend tests pass**.

## i18n

`blockEditor.toolbar.insertMath` + 4 `editor.prompt.math*` strings in en.json + ru.json. `i18n:check` parity ✓.

## Test plan

- [x] `pytest tests/` — 751 passed
- [x] `ruff check` + `mypy app/` clean
- [x] `npm run lint` + `tsc --noEmit` + `test:run` + `i18n:check` clean
- [ ] CI
- [ ] Manually: insert math via Σ → reload chapter → KaTeX renders; type `$E=mc^2$` → auto-converts