### PR TITLE
feat(bilingual): TDD — per-field source-language detection in pipeline (B2)

### DIFF
--- a/backend/app/services/translation/orchestrator.py
+++ b/backend/app/services/translation/orchestrator.py
@@ -63,12 +63,22 @@ class TranslationFieldSpec:
 
     ``text`` is allowed to be empty / ``None``; the orchestrator skips those
     rows so the caller can build the spec list naively without filtering.
+
+    ``source_locale`` is an OPTIONAL per-field override of the
+    entity-level source locale. When set, this field's translation
+    fires from this language into every OTHER supported locale —
+    regardless of the entity-level ``source_locale`` passed to
+    ``translate_entity_fields``. Callers populate it from a
+    per-field language detector (see ``reconcile_entity``) so an
+    entity whose title is in one language and description in another
+    gets each field translated in the correct direction.
     """
 
     field: TranslationField
     text: str | None
     # See ``TranslationRequest.content_kind`` — chooses prompt nuances.
     content_kind: ContentKind = "plain"
+    source_locale: LocaleCode | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,10 +127,11 @@ def translate_entity_fields(
         logger.info("Translation disabled; skipping %s:%s", entity_type, entity_id)
         return OrchestratorReport()
 
-    targets = target_locales if target_locales is not None else other_locales(source_locale)
-    if not targets:
-        return OrchestratorReport()
-
+    # ``target_locales`` is a caller override for the entire batch.
+    # When unset (the common case), each field computes its own targets
+    # from its own ``source_locale`` (per-field detection in
+    # ``reconcile_entity``) — that's what makes mixed-language entities
+    # translate in the correct direction per field.
     active_provider = provider or get_translation_provider()
     translated = 0
     skipped = 0
@@ -137,14 +148,23 @@ def translate_entity_fields(
             # not rows that never had work to do.
             continue
 
-        source_hash = compute_source_hash(text, locale=source_locale)
-        for target in targets:
+        # Per-field source-locale override (set by ``reconcile_entity``
+        # after running the language detector on this field's text).
+        # Falls back to the entity-level source_locale when unset, which
+        # preserves the existing single-language behaviour for callers
+        # that haven't opted into per-field detection.
+        field_source: LocaleCode = spec.source_locale or source_locale
+        field_targets = target_locales if target_locales is not None else other_locales(field_source)
+        if not field_targets:
+            continue
+        source_hash = compute_source_hash(text, locale=field_source)
+        for target in field_targets:
             outcome = _translate_one_field(
                 db,
                 entity_type=entity_type,
                 entity_id=entity_id,
                 field=spec.field,
-                source_locale=source_locale,
+                source_locale=field_source,
                 target_locale=target,
                 text=text,
                 content_kind=spec.content_kind,

--- a/backend/app/services/translation/registry.py
+++ b/backend/app/services/translation/registry.py
@@ -36,6 +36,7 @@ from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent
 from app.models.quiz import Quiz, QuizOption, QuizQuestion
 from app.schemas.locale import normalize_locale
+from app.services.language_detection import detect_locale
 from app.services.translation.orchestrator import (
     OrchestratorReport,
     TranslationFieldSpec,
@@ -297,14 +298,30 @@ def reconcile_entity(
     course = reg.resolve_course(db, entity)
     if course is None:
         return OrchestratorReport()
-    source_locale: LocaleCode = normalize_locale(course.source_locale)
+    course_source: LocaleCode = normalize_locale(course.source_locale)
 
     fields: list[TranslationFieldSpec] = []
     for fs in reg.fields:
         text = getattr(entity, fs.attr, None)
         if text is None or not str(text).strip():
             continue
-        fields.append(TranslationFieldSpec(field=fs.name, text=text, content_kind=fs.content_kind))
+        # Per-field language detection: the entity's actual content
+        # may be in a language different from the course's declared
+        # source (e.g. a teacher who pastes an English chapter title
+        # into a Russian-source course). The detector returns ``None``
+        # on sub-threshold or no-signal input; in that case we fall
+        # back to the course-level source so the existing behaviour
+        # is preserved for ambiguous fields.
+        detected = detect_locale(str(text))
+        field_source: LocaleCode = detected or course_source
+        fields.append(
+            TranslationFieldSpec(
+                field=fs.name,
+                text=text,
+                content_kind=fs.content_kind,
+                source_locale=field_source,
+            )
+        )
     if not fields:
         return OrchestratorReport()
 
@@ -316,7 +333,12 @@ def reconcile_entity(
         db,
         entity_type=entity_type,
         entity_id=str(entity.id),  # type: ignore[attr-defined]
-        source_locale=source_locale,
+        # ``source_locale`` here is the entity-level fallback for any
+        # field whose own ``source_locale`` is unset (couldn't be
+        # detected). Per-field overrides set above in ``fields`` are
+        # what actually drives the translation direction when the
+        # entity's content drifts from the course's declared source.
+        source_locale=course_source,
         fields=fields,
         context=context,
         provider=provider,

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -600,12 +600,18 @@ def test_walker_finds_quizzes_attached_via_chapter_id_only(db: Session):
     )
     db.add(chapter)
     db.flush()
-    quiz = Quiz(chapter_id=chapter.id, title="Pop quiz", description="Test")
+    # Russian content (course source_locale='ru'); per-entity language
+    # detection (PR B2) means each field is translated FROM its own
+    # detected language. To keep this test about *whether the walker
+    # finds the quiz* (not about translation direction), seed Russian
+    # text so the detector agrees with the course's source and the
+    # original ``[en]`` assertion stays meaningful.
+    quiz = Quiz(chapter_id=chapter.id, title="Контрольная работа", description="Проверка знаний")
     db.add(quiz)
     db.flush()
     question = QuizQuestion(
         quiz_id=quiz.id,
-        question_text="What is the answer?",
+        question_text="Какой правильный ответ на этот вопрос?",
         question_type="multiple_choice",
         order_index=0,
         points=1,
@@ -614,7 +620,7 @@ def test_walker_finds_quizzes_attached_via_chapter_id_only(db: Session):
     db.flush()
     option = QuizOption(
         question_id=question.id,
-        option_text="The answer",
+        option_text="Правильный ответ номер один",
         is_correct=True,
         order_index=0,
     )

--- a/backend/tests/test_translation_per_entity_source.py
+++ b/backend/tests/test_translation_per_entity_source.py
@@ -1,4 +1,3 @@
-# ruff: noqa: RUF001
 """TDD spec: per-entity source-language detection.
 
 After PR #526 (course-level detection) and PR #527 (purge on locale
@@ -156,9 +155,7 @@ class TestReconcileEntityDetectsPerFieldLanguage:
 
     def test_english_chapter_in_russian_course_translates_en_to_ru(self, db: Session):
         course = _make_course(db, source_locale="ru")
-        chapter = _make_chapter(
-            db, course, title="Welcome to the chapter on Genesis"
-        )
+        chapter = _make_chapter(db, course, title="Welcome to the chapter on Genesis")
         provider = _RecordingProvider()
 
         reconcile_entity(db, "chapter", chapter, provider=provider)
@@ -174,9 +171,7 @@ class TestReconcileEntityDetectsPerFieldLanguage:
 
     def test_russian_chapter_in_english_course_translates_ru_to_en(self, db: Session):
         course = _make_course(db, source_locale="en")
-        chapter = _make_chapter(
-            db, course, title="Введение в книгу Бытия и её главы"
-        )
+        chapter = _make_chapter(db, course, title="Введение в книгу Бытия и её главы")
         provider = _RecordingProvider()
 
         reconcile_entity(db, "chapter", chapter, provider=provider)
@@ -189,9 +184,7 @@ class TestReconcileEntityDetectsPerFieldLanguage:
     def test_chapter_in_same_language_as_course_uses_course_source(self, db: Session):
         """No regression for the common case: chapter matches course."""
         course = _make_course(db, source_locale="ru")
-        chapter = _make_chapter(
-            db, course, title="Введение в книгу Бытия и её главы"
-        )
+        chapter = _make_chapter(db, course, title="Введение в книгу Бытия и её главы")
         provider = _RecordingProvider()
 
         reconcile_entity(db, "chapter", chapter, provider=provider)
@@ -201,9 +194,7 @@ class TestReconcileEntityDetectsPerFieldLanguage:
         assert provider.calls[0]["source_locale"] == "ru"
         assert provider.calls[0]["target_locale"] == "en"
 
-    def test_chapter_with_unintelligible_title_falls_back_to_course_source(
-        self, db: Session
-    ):
+    def test_chapter_with_unintelligible_title_falls_back_to_course_source(self, db: Session):
         """Too short / no signal: fall back to course.source_locale.
         Otherwise a 2-letter title silently flips translation direction."""
         course = _make_course(db, source_locale="ru")
@@ -225,9 +216,7 @@ class TestReconcileEntityHandlesMixedFieldLanguages:
     independently — the orchestrator's per-field translate call uses
     each field's own detected source."""
 
-    def test_module_with_mixed_field_languages_translates_each_separately(
-        self, db: Session
-    ):
+    def test_module_with_mixed_field_languages_translates_each_separately(self, db: Session):
         course = _make_course(db, source_locale="ru")
         module = Module(
             id=str(uuid.uuid4()),

--- a/backend/tests/test_translation_per_entity_source.py
+++ b/backend/tests/test_translation_per_entity_source.py
@@ -1,0 +1,255 @@
+# ruff: noqa: RUF001
+"""TDD spec: per-entity source-language detection.
+
+After PR #526 (course-level detection) and PR #527 (purge on locale
+flip), the next bilingual gap is per-entity drift: a teacher writing
+inside a RU-source course can author one chapter in English (or vice
+versa). The pipeline today reads ``course.source_locale`` for every
+nested entity, mistranslates the off-language ones, and the resolve
+path serves the wrong language to students.
+
+Spec:
+  * Pipeline: each ``reconcile_entity`` call detects the actual
+    language of EACH text field and uses that — not the course's
+    declared source — as the translation source. Fields with no
+    detection signal fall back to the course's source_locale.
+  * Resolve: the display path detects the language of an entity's
+    base text per field; when display_locale matches the detected
+    source, return the base text (no overlay lookup); otherwise
+    serve the overlay.
+
+Tests written BEFORE implementation — RED first commit.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from pydantic import SecretStr
+from sqlalchemy.orm import Session
+
+from app.models.course import Chapter, Course, Module
+from app.models.user import User, UserRole
+from app.services.translation.registry import reconcile_entity
+from app.services.translation.service import reset_translation_provider_cache
+
+TEACHER_ID = uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+
+
+@pytest.fixture
+def db():
+    from tests.conftest import test_engine
+
+    session = Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture(autouse=True)
+def _enable_translation(monkeypatch):
+    """Enable the translation provider for these tests; mirrors the
+    existing pattern from ``test_translation_orchestrator.py``."""
+    monkeypatch.setattr(
+        "app.services.translation.service.settings.GEMINI_API_KEY",
+        SecretStr("fake-test-key"),
+        raising=False,
+    )
+    reset_translation_provider_cache()
+    yield
+    reset_translation_provider_cache()
+
+
+def _make_teacher(db: Session) -> User:
+    existing = db.query(User).filter(User.id == TEACHER_ID).first()
+    if existing:
+        return existing
+    user = User(
+        id=TEACHER_ID,
+        email=f"per-entity-{uuid.uuid4()}@test",
+        full_name="Test Teacher",
+        role=UserRole.TEACHER.value,
+        preferred_locale="en",
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _make_course(db: Session, **overrides: Any) -> Course:
+    _make_teacher(db)
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "title": "RU course default title",
+        "description": "RU course default description",
+        "status": "published",
+        "source_locale": "ru",
+        "created_by": TEACHER_ID,
+    }
+    defaults.update(overrides)
+    course = Course(**defaults)
+    db.add(course)
+    db.commit()
+    db.refresh(course)
+    return course
+
+
+def _make_chapter(db: Session, course: Course, *, title: str) -> Chapter:
+    module = Module(
+        id=str(uuid.uuid4()),
+        course_id=course.id,
+        title="Some module",
+        order_index=0,
+    )
+    db.add(module)
+    db.flush()
+    chapter = Chapter(
+        id=str(uuid.uuid4()),
+        module_id=module.id,
+        title=title,
+        order_index=0,
+        chapter_type="reading",
+    )
+    db.add(chapter)
+    db.commit()
+    db.refresh(chapter)
+    return chapter
+
+
+class _RecordingProvider:
+    """Records the locale arguments each translate call was given, so
+    the test can assert which direction the orchestrator picked."""
+
+    name = "recording"
+
+    def __init__(self):
+        self.calls: list[dict[str, Any]] = []
+
+    def translate(self, request):
+        self.calls.append(
+            {
+                "text": request.text,
+                "source_locale": request.source_locale,
+                "target_locale": request.target_locale,
+                "content_kind": request.content_kind,
+            }
+        )
+        from app.services.translation.protocol import TranslationResult
+
+        return TranslationResult(
+            text=f"[{request.target_locale}] {request.text}",
+            model="recording",
+        )
+
+    def translate_batch(self, requests):
+        return [self.translate(r) for r in requests]
+
+
+class TestReconcileEntityDetectsPerFieldLanguage:
+    """When an entity's text is in a different language than its
+    course's declared source, the orchestrator must translate FROM
+    the entity's actual language to all OTHER supported locales —
+    not from the course's declared (and wrong) source."""
+
+    def test_english_chapter_in_russian_course_translates_en_to_ru(self, db: Session):
+        course = _make_course(db, source_locale="ru")
+        chapter = _make_chapter(
+            db, course, title="Welcome to the chapter on Genesis"
+        )
+        provider = _RecordingProvider()
+
+        reconcile_entity(db, "chapter", chapter, provider=provider)
+
+        # The chapter title is English. Pipeline should detect EN and
+        # translate to RU (the "other" locale relative to EN), NOT to
+        # EN (which would be the "other" relative to the course's
+        # declared RU).
+        assert len(provider.calls) == 1, "Should make one EN→RU call, not RU→EN"
+        call = provider.calls[0]
+        assert call["source_locale"] == "en"
+        assert call["target_locale"] == "ru"
+
+    def test_russian_chapter_in_english_course_translates_ru_to_en(self, db: Session):
+        course = _make_course(db, source_locale="en")
+        chapter = _make_chapter(
+            db, course, title="Введение в книгу Бытия и её главы"
+        )
+        provider = _RecordingProvider()
+
+        reconcile_entity(db, "chapter", chapter, provider=provider)
+
+        assert len(provider.calls) == 1
+        call = provider.calls[0]
+        assert call["source_locale"] == "ru"
+        assert call["target_locale"] == "en"
+
+    def test_chapter_in_same_language_as_course_uses_course_source(self, db: Session):
+        """No regression for the common case: chapter matches course."""
+        course = _make_course(db, source_locale="ru")
+        chapter = _make_chapter(
+            db, course, title="Введение в книгу Бытия и её главы"
+        )
+        provider = _RecordingProvider()
+
+        reconcile_entity(db, "chapter", chapter, provider=provider)
+
+        # Russian chapter, Russian course → translate RU→EN.
+        assert len(provider.calls) == 1
+        assert provider.calls[0]["source_locale"] == "ru"
+        assert provider.calls[0]["target_locale"] == "en"
+
+    def test_chapter_with_unintelligible_title_falls_back_to_course_source(
+        self, db: Session
+    ):
+        """Too short / no signal: fall back to course.source_locale.
+        Otherwise a 2-letter title silently flips translation direction."""
+        course = _make_course(db, source_locale="ru")
+        chapter = _make_chapter(db, course, title="X")  # below detector threshold
+        provider = _RecordingProvider()
+
+        reconcile_entity(db, "chapter", chapter, provider=provider)
+
+        assert len(provider.calls) == 1
+        # Fall back to course source (ru) → translate to other locale (en).
+        assert provider.calls[0]["source_locale"] == "ru"
+        assert provider.calls[0]["target_locale"] == "en"
+
+
+class TestReconcileEntityHandlesMixedFieldLanguages:
+    """An entity can have title in one language and description in
+    another (e.g. a Russian course with an English announcement that
+    accidentally has a Russian subtitle). Each field is detected
+    independently — the orchestrator's per-field translate call uses
+    each field's own detected source."""
+
+    def test_module_with_mixed_field_languages_translates_each_separately(
+        self, db: Session
+    ):
+        course = _make_course(db, source_locale="ru")
+        module = Module(
+            id=str(uuid.uuid4()),
+            course_id=course.id,
+            title="Module 1: Introduction to Genesis",  # English
+            description="Описание модуля на русском языке",  # Russian
+            order_index=0,
+        )
+        db.add(module)
+        db.commit()
+        db.refresh(module)
+        provider = _RecordingProvider()
+
+        reconcile_entity(db, "module", module, provider=provider)
+
+        # Two calls — one per field, each with its own detected source.
+        assert len(provider.calls) == 2
+        title_call = next(c for c in provider.calls if "Genesis" in c["text"])
+        desc_call = next(c for c in provider.calls if "Описание" in c["text"])
+
+        assert title_call["source_locale"] == "en"
+        assert title_call["target_locale"] == "ru"
+
+        assert desc_call["source_locale"] == "ru"
+        assert desc_call["target_locale"] == "en"


### PR DESCRIPTION
## Summary

Third in the bilingual TDD series (after #526 source detection, #527 stale-purge). Closes the gap where a teacher writing inside a RU-source course can author one chapter in English (or vice versa) — today the pipeline reads \`course.source_locale\` for every nested entity and translates that mismatched chapter in the wrong direction.

## TDD cycle

- **Commit 1 (RED)** — 5 new tests in \`test_translation_per_entity_source.py\`, 3 failing.
- **Commit 2 (GREEN)** — extends the orchestrator + registry with per-field detection. All 5 pass; one existing walker test updated for the new contract.

## What lands

### \`orchestrator.py\` — per-field source override

\`TranslationFieldSpec\` gains an optional \`source_locale\` per-field. Default \`None\` preserves existing entity-level behaviour. \`translate_entity_fields\` resolves each spec's \`source_locale or source_locale_arg\` and computes its own \`other_locales(field_source)\` per field. The entity-level \`source_locale\` parameter is now the **fallback** for fields with no detected language (sub-threshold or no-signal text).

### \`registry.py\` — detection wired in

\`reconcile_entity\` runs \`detect_locale\` on each translatable text field. Detected language becomes that field's \`source_locale\` on the spec; entity-level \`course_source\` stays the fallback.

## What this fixes

- **Russian title in English-source course** → translates RU→EN (was EN→RU, garbage)
- **English title in Russian-source course** → translates EN→RU (was RU→EN, garbage)
- **Mixed-language entity** (title in EN, description in RU on the same module): each field gets its own per-field detection — title translates EN→RU and description RU→EN in the same reconcile call

## What this does NOT fix (separate follow-up)

The RESOLVE path (\`resolve_for_display.py\`) still uses \`course.source_locale\` for the display-vs-source equality check. After this PR the pipeline produces correct rows for the correct target locales, so the EN student sees the EN translation row when an entity is RU-only — but an EN student looking at an EN-authored chapter in a RU-source course will go through the \`en != course.ru\` branch and find no overlay (correct base text returned by fallback). The RU-display case for the EN entity is the gap left for the next PR — needs \`detect_locale\` in the resolve path too.

## Tests

**5 new in \`test_translation_per_entity_source.py\`:**
- \`test_english_chapter_in_russian_course_translates_en_to_ru\`
- \`test_russian_chapter_in_english_course_translates_ru_to_en\`
- \`test_chapter_in_same_language_as_course_uses_course_source\`
- \`test_chapter_with_unintelligible_title_falls_back_to_course_source\`
- \`test_module_with_mixed_field_languages_translates_each_separately\`

**1 existing updated:** \`test_walker_finds_quizzes_attached_via_chapter_id_only\` — quiz text changed from English to Russian so the test stays about *whether the walker finds the quiz* and not about translation direction.

## Test plan

- [x] \`python -m pytest tests/\` — 799 passed
- [x] \`python -m ruff check .\` clean
- [x] \`python -m ruff format --check .\` clean
- [x] \`mypy --config-file mypy.ini\` — 119 source files, no issues
- [ ] Frontend untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)