### PR TITLE
feat(bilingual): V1 phase 1b — dual-write course title/description

### DIFF
--- a/backend/app/services/course_service/_courses.py
+++ b/backend/app/services/course_service/_courses.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 
 from app.models.course import Chapter, Course, Module
+from app.services.content_versions import record_human_version
 from app.services.language_detection import detect_locale
 
 if TYPE_CHECKING:
@@ -17,6 +18,67 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from app.schemas.course import CourseCreate, CourseUpdate
+
+
+_TRANSLATABLE_COURSE_FIELDS = ("title", "description")
+
+
+def _dual_write_course_content(
+    db: Session,
+    course: Course,
+    *,
+    authored_by: str | UUID | None,
+    course_fallback: str | None,
+    only_fields: set[str] | None = None,
+) -> None:
+    """Write a ``content_versions`` row for every translatable field
+    on ``course`` that the caller wrote.
+
+    Each field's locale is detected from its own text (so a course
+    with an English title and Russian description gets two rows with
+    different ``locale`` values). Detection falls back to the course
+    source locale when the field's text is too short or has no
+    language signal.
+
+    ``only_fields`` is the set of fields the caller actually wrote;
+    ``None`` means "every translatable field" (used on create).
+    Filtering is important on PATCH so a description-only update
+    doesn't supersede the title row.
+
+    ``authored_by`` is the user id the route layer attributes the
+    write to (course owner on create, owner on update). Stored on
+    the row so the future preacher-style audit UI can show who
+    wrote what.
+    """
+    fields: tuple[str, ...]
+    if only_fields is None:
+        fields = _TRANSLATABLE_COURSE_FIELDS
+    else:
+        fields = tuple(f for f in _TRANSLATABLE_COURSE_FIELDS if f in only_fields)
+    author_uuid: UUID | None = None
+    if authored_by is not None:
+        author_uuid = authored_by if isinstance(authored_by, uuid.UUID) else uuid.UUID(str(authored_by))
+    for field in fields:
+        text = getattr(course, field, None)
+        if not text or not str(text).strip():
+            continue
+        detected = detect_locale(str(text))
+        locale = detected or course_fallback
+        if locale is None:
+            # No signal AND no course-level fallback — skip. Dual-write
+            # without a locale would be nonsensical and the field will
+            # come back through this path the next time the entity is
+            # saved with enough context.
+            continue
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=str(course.id),
+            field=field,
+            locale=locale,
+            text=str(text),
+            authored_by=author_uuid,
+        )
 
 
 def _resolve_source_locale(
@@ -75,6 +137,8 @@ def create_course(
     if resolved_locale is not None:
         course.source_locale = resolved_locale
     db.add(course)
+    db.flush()
+    _dual_write_course_content(db, course, authored_by=user_id, course_fallback=resolved_locale)
     db.commit()
     db.refresh(course)
     return course
@@ -97,6 +161,17 @@ def update_course(db: Session, course: Course, data: CourseUpdate) -> Course:
         )
         if detected is not None:
             course.source_locale = detected
+    db.flush()
+    # Dual-write to content_versions only for fields the caller actually
+    # touched — a PATCH that didn't include ``description`` mustn't
+    # supersede the existing description row.
+    _dual_write_course_content(
+        db,
+        course,
+        authored_by=course.created_by,
+        course_fallback=course.source_locale,
+        only_fields={f for f in ("title", "description") if f in patch},
+    )
     db.commit()
     db.refresh(course)
     # When the source locale flips, every existing ``content_translations``

--- a/backend/tests/test_courses_dual_write.py
+++ b/backend/tests/test_courses_dual_write.py
@@ -1,0 +1,171 @@
+# ruff: noqa: RUF001
+"""Phase 1b integration tests: course create/update dual-writes
+into ``content_versions``.
+
+Pins the contract: every course title/description that gets written
+to the entity column ALSO appears as an active human row in
+``content_versions`` with the correct per-field detected locale.
+
+Reads stay on the entity columns for now (Phase 2 is when the
+dual-read layer flips on); these tests just verify the SHADOW
+write — the resolve path is untouched.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.content_version import ContentVersion
+from app.models.user import User, UserRole
+from app.schemas.course import CourseCreate, CourseUpdate
+from app.services.course_service._courses import create_course, update_course
+
+
+@pytest.fixture
+def db():
+    from tests.conftest import test_engine
+
+    session = Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def teacher(db: Session) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email=f"dual-write-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Dual-Write Teacher",
+        role=UserRole.TEACHER.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _active_rows(db: Session, course_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == "course",
+            ContentVersion.entity_id == course_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .order_by(ContentVersion.field)
+        .all()
+    )
+
+
+class TestCreateCourseDualWrite:
+    def test_writes_title_and_description_rows(self, db: Session, teacher: User):
+        course = create_course(
+            db,
+            CourseCreate(title="Bible Study 101", description="Intro to scripture."),
+            user_id=teacher.id,
+            source_locale="en",
+        )
+        rows = _active_rows(db, course.id)
+        by_field = {r.field: r for r in rows}
+        assert set(by_field.keys()) == {"title", "description"}
+        assert by_field["title"].text == "Bible Study 101"
+        assert by_field["title"].origin == "human"
+        assert by_field["title"].status == "ok"
+        assert by_field["title"].authored_by == teacher.id
+        assert by_field["description"].text == "Intro to scripture."
+
+    def test_per_field_locale_detection(self, db: Session, teacher: User):
+        # English title, Russian description — each row should land
+        # in the correct locale.
+        course = create_course(
+            db,
+            CourseCreate(title="Bible Study 101", description="Введение в Писание."),
+            user_id=teacher.id,
+            source_locale="en",
+        )
+        rows = {r.field: r for r in _active_rows(db, course.id)}
+        assert rows["title"].locale == "en"
+        assert rows["description"].locale == "ru"
+
+    def test_skips_empty_description(self, db: Session, teacher: User):
+        course = create_course(
+            db,
+            CourseCreate(title="Bible Study 101", description=None),
+            user_id=teacher.id,
+            source_locale="en",
+        )
+        rows = _active_rows(db, course.id)
+        assert [r.field for r in rows] == ["title"]
+
+    def test_falls_back_to_course_source_locale_when_undetectable(self, db: Session, teacher: User):
+        # ASCII non-letter title — detector returns None, falls back
+        # to the course source_locale.
+        course = create_course(
+            db,
+            CourseCreate(title="123", description=None),
+            user_id=teacher.id,
+            source_locale="ru",
+        )
+        rows = _active_rows(db, course.id)
+        assert len(rows) == 1
+        assert rows[0].locale == "ru"
+
+
+class TestUpdateCourseDualWrite:
+    def test_title_change_supersedes_old_title_row(self, db: Session, teacher: User):
+        course = create_course(
+            db,
+            CourseCreate(title="Старый заголовок", description="Описание."),
+            user_id=teacher.id,
+            source_locale="ru",
+        )
+        original_title_row = next(r for r in _active_rows(db, course.id) if r.field == "title")
+        update_course(db, course, CourseUpdate(title="Новый заголовок"))
+        # Active row count unchanged (still 2: title + description).
+        active = _active_rows(db, course.id)
+        assert len(active) == 2
+        active_title = next(r for r in active if r.field == "title")
+        assert active_title.text == "Новый заголовок"
+        # Original title row is now superseded but preserved in history.
+        db.refresh(original_title_row)
+        assert original_title_row.superseded_by == active_title.id
+        # Description row was NOT touched (PATCH only included title).
+        descs = (
+            db.query(ContentVersion)
+            .filter(
+                ContentVersion.entity_id == course.id,
+                ContentVersion.field == "description",
+            )
+            .all()
+        )
+        assert len(descs) == 1  # never re-written → no version history bump
+
+    def test_unchanged_title_is_idempotent(self, db: Session, teacher: User):
+        course = create_course(
+            db,
+            CourseCreate(title="Стабильный", description="Текст."),
+            user_id=teacher.id,
+            source_locale="ru",
+        )
+        original_title_id = next(r.id for r in _active_rows(db, course.id) if r.field == "title")
+        # PATCH with identical title text → no supersession.
+        update_course(db, course, CourseUpdate(title="Стабильный"))
+        active_title = next(r for r in _active_rows(db, course.id) if r.field == "title")
+        assert active_title.id == original_title_id
+
+    def test_non_text_patch_does_not_touch_content_versions(self, db: Session, teacher: User):
+        course = create_course(
+            db,
+            CourseCreate(title="Курс", description="Описание."),
+            user_id=teacher.id,
+            source_locale="ru",
+        )
+        ids_before = {r.id for r in _active_rows(db, course.id)}
+        # PATCH that touches only image_url — content_versions stays untouched.
+        update_course(db, course, CourseUpdate(image_url="https://example.com/x.png"))
+        ids_after = {r.id for r in _active_rows(db, course.id)}
+        assert ids_before == ids_after


### PR DESCRIPTION
## What

Wires the `record_human_version` helper (shipped in #532) into `create_course` and `update_course`. Every course title/description written to the entity column ALSO appears as an active human row in `content_versions` with the correct per-field detected locale.

**Still zero read-side change** — every resolve path still reads from entity columns. Phase 2 introduces dual-read with mismatch logging; Phase 4 flips reads exclusive.

## How

A small private helper `_dual_write_course_content`:

```python
for field in ("title", "description"):
    text = getattr(course, field, None)
    if not text or not str(text).strip():
        continue
    detected = detect_locale(str(text))
    locale = detected or course_fallback
    if locale is None:
        continue   # no signal & no fallback — skip (re-saved later)
    record_human_version(
        db,
        entity_type="course",
        entity_id=str(course.id),
        field=field,
        locale=locale,
        text=str(text),
        authored_by=author_uuid,
    )
```

`create_course` calls it with `only_fields=None` (every translatable field). `update_course` passes `only_fields={f for f in (title, description) if f in patch}` so a description-only PATCH never supersedes the title row.

## Tests (7, all green)

| Test | Pins |
|---|---|
| `test_writes_title_and_description_rows` | Both fields written as `origin=human, status=ok, authored_by=<teacher>` |
| `test_per_field_locale_detection` | EN title + RU description → two rows with different `locale` |
| `test_skips_empty_description` | NULL/empty description doesn't insert a phantom row |
| `test_falls_back_to_course_source_locale_when_undetectable` | Non-letter title falls back to course `source_locale` |
| `test_title_change_supersedes_old_title_row` | Old row superseded, history preserved, description row untouched |
| `test_unchanged_title_is_idempotent` | Same text → no version churn |
| `test_non_text_patch_does_not_touch_content_versions` | Image-only PATCH leaves the table untouched |

**891/891 backend tests passing. Ruff + mypy clean.**

## Next

- **1c**: modules + chapters
- **1d**: chapter_blocks (the HTML-rich case)
- **1e**: quizzes + questions + options
- **1f**: assignments + announcements + course_events + cohorts
- **1g**: MT pipeline dual-write (orchestrator → `record_mt_version` + `record_mt_failure`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
