### PR TITLE
feat(bilingual): V1 phase 0 — content_versions foundation

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.chapter_block import ChapterBlock
 from app.models.chapter_progress import ChapterProgress
 from app.models.cohort import Cohort
 from app.models.content_translation import ContentTranslation
+from app.models.content_version import ContentVersion
 from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent
 from app.models.enrollment import Enrollment
@@ -34,6 +35,7 @@ __all__ = [
     "ChapterProgress",
     "Cohort",
     "ContentTranslation",
+    "ContentVersion",
     "Course",
     "CourseEvent",
     "CoursePrerequisite",

--- a/backend/app/models/content_version.py
+++ b/backend/app/models/content_version.py
@@ -1,0 +1,183 @@
+"""ORM mapping for ``content_versions`` — the single multi-locale text store.
+
+Replaces the dual-table model (entity text columns = source +
+``content_translations`` = overlay). Every ``(entity, field, locale)``
+is a first-class row with its own provenance, status, and version
+chain.
+
+Phase rollout
+-------------
+
+Phase 0 (this file): table + model + Pydantic mirror. Zero behaviour
+change — nothing reads or writes from it yet.
+
+Phase 1: dual-writes from every entity write path + the MT
+pipeline. Reads still go to entity columns + ``content_translations``.
+
+Phase 2: dual-reads. Resolve tries this table first, falls back to
+the legacy stores. Mismatches logged.
+
+Phase 3: backfill existing data into here.
+
+Phase 4: switch reads exclusive.
+
+Phase 5: drop entity text columns + drop ``content_translations`` +
+delete dead overlay code.
+
+Design rules pinned by the schema
+---------------------------------
+
+* ``locale`` has no CHECK constraint at the DB level — adding a new
+  language is INSERT, not DDL. The supported set is validated only at
+  the API edge via the Pydantic ``LocaleCode`` Literal.
+* Exactly one ACTIVE version per ``(entity, field, locale)`` via the
+  partial unique index ``uniq_content_versions_active``. Updates
+  supersede (set the old row's ``superseded_by``) instead of
+  overwriting — translation history is never destroyed.
+* ``origin`` distinguishes ``human`` (typed by a teacher / admin) from
+  ``mt`` (Gemini output). The MT pipeline never overwrites a ``human``
+  row; that's enforced by the orchestrator, not by a DB constraint
+  (constraint would be too restrictive — operators can override).
+* ``source_version_id`` lets MT rows point at the EXACT version they
+  were translated from. When a human row is superseded, every MT
+  derivative is precisely invalidatable — no more blunderbuss
+  ``purge_course_translations``.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID as PgUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+# Mirrors ``content_versions.entity_type`` (no DB CHECK — see schema
+# comment). The set here is the SUPPORTED-by-the-app surface; adding
+# a new entity type means appending here AND ensuring the registry
+# (``app/services/translation/registry.py`` or its V1 successor)
+# knows how to walk it. No migration needed.
+ContentVersionEntityType = Literal[
+    "course",
+    "module",
+    "chapter",
+    "chapter_block",
+    "quiz",
+    "quiz_question",
+    "quiz_option",
+    "assignment",
+    "announcement",
+    "course_event",
+    "cohort",
+]
+
+ContentVersionField = Literal[
+    "title",
+    "description",
+    "content",
+    "question_text",
+    "option_text",
+    "instructions",
+]
+
+ContentVersionOrigin = Literal["human", "mt"]
+ContentVersionStatus = Literal["ok", "failed", "failed_permanent"]
+
+# How many MT attempts we tolerate before promoting to
+# ``failed_permanent``. Centralised here so admin tooling that
+# re-queues a row refers back to the same constant.
+CONTENT_VERSION_MAX_ATTEMPTS = 5
+
+
+class ContentVersion(Base):
+    __tablename__ = "content_versions"
+    __table_args__ = (
+        # Partial unique: exactly one ACTIVE version per
+        # (entity, field, locale). Superseded rows are excluded so a
+        # teacher can supersede a translation without violating the
+        # constraint. Both ``postgresql_where`` (prod) and
+        # ``sqlite_where`` (tests) are required — without the SQLite
+        # variant, SQLite emits a full unique constraint that would
+        # forbid supersession.
+        Index(
+            "uniq_content_versions_active",
+            "entity_type",
+            "entity_id",
+            "field",
+            "locale",
+            unique=True,
+            postgresql_where="superseded_by IS NULL",
+            sqlite_where=text("superseded_by IS NULL"),
+        ),
+        Index(
+            "ix_content_versions_active_lookup",
+            "entity_type",
+            "entity_id",
+            "locale",
+            postgresql_where="superseded_by IS NULL AND status = 'ok'",
+            sqlite_where=text("superseded_by IS NULL AND status = 'ok'"),
+        ),
+        Index("ix_content_versions_entity", "entity_type", "entity_id"),
+        Index(
+            "ix_content_versions_source_version",
+            "source_version_id",
+            postgresql_where="source_version_id IS NOT NULL",
+            sqlite_where=text("source_version_id IS NOT NULL"),
+        ),
+        CheckConstraint("origin IN ('human', 'mt')", name="content_versions_origin_check"),
+        CheckConstraint(
+            "status IN ('ok', 'failed', 'failed_permanent')",
+            name="content_versions_status_check",
+        ),
+        CheckConstraint("attempts >= 0", name="content_versions_attempts_check"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    entity_type: Mapped[str] = mapped_column(Text)
+    entity_id: Mapped[str] = mapped_column(Text)
+    field: Mapped[str] = mapped_column(Text)
+    locale: Mapped[str] = mapped_column(Text)
+
+    text: Mapped[str] = mapped_column(Text)
+
+    origin: Mapped[str] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(Text, default="ok", server_default="ok")
+
+    source_hash: Mapped[str | None] = mapped_column(Text)
+    source_locale: Mapped[str | None] = mapped_column(Text)
+    source_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("content_versions.id", ondelete="SET NULL"),
+    )
+
+    authored_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("profiles.id", ondelete="SET NULL"),
+    )
+
+    attempts: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+
+    superseded_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("content_versions.id", ondelete="SET NULL"),
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ContentVersion entity={self.entity_type}:{self.entity_id} "
+            f"field={self.field} locale={self.locale} "
+            f"origin={self.origin} status={self.status}>"
+        )

--- a/backend/tests/test_content_versions_schema.py
+++ b/backend/tests/test_content_versions_schema.py
@@ -1,0 +1,275 @@
+"""Schema-level tests for ``content_versions``.
+
+Phase 0 of the V1 migration (single multi-locale content store). This
+file pins the schema-level invariants — anything a future migration
+might break needs to fail loudly here.
+
+What's pinned
+-------------
+
+* Required vs nullable columns (text + identifiers required; MT-only
+  provenance nullable).
+* CHECK constraints (``origin``, ``status``, ``attempts >= 0``).
+* The active-uniqueness rule: exactly one current version per
+  ``(entity, field, locale)`` — duplicate inserts when both are
+  active must fail.
+* Supersession is the only legal way to "update" a version — the old
+  row stays, the new row points back via ``superseded_by``.
+* Locale has NO CHECK constraint — adding a new language must be
+  pure INSERT, not DDL.
+* Foreign keys (``source_version_id``, ``authored_by``,
+  ``superseded_by``) have ON DELETE SET NULL so deleting a user or
+  superseded row doesn't cascade-destroy history.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.content_version import (
+    CONTENT_VERSION_MAX_ATTEMPTS,
+    ContentVersion,
+)
+
+
+@pytest.fixture
+def db():
+    from tests.conftest import test_engine
+
+    session = Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_row(
+    db: Session,
+    *,
+    entity_type: str = "course",
+    entity_id: str = "ent-1",
+    field: str = "title",
+    locale: str = "en",
+    text: str = "Hello",
+    origin: str = "human",
+    **overrides,
+) -> ContentVersion:
+    row = ContentVersion(
+        id=uuid.uuid4(),
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        locale=locale,
+        text=text,
+        origin=origin,
+        **overrides,
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+class TestRequiredFields:
+    """The five identifying columns + ``text`` + ``origin`` are all
+    NOT NULL. A row missing any of them is meaningless."""
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["entity_type", "entity_id", "field", "locale", "text", "origin"],
+    )
+    def test_missing_required_field_rejected(self, db: Session, missing_field: str):
+        kwargs: dict = {
+            "entity_type": "course",
+            "entity_id": "x",
+            "field": "title",
+            "locale": "en",
+            "text": "Hello",
+            "origin": "human",
+        }
+        kwargs.pop(missing_field)
+        # Pass via ORM; SQLAlchemy + DB NOT NULL should reject. We
+        # construct the row manually so a missing kwarg surfaces as
+        # the DB's NOT NULL violation, not a Python TypeError.
+        row = ContentVersion(id=uuid.uuid4(), **kwargs)
+        db.add(row)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_optional_columns_accept_null(self, db: Session):
+        # MT-only columns + authored_by + superseded_by are all nullable.
+        row = _make_row(db, origin="human")
+        assert row.source_hash is None
+        assert row.source_locale is None
+        assert row.source_version_id is None
+        assert row.authored_by is None
+        assert row.superseded_by is None
+
+
+class TestOriginAndStatusChecks:
+    def test_invalid_origin_rejected(self, db: Session):
+        with pytest.raises(IntegrityError):
+            _make_row(db, origin="invalid")
+        db.rollback()
+
+    @pytest.mark.parametrize("origin", ["human", "mt"])
+    def test_valid_origin_accepted(self, db: Session, origin: str):
+        row = _make_row(db, origin=origin, entity_id=f"e-{origin}")
+        assert row.origin == origin
+
+    def test_invalid_status_rejected(self, db: Session):
+        row = ContentVersion(
+            id=uuid.uuid4(),
+            entity_type="course",
+            entity_id="x",
+            field="title",
+            locale="en",
+            text="x",
+            origin="human",
+            status="bogus",
+        )
+        db.add(row)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    @pytest.mark.parametrize("status", ["ok", "failed", "failed_permanent"])
+    def test_valid_status_accepted(self, db: Session, status: str):
+        row = _make_row(db, entity_id=f"e-{status}", status=status)
+        assert row.status == status
+
+    def test_status_defaults_to_ok(self, db: Session):
+        row = _make_row(db)
+        assert row.status == "ok"
+
+
+class TestActiveUniqueness:
+    """At most one active version per (entity, field, locale). The
+    constraint is partial — superseded rows are excluded — so
+    versioning by supersession remains legal."""
+
+    def test_two_active_rows_with_same_key_rejected(self, db: Session):
+        _make_row(db, entity_id="dup-1", field="title", locale="en")
+        # Second row with the same active key violates the partial
+        # unique index.
+        with pytest.raises(IntegrityError):
+            _make_row(db, entity_id="dup-1", field="title", locale="en")
+        db.rollback()
+
+    def test_same_key_different_locale_is_fine(self, db: Session):
+        _make_row(db, entity_id="multi-1", field="title", locale="en")
+        _make_row(db, entity_id="multi-1", field="title", locale="ru")
+        rows = (
+            db.query(ContentVersion)
+            .filter(ContentVersion.entity_id == "multi-1", ContentVersion.field == "title")
+            .all()
+        )
+        assert {r.locale for r in rows} == {"en", "ru"}
+
+    def test_same_key_different_field_is_fine(self, db: Session):
+        _make_row(db, entity_id="multi-2", field="title", locale="en")
+        _make_row(db, entity_id="multi-2", field="description", locale="en")
+        count = (
+            db.query(ContentVersion)
+            .filter(ContentVersion.entity_id == "multi-2", ContentVersion.locale == "en")
+            .count()
+        )
+        assert count == 2
+
+    def test_supersession_releases_active_slot(self, db: Session):
+        # The partial unique index permits ONE active row per key but
+        # any number of superseded ones. We verify the end-state
+        # directly: insert the new version first (call it v2) so it
+        # owns the active slot, then insert the older version (v1)
+        # already pointing at v2 via ``superseded_by``. The two rows
+        # coexist for the same (entity, field, locale) because v1 is
+        # inactive.
+        #
+        # We deliberately don't test the live "supersede an existing
+        # active row" write sequence here — that requires deferring
+        # FK checks (Postgres DEFERRABLE INITIALLY DEFERRED) and is
+        # an app-write-helper concern that lives in its own test
+        # once the helper exists.
+        v2 = _make_row(db, entity_id="super-1", field="title", locale="en", text="v2")
+        db.add(
+            ContentVersion(
+                id=uuid.uuid4(),
+                entity_type="course",
+                entity_id="super-1",
+                field="title",
+                locale="en",
+                text="v1",
+                origin="human",
+                superseded_by=v2.id,
+            )
+        )
+        db.commit()
+        active_rows = (
+            db.query(ContentVersion)
+            .filter(
+                ContentVersion.entity_id == "super-1",
+                ContentVersion.field == "title",
+                ContentVersion.locale == "en",
+                ContentVersion.superseded_by.is_(None),
+            )
+            .all()
+        )
+        assert len(active_rows) == 1
+        assert active_rows[0].text == "v2"
+        # History preserved: v1 still in the table, just inactive.
+        all_rows = (
+            db.query(ContentVersion)
+            .filter(
+                ContentVersion.entity_id == "super-1",
+                ContentVersion.field == "title",
+                ContentVersion.locale == "en",
+            )
+            .all()
+        )
+        assert {r.text for r in all_rows} == {"v1", "v2"}
+
+
+class TestLocaleHasNoDbCheck:
+    """The whole point of the design: adding a new language must be
+    INSERT, not DDL. The DB MUST NOT have a CHECK constraint on
+    ``locale``."""
+
+    def test_arbitrary_locale_string_accepted(self, db: Session):
+        # The Pydantic Literal at the API edge controls the
+        # supported set — but at the DB level, ``locale`` is just
+        # text. Any string fits. ``yo-Latn-NG`` is a real BCP-47
+        # locale (Yoruba in Latin script in Nigeria); we don't
+        # support it today but the DB must let us tomorrow.
+        row = _make_row(db, locale="yo-Latn-NG", entity_id="locale-test")
+        assert row.locale == "yo-Latn-NG"
+
+
+class TestAttemptsCheck:
+    def test_negative_attempts_rejected(self, db: Session):
+        row = ContentVersion(
+            id=uuid.uuid4(),
+            entity_type="course",
+            entity_id="att-1",
+            field="title",
+            locale="en",
+            text="x",
+            origin="mt",
+            attempts=-1,
+        )
+        db.add(row)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_zero_attempts_is_the_default(self, db: Session):
+        row = _make_row(db)
+        assert row.attempts == 0
+
+    def test_max_attempts_constant_exposed(self):
+        # Centralised constant so admin tooling that re-queues a row
+        # refers to the same threshold the orchestrator uses.
+        assert CONTENT_VERSION_MAX_ATTEMPTS == 5

--- a/supabase/migrations/20260527230000_content_versions_foundation.sql
+++ b/supabase/migrations/20260527230000_content_versions_foundation.sql
@@ -1,0 +1,167 @@
+-- =====================================================================
+-- ``content_versions`` — single multi-locale content store.
+--
+-- Replaces the dual-model "text on entity columns (source) + overlay
+-- in content_translations (translations)" with a symmetric one-table
+-- design: every (entity, field, locale) is its own first-class row.
+--
+-- Design principles
+--   * No language is privileged. ``locale`` is just a column, not a
+--     CHECK constraint — adding a new language is INSERT, not DDL.
+--   * Version history via ``superseded_by``: updates never destroy
+--     prior text. Only the active version per (entity, field, locale)
+--     has ``superseded_by IS NULL``; the partial unique index
+--     ``uniq_content_versions_active`` enforces exactly one.
+--   * ``origin='human'`` rows are authored by teachers / admins;
+--     ``origin='mt'`` rows are machine-translated and remember their
+--     source via ``source_version_id`` for precise cascade
+--     invalidation when the source human row updates.
+--   * ``status`` tracks failure state for the MT path; human rows are
+--     always ``ok`` by construction.
+--
+-- This table is created EMPTY. Phase 1 begins dual-writes into it
+-- from every entity write path. Phase 2 begins dual-reads. Phase 3
+-- backfills existing entity columns + content_translations into here.
+-- Phase 4 flips reads exclusive. Phase 5 drops entity text columns
+-- and the legacy content_translations table.
+-- =====================================================================
+
+CREATE TABLE content_versions (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Polymorphic anchor: the entity this content belongs to.
+  -- ``entity_type`` deliberately has no CHECK constraint here so a
+  -- future new translatable entity type (a new content category we
+  -- haven't shipped yet) needs no migration. Validation lives in the
+  -- Pydantic Literal mirror at the API edge.
+  entity_type         text NOT NULL,
+  entity_id           text NOT NULL,
+  field               text NOT NULL,
+
+  -- The locale this row's text is written in. No CHECK — adding a new
+  -- language is a zero-DDL operation. Pydantic Literal is the single
+  -- source of truth at the API edge.
+  locale              text NOT NULL,
+
+  text                text NOT NULL,
+
+  -- ``human`` rows are authored by teachers (or admins via overrides)
+  -- and are never overwritten by the MT pipeline. ``mt`` rows are
+  -- machine translations the pipeline owns end to end.
+  origin              text NOT NULL CHECK (origin IN ('human', 'mt')),
+
+  -- MT lifecycle status. ``human`` rows are always 'ok' by
+  -- construction (they have no failure mode — they're typed in).
+  -- ``failed`` rows retry on the next pipeline pass up to a cap;
+  -- ``failed_permanent`` rows stop retrying and need manual review.
+  status              text NOT NULL DEFAULT 'ok'
+                      CHECK (status IN ('ok', 'failed', 'failed_permanent')),
+
+  -- MT-only provenance: hash of (source_text + source_locale) at
+  -- translation time. Allows the orchestrator to short-circuit on
+  -- unchanged sources (``status='ok'`` + matching hash → skip
+  -- Gemini). NULL for human rows.
+  source_hash         text,
+
+  -- MT-only: the locale of the source this row was translated FROM.
+  -- Lets the resolver and the cascade-invalidation logic answer
+  -- "given the EN human source changed, which MT rows need
+  -- re-translation?" without re-detecting language at runtime.
+  source_locale       text,
+
+  -- MT-only FK: the exact version row this MT was translated from.
+  -- When a human row supersedes itself (teacher rewrites), every MT
+  -- row with ``source_version_id`` pointing at the superseded human
+  -- version is now stale and can be cascaded precisely (vs the
+  -- current ``purge_course_translations`` blunderbuss that nukes
+  -- everything for the course). NULL for human rows and for legacy
+  -- MT rows backfilled before this FK was available.
+  source_version_id   uuid REFERENCES content_versions(id) ON DELETE SET NULL,
+
+  -- The human who wrote this version. NULL for MT rows and for human
+  -- rows whose author was deleted from the platform.
+  authored_by         uuid REFERENCES profiles(id) ON DELETE SET NULL,
+
+  -- How many translation attempts this MT row has burned. Resets to
+  -- 0 implicitly when a row goes back to ``ok``. Always 0 for human
+  -- rows.
+  attempts            int NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+
+  -- Version history pointer. When a row is superseded, the new
+  -- version sets the old version's ``superseded_by`` to its own id.
+  -- The old row stays in the table forever — translation history
+  -- never gets destroyed, only marked inactive.
+  superseded_by       uuid REFERENCES content_versions(id) ON DELETE SET NULL,
+
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- Active uniqueness: exactly ONE current version per
+-- (entity, field, locale). Superseded rows are excluded so a teacher
+-- can supersede a translation without violating uniqueness.
+CREATE UNIQUE INDEX uniq_content_versions_active
+  ON content_versions (entity_type, entity_id, field, locale)
+  WHERE superseded_by IS NULL;
+
+-- Hot-path read index: "give me every current version for this
+-- entity, in this locale". The resolver hits this on every
+-- chapter/course render — needs to be a partial index that already
+-- filters out superseded + failed rows so the planner doesn't even
+-- consider them.
+CREATE INDEX ix_content_versions_active_lookup
+  ON content_versions (entity_type, entity_id, locale)
+  WHERE superseded_by IS NULL AND status = 'ok';
+
+-- Per-entity bulk index: needed for the "delete all rows for this
+-- course" administrative purge and for the cascade-invalidation
+-- query "find every MT row sourced from this human row's chain".
+CREATE INDEX ix_content_versions_entity
+  ON content_versions (entity_type, entity_id);
+
+-- MT cascade index: when a human row updates, find every MT row
+-- that was derived from it (or from any of its prior versions).
+CREATE INDEX ix_content_versions_source_version
+  ON content_versions (source_version_id)
+  WHERE source_version_id IS NOT NULL;
+
+-- ``updated_at`` auto-bump trigger — matches the convention used
+-- everywhere else in the schema.
+CREATE OR REPLACE FUNCTION content_versions_set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER content_versions_updated_at
+  BEFORE UPDATE ON content_versions
+  FOR EACH ROW
+  EXECUTE FUNCTION content_versions_set_updated_at();
+
+-- RLS — service role has full access (backend uses it for writes);
+-- authenticated users can read any ok+active row (resolve path needs
+-- this for student-facing translations). No direct INSERT/UPDATE from
+-- end users — every mutation flows through the backend's typed write
+-- helpers which use the service role.
+ALTER TABLE content_versions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY content_versions_service_role_all
+  ON content_versions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY content_versions_authenticated_read
+  ON content_versions
+  FOR SELECT
+  TO authenticated
+  USING (status = 'ok' AND superseded_by IS NULL);
+
+CREATE POLICY content_versions_anon_read
+  ON content_versions
+  FOR SELECT
+  TO anon
+  USING (status = 'ok' AND superseded_by IS NULL);


### PR DESCRIPTION
## What

Phase 0 of the V1 bilingual architectural rebuild — lays down the empty `content_versions` table, ORM mapping, and schema-invariant tests. **Zero behaviour change** — nothing reads or writes from it yet.

This is the foundation of a 6-phase migration that replaces today's two-store model (source text on entity columns + translations overlay in `content_translations`) with a single symmetric store where every `(entity, field, locale)` is a first-class row.

## Why

Today's model treats one language as "source" and the rest as overlay. That assumption broke at least once already (Vadym's "Тайтл" course, where a Russian-content course got `source_locale='en'` because the teacher's UI was English). It also doesn't scale: every new language adds overlay complexity and every "source rewrite" loses translation history.

The new model is symmetric:

* `locale` is just a column. Adding a language is INSERT + a Pydantic Literal append. **Zero DDL.**
* Every version is preserved via `superseded_by` — translation history never gets destroyed.
* MT rows point at their exact source version (`source_version_id`), so cascade invalidation when a human row updates is precise instead of the current blunderbuss `purge_course_translations`.

## What's in this PR

| File | Purpose |
|---|---|
| `supabase/migrations/20260527230000_content_versions_foundation.sql` | The full DDL (already applied to prod via MCP — committing for git tracking) |
| `backend/app/models/content_version.py` | SQLAlchemy ORM + `ContentVersionEntityType` / `ContentVersionField` / `ContentVersionOrigin` / `ContentVersionStatus` Literals + `CONTENT_VERSION_MAX_ATTEMPTS` constant |
| `backend/app/models/__init__.py` | Registers the model |
| `backend/tests/test_content_versions_schema.py` | 23 schema-invariant tests |

## Tests pin (all 23 green)

* Required columns reject NULL (5 identifiers + `text` + `origin`)
* `origin` CHECK rejects anything other than `human` / `mt`
* `status` CHECK rejects anything other than `ok` / `failed` / `failed_permanent`
* `attempts >= 0`
* Partial unique permits exactly one active row per `(entity, field, locale)`
* Same key, different `locale` or `field` → coexist fine
* Supersession releases the active slot; history is preserved
* **Locale has no CHECK** — arbitrary BCP-47 strings accepted at the DB level
* `CONTENT_VERSION_MAX_ATTEMPTS` exposed for admin tooling

Full backend regression: **861/861 passing.** Ruff clean. Mypy clean.

## Migration trail

| Phase | What | Status |
|---|---|---|
| 0 | Foundation (this PR) | shipping |
| 1 | Dual-write on every write path | next |
| 2 | Dual-read with mismatch logging | pending |
| 3 | Backfill existing entity columns + content_translations into content_versions | pending |
| 4 | Switch reads exclusive | pending |
| 5 | Drop entity text columns, drop content_translations, delete dead overlay code | pending |

## Risk

Trivial — the table is empty and unread. Worst case is rolling back a single migration that no production code path depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
