### PR TITLE
style(editor): char-count progress bar + URL validation on links (P7+P8)

### DIFF
--- a/frontend/src/components/editor/RichTextEditor.tsx
+++ b/frontend/src/components/editor/RichTextEditor.tsx
@@ -200,9 +200,15 @@ export default function RichTextEditor({
 }
 
 /**
- * Footer counter showing ``N / LIMIT`` with editorial colour shifts as
- * the user nears the cap. Lives inside this module — purely
- * presentational, single caller, no need for its own file.
+ * Footer counter showing a slim progress bar + ``N / LIMIT`` label,
+ * with editorial colour shifts as the user nears the cap. The bar
+ * gives teachers an at-a-glance "how full is this block?" cue
+ * without needing to read the digits — useful when the limit is
+ * five-digit (``chapter_blocks.content`` is 500 000) and the absolute
+ * count is hard to feel.
+ *
+ * Single caller; lives in this module to keep the editor's
+ * presentational surface scoped to one file.
  */
 function CharacterCounter({
   count,
@@ -213,22 +219,47 @@ function CharacterCounter({
   limit: number;
   t: (k: string, opts?: Record<string, unknown>) => string;
 }) {
-  const ratio = count / limit;
+  const ratio = Math.min(count / limit, 1);
   const tone = ratio >= 1 ? "destructive" : ratio >= 0.9 ? "warning" : "muted";
+  // Convert to a 0–100 integer so the inline ``width`` style stays
+  // stable across renders; React would otherwise compare new float
+  // strings ("23.4%") each keystroke even when visually unchanged.
+  const percent = Math.round(ratio * 100);
   return (
-    <div
-      aria-live="polite"
-      className="flex justify-end border-t border-input px-3 py-1.5 text-xs tabular-nums"
-    >
-      <span
-        className={cn(
-          tone === "muted" && "text-muted-foreground",
-          tone === "warning" && "text-warning",
-          tone === "destructive" && "text-destructive font-medium",
-        )}
+    <div className="border-t border-input">
+      <div
+        className="h-0.5 w-full bg-muted/60"
+        role="presentation"
+        aria-hidden="true"
       >
-        {t("blockEditor.toolbar.characters", { count, limit })}
-      </span>
+        <div
+          className={cn(
+            "h-full transition-[width] duration-150 ease-out",
+            tone === "muted" && "bg-muted-foreground/40",
+            tone === "warning" && "bg-warning",
+            tone === "destructive" && "bg-destructive",
+          )}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <div
+        // ``aria-live: polite`` is intentional — at threshold crossings
+        // the assertive tone change in the label below tells the user
+        // they're nearing the cap without spamming every keystroke.
+        aria-live="polite"
+        className="flex items-center justify-between px-3 py-1.5 text-xs tabular-nums"
+      >
+        <span
+          className={cn(
+            "transition-colors",
+            tone === "muted" && "text-muted-foreground",
+            tone === "warning" && "text-warning font-medium",
+            tone === "destructive" && "text-destructive font-medium",
+          )}
+        >
+          {t("blockEditor.toolbar.characters", { count, limit })}
+        </span>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/editor/useMediaPrompts.ts
+++ b/frontend/src/components/editor/useMediaPrompts.ts
@@ -7,6 +7,39 @@ import { toast } from "@/lib/toast";
 import type { useImageUpload } from "./useImageUpload";
 
 /**
+ * Accept "naked" hostnames (``example.com/page``) by prepending
+ * ``https://`` when the user didn't include a scheme. Then validate
+ * the result parses as a real URL with an http(s) scheme. Returns
+ * the normalised URL string or ``null`` if the input is unusable.
+ *
+ * Without this, a teacher who types ``example.com`` ends up with a
+ * relative ``<a href="example.com">`` that resolves against the
+ * chapter URL — broken in production. We catch the common case here
+ * so the user sees an immediate toast instead of discovering it as
+ * a student.
+ */
+function normalizeAndValidateUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const candidate =
+    /^[a-z][a-z0-9+.-]*:/i.test(trimmed) || trimmed.startsWith("//")
+      ? trimmed
+      : `https://${trimmed}`;
+  try {
+    const parsed = new URL(candidate);
+    // Only http(s) for chapter links — ``mailto:`` / ``tel:`` are
+    // valid URL schemes but we don't want them silently sneaking
+    // through this code path.
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Bundles the "media insert" handlers that all rely on a URL prompt:
  * link, image (with upload + URL fallback), YouTube, audio.
  *
@@ -37,7 +70,15 @@ export function useMediaPrompts(
       editor.chain().focus().extendMarkRange("link").unsetLink().run();
       return;
     }
-    editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
+    const normalized = normalizeAndValidateUrl(url);
+    if (!normalized) {
+      toast({
+        title: t("editor.toast.invalidUrl"),
+        variant: "destructive",
+      });
+      return;
+    }
+    editor.chain().focus().extendMarkRange("link").setLink({ href: normalized }).run();
   }, [editor, prompt, t]);
 
   const addImage = useCallback(() => {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1957,7 +1957,8 @@
   "editor": {
     "toast": {
       "imageUploadFailed": "Image upload failed",
-      "audioUrlInvalid": "Audio URL must start with http(s)"
+      "audioUrlInvalid": "Audio URL must start with http(s)",
+      "invalidUrl": "That doesn't look like a valid URL. Use a full address like https://example.com/page."
     },
     "prompt": {
       "addLinkTitle": "Add link",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1640,7 +1640,8 @@
   "editor": {
     "toast": {
       "imageUploadFailed": "Не удалось загрузить изображение",
-      "audioUrlInvalid": "URL аудио должен начинаться с http(s)"
+      "audioUrlInvalid": "URL аудио должен начинаться с http(s)",
+      "invalidUrl": "Это не похоже на корректный URL. Используйте полный адрес, например https://example.com/page."
     },
     "prompt": {
       "addLinkTitle": "Добавить ссылку",


### PR DESCRIPTION
## Summary

Two small polish items from the audit. Bundled because both touch `RichTextEditor` / `useMediaPrompts` and neither was worth its own PR.

## Character counter — progress bar

The old footer was a single right-aligned label ("100 / 500 characters"). At five-digit limits (`chapter_blocks.content` is 500 000) the absolute count is hard to feel — a teacher can't tell whether they're at 12% or 88% from the digits alone.

Replaces the flat label with a slim 2px progress bar (`h-0.5`) above the label. The bar fills 0–100% with the same three-tone ramp the label uses: `muted-foreground/40` below 90%, full `--warning` at 90–100%, `--destructive` at the cap. `transition` on width gives a soft fill rather than a stuttering re-render.

The label now reads bolder at the warning + destructive tones (`font-medium`) so the threshold transition is visible even for a sighted user who isn't watching the bar.

## Link prompt — URL validation

**Before:** typing `example.com` (no scheme) into the link prompt stored `<a href="example.com">` — a relative link that resolved against the chapter URL and 404'd in production. The teacher wouldn't notice until a student tried it.

**New `normalizeAndValidateUrl` helper:**
- If the input already has a scheme (`https:`, `mailto:`) or starts with `//` (protocol-relative), pass through.
- Otherwise prepend `https://` so naked hostnames work.
- Validate the result parses as a real `URL` and the protocol is `http(s):` — anything else gets rejected.

On rejection, `editor.toast.invalidUrl` fires:
- EN: "That doesn't look like a valid URL. Use a full address like https://example.com/page."
- RU: "Это не похоже на корректный URL. Используйте полный адрес, например https://example.com/page."

Other prompts (YouTube, audio, image-URL fallback) already had domain-specific validators downstream (`setYoutubeVideo`, `setAudio`); no change needed there. Math prompt has no URL component.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 316 passed across 45 files
- [x] `npm run i18n:check` — parity
- [ ] Manual: open editor with character limit → watch progress bar fill, change colour at 90% and 100%
- [ ] Manual: open link prompt, type `example.com` → see toast, link not inserted; type `https://example.com` → link inserted
- [ ] Backend untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
