### PR TITLE
fix(editor): round-trip math + toggle through DOMPurify, fix KaTeX dark mode

### DIFF
--- a/backend/app/core/sanitize.py
+++ b/backend/app/core/sanitize.py
@@ -101,18 +101,19 @@ _ALLOWED_ATTRIBUTES: dict[str, list[str]] = {
     "th": ["colspan", "rowspan", "scope", "class", "id"],
     # Inline-math markers from ``@aarkue/tiptap-math-extension``. The
     # extension stores math as ``<span data-type="inlineMath"
-    # data-latex="..." data-display="..." data-evaluate="...">$x^2$</span>``
-    # and the BlockRenderer renders KaTeX into the marker at view time.
-    # Same per-tag-overrides-wildcard rule as the table cells —
-    # ``class`` / ``id`` are repeated so highlight.js token spans and
-    # any other span use still keeps its class.
+    # data-latex="..." data-display="...">$x^2$</span>`` and the
+    # chapter renderer feeds the LaTeX to KaTeX at view time. The
+    # extension is configured with ``evaluation: false`` so the symbolic
+    # ``data-evaluate`` attr it would otherwise emit never ships; we
+    # don't allowlist it. Same per-tag-overrides-wildcard rule as table
+    # cells — ``class`` / ``id`` are repeated so highlight.js token
+    # spans (and any other span use) keep their class.
     "span": [
         "class",
         "id",
         "data-type",
         "data-latex",
         "data-display",
-        "data-evaluate",
     ],
     # ``div`` and ``details`` both carry ``data-callout`` from the
     # TipTap Callout extension (info / verse / takeaway / warning go on

--- a/backend/tests/test_sanitize.py
+++ b/backend/tests/test_sanitize.py
@@ -109,18 +109,22 @@ class TestCodeBlockAllowlist:
 
 class TestMathMarkerAllowlist:
     """The TipTap math extension stores math as
-    ``<span data-type="inlineMath" data-latex="..." data-display="..."
-    data-evaluate="...">$x^2$</span>``. The BlockRenderer re-runs
-    ``katex.render`` over each marker at view time, so the data-*
-    attributes must round-trip through bleach intact — otherwise the
-    chapter view shows the raw ``$x^2$`` delimiters instead of the
-    rendered formula.
+    ``<span data-type="inlineMath" data-latex="..." data-display="...">
+    $x^2$</span>``. The BlockRenderer re-runs ``katex.render`` over each
+    marker at view time, so the data-* attributes must round-trip
+    through bleach intact — otherwise the chapter view shows the raw
+    ``$x^2$`` delimiters instead of the rendered formula.
+
+    (The extension can also emit ``data-evaluate`` for symbolic-math
+    evaluation, but we configure ``evaluation: false`` on the frontend
+    so the attribute never ships. It is *not* in the sanitiser
+    allowlist — see ``test_data_evaluate_attr_is_stripped``.)
     """
 
     def test_inline_math_marker_survives(self):
         html = (
             '<p>Theorem: <span data-type="inlineMath" data-latex="a^2+b^2=c^2" '
-            'data-display="no" data-evaluate="no">$a^2+b^2=c^2$</span>.</p>'
+            'data-display="no">$a^2+b^2=c^2$</span>.</p>'
         )
         cleaned = sanitize_string(html)
         assert 'data-type="inlineMath"' in cleaned
@@ -130,11 +134,24 @@ class TestMathMarkerAllowlist:
     def test_block_math_marker_survives(self):
         html = (
             '<p><span data-type="inlineMath" data-latex="\\sum_{i=0}^n i" '
-            'data-display="yes" data-evaluate="no">$$\\sum_{i=0}^n i$$</span></p>'
+            'data-display="yes">$$\\sum_{i=0}^n i$$</span></p>'
         )
         cleaned = sanitize_string(html)
         assert 'data-display="yes"' in cleaned
         assert "\\sum_{i=0}^n i" in cleaned
+
+    def test_data_evaluate_attr_is_stripped(self):
+        # The math extension is configured ``evaluation: false`` so it
+        # never emits ``data-evaluate``. We don't allowlist it; assert
+        # it stays stripped so a future re-enable of the symbolic
+        # evaluator is a deliberate two-step decision (frontend config
+        # + sanitiser allowlist), not an accidental leak.
+        cleaned = sanitize_string(
+            '<span data-type="inlineMath" data-latex="1+2" data-display="no" data-evaluate="yes">$1+2$</span>'
+        )
+        assert "data-evaluate" not in cleaned
+        # The legitimate attrs still survive.
+        assert 'data-type="inlineMath"' in cleaned
 
     def test_other_span_attrs_still_stripped(self):
         # Defence-in-depth: a malicious span carrying a non-allowlisted
@@ -175,7 +192,17 @@ class TestToggleCalloutAllowlist:
         cleaned = sanitize_string(html)
         assert "<details" in cleaned
         assert "<summary>What is grace?</summary>" in cleaned
-        assert "open" in cleaned
+        # ``open`` is a boolean HTML attribute — bleach normalises it to
+        # ``open`` or ``open=""``; assert the attribute is present on the
+        # element itself rather than just somewhere in the string.
+        assert "<details" in cleaned and (" open>" in cleaned or 'open=""' in cleaned)
+
+    def test_details_without_open_attr_stays_collapsed(self):
+        # Teachers default to collapsed toggles; the ``open`` attr only
+        # appears when explicitly set. Make sure bleach doesn't inject
+        # it as a side effect of widening the allowlist.
+        cleaned = sanitize_string('<details data-callout="toggle"><summary>q</summary><p>a</p></details>')
+        assert "open" not in cleaned
 
     def test_details_strips_event_handlers(self):
         # Defence-in-depth — ``ontoggle`` would fire on every expand, so

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -772,3 +772,21 @@ details.callout-toggle > summary + * {
 .hljs-strong {
   font-weight: 700;
 }
+
+/* KaTeX ships its own stylesheet with hardcoded text colors on a few
+ * structural classes (notably ``.mord`` for ordinary math atoms). The
+ * defaults look fine in light mode but become low-contrast on a dark
+ * background. Force the foreground colour from the semantic token so
+ * formulas stay legible in both themes. ``.katex`` is namespaced —
+ * scoping the override here doesn't touch surrounding prose. */
+.katex,
+.katex .mord,
+.katex .mbin,
+.katex .mrel,
+.katex .mopen,
+.katex .mclose,
+.katex .mpunct,
+.katex .minner,
+.katex .mop {
+  color: hsl(var(--foreground));
+}

--- a/frontend/src/lib/__tests__/callout-toggle.test.ts
+++ b/frontend/src/lib/__tests__/callout-toggle.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import { renderToggleCalloutsIn } from "../callout-toggle"
+
+function makeContainer(innerHTML: string): HTMLDivElement {
+  const div = document.createElement("div")
+  div.innerHTML = innerHTML
+  return div
+}
+
+describe("renderToggleCalloutsIn", () => {
+  it("rewrites a toggle div to native details/summary", () => {
+    const container = makeContainer(
+      '<div data-callout="toggle" class="callout callout-toggle">' +
+        "<p>What is grace?</p><p>Unmerited favor.</p>" +
+        "</div>",
+    )
+    renderToggleCalloutsIn(container)
+    const details = container.querySelector("details")
+    expect(details).not.toBeNull()
+    expect(details?.getAttribute("data-callout")).toBe("toggle")
+    expect(details?.getAttribute("class")).toBe("callout callout-toggle")
+    const summary = details?.querySelector("summary")
+    expect(summary?.textContent).toBe("What is grace?")
+    const body = details?.querySelectorAll(":scope > p")
+    expect(body?.length).toBe(1)
+    expect(body?.[0]?.textContent).toBe("Unmerited favor.")
+  })
+
+  it("preserves inline formatting inside the first paragraph", () => {
+    const container = makeContainer(
+      '<div data-callout="toggle"><p>Read <strong>John 1:1</strong></p><p>body</p></div>',
+    )
+    renderToggleCalloutsIn(container)
+    const summary = container.querySelector("details > summary")
+    expect(summary?.innerHTML).toBe("Read <strong>John 1:1</strong>")
+  })
+
+  it("is idempotent: second call leaves DOM unchanged", () => {
+    const container = makeContainer(
+      '<div data-callout="toggle"><p>q</p><p>a</p></div>',
+    )
+    renderToggleCalloutsIn(container)
+    const firstHtml = container.innerHTML
+    renderToggleCalloutsIn(container)
+    expect(container.innerHTML).toBe(firstHtml)
+    // And no nested details accidentally created on the second pass.
+    expect(container.querySelectorAll("details").length).toBe(1)
+  })
+
+  it("preserves id and arbitrary class attributes on the rewritten element", () => {
+    const container = makeContainer(
+      '<div data-callout="toggle" id="custom-id" class="callout callout-toggle special-class">' +
+        "<p>q</p><p>a</p></div>",
+    )
+    renderToggleCalloutsIn(container)
+    const details = container.querySelector("details")
+    expect(details?.getAttribute("id")).toBe("custom-id")
+    expect(details?.getAttribute("class")).toBe(
+      "callout callout-toggle special-class",
+    )
+  })
+
+  it("flags an empty toggle as rendered without throwing", () => {
+    const container = makeContainer('<div data-callout="toggle"></div>')
+    expect(() => renderToggleCalloutsIn(container)).not.toThrow()
+    const div = container.querySelector('div[data-callout="toggle"]')
+    expect(div?.getAttribute("data-toggle-rendered")).toBe("true")
+    // The empty case is intentionally left as a div, not promoted to
+    // details — there's no summary content to put inside one.
+    expect(container.querySelector("details")).toBeNull()
+  })
+
+  it("leaves non-toggle callouts (info, verse, …) alone", () => {
+    const container = makeContainer(
+      '<div data-callout="info"><p>note</p></div>' +
+        '<div data-callout="verse"><p>scripture</p></div>',
+    )
+    renderToggleCalloutsIn(container)
+    expect(container.querySelectorAll("details").length).toBe(0)
+    expect(container.querySelectorAll("div[data-callout]").length).toBe(2)
+  })
+
+  it("does nothing when container is null", () => {
+    expect(() => renderToggleCalloutsIn(null)).not.toThrow()
+  })
+})

--- a/frontend/src/lib/__tests__/katex-render.test.ts
+++ b/frontend/src/lib/__tests__/katex-render.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { renderMathIn } from "../katex-render"
+
+function makeContainer(innerHTML: string): HTMLDivElement {
+  const div = document.createElement("div")
+  div.innerHTML = innerHTML
+  return div
+}
+
+describe("renderMathIn", () => {
+  it("renders an inline math marker via KaTeX", () => {
+    const container = makeContainer(
+      '<p><span data-type="inlineMath" data-latex="x^2" data-display="no">$x^2$</span></p>',
+    )
+    renderMathIn(container)
+    const span = container.querySelector('span[data-type="inlineMath"]')
+    expect(span?.getAttribute("data-katex-rendered")).toBe("true")
+    // KaTeX emits a ``.katex`` wrapper inside the marker.
+    expect(span?.querySelector(".katex")).not.toBeNull()
+  })
+
+  it("respects data-display=yes for block math", () => {
+    const container = makeContainer(
+      '<span data-type="inlineMath" data-latex="\\sum_{i=0}^n i" data-display="yes">$$\\sum$$</span>',
+    )
+    renderMathIn(container)
+    const span = container.querySelector('span[data-type="inlineMath"]')
+    expect(span?.querySelector(".katex-display")).not.toBeNull()
+  })
+
+  it("is idempotent: the rendered flag stops a second pass", () => {
+    const container = makeContainer(
+      '<span data-type="inlineMath" data-latex="a" data-display="no">$a$</span>',
+    )
+    renderMathIn(container)
+    const firstHtml = container.innerHTML
+    renderMathIn(container)
+    expect(container.innerHTML).toBe(firstHtml)
+  })
+
+  it("skips markers with no data-latex (corrupt HTML)", () => {
+    const container = makeContainer(
+      '<span data-type="inlineMath" data-display="no">$x$</span>',
+    )
+    expect(() => renderMathIn(container)).not.toThrow()
+    const span = container.querySelector('span[data-type="inlineMath"]')
+    // No render attempted → no rendered flag set.
+    expect(span?.getAttribute("data-katex-rendered")).toBeNull()
+    expect(span?.querySelector(".katex")).toBeNull()
+  })
+
+  it("one bad expression doesn't blank out neighbouring markers", () => {
+    const container = makeContainer(
+      '<span data-type="inlineMath" data-latex="x^2" data-display="no">$x^2$</span>' +
+        '<span data-type="inlineMath" data-latex="\\unknown{" data-display="no">bad</span>' +
+        '<span data-type="inlineMath" data-latex="y_1" data-display="no">$y_1$</span>',
+    )
+    expect(() => renderMathIn(container)).not.toThrow()
+    const spans = container.querySelectorAll('span[data-type="inlineMath"]')
+    // First + third are valid → flagged. Middle one with ``strict: "ignore"``
+    // also renders (KaTeX shows the broken source) → also flagged.
+    expect(spans[0]?.getAttribute("data-katex-rendered")).toBe("true")
+    expect(spans[2]?.getAttribute("data-katex-rendered")).toBe("true")
+  })
+
+  it("does nothing when container is null", () => {
+    expect(() => renderMathIn(null)).not.toThrow()
+  })
+})

--- a/frontend/src/lib/__tests__/sanitize.test.ts
+++ b/frontend/src/lib/__tests__/sanitize.test.ts
@@ -81,4 +81,33 @@ describe("sanitizeHtml", () => {
     )
     expect(output).not.toContain("style=")
   })
+
+  it("preserves math marker data attributes so KaTeX can render", () => {
+    // Without ``data-type`` / ``data-latex`` / ``data-display`` in the
+    // DOMPurify allowlist the marker would lose its identity and the
+    // student would see the raw ``$x^2$`` source. This pins the
+    // post-merge fix from PR #504.
+    const output = sanitizeHtml(
+      '<p>see: <span data-type="inlineMath" data-latex="x^2" ' +
+        'data-display="no">$x^2$</span>.</p>',
+    )
+    expect(output).toContain('data-type="inlineMath"')
+    expect(output).toContain('data-latex="x^2"')
+    expect(output).toContain('data-display="no"')
+  })
+
+  it("preserves <details> + <summary> for the toggle callout shape", () => {
+    // The toggle callout is stored as ``<div data-callout="toggle">``
+    // and rewritten to native ``<details>`` at view time. Both shapes
+    // need to round-trip through DOMPurify intact — div for the
+    // editor reload path, details for any case where the rewritten
+    // shape is re-sanitised (e.g. pasted into another chapter).
+    const output = sanitizeHtml(
+      '<details data-callout="toggle" class="callout callout-toggle">' +
+        "<summary>q</summary><p>a</p></details>",
+    )
+    expect(output).toContain("<details")
+    expect(output).toContain("<summary>q</summary>")
+    expect(output).toContain('data-callout="toggle"')
+  })
 })

--- a/frontend/src/lib/sanitize.ts
+++ b/frontend/src/lib/sanitize.ts
@@ -43,10 +43,21 @@ DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
 })
 
 const SANITIZE_CONFIG = {
-  ADD_TAGS: ["iframe"],
+  // ``details`` + ``summary`` carry the chapter-renderer rewrite of the
+  // toggle-callout block (see ``frontend/src/lib/callout-toggle.ts``).
+  // Naming them explicitly keeps the dependency stable if a future
+  // DOMPurify upgrade tightens its built-in HTML5 allowlist.
+  ADD_TAGS: ["iframe", "details", "summary"],
+  // ``data-type`` / ``data-latex`` / ``data-display`` carry the math
+  // marker shape from ``@aarkue/tiptap-math-extension``; the renderer
+  // walks ``span[data-type="inlineMath"]`` and feeds the LaTeX to
+  // KaTeX. Without these attrs in ``ADD_ATTR`` DOMPurify drops them,
+  // leaving the literal ``$x^2$`` delimiter span behind instead of
+  // a rendered formula.
   ADD_ATTR: [
     "allow", "allowfullscreen", "frameborder", "src", "loading",
     "referrerpolicy", "data-callout", "data-youtube-embed",
+    "data-type", "data-latex", "data-display",
     "alt", "width", "height",
   ],
   // Explicitly whitelist safe URI schemes; anything else gets stripped.


### PR DESCRIPTION
## Summary

Three real bugs landed alongside the ED1–ED6 editor batch. None surfaced because the frontend sanitiser path (`ChapterView`) only runs at view time and the tests we shipped only covered the **backend** bleach path. This PR fixes the bugs, adds the missing tests, and strips one piece of dead config.

### 1. Math markers stripped on the student page (the real one)

`ChapterView.TextBlockRender` runs `sanitizeHtml` (DOMPurify) on the backend-stored HTML before mounting it via `dangerouslySetInnerHTML`. The DOMPurify allowlist in `frontend/src/lib/sanitize.ts` had `data-callout` but **not** `data-type` / `data-latex` / `data-display`. Net effect:

- The `<span data-type="inlineMath" data-latex="x^2">` markers emitted by `@aarkue/tiptap-math-extension` lost their identity at the chapter render path
- `renderMathIn` then found zero matching markers
- The student saw the raw `$x^2$` source instead of a rendered formula

Same root cause for the toggle-callout's rewritten shape: DOMPurify didn't have `details` or `summary` in `ADD_TAGS`. The stored `<div data-callout="toggle">` worked because the rewrite happens in `renderToggleCalloutsIn` *after* sanitisation, but any `<details>` arriving already-rewritten (e.g. pasted from another chapter, imported HTML) would have been stripped.

**Fix:** add the math marker data attrs to `ADD_ATTR` and `details` + `summary` to `ADD_TAGS`. New vitest cases in `sanitize.test.ts` pin both shapes — they would have caught this in CI if they had existed.

### 2. `data-evaluate` — dead allowlist entry

`RichTextEditor.tsx` configures the math extension with `evaluation: false`, which disables the symbolic evaluator and keeps `data-evaluate` out of every emitted marker. We were still allowlisting it in `backend/app/core/sanitize.py` and asserting it in test fixtures. Remove the entry; new `test_data_evaluate_attr_is_stripped` makes the absence deliberate — re-enabling the evaluator is now a two-step decision (frontend config + sanitiser allowlist), not an accidental leak.

### 3. KaTeX in dark mode

KaTeX's bundled stylesheet hardcodes a few text colours on its structural classes (`.mord` and friends) rather than using `inherit`. The defaults are fine in light mode but lose contrast on the dark theme — math sections went from "readable" to "low-contrast" the moment the user flipped themes. Override the relevant classes in `index.css` to use `hsl(var(--foreground))`, which already flips via the `.dark` root selector. Scoped to `.katex` so surrounding prose-cascade typography is unaffected.

### Process bugs alongside

**4.** Two new vitest suites for the view-time helpers — `renderToggleCalloutsIn` (7 cases) and `renderMathIn` (6 cases). Both walk jsdom fixtures and cover: happy path, idempotency, empty / malformed input, the null-container guard, and the per-marker try/catch fallback. These should have shipped in the original ED5 and ED6 PRs.

**5.** Tightened a sanitiser test that was matching `open` as a substring anywhere in the cleaned HTML; switched to checking the attribute is on the `<details>` element itself. New `test_details_without_open_attr_stays_collapsed` pins the inverse case.

## Test plan

- [x] `pytest tests/` — 756 passed (22 sanitiser cases, +2)
- [x] `python -m ruff check .` + `ruff format --check .` clean
- [x] `mypy --config-file mypy.ini` — 117 files, no issues
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 310 passed across 44 files (+15 new across 3 suites)
- [x] `npm run i18n:check` — locale bundles in parity
- [ ] Manual: open a chapter with inline math in dark mode → verify legibility (deferred to live preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
