### PR TITLE
style(editor): sticky toolbar + mobile overflow + viewport-aware dropdowns (P2)

### DIFF
--- a/frontend/src/components/editor/CalloutDropdown.tsx
+++ b/frontend/src/components/editor/CalloutDropdown.tsx
@@ -12,6 +12,7 @@ import {
 
 import { cn } from "@/lib/utils";
 import type { CalloutVariant } from "./CalloutExtension";
+import { useDropdownPosition } from "./useDropdownPosition";
 
 interface CalloutChoice {
   value: CalloutVariant;
@@ -52,6 +53,9 @@ export function CalloutDropdown({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  // Panel width matches the ``w-52`` tailwind class on the menu.
+  const { alignClass } = useDropdownPosition(open, triggerRef, 208);
 
   useEffect(() => {
     if (!open) return;
@@ -86,6 +90,7 @@ export function CalloutDropdown({
   return (
     <div className="relative" ref={containerRef}>
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         title={t("blockEditor.callout.trigger")}
@@ -106,7 +111,10 @@ export function CalloutDropdown({
         <div
           role="menu"
           aria-label={t("blockEditor.callout.trigger")}
-          className="absolute left-0 top-full z-20 mt-1 w-52 rounded-md border bg-background py-1 shadow-lg"
+          className={cn(
+            "absolute top-full z-20 mt-1 w-52 rounded-md border bg-background py-1 shadow-lg",
+            alignClass,
+          )}
         >
           {CALLOUT_VARIANTS.map((v) => {
             const Icon = v.icon;

--- a/frontend/src/components/editor/CodeBlockDropdown.tsx
+++ b/frontend/src/components/editor/CodeBlockDropdown.tsx
@@ -5,6 +5,7 @@ import { Code2, ChevronDown, Check } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { CODE_LANGUAGES, CODE_LANGUAGE_LABELS, type CodeLanguage } from "./lowlight";
+import { useDropdownPosition } from "./useDropdownPosition";
 
 /**
  * Toolbar slot for code blocks. Mirrors the ``TableDropdown`` pattern:
@@ -26,6 +27,9 @@ export function CodeBlockDropdown({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  // Panel width matches the ``w-44`` tailwind class on the menu.
+  const { alignClass } = useDropdownPosition(open, triggerRef, 176);
 
   useEffect(() => {
     if (!open) return;
@@ -65,6 +69,7 @@ export function CodeBlockDropdown({
   return (
     <div className="relative" ref={containerRef}>
       <button
+        ref={triggerRef}
         type="button"
         onClick={triggerClick}
         title={
@@ -93,7 +98,10 @@ export function CodeBlockDropdown({
         <div
           role="menu"
           aria-label={t("blockEditor.codeBlock.changeLanguage")}
-          className="absolute left-0 top-full z-20 mt-1 w-44 rounded-md border bg-background py-1 shadow-lg"
+          className={cn(
+            "absolute top-full z-20 mt-1 w-44 rounded-md border bg-background py-1 shadow-lg",
+            alignClass,
+          )}
         >
           {CODE_LANGUAGES.map((lang) => (
             <button

--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -101,7 +101,19 @@ export function EditorToolbar({
     <div
       role="toolbar"
       aria-label={t("blockEditor.toolbar.ariaLabel")}
-      className="flex flex-wrap items-center gap-0.5 border-b border-input px-2 py-1.5"
+      // ``sticky top-0`` keeps the toolbar visible while teachers
+      // scroll long chapters. ``z-20`` sits above prose content but
+      // below modal/dialog overlays (z-50). ``bg-background`` is
+      // required for sticky semi-transparent flicker over the
+      // ProseMirror surface below.
+      //
+      // Mobile responsiveness: at small widths the 17+ button row
+      // becomes a horizontal scroller (``flex-nowrap overflow-x-auto``)
+      // rather than wrapping to 2-3 lines. ``sm:flex-wrap`` restores
+      // the original wrap behaviour above the ``sm`` breakpoint where
+      // there's enough room. ``no-scrollbar`` (utility added in
+      // index.css) hides the visible bar — touch scroll still works.
+      className="sticky top-0 z-20 flex flex-nowrap items-center gap-0.5 overflow-x-auto border-b border-input bg-background px-2 py-1.5 no-scrollbar sm:flex-wrap sm:overflow-x-visible"
     >
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleBold().run()}

--- a/frontend/src/components/editor/TableDropdown.tsx
+++ b/frontend/src/components/editor/TableDropdown.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { useDropdownPosition } from "./useDropdownPosition";
 
 /**
  * Single dropdown for every table operation. Mirrors the
@@ -35,6 +36,9 @@ export function TableDropdown({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  // Panel width matches the ``w-56`` tailwind class on the menu.
+  const { alignClass } = useDropdownPosition(open, triggerRef, 224);
 
   useEffect(() => {
     if (!open) return;
@@ -64,6 +68,7 @@ export function TableDropdown({
   return (
     <div className="relative" ref={containerRef}>
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         title={t("blockEditor.table.trigger")}
@@ -84,7 +89,10 @@ export function TableDropdown({
         <div
           role="menu"
           aria-label={t("blockEditor.table.trigger")}
-          className="absolute left-0 top-full z-20 mt-1 w-56 rounded-md border bg-background py-1 shadow-lg"
+          className={cn(
+            "absolute top-full z-20 mt-1 w-56 rounded-md border bg-background py-1 shadow-lg",
+            alignClass,
+          )}
         >
           {!isInTable && (
             <button

--- a/frontend/src/components/editor/useDropdownPosition.ts
+++ b/frontend/src/components/editor/useDropdownPosition.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react"
+
+type Side = "left" | "right"
+
+/**
+ * Picks ``left-0`` or ``right-0`` for an absolutely-positioned menu
+ * panel based on where the trigger sits in the viewport. Without
+ * this, dropdowns anchored to right-edge toolbar buttons overflow
+ * past the right viewport edge — the user sees a clipped or
+ * scroll-required menu.
+ *
+ * We measure on open + on resize, and only once (the trigger doesn't
+ * move while open in our toolbar). Returns the Tailwind class to
+ * apply on the panel; the trigger ref is what's measured.
+ */
+export function useDropdownPosition(
+  open: boolean,
+  triggerRef: React.RefObject<HTMLElement | null>,
+  /** Approximate menu width in pixels — used to predict overflow. Pick
+   * the same number as the panel's ``w-*`` tailwind class so the
+   * heuristic matches reality. */
+  menuWidthPx: number,
+): { side: Side; alignClass: string } {
+  const [side, setSide] = useState<Side>("left")
+
+  useEffect(() => {
+    if (!open || !triggerRef.current) return
+    const measure = () => {
+      const rect = triggerRef.current?.getBoundingClientRect()
+      if (!rect) return
+      const viewportWidth = window.innerWidth
+      // ``rect.left`` is the left edge of the trigger. The menu opens
+      // anchored to that edge by default, which means its right edge
+      // lands at ``rect.left + menuWidthPx``. If that exceeds the
+      // viewport, flip the anchor to the trigger's right edge instead
+      // (panel grows leftwards, fits inside the viewport).
+      const wouldOverflow = rect.left + menuWidthPx > viewportWidth - 8
+      setSide(wouldOverflow ? "right" : "left")
+    }
+    measure()
+    window.addEventListener("resize", measure)
+    return () => window.removeEventListener("resize", measure)
+  }, [open, triggerRef, menuWidthPx])
+
+  return {
+    side,
+    alignClass: side === "left" ? "left-0" : "right-0",
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -188,6 +188,21 @@
 }
 
 @layer utilities {
+  /* Suppress the visible scrollbar on horizontally-scrolling
+   * surfaces that already have a clear affordance (e.g. the
+   * editor toolbar on narrow viewports). Native touch scroll
+   * still works; mouse-wheel sideways scroll on track-pads also
+   * works. */
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@layer utilities {
   @keyframes ambient-mesh {
     0% {
       transform: scale(1) translate3d(0, 0, 0);


### PR DESCRIPTION
## Summary

The editor toolbar had three usability problems on top of the visual polish #506 just landed: it scrolled out of view, it wrapped to 2-3 lines on narrow viewports breaking the visual rhythm, and right-edge dropdown menus could overflow the viewport. This PR fixes all three with minimum CSS / behaviour churn.

## What changed

### Sticky toolbar
- `sticky top-0 z-20 bg-background` on the toolbar container. Now stays at the top of the editor surface while teachers scroll long chapters, so formatting / insert actions remain one click away.
- `z-20` sits above prose content but below modal overlays (z-50).

### Mobile-responsive overflow
- Below `sm` (640px): `flex-nowrap overflow-x-auto` turns the row into a horizontal scroller. 17+ buttons can slide sideways without wrapping to 2-3 lines that eat 20% of the phone viewport. `no-scrollbar` (new utility in index.css) hides the visible scrollbar; touch + track-pad sideways scroll still work.
- At `sm` and above: the original `flex-wrap` layout returns, since at desktop widths there's room for the full row without wrapping.

### Viewport-aware dropdown positioning
- New `useDropdownPosition` hook measures the trigger's `getBoundingClientRect()` on open and on window resize. If anchoring the menu to `left-0` would push its right edge past the viewport, it flips to `right-0` so the menu grows leftwards instead. 8px viewport-edge buffer.
- Applied to all three toolbar dropdowns (Callout, Table, Code Block). The menu widths (208 / 224 / 176 px) are passed to the hook so each dropdown predicts overflow accurately against its own `w-*` Tailwind class.

## What this is not

- **No new dependencies**. `floating-ui` is already pulled in by the TipTap drag-handle but I deliberately didn't reach for it here — the dropdown overflow case is one boolean (left vs right), not full collision/auto-placement, and the hook is 35 lines vs. floating-ui's `useFloating` ceremony.
- **No keyboard-nav changes** (roving tabindex was on the audit list but it's a separate concern — would change tab behaviour across the editor and deserves its own PR).
- **No prop changes** on the editor's external API.

## Test plan

- [x] `npm run lint` clean (max-warnings 0)
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 310 passed across 44 files
- [ ] Manual: open editor on mobile viewport → verify horizontal scroll on toolbar (deferred to live preview)
- [ ] Backend untouched

Stacks on top of #506 (dark-mode contrast). Will rebase if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
