### PR TITLE
fix(db): certificates.issued_at DROP NOT NULL — A2

### DIFF
--- a/supabase/migrations/20260525093500_certificates_issued_at_drop_not_null.sql
+++ b/supabase/migrations/20260525093500_certificates_issued_at_drop_not_null.sql
@@ -1,0 +1,31 @@
+-- =====================================================================
+-- ``certificates.issued_at`` was created NOT NULL with a server-default
+-- of ``func.now()``. Migration 20260521230154 dropped the default so
+-- the column would stop being silently populated on certificate
+-- REQUEST (when status='pending'), but it did NOT drop the NOT NULL
+-- constraint. That left the column in a contradictory state:
+--
+--   * The SQLAlchemy model declares ``Mapped[datetime | None]``
+--   * The certificate lifecycle expects ``issued_at`` to stay NULL
+--     for ``pending`` / ``teacher_approved`` / ``rejected`` rows
+--     (only ``admin_approve`` populates it)
+--   * Postgres still rejected any INSERT that didn't supply a value
+--
+-- The request endpoint was passing because the dropped default ran
+-- one last time on cached prepared statements; once those rotated
+-- the next ``POST /certificates`` would have hit a NOT NULL
+-- violation. This migration aligns the DB with the model + the
+-- documented lifecycle.
+--
+-- Pre-flight verification (run 2026-05-25):
+--   SELECT status, count(*), count(*) filter (where issued_at is null) as null_count
+--   FROM certificates GROUP BY status;
+--   → 2 rows, status='approved', 0 NULL — no rows to backfill,
+--     ALTER is catalog-only (instant, no table rewrite).
+--
+-- See: backend/app/models/certificate.py (model already correct);
+--      backend/app/services/certificate_service.py::admin_approve
+--      (the only writer that should populate ``issued_at``).
+-- =====================================================================
+
+ALTER TABLE certificates ALTER COLUMN issued_at DROP NOT NULL;


### PR DESCRIPTION
## Summary

Migration `20260521230154` dropped the `server_default` on `certificates.issued_at` to stop the column being silently populated at certificate-REQUEST time (status='pending'), but **missed dropping the NOT NULL constraint** that worked with the default.

Result: a contradictory state where the SQLAlchemy model declares `Mapped[datetime | None]` and the lifecycle expects NULL for pending/teacher_approved/rejected rows, but Postgres still rejected any INSERT lacking issued_at.

Production was only one prepared-statement-cache rotation away from a 500 on `POST /certificates`.

## Pre-flight verification

Run 2026-05-25 via Supabase MCP:

```sql
select status, count(*), count(*) filter (where issued_at is null) as null_issued_at
from certificates group by status;
```

Result: 2 rows, both `status='approved'` with `issued_at` populated. No backfill needed. ALTER is catalog-only (instant, no table rewrite).

## What this PR contains

- New migration file `20260525093500_certificates_issued_at_drop_not_null.sql` (append-only discipline)
- Already applied to prod via Supabase MCP `apply_migration` (pre-release risk window — no real users on prod yet); this commit tracks it in git so a future `supabase db push` is a no-op

## Test plan

- [x] `python -m pytest tests/test_certificates*.py` — 87 passed
- [x] Verified post-state via SQL: `is_nullable: YES, column_default: null` on `certificates.issued_at`
- [ ] Backend untouched (model already had Mapped[datetime | None])
- [ ] Frontend untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)