### PR TITLE
fix(types): close 4-way enum mirror drift (cohorts/certs/notifications/chapter_blocks) — A1

### DIFF
--- a/backend/app/models/chapter_block.py
+++ b/backend/app/models/chapter_block.py
@@ -1,15 +1,35 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
 
+# The single source of truth for ``block_type`` values. Mirrors the
+# Postgres CHECK constraint ``chapter_blocks_block_type_check`` (created
+# in supabase migration ``20260521175824_add_check_constraints.sql``).
+# Keeping the literal here means a 4-way mirror change starts in one
+# place: this tuple, the Pydantic ``schemas.chapter_block.BLOCK_TYPES``,
+# the TS ``frontend/src/components/editor/blocks/types.ts``, and a
+# Postgres ALTER on the CHECK.
+BLOCK_TYPES: tuple[str, ...] = ("text", "quiz", "assignment", "file")
+
 
 class ChapterBlock(Base):
     __tablename__ = "chapter_blocks"
-    __table_args__ = (Index("ix_chapter_blocks_chapter_id_order", "chapter_id", "order_index"),)
+    __table_args__ = (
+        Index("ix_chapter_blocks_chapter_id_order", "chapter_id", "order_index"),
+        # Declared here so the SQLAlchemy schema-smoke CI job sees the
+        # constraint that prod's CHECK already enforces. Previously the
+        # model lied — Mapped[str] with no constraint declaration — and
+        # the smoke test couldn't catch a future widening that broke
+        # the Pydantic Literal mirror.
+        CheckConstraint(
+            f"block_type IN ({', '.join(repr(v) for v in BLOCK_TYPES)})",
+            name="chapter_blocks_block_type_check",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     chapter_id: Mapped[str] = mapped_column(ForeignKey("chapters.id", ondelete="CASCADE"))

--- a/backend/app/models/cohort.py
+++ b/backend/app/models/cohort.py
@@ -14,7 +14,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, func
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -31,6 +31,15 @@ class CohortStatus(enum.StrEnum):
     UPCOMING = "upcoming"
     ACTIVE = "active"
     COMPLETED = "completed"
+    # ``archived`` is in the Postgres CHECK constraint
+    # (``cohorts_status_check``) since the table was created, but until
+    # this entry was added the Python enum stopped at ``completed`` —
+    # a service-role write that set ``status='archived'`` would pass
+    # the DB and then fail every Pydantic deserialisation, rendering
+    # the cohort invisible to the API. There is no active code path
+    # that writes ``archived`` today; the value is here so the 4-way
+    # mirror is honest, not because the UX uses it.
+    ARCHIVED = "archived"
 
 
 class Cohort(Base):
@@ -38,6 +47,14 @@ class Cohort(Base):
     __table_args__ = (
         Index("ix_cohorts_status", "status"),
         Index("ix_cohorts_created_by", "created_by"),
+        # Mirrors the Postgres ``cohorts_status_check`` CHECK constraint.
+        # Same 4-way-mirror discipline rule as ``ChapterBlock``: the
+        # constraint already exists in prod; this declaration lets the
+        # schema-smoke CI job see it.
+        CheckConstraint(
+            "status IN ('upcoming', 'active', 'completed', 'archived')",
+            name="cohorts_status_check",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)

--- a/backend/app/schemas/certificate.py
+++ b/backend/app/schemas/certificate.py
@@ -1,7 +1,14 @@
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
+
+# Mirrors the Postgres ``certificates_status_check`` CHECK constraint
+# and the SQLAlchemy ``CertificateStatus`` enum. Without the Literal
+# here, ``CertificateResponse.status`` was ``str`` — any value would
+# deserialise, including ones the DB CHECK would later reject.
+CertificateStatus = Literal["pending", "teacher_approved", "approved", "rejected"]
 
 
 class CertificateResponse(BaseModel):
@@ -15,7 +22,7 @@ class CertificateResponse(BaseModel):
     archived_course_title: str | None = None
     issued_at: datetime | None = None
     certificate_number: str | None = None
-    status: str = "pending"
+    status: CertificateStatus = "pending"
     requested_at: datetime | None = None
     teacher_approved_at: datetime | None = None
     teacher_approved_by: UUID | None = None

--- a/backend/app/schemas/cohort.py
+++ b/backend/app/schemas/cohort.py
@@ -12,6 +12,12 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
+# Mirrors the Postgres ``cohorts_status_check`` CHECK constraint and the
+# SQLAlchemy ``CohortStatus`` enum + ``CheckConstraint`` in
+# ``app/models/cohort.py``. Single literal here keeps both write and read
+# schemas pointing at the same 4-tuple instead of repeating it inline.
+CohortStatus = Literal["upcoming", "active", "completed", "archived"]
+
 
 def _validate_cohort_dates(
     *,
@@ -67,8 +73,11 @@ class CohortUpdate(BaseModel):
     enrollment_end: datetime | None = None
     # ``upcoming → active → completed`` is the intended forward path.
     # Going back from ``completed`` is prevented at the route layer
-    # (see ``update_cohort`` in ``api/v1/cohorts.py``).
-    status: Literal["upcoming", "active", "completed"] | None = None
+    # (see ``update_cohort`` in ``api/v1/cohorts.py``). ``archived`` is in
+    # the type for mirror-completeness with the DB CHECK constraint, but
+    # the route layer should still reject it for a regular UPDATE — only
+    # a dedicated admin "archive cohort" endpoint should set it.
+    status: CohortStatus | None = None
     max_students: int | None = Field(None, ge=1)
 
     @model_validator(mode="after")
@@ -95,7 +104,7 @@ class CohortResponse(BaseModel):
     end_date: datetime
     enrollment_start: datetime | None = None
     enrollment_end: datetime | None = None
-    status: str
+    status: CohortStatus
     max_students: int | None = None
     created_by: UUID | None = None
     created_at: datetime

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,8 +1,23 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
+
+# The full set of notification kinds the system emits. Mirrors the TS
+# ``NotificationType`` union in ``frontend/src/types/index.ts``.
+# Postgres has no CHECK on ``notifications.type`` (it's free-form
+# ``VARCHAR(50)`` so future kinds don't need a migration), so this
+# Literal is the only thing keeping a typo'd ``'certificat_approved'``
+# from sneaking past the API layer.
+NotificationType = Literal[
+    "certificate_approved",
+    "certificate_rejected",
+    "assignment_graded",
+    "new_announcement",
+    "course_update",
+    "enrollment_confirmed",
+]
 
 
 class NotificationResponse(BaseModel):
@@ -10,7 +25,7 @@ class NotificationResponse(BaseModel):
 
     id: UUID
     user_id: UUID
-    type: str
+    type: NotificationType
     title: str
     message: str
     link: str | None = None

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -1293,7 +1293,12 @@ class TestDeleteCourseEvent:
 def _seed_notification(db: Session, *, user_id=TEACHER_ID, is_read=False, title="Test Notification") -> Notification:
     n = Notification(
         user_id=user_id,
-        type="info",
+        # ``new_announcement`` is one of the production notification kinds
+        # (emitted in ``api/v1/announcements.py``). The previous ``"info"``
+        # seed was a test-only literal that no real write path produces;
+        # tightening ``NotificationResponse.type`` to ``Literal[...]``
+        # exposed the divergence.
+        type="new_announcement",
         title=title,
         message="Test message body",
         is_read=is_read,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1675,6 +1675,7 @@
       "statusUpcoming": "Upcoming",
       "statusActive": "Active",
       "statusCompleted": "Completed",
+      "statusArchived": "Archived",
       "createButton": "New cohort",
       "create": "Create",
       "creating": "Creating…",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1354,6 +1354,7 @@
       "statusUpcoming": "Скоро",
       "statusActive": "Активная",
       "statusCompleted": "Завершена",
+      "statusArchived": "В архиве",
       "createButton": "Новая когорта",
       "create": "Создать",
       "creating": "Создаём…",

--- a/frontend/src/pages/Admin/cohorts/CohortStatusPicker.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortStatusPicker.tsx
@@ -19,18 +19,26 @@ interface Props {
   ariaLabel?: string
 }
 
+// ``archived`` is in the ``Cohort["status"]`` union for mirror parity
+// with the Postgres CHECK constraint (see backend ``CohortStatus``),
+// but no production write path emits it today. Excluding it from
+// ``STATUS_ORDER`` means the picker doesn't offer ``archived`` as a
+// transition; the badge + i18n maps still cover it so a cohort that
+// somehow ends up archived renders coherently.
 const STATUS_ORDER: Cohort["status"][] = ["upcoming", "active", "completed"]
 
 const STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
   upcoming: "info",
   active: "success",
   completed: "muted",
+  archived: "muted",
 }
 
 const STATUS_I18N_KEY: Record<Cohort["status"], string> = {
   upcoming: "admin.cohorts.statusUpcoming",
   active: "admin.cohorts.statusActive",
   completed: "admin.cohorts.statusCompleted",
+  archived: "admin.cohorts.statusArchived",
 }
 
 /**

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -27,6 +27,10 @@ const STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
   upcoming: "info",
   active: "success",
   completed: "muted",
+  // ``archived`` is in ``Cohort["status"]`` to match the DB CHECK
+  // (see backend ``CohortStatus``); no UX writes it today, but the
+  // map must cover every union member so a future archive flow renders.
+  archived: "muted",
 }
 
 // Static i18n key lookup so the keyCoverage check sees each literal;
@@ -36,6 +40,7 @@ const STATUS_LABEL_KEYS: Record<Cohort["status"], string> = {
   upcoming: "admin.cohorts.statusUpcoming",
   active: "admin.cohorts.statusActive",
   completed: "admin.cohorts.statusCompleted",
+  archived: "admin.cohorts.statusArchived",
 }
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const

--- a/frontend/src/pages/Course/detail/NotEnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/NotEnrolledView.tsx
@@ -19,16 +19,22 @@ interface Props {
   onEnroll: (cohortId?: string) => Promise<void> | void
 }
 
+// Same mirror-completeness rule as ``CohortStatusPicker``: the
+// ``archived`` value exists in the ``Cohort["status"]`` union to match
+// the DB CHECK constraint, but no production code path writes it. The
+// maps include it so a defensively-archived cohort still renders.
 const COHORT_STATUS_BADGE: Record<Cohort["status"], "success" | "info" | "muted"> = {
   upcoming: "info",
   active: "success",
   completed: "muted",
+  archived: "muted",
 }
 
 const COHORT_STATUS_KEY: Record<Cohort["status"], string> = {
   upcoming: "admin.cohorts.statusUpcoming",
   active: "admin.cohorts.statusActive",
   completed: "admin.cohorts.statusCompleted",
+  archived: "admin.cohorts.statusArchived",
 }
 
 export function NotEnrolledView({

--- a/frontend/src/services/cohorts.ts
+++ b/frontend/src/services/cohorts.ts
@@ -31,7 +31,11 @@ export interface UpdateCohortBody {
   end_date?: string
   enrollment_start?: string | null
   enrollment_end?: string | null
-  status?: "upcoming" | "active" | "completed"
+  // Mirrors backend ``CohortStatus`` literal + Postgres ``cohorts_status_check``.
+  // ``archived`` is in the type for completeness with the DB CHECK; no UX
+  // sets it today, but the listCohorts filter (admin tab) needs to accept
+  // it so the same union flows through every cohort-related call.
+  status?: "upcoming" | "active" | "completed" | "archived"
   max_students?: number | null
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -285,7 +285,10 @@ export interface Cohort {
   end_date: string
   enrollment_start: string | null
   enrollment_end: string | null
-  status: 'upcoming' | 'active' | 'completed'
+  // Mirrors backend `CohortStatus` literal + Postgres `cohorts_status_check`.
+  // `archived` is in the type for completeness with the DB CHECK; no UX
+  // sets it today.
+  status: 'upcoming' | 'active' | 'completed' | 'archived'
   max_students: number | null
   created_by: string | null
   created_at: string


### PR DESCRIPTION
## Summary

A deep schema-vs-code audit (Supabase MCP introspection + grep across Python + TS) surfaced **four enum mirrors** where the four sides of the contract (Postgres CHECK ↔ SQLAlchemy ↔ Pydantic ↔ TypeScript) had silently drifted out of alignment. Each one is a latent bug: the looser side accepts a value the stricter side will reject, producing either a 500 on read, a silent type-narrowing failure, or a row that's invisible to the API.

## What changed

### 1. `cohorts.status` — 4-side mirror complete

Postgres `cohorts_status_check` allows 4 values: `upcoming|active|completed|archived`. Python `CohortStatus` enum + `CohortUpdate.status` Literal + TS `Cohort.status` union all stopped at the first 3.

A service-role write that ever set `status='archived'` would pass the DB CHECK, then **fail every Pydantic deserialisation, leaving the cohort invisible to the API** and to admin tooling.

Fix:
- Add `ARCHIVED` to the Python enum
- Add a Postgres-mirroring `CheckConstraint` to the SQLAlchemy model so the schema-smoke CI job sees the same set prod enforces
- Introduce a single `CohortStatus = Literal[...]` in the schemas module and use it for both `CohortUpdate` and `CohortResponse`
- Extend the TS union + the three Record-typed status maps (CohortStatusPicker, NotEnrolledView, CohortsTab) to cover `archived`, plus an `admin.cohorts.statusArchived` i18n key in EN + RU

No write path emits `archived` today; the UX simply renders coherently if a future write does.

### 2. `certificates.status` — Pydantic was `str`

`CertificateResponse.status: str = "pending"` accepted any string. The Postgres CHECK and the SQLAlchemy `CertificateStatus` enum both pin the 4-value set, but the Pydantic response would happily round-trip `"foo"`.

Fix: introduce `CertificateStatus = Literal["pending", "teacher_approved", "approved", "rejected"]` and use it on the response field.

### 3. `notifications.type` — TS was strictest, Pydantic was free-form

Postgres has no CHECK on `notifications.type` (intentionally left free-form so new notification kinds don't need a migration), the SQLAlchemy model and Pydantic schema both typed it as `str`, but the TypeScript `NotificationType` union locked it to 6 specific values. A backend that emitted a typo'd kind (`'certificat_approved'`) would silently break the frontend.

Fix: pin `NotificationType = Literal["certificate_approved", "certificate_rejected", "assignment_graded", "new_announcement", "course_update", "enrollment_confirmed"]` on the Pydantic response. The DB stays free-form so a future kind only needs an enum extension on the Python + TS sides.

**Required test fixture update:** `_seed_notification` in `test_cohorts_calendar_notifications.py` was creating rows with `type='info'` — a value no production write path emits. Switched to `'new_announcement'` (what `api/v1/announcements.py` actually sends).

### 4. `chapter_blocks.block_type` — model didn't declare its CHECK

Postgres CHECK allows 4 values; the SQLAlchemy model just had `Mapped[str]` with no constraint declared. The schema-smoke CI job couldn't detect a future drift between the migration set and the model.

Fix: declare a `CheckConstraint` in `__table_args__` mirroring the Postgres constraint, sourced from a single `BLOCK_TYPES` tuple at the top of the model.

## What this is not

- **No Postgres DDL.** Every CHECK in this PR already exists in prod; we're only making the Python side accurate so the schema-smoke job is honest.
- **No removal of `archived` from the cohort CHECK** — that's a separate decision (defer or wire up an archive flow first).
- **No tightening of `notifications.type` at the DB level** — it was deliberately left free-form, only the Python response now validates the known set.

## Test plan

- [x] `python -m pytest tests/` — 756 passed
- [x] `python -m ruff check .` clean
- [x] `mypy --config-file mypy.ini` — 117 files, no issues
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 316 passed
- [x] `npm run i18n:check` — parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)
