### PR TITLE
feat(bilingual): V1 phase 1c — dual-write modules + chapters

### DIFF
--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -7,6 +7,7 @@ all funnel through ``record_human_version`` / ``record_mt_version``
 / ``record_mt_failure``.
 """
 
+from app.services.content_versions.dual_write import dual_write_entity_content
 from app.services.content_versions.write import (
     record_human_version,
     record_mt_failure,
@@ -14,6 +15,7 @@ from app.services.content_versions.write import (
 )
 
 __all__ = [
+    "dual_write_entity_content",
     "record_human_version",
     "record_mt_failure",
     "record_mt_version",

--- a/backend/app/services/content_versions/dual_write.py
+++ b/backend/app/services/content_versions/dual_write.py
@@ -1,0 +1,98 @@
+"""Shared per-field dual-write helper used by every entity write
+path during Phase 1.
+
+The pattern repeats for every translatable entity:
+
+1. Read each translatable field's text from the entity.
+2. Detect that field's language (or fall back to a caller-supplied
+   locale when the detector has no signal).
+3. Call ``record_human_version`` once per field.
+
+Centralising it here keeps every call site to a 4-line invocation,
+and means a future change to language-detection / fallback strategy
+edits ONE function instead of N.
+
+Reads still go to entity columns. Phase 2 introduces the dual-read
+layer; Phase 4 flips reads exclusive.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from app.services.content_versions.write import record_human_version
+from app.services.language_detection import detect_locale
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sqlalchemy.orm import Session
+
+
+def dual_write_entity_content(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    entity: object,
+    fields: Iterable[str],
+    fallback_locale: str | None,
+    authored_by: str | uuid.UUID | None = None,
+    only_fields: set[str] | None = None,
+) -> None:
+    """Write a ``content_versions`` human row for every translatable
+    field on ``entity`` that the caller wrote.
+
+    Per-field detection: each field's locale is decided from its own
+    text. Two fields on the same entity can land in different locales
+    (an EN title and a RU description are normal). Detection falls
+    back to ``fallback_locale`` when the field text is too short to
+    classify or has no language signal.
+
+    ``only_fields`` filters to the fields the caller actually wrote
+    (used on UPDATE so a description-only PATCH doesn't supersede
+    the title row). ``None`` means "every field in ``fields``".
+
+    ``authored_by`` is stored on the row when known. Accepts a UUID
+    or a string-coerceable id.
+    """
+    if only_fields is None:
+        target_fields: list[str] = list(fields)
+    else:
+        target_fields = [f for f in fields if f in only_fields]
+
+    if not target_fields:
+        return
+
+    author_uuid = _coerce_uuid(authored_by)
+
+    for field in target_fields:
+        text = getattr(entity, field, None)
+        if not text or not str(text).strip():
+            continue
+        text_str = str(text)
+        detected = detect_locale(text_str)
+        locale = detected or fallback_locale
+        if locale is None:
+            # No signal AND no fallback — skip. The field re-enters
+            # this path the next time the entity is saved with
+            # enough surrounding context to resolve a fallback.
+            continue
+        record_human_version(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            locale=locale,
+            text=text_str,
+            authored_by=author_uuid,
+        )
+
+
+def _coerce_uuid(value: str | uuid.UUID | None) -> uuid.UUID | None:
+    if value is None:
+        return None
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))

--- a/backend/app/services/course_service/_chapters.py
+++ b/backend/app/services/course_service/_chapters.py
@@ -8,12 +8,16 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import func
 
-from app.models.course import Chapter
+from app.models.course import Chapter, Course, Module
+from app.services.content_versions import dual_write_entity_content
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from app.schemas.course import ChapterCreate, ChapterUpdate
+
+
+_TRANSLATABLE_CHAPTER_FIELDS = ("title",)
 
 
 def _next_chapter_order(db: Session, module_id: str) -> int:
@@ -24,6 +28,19 @@ def _next_chapter_order(db: Session, module_id: str) -> int:
         .scalar()
     )
     return 0 if current_max is None else current_max + 1
+
+
+def _course_source_locale_for_module(db: Session, module_id: str) -> str | None:
+    """Walk ``Chapter -> Module -> Course`` to find the parent course's
+    source locale. Used as the fallback when a chapter title alone
+    can't be classified by the language detector.
+    """
+    return (
+        db.query(Course.source_locale)
+        .join(Module, Module.course_id == Course.id)
+        .filter(Module.id == module_id)
+        .scalar()
+    )
 
 
 def create_chapter(db: Session, module_id: str, data: ChapterCreate) -> Chapter:
@@ -40,14 +57,34 @@ def create_chapter(db: Session, module_id: str, data: ChapterCreate) -> Chapter:
         is_locked=data.is_locked,
     )
     db.add(chapter)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="chapter",
+        entity_id=str(chapter.id),
+        entity=chapter,
+        fields=_TRANSLATABLE_CHAPTER_FIELDS,
+        fallback_locale=_course_source_locale_for_module(db, module_id),
+    )
     db.commit()
     db.refresh(chapter)
     return chapter
 
 
 def update_chapter(db: Session, chapter: Chapter, data: ChapterUpdate) -> Chapter:
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(chapter, field, value)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="chapter",
+        entity_id=str(chapter.id),
+        entity=chapter,
+        fields=_TRANSLATABLE_CHAPTER_FIELDS,
+        fallback_locale=_course_source_locale_for_module(db, chapter.module_id),
+        only_fields={f for f in _TRANSLATABLE_CHAPTER_FIELDS if f in patch},
+    )
     db.commit()
     db.refresh(chapter)
     return chapter

--- a/backend/app/services/course_service/_courses.py
+++ b/backend/app/services/course_service/_courses.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 
 from app.models.course import Chapter, Course, Module
-from app.services.content_versions import record_human_version
+from app.services.content_versions import dual_write_entity_content
 from app.services.language_detection import detect_locale
 
 if TYPE_CHECKING:
@@ -21,64 +21,6 @@ if TYPE_CHECKING:
 
 
 _TRANSLATABLE_COURSE_FIELDS = ("title", "description")
-
-
-def _dual_write_course_content(
-    db: Session,
-    course: Course,
-    *,
-    authored_by: str | UUID | None,
-    course_fallback: str | None,
-    only_fields: set[str] | None = None,
-) -> None:
-    """Write a ``content_versions`` row for every translatable field
-    on ``course`` that the caller wrote.
-
-    Each field's locale is detected from its own text (so a course
-    with an English title and Russian description gets two rows with
-    different ``locale`` values). Detection falls back to the course
-    source locale when the field's text is too short or has no
-    language signal.
-
-    ``only_fields`` is the set of fields the caller actually wrote;
-    ``None`` means "every translatable field" (used on create).
-    Filtering is important on PATCH so a description-only update
-    doesn't supersede the title row.
-
-    ``authored_by`` is the user id the route layer attributes the
-    write to (course owner on create, owner on update). Stored on
-    the row so the future preacher-style audit UI can show who
-    wrote what.
-    """
-    fields: tuple[str, ...]
-    if only_fields is None:
-        fields = _TRANSLATABLE_COURSE_FIELDS
-    else:
-        fields = tuple(f for f in _TRANSLATABLE_COURSE_FIELDS if f in only_fields)
-    author_uuid: UUID | None = None
-    if authored_by is not None:
-        author_uuid = authored_by if isinstance(authored_by, uuid.UUID) else uuid.UUID(str(authored_by))
-    for field in fields:
-        text = getattr(course, field, None)
-        if not text or not str(text).strip():
-            continue
-        detected = detect_locale(str(text))
-        locale = detected or course_fallback
-        if locale is None:
-            # No signal AND no course-level fallback — skip. Dual-write
-            # without a locale would be nonsensical and the field will
-            # come back through this path the next time the entity is
-            # saved with enough context.
-            continue
-        record_human_version(
-            db,
-            entity_type="course",
-            entity_id=str(course.id),
-            field=field,
-            locale=locale,
-            text=str(text),
-            authored_by=author_uuid,
-        )
 
 
 def _resolve_source_locale(
@@ -138,7 +80,15 @@ def create_course(
         course.source_locale = resolved_locale
     db.add(course)
     db.flush()
-    _dual_write_course_content(db, course, authored_by=user_id, course_fallback=resolved_locale)
+    dual_write_entity_content(
+        db,
+        entity_type="course",
+        entity_id=str(course.id),
+        entity=course,
+        fields=_TRANSLATABLE_COURSE_FIELDS,
+        fallback_locale=resolved_locale,
+        authored_by=user_id,
+    )
     db.commit()
     db.refresh(course)
     return course
@@ -165,12 +115,15 @@ def update_course(db: Session, course: Course, data: CourseUpdate) -> Course:
     # Dual-write to content_versions only for fields the caller actually
     # touched — a PATCH that didn't include ``description`` mustn't
     # supersede the existing description row.
-    _dual_write_course_content(
+    dual_write_entity_content(
         db,
-        course,
+        entity_type="course",
+        entity_id=str(course.id),
+        entity=course,
+        fields=_TRANSLATABLE_COURSE_FIELDS,
+        fallback_locale=course.source_locale,
         authored_by=course.created_by,
-        course_fallback=course.source_locale,
-        only_fields={f for f in ("title", "description") if f in patch},
+        only_fields={f for f in _TRANSLATABLE_COURSE_FIELDS if f in patch},
     )
     db.commit()
     db.refresh(course)

--- a/backend/app/services/course_service/_modules.py
+++ b/backend/app/services/course_service/_modules.py
@@ -8,12 +8,16 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import func
 
-from app.models.course import Chapter, Module
+from app.models.course import Chapter, Course, Module
+from app.services.content_versions import dual_write_entity_content
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from app.schemas.course import ModuleCreate, ModuleUpdate
+
+
+_TRANSLATABLE_MODULE_FIELDS = ("title", "description")
 
 
 def _next_module_order(db: Session, course_id: str) -> int:
@@ -24,6 +28,16 @@ def _next_module_order(db: Session, course_id: str) -> int:
         .scalar()
     )
     return 0 if current_max is None else current_max + 1
+
+
+def _course_source_locale(db: Session, course_id: str) -> str | None:
+    """Cheap single-column lookup of the parent course's source locale.
+
+    Used as the per-field detection fallback when a module / chapter
+    title can't be classified on its own (short titles like "1" or
+    "Часть 1" often can't).
+    """
+    return db.query(Course.source_locale).filter(Course.id == course_id).scalar()
 
 
 def create_module(db: Session, course_id: str, data: ModuleCreate) -> Module:
@@ -41,14 +55,34 @@ def create_module(db: Session, course_id: str, data: ModuleCreate) -> Module:
         due_date=data.due_date,
     )
     db.add(module)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="module",
+        entity_id=str(module.id),
+        entity=module,
+        fields=_TRANSLATABLE_MODULE_FIELDS,
+        fallback_locale=_course_source_locale(db, course_id),
+    )
     db.commit()
     db.refresh(module)
     return module
 
 
 def update_module(db: Session, module: Module, data: ModuleUpdate) -> Module:
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(module, field, value)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="module",
+        entity_id=str(module.id),
+        entity=module,
+        fields=_TRANSLATABLE_MODULE_FIELDS,
+        fallback_locale=_course_source_locale(db, module.course_id),
+        only_fields={f for f in _TRANSLATABLE_MODULE_FIELDS if f in patch},
+    )
     db.commit()
     db.refresh(module)
     return module

--- a/backend/tests/test_modules_chapters_dual_write.py
+++ b/backend/tests/test_modules_chapters_dual_write.py
@@ -1,0 +1,163 @@
+# ruff: noqa: RUF001
+"""Phase 1c integration tests: module / chapter create/update
+dual-writes into ``content_versions``.
+
+Pins behaviour parallel to ``test_courses_dual_write.py``:
+
+* Each create writes one ``content_versions`` row per translatable
+  field with per-field detected locale.
+* Each update supersedes only the fields the caller actually wrote.
+* Short titles that the detector can't classify fall back to the
+  parent course's ``source_locale``.
+
+Modules have (title, description); chapters have just (title,).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.content_version import ContentVersion
+from app.models.user import User, UserRole
+from app.schemas.course import (
+    ChapterCreate,
+    ChapterUpdate,
+    CourseCreate,
+    ModuleCreate,
+    ModuleUpdate,
+)
+from app.services.course_service._chapters import create_chapter, update_chapter
+from app.services.course_service._courses import create_course
+from app.services.course_service._modules import create_module, update_module
+
+
+@pytest.fixture
+def db():
+    from tests.conftest import test_engine
+
+    session = Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def teacher(db: Session) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email=f"mc-dw-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Module/Chapter Teacher",
+        role=UserRole.TEACHER.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _active_rows(db: Session, entity_type: str, entity_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .order_by(ContentVersion.field)
+        .all()
+    )
+
+
+def _make_course(db: Session, teacher: User, *, locale: str = "ru"):
+    title, desc = ("Учебник", "Курс.") if locale == "ru" else ("Textbook", "Course on scripture.")
+    return create_course(
+        db,
+        CourseCreate(title=title, description=desc),
+        user_id=teacher.id,
+        source_locale=locale,
+    )
+
+
+class TestModuleDualWrite:
+    def test_create_writes_title_and_description(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(
+            db,
+            course.id,
+            ModuleCreate(title="Модуль 1", description="О первой части."),
+        )
+        rows = {r.field: r for r in _active_rows(db, "module", module.id)}
+        assert set(rows.keys()) == {"title", "description"}
+        assert rows["title"].text == "Модуль 1"
+        assert rows["title"].locale == "ru"
+        assert rows["description"].locale == "ru"
+
+    def test_create_with_no_description_skips_description_row(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Модуль", description=None))
+        rows = _active_rows(db, "module", module.id)
+        assert [r.field for r in rows] == ["title"]
+
+    def test_short_title_falls_back_to_course_source_locale(self, db: Session, teacher: User):
+        # Title of just "1" — detector cannot classify; fallback is
+        # the parent course's source_locale ("ru" here).
+        course = _make_course(db, teacher, locale="ru")
+        module = create_module(db, course.id, ModuleCreate(title="1", description=None))
+        rows = _active_rows(db, "module", module.id)
+        assert len(rows) == 1
+        assert rows[0].locale == "ru"
+
+    def test_update_title_supersedes_old_title_only(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(
+            db,
+            course.id,
+            ModuleCreate(title="Старое", description="Описание."),
+        )
+        original_title = next(r for r in _active_rows(db, "module", module.id) if r.field == "title")
+        update_module(db, module, ModuleUpdate(title="Новое"))
+        active_title = next(r for r in _active_rows(db, "module", module.id) if r.field == "title")
+        assert active_title.text == "Новое"
+        db.refresh(original_title)
+        assert original_title.superseded_by == active_title.id
+        # description row is untouched (only one version of it).
+        desc_versions = (
+            db.query(ContentVersion)
+            .filter(ContentVersion.entity_id == module.id, ContentVersion.field == "description")
+            .count()
+        )
+        assert desc_versions == 1
+
+
+class TestChapterDualWrite:
+    def test_create_writes_title_row(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Раздел", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="Глава 1"))
+        rows = _active_rows(db, "chapter", chapter.id)
+        assert [r.field for r in rows] == ["title"]
+        assert rows[0].text == "Глава 1"
+        assert rows[0].locale == "ru"
+
+    def test_short_chapter_title_falls_back_to_course_source_locale(self, db: Session, teacher: User):
+        # English course → English fallback when title has no signal.
+        course = _make_course(db, teacher, locale="en")
+        module = create_module(db, course.id, ModuleCreate(title="Module", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="1"))
+        rows = _active_rows(db, "chapter", chapter.id)
+        assert len(rows) == 1
+        assert rows[0].locale == "en"
+
+    def test_update_title_supersedes(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Раздел", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="Глава первая"))
+        original = next(iter(_active_rows(db, "chapter", chapter.id)))
+        update_chapter(db, chapter, ChapterUpdate(title="Глава вторая"))
+        active = next(iter(_active_rows(db, "chapter", chapter.id)))
+        assert active.text == "Глава вторая"
+        db.refresh(original)
+        assert original.superseded_by == active.id


### PR DESCRIPTION
## What

Extends Phase 1 dual-write to modules + chapters and refactors the existing course path through a shared helper. Builds on #533.

## How

New shared helper `dual_write_entity_content` (`app/services/content_versions/dual_write.py`) replaces three copies of the pattern that would have grown across courses, modules, chapters. Any new translatable entity now adds ~4 lines to its write function:

```python
dual_write_entity_content(
    db,
    entity_type="module",
    entity_id=str(module.id),
    entity=module,
    fields=("title", "description"),
    fallback_locale=_course_source_locale(db, course_id),
)
```

The `fallback_locale` lookup is the only entity-specific piece — chapters walk `Chapter → Module → Course`; modules look up `Course` directly; courses use their own `source_locale`.

## Tests (7 new, 14 total dual-write tests)

| Entity | Pinned |
|---|---|
| Module create | title + description rows / empty description skipped / short title falls back to course locale |
| Module update | title-only PATCH supersedes title row only, description untouched |
| Chapter create | title row written / short title falls back to course locale (via Module → Course walk) |
| Chapter update | title supersedes |

**898/898 backend tests passing. Ruff + mypy clean.**

## Next

- **1d**: chapter_blocks (HTML-rich case)
- **1e**: quizzes + questions + options
- **1f**: assignments + announcements + course_events + cohorts
- **1g**: MT pipeline dual-write

🤖 Generated with [Claude Code](https://claude.com/claude-code)
