### PR TITLE
feat(editor): image upload error detail + size/type validation (P14)

### DIFF
--- a/frontend/src/components/editor/useImageUpload.ts
+++ b/frontend/src/components/editor/useImageUpload.ts
@@ -4,7 +4,15 @@ import type { Editor } from "@tiptap/react";
 import type { EditorView } from "@tiptap/pm/view";
 
 import { storageService } from "@/services/storage";
+import { getErrorDetail } from "@/lib/errorDetail";
 import { toast } from "@/lib/toast";
+
+/** Largest image we accept on the upload path. The bucket itself
+ *  enforces a higher cap server-side; this client check fails fast so
+ *  teachers don't burn a network round-trip on an obviously-too-big
+ *  file. 10 MB covers high-quality screenshots, screen-printed
+ *  diagrams, and photos straight off a phone. */
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 
 /**
  * Image upload state + handlers shared between the RichTextEditor's
@@ -17,14 +25,45 @@ import { toast } from "@/lib/toast";
 export function useImageUpload() {
   const { t } = useTranslation();
   const [uploading, setUploading] = useState(false);
+  /** The most recent upload failure reason — surfaced by
+   *  ``useMediaPrompts`` so the URL-fallback dialog can show the
+   *  teacher *why* the upload failed (file too large, network
+   *  error, storage rejected by bucket policy, etc.). Reset on the
+   *  next successful upload or another failure. */
+  const [lastError, setLastError] = useState<string | null>(null);
 
   const upload = useCallback(
     async (file: File): Promise<string | null> => {
+      // Upfront client-side checks so a 50 MB photo gets a clear
+      // toast immediately instead of after a 30-second network
+      // round trip. Both errors are recorded so the URL-fallback
+      // prompt can repeat them.
+      if (!file.type.startsWith("image/")) {
+        const message = t("editor.toast.imageWrongType", { type: file.type || "?" });
+        setLastError(message);
+        toast({ title: message, variant: "destructive" });
+        return null;
+      }
+      if (file.size > MAX_IMAGE_BYTES) {
+        const message = t("editor.toast.imageTooLarge", {
+          maxMb: Math.round(MAX_IMAGE_BYTES / 1024 / 1024),
+        });
+        setLastError(message);
+        toast({ title: message, variant: "destructive" });
+        return null;
+      }
       setUploading(true);
+      setLastError(null);
       try {
-        return await storageService.uploadContentImage(file);
-      } catch {
-        toast({ title: t("editor.toast.imageUploadFailed"), variant: "destructive" });
+        const url = await storageService.uploadContentImage(file);
+        return url;
+      } catch (error: unknown) {
+        const detail = getErrorDetail(error);
+        const message = detail
+          ? t("editor.toast.imageUploadFailedDetail", { detail })
+          : t("editor.toast.imageUploadFailed");
+        setLastError(message);
+        toast({ title: message, variant: "destructive" });
         return null;
       } finally {
         setUploading(false);
@@ -101,5 +140,5 @@ export function useImageUpload() {
     [upload],
   );
 
-  return { uploading, uploadAndInsert, handleDrop, handlePaste };
+  return { uploading, uploadAndInsert, handleDrop, handlePaste, lastError };
 }

--- a/frontend/src/components/editor/useMediaPrompts.ts
+++ b/frontend/src/components/editor/useMediaPrompts.ts
@@ -92,15 +92,29 @@ export function useMediaPrompts(
       const inserted = await imageUpload.uploadAndInsert(file, editor);
       if (inserted) return;
       // Upload failed: give the user an escape hatch so they can paste
-      // an existing URL instead of silently losing their action.
+      // an existing URL instead of silently losing their action. The
+      // dialog description shows the actual failure reason (file too
+      // big, wrong type, network error) when available so the teacher
+      // knows whether to try a different file or just use a URL.
+      const fallbackReason = imageUpload.lastError;
       const url = await prompt({
         title: t("editor.prompt.uploadFailedTitle"),
-        description: t("editor.prompt.uploadFailedDescription"),
+        description: fallbackReason ?? t("editor.prompt.uploadFailedDescription"),
         placeholder: t("editor.prompt.imageUrlPlaceholder"),
         inputType: "url",
         confirmLabel: t("editor.prompt.uploadFailedConfirm"),
       });
-      if (url) editor.chain().focus().setImage({ src: url }).run();
+      if (!url) return;
+      // The URL-fallback path benefits from the same scheme-validation
+      // the link prompt uses (#510). A teacher pasting ``example.com``
+      // wouldn't notice the relative URL until a student saw the
+      // broken image.
+      const normalized = normalizeAndValidateUrl(url);
+      if (!normalized) {
+        toast({ title: t("editor.toast.invalidUrl"), variant: "destructive" });
+        return;
+      }
+      editor.chain().focus().setImage({ src: normalized }).run();
     };
     input.click();
   }, [editor, imageUpload, prompt, t]);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1979,6 +1979,9 @@
   "editor": {
     "toast": {
       "imageUploadFailed": "Image upload failed",
+      "imageUploadFailedDetail": "Image upload failed: {{detail}}",
+      "imageWrongType": "That file isn't an image ({{type}}). Pick a JPG, PNG, WebP, or GIF.",
+      "imageTooLarge": "Image is too large. Maximum size is {{maxMb}} MB.",
       "audioUrlInvalid": "Audio URL must start with http(s)",
       "invalidUrl": "That doesn't look like a valid URL. Use a full address like https://example.com/page."
     },

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1662,6 +1662,9 @@
   "editor": {
     "toast": {
       "imageUploadFailed": "Не удалось загрузить изображение",
+      "imageUploadFailedDetail": "Не удалось загрузить изображение: {{detail}}",
+      "imageWrongType": "Этот файл — не изображение ({{type}}). Выберите JPG, PNG, WebP или GIF.",
+      "imageTooLarge": "Изображение слишком большое. Максимальный размер — {{maxMb}} МБ.",
       "audioUrlInvalid": "URL аудио должен начинаться с http(s)",
       "invalidUrl": "Это не похоже на корректный URL. Используйте полный адрес, например https://example.com/page."
     },


### PR DESCRIPTION
## Summary

When an image upload failed before this PR, the teacher saw a flat "Image upload failed" toast and then a fallback URL dialog with no hint about **why** the upload failed. The audit flagged this as MED severity — teachers were getting no signal to distinguish "file too big" from "wrong file type" from "network error" from "bucket rejected".

## Upfront client checks

- **Wrong file type:** `editor.toast.imageWrongType` toast with the offending MIME (`"That file isn't an image (application/pdf). Pick a JPG, PNG, WebP, or GIF."`). Fails before the network round-trip.
- **File too large:** `editor.toast.imageTooLarge` with the cap in MB (`"Image is too large. Maximum size is 10 MB."`). Cap is a constant `MAX_IMAGE_BYTES` at the top of `useImageUpload`; moving it requires the same conversation as moving the bucket-side limit.
- Both checks set `lastError` so the URL-fallback dialog can repeat the reason.

## Server-side error surfacing

The catch in `upload` now calls `getErrorDetail(error)` and threads the message through `editor.toast.imageUploadFailedDetail` when available. "Image upload failed: Storage quota exceeded for this bucket" is dramatically more actionable than the previous "Image upload failed".

## URL fallback dialog now surfaces the reason

`useMediaPrompts.addImage` reads `imageUpload.lastError` and uses it as the dialog's `description` when present, falling back to the generic `uploadFailedDescription` otherwise. The teacher now sees "Image is too large. Maximum size is 10 MB." **and** the URL input — they can decide whether to compress the file and re-upload, or paste an existing CDN URL.

## URL fallback gets the same scheme validation as the link prompt

When a teacher pastes `example.com/cat.jpg` (no scheme) into the URL-fallback dialog, we now run `normalizeAndValidateUrl` (already shared from #510) and either prepend `https://` or toast `editor.toast.invalidUrl` if the result isn't a valid http(s) URL. Catches the same relative-URL bug the link prompt used to ship.

## i18n

- 3 new `editor.toast.image*` keys in en.json + ru.json
- `i18n:check` reports parity (1556 EN / 1614 RU)

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 316 passed across 45 files
- [x] `npm run i18n:check` — parity
- [ ] Manual: drop a 30 MB photo → "Image is too large" toast. Drop a PDF → "That file isn't an image" toast. Drop a valid PNG when offline → fallback dialog shows network error reason.
- [ ] Backend untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
