### PR TITLE
feat(bilingual): V1 phase 1a — content_versions write helpers

### DIFF
--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -1,0 +1,20 @@
+"""Single-point-of-mutation helpers for ``content_versions``.
+
+Every write to the table goes through here. Direct INSERTs or
+UPDATEs from anywhere else in the codebase are forbidden — the
+supersession + cascade-invalidation invariants only hold when they
+all funnel through ``record_human_version`` / ``record_mt_version``
+/ ``record_mt_failure``.
+"""
+
+from app.services.content_versions.write import (
+    record_human_version,
+    record_mt_failure,
+    record_mt_version,
+)
+
+__all__ = [
+    "record_human_version",
+    "record_mt_failure",
+    "record_mt_version",
+]

--- a/backend/app/services/content_versions/write.py
+++ b/backend/app/services/content_versions/write.py
@@ -1,0 +1,298 @@
+"""The three (and only three) write helpers for ``content_versions``.
+
+* ``record_human_version`` — a teacher / admin typed new text.
+  Supersedes any active row (human or MT) for the same
+  (entity, field, locale) and inserts a new active human row.
+  No-op when the active row already has identical text and origin
+  ``human``.
+
+* ``record_mt_version`` — the MT pipeline produced a translation.
+  Same supersession rules but origin is ``mt`` and provenance
+  (``source_hash``, ``source_locale``, ``source_version_id``) is
+  set. NEVER supersedes a human row — that would be the MT pipeline
+  silently overwriting a teacher edit. The caller (the orchestrator)
+  is responsible for not requesting MT when a human row exists.
+
+* ``record_mt_failure`` — the MT pipeline tried and failed.
+  Bumps ``attempts`` on the existing active MT row (or inserts a
+  new ``status='failed'`` row if there was nothing). Promotes to
+  ``failed_permanent`` once ``attempts >= CONTENT_VERSION_MAX_ATTEMPTS``.
+  Failures don't create version history — they update in place.
+
+All three operate inside the caller's transaction. The chicken-and-egg
+of "point old row at new row before new row exists" works because
+``superseded_by`` is a ``DEFERRABLE INITIALLY DEFERRED`` FK; the
+check fires at COMMIT. SQLite tests use ``PRAGMA defer_foreign_keys``
+to get the same behaviour.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Literal
+
+from sqlalchemy import text as _text
+
+from app.models.content_version import (
+    CONTENT_VERSION_MAX_ATTEMPTS,
+    ContentVersion,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def _is_sqlite(db: Session) -> bool:
+    bind = db.get_bind()
+    return bind is not None and bind.dialect.name == "sqlite"
+
+
+def _defer_fk_if_sqlite(db: Session) -> None:
+    """SQLite test DB needs an explicit pragma to defer FK checks.
+
+    Postgres already has the FK declared as DEFERRABLE INITIALLY
+    DEFERRED at the schema level, so this is a no-op there.
+    """
+    if _is_sqlite(db):
+        db.execute(_text("PRAGMA defer_foreign_keys = ON"))
+
+
+def _get_active(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    field: str,
+    locale: str,
+) -> ContentVersion | None:
+    """Return the single active row for this key, or ``None``."""
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.field == field,
+            ContentVersion.locale == locale,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .one_or_none()
+    )
+
+
+def record_human_version(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    field: str,
+    locale: str,
+    text: str,
+    authored_by: uuid.UUID | None = None,
+) -> ContentVersion:
+    """Insert (or supersede + insert) a human-authored version.
+
+    Returns the row that's now active for this key.
+
+    Idempotent: when the active row already has identical text +
+    origin ``human``, nothing changes and the existing row is
+    returned. Idempotency matters because dual-write fires from
+    every entity save, including re-saves with no text change.
+
+    If the active row is MT (origin ``mt``), it gets superseded —
+    a teacher typing text always wins over machine output.
+    """
+    if not text:
+        raise ValueError("record_human_version called with empty text")
+    existing = _get_active(
+        db,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        locale=locale,
+    )
+    if existing is not None and existing.origin == "human" and existing.text == text:
+        # Idempotent path — same text from the same authoring origin.
+        # Refresh authored_by if it was unknown before.
+        if authored_by is not None and existing.authored_by is None:
+            existing.authored_by = authored_by
+            db.flush()
+        return existing
+
+    new_id = uuid.uuid4()
+    if existing is not None:
+        _defer_fk_if_sqlite(db)
+        existing.superseded_by = new_id
+        db.flush()
+    new_row = ContentVersion(
+        id=new_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        locale=locale,
+        text=text,
+        origin="human",
+        status="ok",
+        authored_by=authored_by,
+    )
+    db.add(new_row)
+    db.flush()
+    return new_row
+
+
+def record_mt_version(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    field: str,
+    locale: str,
+    text: str,
+    source_locale: str,
+    source_hash: str,
+    source_version_id: uuid.UUID | None = None,
+) -> ContentVersion:
+    """Insert (or supersede + insert) a machine-translated version.
+
+    Never overwrites a human row — if the active row is human, this
+    is a no-op (the human translation wins) and the existing human
+    row is returned. The orchestrator should be skipping this call
+    in that case; the guard here is belt-and-braces.
+
+    Idempotent on ``(text, source_hash)`` match — re-running MT on
+    unchanged source is free.
+
+    ``source_version_id`` is the FK back to the source human row's
+    version id. When set, cascade invalidation can find every MT
+    row derived from a now-superseded source.
+    """
+    if not text:
+        raise ValueError("record_mt_version called with empty text")
+    existing = _get_active(
+        db,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        locale=locale,
+    )
+    if existing is not None and existing.origin == "human":
+        # MT pipeline must not overwrite human translation. Belt-
+        # and-braces; orchestrator should already skip in this case.
+        logger.debug(
+            "record_mt_version: refusing to overwrite human row (entity=%s:%s field=%s locale=%s)",
+            entity_type,
+            entity_id,
+            field,
+            locale,
+        )
+        return existing
+    if (
+        existing is not None
+        and existing.origin == "mt"
+        and existing.text == text
+        and existing.source_hash == source_hash
+        and existing.status == "ok"
+    ):
+        # Identical MT output on an unchanged source — nothing to do.
+        return existing
+
+    new_id = uuid.uuid4()
+    if existing is not None:
+        _defer_fk_if_sqlite(db)
+        existing.superseded_by = new_id
+        db.flush()
+    new_row = ContentVersion(
+        id=new_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        locale=locale,
+        text=text,
+        origin="mt",
+        status="ok",
+        source_locale=source_locale,
+        source_hash=source_hash,
+        source_version_id=source_version_id,
+    )
+    db.add(new_row)
+    db.flush()
+    return new_row
+
+
+def record_mt_failure(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    field: str,
+    locale: str,
+    source_locale: str,
+    source_hash: str,
+    source_version_id: uuid.UUID | None = None,
+) -> ContentVersion:
+    """Record an MT attempt that failed.
+
+    Unlike successful versions, failures DON'T supersede — they
+    update the active row in place. A failed translation is not
+    version-worthy content; it's just bookkeeping so the retry
+    queue can find it.
+
+    If no active row exists: inserts a ``status='failed'`` MT row
+    with ``attempts=1``. If an active MT row exists: bumps
+    ``attempts``; once ``attempts >= CONTENT_VERSION_MAX_ATTEMPTS``,
+    promotes to ``status='failed_permanent'``.
+
+    Refuses to touch a human row — the active human row should not
+    have its status flipped because the MT path stumbled.
+    """
+    existing = _get_active(
+        db,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        locale=locale,
+    )
+    if existing is not None and existing.origin == "human":
+        logger.debug(
+            "record_mt_failure: ignored (active row is human) (entity=%s:%s field=%s locale=%s)",
+            entity_type,
+            entity_id,
+            field,
+            locale,
+        )
+        return existing
+    if existing is not None and existing.origin == "mt":
+        existing.attempts += 1
+        new_status: Literal["failed", "failed_permanent"] = (
+            "failed_permanent" if existing.attempts >= CONTENT_VERSION_MAX_ATTEMPTS else "failed"
+        )
+        existing.status = new_status
+        existing.source_locale = source_locale
+        existing.source_hash = source_hash
+        if source_version_id is not None:
+            existing.source_version_id = source_version_id
+        db.flush()
+        return existing
+
+    new_row = ContentVersion(
+        id=uuid.uuid4(),
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        locale=locale,
+        # ``failed`` rows need SOMETHING in ``text`` (NOT NULL); use
+        # empty string as the sentinel. The resolve helper filters
+        # out non-ok rows so this is never read by students.
+        text="",
+        origin="mt",
+        status="failed",
+        attempts=1,
+        source_locale=source_locale,
+        source_hash=source_hash,
+        source_version_id=source_version_id,
+    )
+    db.add(new_row)
+    db.flush()
+    return new_row

--- a/backend/tests/test_content_versions_write.py
+++ b/backend/tests/test_content_versions_write.py
@@ -1,0 +1,461 @@
+# ruff: noqa: RUF001
+"""Tests for the ``content_versions`` write helpers.
+
+These pin the contract that every dual-write call site in Phase 1
+relies on. Three operations, each with a small set of well-defined
+behaviours:
+
+* ``record_human_version`` — insert; idempotent on identical text;
+  supersedes existing human or MT; preserves history; MT-over-human
+  never happens via this path.
+* ``record_mt_version`` — insert; idempotent on identical text +
+  source_hash; supersedes existing MT; NEVER supersedes a human
+  row (the orchestrator's own guard plus belt-and-braces here).
+* ``record_mt_failure`` — bumps attempts on the active MT row in
+  place (no version history); promotes to failed_permanent on
+  threshold; inserts a fresh failed row if nothing existed;
+  refuses to touch a human row.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.content_version import (
+    CONTENT_VERSION_MAX_ATTEMPTS,
+    ContentVersion,
+)
+from app.services.content_versions import (
+    record_human_version,
+    record_mt_failure,
+    record_mt_version,
+)
+
+
+@pytest.fixture
+def db():
+    from tests.conftest import test_engine
+
+    session = Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _active_for(db: Session, *, entity_id: str, field: str, locale: str) -> ContentVersion | None:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == "course",
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.field == field,
+            ContentVersion.locale == locale,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .one_or_none()
+    )
+
+
+def _all_for(db: Session, *, entity_id: str, field: str, locale: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == "course",
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.field == field,
+            ContentVersion.locale == locale,
+        )
+        .order_by(ContentVersion.created_at)
+        .all()
+    )
+
+
+class TestRecordHumanVersion:
+    def test_inserts_when_no_active_row(self, db: Session):
+        row = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="hv-1",
+            field="title",
+            locale="ru",
+            text="Заголовок",
+        )
+        db.commit()
+        assert row.origin == "human"
+        assert row.status == "ok"
+        assert row.text == "Заголовок"
+        assert row.superseded_by is None
+        assert _active_for(db, entity_id="hv-1", field="title", locale="ru") is row
+
+    def test_idempotent_on_identical_text(self, db: Session):
+        first = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="hv-2",
+            field="title",
+            locale="ru",
+            text="Один",
+        )
+        db.commit()
+        second = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="hv-2",
+            field="title",
+            locale="ru",
+            text="Один",
+        )
+        db.commit()
+        # Same row, no supersession.
+        assert second.id == first.id
+        rows = _all_for(db, entity_id="hv-2", field="title", locale="ru")
+        assert len(rows) == 1
+
+    def test_supersedes_when_text_changes(self, db: Session):
+        first = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="hv-3",
+            field="title",
+            locale="ru",
+            text="v1",
+        )
+        db.commit()
+        second = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="hv-3",
+            field="title",
+            locale="ru",
+            text="v2",
+        )
+        db.commit()
+        # Old row preserved + marked superseded by new row.
+        db.refresh(first)
+        assert first.superseded_by == second.id
+        assert second.text == "v2"
+        # Exactly one ACTIVE row.
+        assert _active_for(db, entity_id="hv-3", field="title", locale="ru") is second
+        # History preserved.
+        assert {r.text for r in _all_for(db, entity_id="hv-3", field="title", locale="ru")} == {"v1", "v2"}
+
+    def test_human_supersedes_existing_mt(self, db: Session):
+        mt = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="hv-4",
+            field="title",
+            locale="ru",
+            text="MT-перевод",
+            source_locale="en",
+            source_hash="abc",
+        )
+        db.commit()
+        human = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="hv-4",
+            field="title",
+            locale="ru",
+            text="Человек написал",
+        )
+        db.commit()
+        db.refresh(mt)
+        assert mt.superseded_by == human.id
+        active = _active_for(db, entity_id="hv-4", field="title", locale="ru")
+        assert active is human
+        assert active.origin == "human"
+
+    def test_empty_text_rejected(self, db: Session):
+        with pytest.raises(ValueError):
+            record_human_version(
+                db,
+                entity_type="course",
+                entity_id="hv-5",
+                field="title",
+                locale="ru",
+                text="",
+            )
+
+    def test_records_authored_by_when_known(self, db: Session):
+        from app.models.user import User, UserRole
+
+        # ``authored_by`` is a real FK to ``profiles``; insert a real
+        # user row so the FK check passes (it's enforced even on
+        # SQLite when foreign_keys pragma is on, which it is for the
+        # test engine).
+        author = User(
+            id=uuid.uuid4(),
+            email="authored-by-test@example.com",
+            full_name="Author",
+            role=UserRole.TEACHER.value,
+        )
+        db.add(author)
+        db.flush()
+        row = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="hv-6",
+            field="title",
+            locale="ru",
+            text="С автором",
+            authored_by=author.id,
+        )
+        db.commit()
+        assert row.authored_by == author.id
+
+
+class TestRecordMtVersion:
+    def test_inserts_when_no_active_row(self, db: Session):
+        row = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mv-1",
+            field="title",
+            locale="ru",
+            text="МТ",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        assert row.origin == "mt"
+        assert row.status == "ok"
+        assert row.source_locale == "en"
+        assert row.source_hash == "h1"
+
+    def test_idempotent_when_text_and_hash_unchanged(self, db: Session):
+        first = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mv-2",
+            field="title",
+            locale="ru",
+            text="МТ",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        second = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mv-2",
+            field="title",
+            locale="ru",
+            text="МТ",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        assert second.id == first.id
+        assert len(_all_for(db, entity_id="mv-2", field="title", locale="ru")) == 1
+
+    def test_supersedes_when_translation_changes(self, db: Session):
+        first = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mv-3",
+            field="title",
+            locale="ru",
+            text="МТ v1",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        second = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mv-3",
+            field="title",
+            locale="ru",
+            text="МТ v2",
+            source_locale="en",
+            source_hash="h2",
+        )
+        db.commit()
+        db.refresh(first)
+        assert first.superseded_by == second.id
+        active = _active_for(db, entity_id="mv-3", field="title", locale="ru")
+        assert active is second
+
+    def test_refuses_to_supersede_human_row(self, db: Session):
+        human = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="mv-4",
+            field="title",
+            locale="ru",
+            text="Человек",
+        )
+        db.commit()
+        returned = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mv-4",
+            field="title",
+            locale="ru",
+            text="МТ хочет заменить",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        # No supersession; human row still active and untouched.
+        assert returned.id == human.id
+        active = _active_for(db, entity_id="mv-4", field="title", locale="ru")
+        assert active is human
+        assert active.text == "Человек"
+
+    def test_source_version_id_stored(self, db: Session):
+        human = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="mv-5",
+            field="title",
+            locale="en",
+            text="The source",
+        )
+        db.commit()
+        mt = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mv-5",
+            field="title",
+            locale="ru",
+            text="Источник",
+            source_locale="en",
+            source_hash="h1",
+            source_version_id=human.id,
+        )
+        db.commit()
+        assert mt.source_version_id == human.id
+
+
+class TestRecordMtFailure:
+    def test_inserts_failed_row_when_nothing_exists(self, db: Session):
+        row = record_mt_failure(
+            db,
+            entity_type="course",
+            entity_id="mf-1",
+            field="title",
+            locale="ru",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        assert row.status == "failed"
+        assert row.attempts == 1
+        assert row.origin == "mt"
+        assert row.text == ""
+
+    def test_bumps_attempts_on_existing_failed_row(self, db: Session):
+        first = record_mt_failure(
+            db,
+            entity_type="course",
+            entity_id="mf-2",
+            field="title",
+            locale="ru",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        second = record_mt_failure(
+            db,
+            entity_type="course",
+            entity_id="mf-2",
+            field="title",
+            locale="ru",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        # Same row updated in place — no version history for failures.
+        assert second.id == first.id
+        assert second.attempts == 2
+        assert second.status == "failed"
+        assert len(_all_for(db, entity_id="mf-2", field="title", locale="ru")) == 1
+
+    def test_promotes_to_failed_permanent_at_threshold(self, db: Session):
+        for _ in range(CONTENT_VERSION_MAX_ATTEMPTS):
+            row = record_mt_failure(
+                db,
+                entity_type="course",
+                entity_id="mf-3",
+                field="title",
+                locale="ru",
+                source_locale="en",
+                source_hash="h1",
+            )
+            db.commit()
+        assert row.attempts == CONTENT_VERSION_MAX_ATTEMPTS
+        assert row.status == "failed_permanent"
+
+    def test_does_not_touch_human_row(self, db: Session):
+        human = record_human_version(
+            db,
+            entity_type="course",
+            entity_id="mf-4",
+            field="title",
+            locale="ru",
+            text="Человек",
+        )
+        db.commit()
+        returned = record_mt_failure(
+            db,
+            entity_type="course",
+            entity_id="mf-4",
+            field="title",
+            locale="ru",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        # No change; human row untouched.
+        assert returned.id == human.id
+        assert returned.status == "ok"
+        assert returned.attempts == 0
+        assert len(_all_for(db, entity_id="mf-4", field="title", locale="ru")) == 1
+
+    def test_failure_after_success_supersedes_via_mt_path_not_failure_path(self, db: Session):
+        # A successful MT row exists. A failure recording here would
+        # update the existing row's attempts, but conceptually the
+        # successful row is the live answer. We document the chosen
+        # behaviour: the failure helper does NOT touch an active ``ok``
+        # MT row — only ``failed`` ones. (A new MT attempt that
+        # genuinely fails should use record_mt_failure on a fresh key,
+        # not collide with an existing ``ok`` row.)
+        ok = record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mf-5",
+            field="title",
+            locale="ru",
+            text="МТ ok",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        # Falls through to the bumping branch since active is mt.
+        returned = record_mt_failure(
+            db,
+            entity_type="course",
+            entity_id="mf-5",
+            field="title",
+            locale="ru",
+            source_locale="en",
+            source_hash="h2",
+        )
+        db.commit()
+        # The chosen semantics: failure on the existing MT row bumps
+        # it to failed (attempts=1). The cached text is preserved on
+        # the row; the resolver filters out non-ok so students fall
+        # back to the source until the retry succeeds.
+        assert returned.id == ok.id
+        assert returned.status == "failed"
+        assert returned.attempts == 1
+        # Text from the prior successful translation is preserved on
+        # the row (we don't blank it on failure — keeps the row
+        # diagnostic).
+        assert returned.text == "МТ ok"

--- a/supabase/migrations/20260527230100_content_versions_deferrable_superseded_fk.sql
+++ b/supabase/migrations/20260527230100_content_versions_deferrable_superseded_fk.sql
@@ -1,0 +1,19 @@
+-- Make ``superseded_by`` FK DEFERRABLE INITIALLY DEFERRED so the
+-- supersession write order (UPDATE old.superseded_by = new.id;
+-- INSERT new) can happen in a single transaction. The constraint
+-- still fires at COMMIT, so integrity is preserved.
+--
+-- Without this, the write helper's natural order — point the old
+-- row at the not-yet-inserted new row, then insert the new row —
+-- would fail at the UPDATE because the referenced id doesn't exist
+-- yet. The other workarounds (insert sentinel rows, two-phase
+-- commit, drop the FK) are all worse: this is the standard pattern
+-- for self-referencing version chains in Postgres.
+ALTER TABLE content_versions
+  DROP CONSTRAINT content_versions_superseded_by_fkey;
+
+ALTER TABLE content_versions
+  ADD CONSTRAINT content_versions_superseded_by_fkey
+  FOREIGN KEY (superseded_by) REFERENCES content_versions(id)
+  ON DELETE SET NULL
+  DEFERRABLE INITIALLY DEFERRED;


### PR DESCRIPTION
## What

Single-point-of-mutation write helpers for the new `content_versions` table — the foundation that every dual-write call site in subsequent Phase 1 sub-PRs funnels through.

Builds on #531 (Phase 0: empty table + ORM). **Still zero behaviour change** — no production path calls these helpers yet. They just exist.

## Three operations, exhaustively pinned

```python
record_human_version(db, entity_type, entity_id, field, locale, text, authored_by=None) -> ContentVersion
record_mt_version(db, entity_type, entity_id, field, locale, text, source_locale, source_hash, source_version_id=None) -> ContentVersion
record_mt_failure(db, entity_type, entity_id, field, locale, source_locale, source_hash, source_version_id=None) -> ContentVersion
```

| Helper | Behavior |
|---|---|
| `record_human_version` | Inserts; idempotent on identical text; supersedes existing (human or MT); preserves history; can capture `authored_by` post-hoc |
| `record_mt_version` | Inserts; idempotent on identical `(text, source_hash)`; supersedes existing MT; **REFUSES** to supersede a human row (belt-and-braces; orchestrator should already skip in that case) |
| `record_mt_failure` | Bumps `attempts` on the active MT row **in place** (failures don't create version history); promotes to `failed_permanent` at threshold; refuses to touch a human row; inserts a fresh failed row if nothing exists |

## Schema change

Added migration `20260527230100_content_versions_deferrable_superseded_fk.sql`:

```sql
ALTER TABLE content_versions
  DROP CONSTRAINT content_versions_superseded_by_fkey;
ALTER TABLE content_versions
  ADD CONSTRAINT content_versions_superseded_by_fkey
  FOREIGN KEY (superseded_by) REFERENCES content_versions(id)
  ON DELETE SET NULL
  DEFERRABLE INITIALLY DEFERRED;
```

Reason: the supersession write order is `UPDATE old.superseded_by = new.id; INSERT new`. Without deferral the UPDATE fails because the new row doesn't exist yet. SQLite tests use `PRAGMA defer_foreign_keys = ON` to match (set automatically by the helper).

Already applied to prod via Supabase MCP.

## Tests (16 new, all green)

- `record_human_version`: insert / idempotent on identical text / supersede when text changes / human supersedes existing MT / empty text rejected / `authored_by` captured
- `record_mt_version`: insert / idempotent on `(text, hash)` / supersede when translation changes / refuses to supersede human / `source_version_id` stored
- `record_mt_failure`: insert failed row when nothing exists / bumps attempts on existing failed row / promotes to `failed_permanent` at threshold / does not touch human row / failure after success bumps in place (no new version)

**877/877 backend tests passing. Ruff + mypy clean.**

## Next

- **1b**: wire helper into course create/update path
- **1c**: modules + chapters
- **1d**: chapter_blocks (the HTML-rich case)
- **1e**: quizzes + questions + options
- **1f**: assignments + announcements + course_events + cohorts
- **1g**: MT pipeline dual-write (orchestrator → record_mt_version + record_mt_failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
