### PR TITLE
feat(module-editor): type-specific default chapter titles (P12)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1403,7 +1403,11 @@
   },
   "moduleEditor": {
     "defaults": {
-      "chapterTitle": "Chapter {{n}}"
+      "chapterTitle": "Chapter {{n}}",
+      "readingTitle": "Lesson {{n}}",
+      "quizTitle": "Quiz {{n}}",
+      "examTitle": "Exam {{n}}",
+      "assignmentTitle": "Assignment {{n}}"
     },
     "toast": {
       "moduleNotFound": "Module not found",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1076,7 +1076,11 @@
   },
   "moduleEditor": {
     "defaults": {
-      "chapterTitle": "Глава {{n}}"
+      "chapterTitle": "Глава {{n}}",
+      "readingTitle": "Урок {{n}}",
+      "quizTitle": "Тест {{n}}",
+      "examTitle": "Экзамен {{n}}",
+      "assignmentTitle": "Задание {{n}}"
     },
     "toast": {
       "moduleNotFound": "Модуль не найден",

--- a/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
+++ b/frontend/src/pages/Teacher/moduleEditor/useModuleEditor.ts
@@ -119,12 +119,26 @@ export function useModuleEditor(
     if (addingChapterRef.current) return;
     addingChapterRef.current = true;
     const order = mod.chapters?.length ?? 0;
+    // Default title counts existing chapters of the SAME type so
+    // teachers see "Quiz 2" rather than "Chapter 5" when adding their
+    // second quiz to a mostly-reading module. Falls back to the
+    // generic ``defaults.chapterTitle`` key when the type-specific
+    // key is missing (defensive for future chapter types).
+    const sameTypeCount =
+      (mod.chapters ?? []).filter((c) => c.chapter_type === chapterType).length;
+    const typeSpecificKey = `moduleEditor.defaults.${chapterType}Title`;
+    const fallbackKey = "moduleEditor.defaults.chapterTitle";
+    const typeSpecific = t(typeSpecificKey, { n: sameTypeCount + 1 });
+    const seededTitle =
+      typeSpecific === typeSpecificKey
+        ? t(fallbackKey, { n: order + 1 })
+        : typeSpecific;
     try {
       const ch = await coursesService.createChapter(courseId, moduleId, {
         // Seed in the teacher's UI locale. Persisted as-is, so the
         // previous ``Chapter N`` literal stuck English into every
         // Russian-UI teacher's course tree until they renamed it.
-        title: t("moduleEditor.defaults.chapterTitle", { n: order + 1 }),
+        title: seededTitle,
         order_index: order,
         chapter_type: chapterType,
       });


### PR DESCRIPTION
## Summary

Stacks on #509 (4-card chapter creation UX). When a teacher picks `+ Quiz` from the new chooser, the previous default `Chapter 5` was inconsistent — it counted **total** chapters, not chapters of that type, and the label didn't hint at the content shape they'd just chosen.

## New behaviour

- `+ Reading` → "Lesson N" / "Урок N"
- `+ Quiz` → "Quiz N" / "Тест N"
- `+ Exam` → "Exam N" / "Экзамен N"
- `+ Assignment` → "Assignment N" / "Задание N"

Where `N` is the count of chapters of **that type** in the module plus one. So a module with three lessons followed by a new quiz gets "Quiz 1", not "Chapter 4" — the title reads as a meaningful label rather than a sequence marker.

## Fallback

The generic `Chapter {{n}}` key stays in both bundles as a defensive fallback: if `t(typeSpecificKey)` returns the key string (i.e. the key isn't found in the bundle — happens if a new chapter type ever ships before its locale entry), we revert to `Chapter N` with the total order index. Adding a fifth chapter type later doesn't break title generation.

Teachers who like the old terse "Chapter N" can rename freely — the seed is just the first save, not a constraint.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 316 passed
- [x] `npm run i18n:check` — parity (1549 EN / 1609 RU)
- [ ] Manual: add 3 readings + 1 quiz to a module → see "Lesson 1", "Lesson 2", "Lesson 3", "Quiz 1" instead of "Chapter 1..4"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
