### PR TITLE
refactor(frontend): AssignmentPanel dedup cleanup + ROUTES constants module — A4

### DIFF
--- a/frontend/src/components/assignment/AssignmentPanel.tsx
+++ b/frontend/src/components/assignment/AssignmentPanel.tsx
@@ -8,26 +8,6 @@ import { coursesService } from "@/services/courses"
 import { getErrorDetail } from "@/lib/errorDetail"
 import { toast } from "@/lib/toast"
 import type { Assignment, AssignmentSubmission } from "@/types"
-
-// Per-chapter request dedup. A reading chapter with N assignment blocks
-// mounts N AssignmentPanel instances simultaneously, each one
-// requesting the same `/api/v1/chapters/{id}/assignments` list. Without
-// this map every block fires its own identical network call. The entry
-// is dropped once the promise settles so subsequent mounts refetch
-// fresh data.
-const inflightChapterAssignments = new Map<string, Promise<Assignment[]>>()
-
-function fetchChapterAssignmentsDeduped(chapterId: string): Promise<Assignment[]> {
-  const existing = inflightChapterAssignments.get(chapterId)
-  if (existing) return existing
-  const promise = coursesService.getChapterAssignments(chapterId).finally(() => {
-    if (inflightChapterAssignments.get(chapterId) === promise) {
-      inflightChapterAssignments.delete(chapterId)
-    }
-  })
-  inflightChapterAssignments.set(chapterId, promise)
-  return promise
-}
 import PageSpinner from "@/components/ui/PageSpinner"
 import { formatDate } from "@/i18n/format"
 import {
@@ -65,7 +45,14 @@ export default function AssignmentPanel({ chapterId, assignmentId, onSubmitted, 
       setLoading(true)
       setFetchError(false)
       try {
-        const all = await fetchChapterAssignmentsDeduped(chapterId)
+        // ``services/api.ts`` already dedups concurrent identical GETs
+        // via its ``dedupeKey`` machinery — a chapter that mounts N
+        // AssignmentPanel instances simultaneously will see N callers
+        // share one in-flight request automatically. The previous
+        // per-module ``inflightChapterAssignments`` Map duplicated
+        // that behaviour and would have diverged if the api-layer
+        // policy ever changed.
+        const all = await coursesService.getChapterAssignments(chapterId)
         if (cancelled) return
         const data = assignmentId ? all.filter((a) => a.id === assignmentId) : all
         setAssignments(data)

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -1,0 +1,61 @@
+/**
+ * Single source of truth for every URL path the app routes to.
+ *
+ * Why: a hardcoded ``<Link to="/teacher">`` scattered across 30+ files
+ * means renaming ``/teacher`` → ``/instructor`` becomes a grep-and-replace
+ * across the whole frontend, and accidental drift between two near-
+ * identical strings (``"/course"`` vs ``"/courses"``) silently 404s in
+ * one place while working everywhere else.
+ *
+ * Convention
+ *
+ *  - Top-level paths are exported as ``UPPER_CASE`` constants.
+ *  - Parametrised paths are exported as builder functions that take
+ *    the segment values and return the assembled URL — this catches
+ *    typos at compile time, not at runtime.
+ *  - The constants live in one flat ``ROUTES`` object so call sites
+ *    read as ``ROUTES.TEACHER`` / ``ROUTES.courseDetail(id)`` —
+ *    discoverable via IDE autocomplete from any importing file.
+ *
+ * This file is the *pattern*; routes are migrated as call sites are
+ * touched rather than in one mega-grep. New routes added going
+ * forward should land here first.
+ */
+
+export const ROUTES = {
+  // ── Public ────────────────────────────────────────────────────────
+  HOME: "/",
+  COURSES: "/courses",
+  courseDetail: (courseId: string) => `/courses/${courseId}`,
+  chapter: (courseId: string, moduleId: string, chapterId: string) =>
+    `/courses/${courseId}/modules/${moduleId}/chapters/${chapterId}`,
+
+  // ── Auth ──────────────────────────────────────────────────────────
+  LOGIN: "/login",
+  REGISTER: "/register",
+  FORGOT_PASSWORD: "/forgot-password",
+  RESET_PASSWORD: "/auth/reset-password",
+  AUTH_CALLBACK: "/auth/callback",
+  AUTH_CONFIRM: "/auth/confirm",
+
+  // ── Authenticated student / user ──────────────────────────────────
+  DASHBOARD: "/dashboard",
+  PROFILE: "/profile",
+  CERTIFICATES: "/certificates",
+  CALENDAR: "/calendar",
+
+  // ── Teacher ───────────────────────────────────────────────────────
+  TEACHER: "/teacher",
+  teacherCourseEditor: (courseId: string) => `/teacher/courses/${courseId}`,
+  teacherModuleEditor: (courseId: string, moduleId: string) =>
+    `/teacher/courses/${courseId}/modules/${moduleId}/edit`,
+  teacherChapterEditor: (courseId: string, moduleId: string, chapterId: string) =>
+    `/teacher/courses/${courseId}/modules/${moduleId}/chapters/${chapterId}/edit`,
+  teacherGradebook: (courseId: string) => `/teacher/courses/${courseId}/gradebook`,
+  teacherStudentProgress: (courseId: string) => `/teacher/courses/${courseId}/progress`,
+  teacherCourseAnalytics: (courseId: string) => `/teacher/courses/${courseId}/analytics`,
+
+  // ── Admin ─────────────────────────────────────────────────────────
+  ADMIN: "/admin",
+  ADMIN_COHORTS_TAB: "/admin?tab=cohorts",
+} as const


### PR DESCRIPTION
## Summary

Two findings from the deep frontend architecture audit (2026-05-25), bundled because both are scoped fixes.

### 1. AssignmentPanel reinvented the api-layer dedup

The component shipped a per-chapter `inflightChapterAssignments` Map to coalesce concurrent `GET /api/v1/chapters/{id}/assignments` requests. But `services/api.ts` **already implements global request dedup** via a `dedupeKey` helper applied to every GET — N AssignmentPanel instances mounting simultaneously already share a single in-flight request through the axios layer.

The component-level Map was a re-invention that diverges if the api-layer policy ever changes. Dropped 18 lines + the `fetchChapterAssignmentsDeduped` helper; the load path now just calls `coursesService.getChapterAssignments(chapterId)` directly.

### 2. New `lib/routes.ts` constants module

Currently 30+ files hardcode path strings like `<Link to="/teacher">` or `` navigate(`/courses/${id}`) ``. A future rename (`/teacher` → `/instructor`) becomes a fragile grep, and the `"/course"` vs `"/courses"` drift case silently 404s on one page while working everywhere else.

The new module exports:
- Flat `UPPER_CASE` constants for top-level paths (`HOME`, `COURSES`, `LOGIN`, `DASHBOARD`, `TEACHER`, `ADMIN`, `PROFILE`, `CERTIFICATES`, `CALENDAR`, `REGISTER`, `FORGOT_PASSWORD`, `RESET_PASSWORD`, etc.)
- Builder functions for parametrised routes (`courseDetail(id)`, `chapter(courseId, moduleId, chapterId)`, `teacherChapterEditor(...)`, etc.) — typo'd segment names become compile errors instead of runtime 404s

**This commit lands the pattern + the constants module.** Call-site migration is deferred to a per-route follow-up so the touched surface stays small and reviewable; new code added going forward should use `ROUTES.*` from the start.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 316 passed across 45 files
- [ ] Backend untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)