### PR TITLE
feat(editor): copy-to-clipboard on code blocks + token coverage + visual polish (P3)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -935,7 +935,10 @@
     },
     "codeBlock": {
       "insert": "Insert code block",
-      "changeLanguage": "Change language"
+      "changeLanguage": "Change language",
+      "copy": "Copy",
+      "copied": "Copied",
+      "copyAriaLabel": "Copy code to clipboard"
     },
     "deleteBlockAria": "Delete {{label}} block"
   },

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -590,7 +590,10 @@
     },
     "codeBlock": {
       "insert": "Вставить блок кода",
-      "changeLanguage": "Сменить язык"
+      "changeLanguage": "Сменить язык",
+      "copy": "Копировать",
+      "copied": "Скопировано",
+      "copyAriaLabel": "Скопировать код в буфер обмена"
     },
     "deleteBlockAria": "Удалить блок «{{label}}»"
   },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -544,13 +544,22 @@
   @apply my-8 border-border;
 }
 .prose code {
-  @apply px-1.5 py-0.5 rounded bg-muted text-[0.9em] font-mono;
+  /* Inline code (``<code>`` outside a ``<pre>``). The muted-foreground
+   * accent on the colour distinguishes it from regular text without
+   * shouting; the subtle border + thin background reads as a "code
+   * snippet" rather than just bolded prose. */
+  @apply rounded border border-border bg-muted px-1.5 py-0.5 text-[0.9em] font-mono text-foreground;
 }
 .prose pre {
-  @apply my-4 p-4 rounded-md bg-muted text-sm font-mono overflow-x-auto;
+  /* Block code. Stronger surface than inline (full bg-muted, not
+   * /70) so it reads as a distinct block in dark mode where the
+   * card surface and a 70%-opacity muted overlay are too close. */
+  @apply my-4 overflow-x-auto rounded-md border border-border bg-muted p-4 text-sm font-mono;
 }
 .prose pre code {
-  @apply p-0 bg-transparent;
+  /* Block-code's inner ``<code>`` shouldn't carry the inline pill
+   * styling; the parent ``<pre>`` already owns the surface. */
+  @apply border-0 bg-transparent p-0;
 }
 .prose img {
   @apply my-6 rounded-md;
@@ -745,7 +754,12 @@ details.callout-toggle > summary + * {
    contrast without bundling a third-party theme stylesheet. */
 .prose pre,
 .ProseMirror pre {
-  @apply my-4 overflow-x-auto rounded-md border border-border bg-muted/70 p-4;
+  /* Same surface treatment as ``.prose pre`` above so the editor
+   * preview matches the rendered chapter exactly. ``bg-muted`` (no
+   * opacity) gives strong contrast against the card surface in
+   * dark mode; ``border-border`` lifts the block visually without
+   * needing a drop shadow. */
+  @apply my-4 overflow-x-auto rounded-md border border-border bg-muted p-4;
 }
 .prose pre code,
 .ProseMirror pre code {
@@ -789,8 +803,19 @@ details.callout-toggle > summary + * {
 }
 .hljs-variable,
 .hljs-template-variable,
-.hljs-tag {
+.hljs-tag,
+.hljs-subst {
   color: hsl(var(--accent));
+}
+.hljs-function,
+.hljs-params,
+.hljs-class {
+  /* Function definitions and class names — most languages emit
+   * these for ``def``/``function``/``class`` blocks. Without an
+   * explicit colour they inherit the body foreground, which is
+   * fine but loses the ``this is the named entity`` cue that
+   * makes scan-reading code easier. */
+  color: hsl(var(--info));
 }
 .hljs-deletion {
   color: hsl(var(--destructive));

--- a/frontend/src/lib/__tests__/codeblock-copy.test.ts
+++ b/frontend/src/lib/__tests__/codeblock-copy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { attachCopyButtonsIn } from "../codeblock-copy"
+
+const LABELS = {
+  copy: "Copy",
+  copied: "Copied",
+  ariaLabel: "Copy code to clipboard",
+}
+
+function makeContainer(innerHTML: string): HTMLDivElement {
+  const div = document.createElement("div")
+  div.innerHTML = innerHTML
+  return div
+}
+
+describe("attachCopyButtonsIn", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    })
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("attaches a Copy button to every <pre> block", () => {
+    const container = makeContainer(
+      "<pre><code>const a = 1</code></pre>" +
+        "<p>plain text between blocks</p>" +
+        "<pre><code>print(2)</code></pre>",
+    )
+    attachCopyButtonsIn(container, LABELS)
+    const buttons = container.querySelectorAll("pre > button")
+    expect(buttons.length).toBe(2)
+    expect(buttons[0]?.textContent).toBe("Copy")
+    expect(buttons[0]?.getAttribute("aria-label")).toBe(
+      "Copy code to clipboard",
+    )
+  })
+
+  it("is idempotent — second pass does not duplicate buttons", () => {
+    const container = makeContainer(
+      "<pre><code>const a = 1</code></pre>",
+    )
+    attachCopyButtonsIn(container, LABELS)
+    attachCopyButtonsIn(container, LABELS)
+    expect(container.querySelectorAll("pre > button").length).toBe(1)
+  })
+
+  it("writes the inner code text to clipboard on click", async () => {
+    const container = makeContainer(
+      "<pre><code>const x = 42</code></pre>",
+    )
+    attachCopyButtonsIn(container, LABELS)
+    const button = container.querySelector("pre > button") as HTMLButtonElement
+    button.click()
+    // Microtask + async clipboard call; flush.
+    await vi.runAllTimersAsync()
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("const x = 42")
+  })
+
+  it("flashes the Copied label after a successful copy", async () => {
+    const container = makeContainer("<pre><code>x</code></pre>")
+    attachCopyButtonsIn(container, LABELS)
+    const button = container.querySelector("pre > button") as HTMLButtonElement
+    button.click()
+    // Allow the awaited clipboard promise to resolve so the
+    // post-resolve mutation runs.
+    await Promise.resolve()
+    expect(button.textContent).toBe("Copied")
+    vi.advanceTimersByTime(1500)
+    expect(button.textContent).toBe("Copy")
+  })
+
+  it("falls back silently if clipboard.writeText rejects", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+      writable: true,
+      configurable: true,
+    })
+    const container = makeContainer("<pre><code>x</code></pre>")
+    attachCopyButtonsIn(container, LABELS)
+    const button = container.querySelector("pre > button") as HTMLButtonElement
+    // Should not throw despite the rejection.
+    expect(() => button.click()).not.toThrow()
+  })
+
+  it("does nothing when container is null", () => {
+    expect(() => attachCopyButtonsIn(null, LABELS)).not.toThrow()
+  })
+})

--- a/frontend/src/lib/codeblock-copy.ts
+++ b/frontend/src/lib/codeblock-copy.ts
@@ -1,0 +1,77 @@
+/**
+ * Walks ``container`` for ``<pre>`` blocks (the rendered shape of
+ * code blocks from ``CodeBlockLowlight``) and attaches a small
+ * "Copy" button to each. The button copies the inner code text
+ * (not the highlighted token DOM) to the clipboard and flashes a
+ * brief "Copied" state on success.
+ *
+ * Why a DOM walk instead of a React component? The chapter HTML
+ * is dropped via ``dangerouslySetInnerHTML``; there's no React
+ * tree to inject into. We use the same view-time-rewrite pattern
+ * the math + toggle-callout renderers use (see
+ * ``lib/katex-render.ts`` and ``lib/callout-toggle.ts``).
+ * Idempotent via the ``data-copy-attached`` flag.
+ *
+ * Localisation note: the helper accepts ``labels`` so callers can
+ * pass i18n strings without forcing this lib to import i18next.
+ */
+export interface CopyLabels {
+  copy: string
+  copied: string
+  ariaLabel: string
+}
+
+export function attachCopyButtonsIn(
+  container: HTMLElement | null,
+  labels: CopyLabels,
+): void {
+  if (!container) return
+  const blocks = container.querySelectorAll<HTMLPreElement>(
+    "pre:not([data-copy-attached])",
+  )
+  for (const pre of blocks) {
+    pre.setAttribute("data-copy-attached", "true")
+    // The button is absolutely positioned over the top-right corner
+    // of the ``<pre>``; the parent gets ``relative`` so the button
+    // anchors correctly.
+    pre.style.position = pre.style.position || "relative"
+
+    const button = document.createElement("button")
+    button.type = "button"
+    button.setAttribute("aria-label", labels.ariaLabel)
+    button.textContent = labels.copy
+    // Tailwind utility classes inlined here because the helper
+    // doesn't go through the JSX path. The classes match the
+    // ``.prose pre`` semantic-token palette so the button looks
+    // native in both themes.
+    button.className =
+      "absolute right-2 top-2 z-10 rounded border border-border bg-background/90 px-2 py-1 text-xs font-medium text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 focus:opacity-100"
+
+    // Make the button appear on hover by promoting the parent to a
+    // tailwind ``group``. Idempotent: ``classList.add`` doesn't
+    // duplicate.
+    pre.classList.add("group")
+
+    button.addEventListener("click", async () => {
+      const codeEl = pre.querySelector("code")
+      const text = (codeEl ?? pre).textContent ?? ""
+      try {
+        await navigator.clipboard.writeText(text)
+        const original = button.textContent
+        button.textContent = labels.copied
+        // Restore the label after a short flash. Using a class
+        // toggle would be cleaner but adds CSS surface for a
+        // one-off ephemeral state.
+        window.setTimeout(() => {
+          button.textContent = original
+        }, 1400)
+      } catch {
+        // Clipboard write can fail on insecure origins or when
+        // permission is denied. Fail silently — the teacher / student
+        // can still select + Cmd+C the text manually.
+      }
+    })
+
+    pre.appendChild(button)
+  }
+}

--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -4,6 +4,7 @@ import { useParams, Link, useNavigate } from "react-router-dom"
 import { sanitizeHtml as sanitize } from "@/lib/sanitize"
 import { renderMathIn } from "@/lib/katex-render"
 import { renderToggleCalloutsIn } from "@/lib/callout-toggle"
+import { attachCopyButtonsIn } from "@/lib/codeblock-copy"
 import PageSpinner from "@/components/ui/PageSpinner"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
@@ -44,6 +45,7 @@ import { chapterViewSteps } from "@/lib/tourSteps"
  * a stable host element to anchor against.
  */
 function TextBlockRender({ html }: { html: string }) {
+  const { t } = useTranslation()
   const ref = useRef<HTMLDivElement>(null)
   useEffect(() => {
     // Order matters: ``renderToggleCalloutsIn`` rewrites parent
@@ -54,7 +56,12 @@ function TextBlockRender({ html }: { html: string }) {
     // toggle-first avoids extra DOM churn.
     renderToggleCalloutsIn(ref.current)
     renderMathIn(ref.current)
-  }, [html])
+    attachCopyButtonsIn(ref.current, {
+      copy: t("blockEditor.codeBlock.copy"),
+      copied: t("blockEditor.codeBlock.copied"),
+      ariaLabel: t("blockEditor.codeBlock.copyAriaLabel"),
+    })
+  }, [html, t])
   return (
     <div
       ref={ref}


### PR DESCRIPTION
## Summary

Three small but visible upgrades to code blocks, none of which needed an extension config change or a schema migration.

## What changed

### Copy-to-clipboard button at view time

- **New `lib/codeblock-copy.ts`** :: `attachCopyButtonsIn(container, labels)` walks every `<pre>` element in the rendered chapter HTML and pins a small absolute-positioned "Copy" button to the top-right corner. The button text flashes "Copied" for 1.4s on success and silently no-ops on clipboard-write rejection (which can happen on insecure origins or when permission is denied).
- Idempotent via `data-copy-attached` flag — the same view-time DOM-walk pattern `renderToggleCalloutsIn` and `renderMathIn` use. **No new dependencies.**
- Button appears on parent-hover via `group-hover:opacity-100` so it doesn't compete with the code itself when the student is just reading.
- Wired into `ChapterView.TextBlockRender` alongside the math + toggle renderers. Labels pass through i18next so EN/RU surfaces stay symmetric.
- **Editor-side: deliberately not added.** Inside the editor a teacher can already select + Cmd/Ctrl+C and adding a button there would fight with the language-picker dropdown for the same corner.

### Syntax token coverage

- Added `.hljs-subst` (template-literal interpolation) to the accent-colour group. Without it, `${expression}` in JS or f-string interpolations in Python rendered as foreground text while the surrounding string was green — distracting.
- Added `.hljs-function`, `.hljs-params`, `.hljs-class` to the info-colour group. Function and class definitions now pick up the same visual cue as types and titles, which makes scan-reading a code sample for `def foo()` or `class Bar` much faster.

### Visual definition

- Block `<pre>` background `bg-muted/70` → `bg-muted` (no opacity). 70% over the dark card surface left the code block looking like part of the surrounding text rather than a distinct element; full opacity restores the visual hierarchy in dark mode.
- Inline `<code>` (outside a `<pre>`) now gets an explicit `border border-border` + `text-foreground` colour. Before, inline code inherited from prose and looked indistinguishable from bolded text in dark mode.
- The `.prose pre code` (block-code's inner) gets a `border-0` reset so the inline `border` doesn't bleed inside the parent's surface.

## i18n

- `blockEditor.codeBlock.copy` / `copied` / `copyAriaLabel` added to en.json + ru.json
- `i18n:check` reports parity

## Test plan

- [x] 6 new vitest cases in `codeblock-copy.test.ts` cover the happy path, idempotency, the actual clipboard call shape (asserts `writeText` got the inner `<code>` textContent, not the parent `<pre>`'s tokenised DOM), the flash-then-restore label flow, the clipboard-rejection silent-fallback, and the null-container guard.
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 316 passed across 45 files
- [x] `npm run i18n:check` — parity
- [ ] Manual: open a chapter with a code block → hover → click Copy → verify clipboard contents (deferred to live preview)

Stacks on #506 (dark-mode contrast) + #507 (toolbar UX); no file overlap with #507 so the rebase will be a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
