### PR TITLE
feat(bilingual): V1 phase 1e — dual-write quizzes/questions/options

### DIFF
--- a/backend/app/api/v1/blocks.py
+++ b/backend/app/api/v1/blocks.py
@@ -8,9 +8,11 @@ from app.api.dependencies import get_current_user, require_teacher, verify_chapt
 from app.core.database import get_db
 from app.core.sanitize import sanitize_string
 from app.models.chapter_block import ChapterBlock
+from app.models.course import Chapter, Course, Module
 from app.models.user import User
 from app.schemas.chapter_block import BlockCreate, BlockReorderItem, BlockResponse, BlockUpdate
 from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.content_versions import dual_write_entity_content
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
     localize_chapter_block_rows,
@@ -18,6 +20,24 @@ from app.services.translation.resolve_for_display import (
 )
 
 router = APIRouter(prefix="/blocks", tags=["blocks"])
+
+
+_TRANSLATABLE_BLOCK_FIELDS = ("content",)
+
+
+def _course_source_locale_for_chapter(db: Session, chapter_id: str) -> str | None:
+    """Walk ``ChapterBlock -> Chapter -> Module -> Course`` to find the
+    parent course's source locale for use as the dual-write fallback
+    when block ``content`` is too short or non-letter for the
+    detector to classify on its own.
+    """
+    return (
+        db.query(Course.source_locale)
+        .join(Module, Module.course_id == Course.id)
+        .join(Chapter, Chapter.module_id == Module.id)
+        .filter(Chapter.id == chapter_id)
+        .scalar()
+    )
 
 
 @router.get("/chapter/{chapter_id}", response_model=list[BlockResponse])
@@ -101,6 +121,16 @@ def create_block(
     )
     db.add(block)
     try:
+        db.flush()
+        dual_write_entity_content(
+            db,
+            entity_type="chapter_block",
+            entity_id=str(block.id),
+            entity=block,
+            fields=_TRANSLATABLE_BLOCK_FIELDS,
+            fallback_locale=_course_source_locale_for_chapter(db, chapter_id),
+            authored_by=teacher.id,
+        )
         db.commit()
     except IntegrityError as exc:
         # quiz_id / assignment_id are FKs — a stale client can pass an id
@@ -143,11 +173,23 @@ def update_block(
     if not block:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Block not found")
     verify_chapter_owner(db, block.chapter_id, teacher)
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         if field == "content" and value:
             value = sanitize_string(value)
         setattr(block, field, value)
     try:
+        db.flush()
+        dual_write_entity_content(
+            db,
+            entity_type="chapter_block",
+            entity_id=str(block.id),
+            entity=block,
+            fields=_TRANSLATABLE_BLOCK_FIELDS,
+            fallback_locale=_course_source_locale_for_chapter(db, block.chapter_id),
+            authored_by=teacher.id,
+            only_fields={f for f in _TRANSLATABLE_BLOCK_FIELDS if f in patch},
+        )
         db.commit()
     except IntegrityError as exc:
         db.rollback()

--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -16,6 +16,7 @@ from app.api.dependencies import (
     verify_chapter_owner,
 )
 from app.core.database import get_db
+from app.models.course import Chapter, Course, Module
 from app.models.quiz import Quiz, QuizExtraAttempt, QuizOption, QuizQuestion
 from app.models.user import User
 from app.schemas.locale import LocaleCode, normalize_locale
@@ -25,6 +26,7 @@ from app.schemas.quiz import (
     QuizStudentResponse,
     QuizUpdate,
 )
+from app.services.content_versions import dual_write_entity_content
 from app.services.translation.pipeline_hooks import (
     reconcile_entity_if_course_published,
     run_course_translation_pipeline_if_published,
@@ -36,6 +38,24 @@ from app.services.translation.resolve_for_display import (
 
 from ._deps import verify_quiz_owner
 from ._router import router
+
+_TRANSLATABLE_QUIZ_FIELDS = ("title", "description")
+_TRANSLATABLE_QUESTION_FIELDS = ("question_text",)
+_TRANSLATABLE_OPTION_FIELDS = ("option_text",)
+
+
+def _course_source_locale_for_chapter(db: Session, chapter_id: str) -> str | None:
+    """Walk ``Quiz -> Chapter -> Module -> Course`` to find the parent
+    course's source locale for use as the dual-write fallback when a
+    short / non-letter field can't be classified by the detector.
+    """
+    return (
+        db.query(Course.source_locale)
+        .join(Module, Module.course_id == Course.id)
+        .join(Chapter, Chapter.module_id == Module.id)
+        .filter(Chapter.id == chapter_id)
+        .scalar()
+    )
 
 
 @router.get("/chapter/{chapter_id}", response_model=QuizStudentResponse | None)
@@ -139,32 +159,67 @@ def create_quiz(
     )
     db.add(quiz)
 
+    questions_to_dual_write: list[tuple[QuizQuestion, list[QuizOption]]] = []
     for q_data in data.questions:
         question_id = uuid.uuid4()
-        db.add(
-            QuizQuestion(
-                id=question_id,
-                quiz_id=quiz_id_val,
-                question_text=q_data.question_text,
-                question_type=q_data.question_type,
-                order_index=q_data.order_index,
-                points=q_data.points,
-                # ``min_words`` is only meaningful for ``essay``; it's
-                # intentionally persisted as-is for every type so that
-                # switching a question to ``essay`` later keeps the hint.
-                min_words=q_data.min_words,
-            )
+        question = QuizQuestion(
+            id=question_id,
+            quiz_id=quiz_id_val,
+            question_text=q_data.question_text,
+            question_type=q_data.question_type,
+            order_index=q_data.order_index,
+            points=q_data.points,
+            # ``min_words`` is only meaningful for ``essay``; it's
+            # intentionally persisted as-is for every type so that
+            # switching a question to ``essay`` later keeps the hint.
+            min_words=q_data.min_words,
         )
+        db.add(question)
+        question_options: list[QuizOption] = []
         for o_data in q_data.options:
-            db.add(
-                QuizOption(
-                    question_id=question_id,
-                    option_text=o_data.option_text,
-                    is_correct=o_data.is_correct,
-                    order_index=o_data.order_index,
-                )
+            opt = QuizOption(
+                question_id=question_id,
+                option_text=o_data.option_text,
+                is_correct=o_data.is_correct,
+                order_index=o_data.order_index,
             )
+            db.add(opt)
+            question_options.append(opt)
+        questions_to_dual_write.append((question, question_options))
 
+    # Flush so child ids (options have server-side defaults) are
+    # populated before dual-write reads them.
+    db.flush()
+    fallback_locale = _course_source_locale_for_chapter(db, data.chapter_id)
+    dual_write_entity_content(
+        db,
+        entity_type="quiz",
+        entity_id=str(quiz.id),
+        entity=quiz,
+        fields=_TRANSLATABLE_QUIZ_FIELDS,
+        fallback_locale=fallback_locale,
+        authored_by=teacher.id,
+    )
+    for question, options in questions_to_dual_write:
+        dual_write_entity_content(
+            db,
+            entity_type="quiz_question",
+            entity_id=str(question.id),
+            entity=question,
+            fields=_TRANSLATABLE_QUESTION_FIELDS,
+            fallback_locale=fallback_locale,
+            authored_by=teacher.id,
+        )
+        for opt in options:
+            dual_write_entity_content(
+                db,
+                entity_type="quiz_option",
+                entity_id=str(opt.id),
+                entity=opt,
+                fields=_TRANSLATABLE_OPTION_FIELDS,
+                fallback_locale=fallback_locale,
+                authored_by=teacher.id,
+            )
     db.commit()
     reloaded = (
         db.query(Quiz)
@@ -193,12 +248,24 @@ def update_quiz(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
     verify_quiz_owner(db, quiz, teacher.id)
 
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(quiz, field, value)
 
     if quiz.quiz_type == "exam" and quiz.max_attempts is None:
         quiz.max_attempts = 1
 
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="quiz",
+        entity_id=str(quiz.id),
+        entity=quiz,
+        fields=_TRANSLATABLE_QUIZ_FIELDS,
+        fallback_locale=_course_source_locale_for_chapter(db, quiz.chapter_id),
+        authored_by=teacher.id,
+        only_fields={f for f in _TRANSLATABLE_QUIZ_FIELDS if f in patch},
+    )
     db.commit()
     reloaded = (
         db.query(Quiz)

--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -7,6 +7,7 @@ all funnel through ``record_human_version`` / ``record_mt_version``
 / ``record_mt_failure``.
 """
 
+from app.services.content_versions.dual_write import dual_write_entity_content
 from app.services.content_versions.write import (
     record_human_version,
     record_mt_failure,
@@ -14,6 +15,7 @@ from app.services.content_versions.write import (
 )
 
 __all__ = [
+    "dual_write_entity_content",
     "record_human_version",
     "record_mt_failure",
     "record_mt_version",

--- a/backend/app/services/content_versions/dual_write.py
+++ b/backend/app/services/content_versions/dual_write.py
@@ -1,0 +1,98 @@
+"""Shared per-field dual-write helper used by every entity write
+path during Phase 1.
+
+The pattern repeats for every translatable entity:
+
+1. Read each translatable field's text from the entity.
+2. Detect that field's language (or fall back to a caller-supplied
+   locale when the detector has no signal).
+3. Call ``record_human_version`` once per field.
+
+Centralising it here keeps every call site to a 4-line invocation,
+and means a future change to language-detection / fallback strategy
+edits ONE function instead of N.
+
+Reads still go to entity columns. Phase 2 introduces the dual-read
+layer; Phase 4 flips reads exclusive.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from app.services.content_versions.write import record_human_version
+from app.services.language_detection import detect_locale
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sqlalchemy.orm import Session
+
+
+def dual_write_entity_content(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    entity: object,
+    fields: Iterable[str],
+    fallback_locale: str | None,
+    authored_by: str | uuid.UUID | None = None,
+    only_fields: set[str] | None = None,
+) -> None:
+    """Write a ``content_versions`` human row for every translatable
+    field on ``entity`` that the caller wrote.
+
+    Per-field detection: each field's locale is decided from its own
+    text. Two fields on the same entity can land in different locales
+    (an EN title and a RU description are normal). Detection falls
+    back to ``fallback_locale`` when the field text is too short to
+    classify or has no language signal.
+
+    ``only_fields`` filters to the fields the caller actually wrote
+    (used on UPDATE so a description-only PATCH doesn't supersede
+    the title row). ``None`` means "every field in ``fields``".
+
+    ``authored_by`` is stored on the row when known. Accepts a UUID
+    or a string-coerceable id.
+    """
+    if only_fields is None:
+        target_fields: list[str] = list(fields)
+    else:
+        target_fields = [f for f in fields if f in only_fields]
+
+    if not target_fields:
+        return
+
+    author_uuid = _coerce_uuid(authored_by)
+
+    for field in target_fields:
+        text = getattr(entity, field, None)
+        if not text or not str(text).strip():
+            continue
+        text_str = str(text)
+        detected = detect_locale(text_str)
+        locale = detected or fallback_locale
+        if locale is None:
+            # No signal AND no fallback — skip. The field re-enters
+            # this path the next time the entity is saved with
+            # enough surrounding context to resolve a fallback.
+            continue
+        record_human_version(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            locale=locale,
+            text=text_str,
+            authored_by=author_uuid,
+        )
+
+
+def _coerce_uuid(value: str | uuid.UUID | None) -> uuid.UUID | None:
+    if value is None:
+        return None
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))

--- a/backend/app/services/course_service/_chapters.py
+++ b/backend/app/services/course_service/_chapters.py
@@ -8,12 +8,16 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import func
 
-from app.models.course import Chapter
+from app.models.course import Chapter, Course, Module
+from app.services.content_versions import dual_write_entity_content
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from app.schemas.course import ChapterCreate, ChapterUpdate
+
+
+_TRANSLATABLE_CHAPTER_FIELDS = ("title",)
 
 
 def _next_chapter_order(db: Session, module_id: str) -> int:
@@ -24,6 +28,19 @@ def _next_chapter_order(db: Session, module_id: str) -> int:
         .scalar()
     )
     return 0 if current_max is None else current_max + 1
+
+
+def _course_source_locale_for_module(db: Session, module_id: str) -> str | None:
+    """Walk ``Chapter -> Module -> Course`` to find the parent course's
+    source locale. Used as the fallback when a chapter title alone
+    can't be classified by the language detector.
+    """
+    return (
+        db.query(Course.source_locale)
+        .join(Module, Module.course_id == Course.id)
+        .filter(Module.id == module_id)
+        .scalar()
+    )
 
 
 def create_chapter(db: Session, module_id: str, data: ChapterCreate) -> Chapter:
@@ -40,14 +57,34 @@ def create_chapter(db: Session, module_id: str, data: ChapterCreate) -> Chapter:
         is_locked=data.is_locked,
     )
     db.add(chapter)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="chapter",
+        entity_id=str(chapter.id),
+        entity=chapter,
+        fields=_TRANSLATABLE_CHAPTER_FIELDS,
+        fallback_locale=_course_source_locale_for_module(db, module_id),
+    )
     db.commit()
     db.refresh(chapter)
     return chapter
 
 
 def update_chapter(db: Session, chapter: Chapter, data: ChapterUpdate) -> Chapter:
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(chapter, field, value)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="chapter",
+        entity_id=str(chapter.id),
+        entity=chapter,
+        fields=_TRANSLATABLE_CHAPTER_FIELDS,
+        fallback_locale=_course_source_locale_for_module(db, chapter.module_id),
+        only_fields={f for f in _TRANSLATABLE_CHAPTER_FIELDS if f in patch},
+    )
     db.commit()
     db.refresh(chapter)
     return chapter

--- a/backend/app/services/course_service/_courses.py
+++ b/backend/app/services/course_service/_courses.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 
 from app.models.course import Chapter, Course, Module
-from app.services.content_versions import record_human_version
+from app.services.content_versions import dual_write_entity_content
 from app.services.language_detection import detect_locale
 
 if TYPE_CHECKING:
@@ -21,64 +21,6 @@ if TYPE_CHECKING:
 
 
 _TRANSLATABLE_COURSE_FIELDS = ("title", "description")
-
-
-def _dual_write_course_content(
-    db: Session,
-    course: Course,
-    *,
-    authored_by: str | UUID | None,
-    course_fallback: str | None,
-    only_fields: set[str] | None = None,
-) -> None:
-    """Write a ``content_versions`` row for every translatable field
-    on ``course`` that the caller wrote.
-
-    Each field's locale is detected from its own text (so a course
-    with an English title and Russian description gets two rows with
-    different ``locale`` values). Detection falls back to the course
-    source locale when the field's text is too short or has no
-    language signal.
-
-    ``only_fields`` is the set of fields the caller actually wrote;
-    ``None`` means "every translatable field" (used on create).
-    Filtering is important on PATCH so a description-only update
-    doesn't supersede the title row.
-
-    ``authored_by`` is the user id the route layer attributes the
-    write to (course owner on create, owner on update). Stored on
-    the row so the future preacher-style audit UI can show who
-    wrote what.
-    """
-    fields: tuple[str, ...]
-    if only_fields is None:
-        fields = _TRANSLATABLE_COURSE_FIELDS
-    else:
-        fields = tuple(f for f in _TRANSLATABLE_COURSE_FIELDS if f in only_fields)
-    author_uuid: UUID | None = None
-    if authored_by is not None:
-        author_uuid = authored_by if isinstance(authored_by, uuid.UUID) else uuid.UUID(str(authored_by))
-    for field in fields:
-        text = getattr(course, field, None)
-        if not text or not str(text).strip():
-            continue
-        detected = detect_locale(str(text))
-        locale = detected or course_fallback
-        if locale is None:
-            # No signal AND no course-level fallback — skip. Dual-write
-            # without a locale would be nonsensical and the field will
-            # come back through this path the next time the entity is
-            # saved with enough context.
-            continue
-        record_human_version(
-            db,
-            entity_type="course",
-            entity_id=str(course.id),
-            field=field,
-            locale=locale,
-            text=str(text),
-            authored_by=author_uuid,
-        )
 
 
 def _resolve_source_locale(
@@ -138,7 +80,15 @@ def create_course(
         course.source_locale = resolved_locale
     db.add(course)
     db.flush()
-    _dual_write_course_content(db, course, authored_by=user_id, course_fallback=resolved_locale)
+    dual_write_entity_content(
+        db,
+        entity_type="course",
+        entity_id=str(course.id),
+        entity=course,
+        fields=_TRANSLATABLE_COURSE_FIELDS,
+        fallback_locale=resolved_locale,
+        authored_by=user_id,
+    )
     db.commit()
     db.refresh(course)
     return course
@@ -165,12 +115,15 @@ def update_course(db: Session, course: Course, data: CourseUpdate) -> Course:
     # Dual-write to content_versions only for fields the caller actually
     # touched — a PATCH that didn't include ``description`` mustn't
     # supersede the existing description row.
-    _dual_write_course_content(
+    dual_write_entity_content(
         db,
-        course,
+        entity_type="course",
+        entity_id=str(course.id),
+        entity=course,
+        fields=_TRANSLATABLE_COURSE_FIELDS,
+        fallback_locale=course.source_locale,
         authored_by=course.created_by,
-        course_fallback=course.source_locale,
-        only_fields={f for f in ("title", "description") if f in patch},
+        only_fields={f for f in _TRANSLATABLE_COURSE_FIELDS if f in patch},
     )
     db.commit()
     db.refresh(course)

--- a/backend/app/services/course_service/_modules.py
+++ b/backend/app/services/course_service/_modules.py
@@ -8,12 +8,16 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import func
 
-from app.models.course import Chapter, Module
+from app.models.course import Chapter, Course, Module
+from app.services.content_versions import dual_write_entity_content
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from app.schemas.course import ModuleCreate, ModuleUpdate
+
+
+_TRANSLATABLE_MODULE_FIELDS = ("title", "description")
 
 
 def _next_module_order(db: Session, course_id: str) -> int:
@@ -24,6 +28,16 @@ def _next_module_order(db: Session, course_id: str) -> int:
         .scalar()
     )
     return 0 if current_max is None else current_max + 1
+
+
+def _course_source_locale(db: Session, course_id: str) -> str | None:
+    """Cheap single-column lookup of the parent course's source locale.
+
+    Used as the per-field detection fallback when a module / chapter
+    title can't be classified on its own (short titles like "1" or
+    "Часть 1" often can't).
+    """
+    return db.query(Course.source_locale).filter(Course.id == course_id).scalar()
 
 
 def create_module(db: Session, course_id: str, data: ModuleCreate) -> Module:
@@ -41,14 +55,34 @@ def create_module(db: Session, course_id: str, data: ModuleCreate) -> Module:
         due_date=data.due_date,
     )
     db.add(module)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="module",
+        entity_id=str(module.id),
+        entity=module,
+        fields=_TRANSLATABLE_MODULE_FIELDS,
+        fallback_locale=_course_source_locale(db, course_id),
+    )
     db.commit()
     db.refresh(module)
     return module
 
 
 def update_module(db: Session, module: Module, data: ModuleUpdate) -> Module:
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(module, field, value)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="module",
+        entity_id=str(module.id),
+        entity=module,
+        fields=_TRANSLATABLE_MODULE_FIELDS,
+        fallback_locale=_course_source_locale(db, module.course_id),
+        only_fields={f for f in _TRANSLATABLE_MODULE_FIELDS if f in patch},
+    )
     db.commit()
     db.refresh(module)
     return module

--- a/backend/tests/test_blocks_dual_write.py
+++ b/backend/tests/test_blocks_dual_write.py
@@ -1,0 +1,184 @@
+# ruff: noqa: RUF001
+"""Phase 1d integration tests: chapter_block create/update dual-writes
+into ``content_versions``.
+
+Block content is HTML — the language detector ignores tag chars by
+construction, so per-field detection works directly on the stored
+markup without a pre-strip step. Pins the same supersession +
+idempotency contract as courses / modules / chapters.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.models.chapter_block import ChapterBlock
+from app.models.content_version import ContentVersion
+from app.models.course import Chapter, Course, Module
+from tests.conftest import TEACHER_ID
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+def _seed_chapter(db: Session, *, course_locale: str = "ru") -> str:
+    """Course → module → chapter; return chapter id."""
+    course = Course(
+        id="course-blocks-dw",
+        title="Учебник" if course_locale == "ru" else "Textbook",
+        created_by=TEACHER_ID,
+        status="draft",
+        source_locale=course_locale,
+    )
+    module = Module(id="mod-blocks-dw", course_id=course.id, title="Раздел", order_index=0)
+    chapter = Chapter(
+        id="ch-blocks-dw",
+        module_id=module.id,
+        title="Глава",
+        order_index=0,
+        chapter_type="text",
+    )
+    db.add_all([course, module, chapter])
+    db.commit()
+    return chapter.id
+
+
+def _active_rows(db: Session, block_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == "chapter_block",
+            ContentVersion.entity_id == block_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .all()
+    )
+
+
+class TestCreateBlockDualWrite:
+    def test_text_block_writes_content_row(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={
+                "block_type": "text",
+                "order_index": 0,
+                "content": "<p>Урок о первой главе книги Бытия.</p>",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        block_id = resp.json()["id"]
+        rows = _active_rows(db, block_id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.field == "content"
+        assert "Урок о первой главе" in row.text
+        assert row.locale == "ru"
+        assert row.origin == "human"
+        assert row.authored_by == TEACHER_ID
+
+    def test_quiz_block_with_no_content_skips_dual_write(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        # Quiz blocks reference a quiz_id and have NULL content; nothing
+        # to write into content_versions.
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={"block_type": "file", "order_index": 0, "file_name": "syllabus.pdf"},
+        )
+        assert resp.status_code == 201, resp.text
+        block_id = resp.json()["id"]
+        assert _active_rows(db, block_id) == []
+
+    def test_html_only_falls_back_to_course_source_locale(self, client: TestClient, db: Session):
+        # ASCII non-letter content — detector returns None; falls back
+        # to the parent course's source_locale (en here).
+        chapter_id = _seed_chapter(db, course_locale="en")
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={"block_type": "text", "order_index": 0, "content": "<p>12345</p>"},
+        )
+        assert resp.status_code == 201, resp.text
+        block_id = resp.json()["id"]
+        rows = _active_rows(db, block_id)
+        assert len(rows) == 1
+        assert rows[0].locale == "en"
+
+
+class TestUpdateBlockDualWrite:
+    def test_content_change_supersedes_old_row(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={
+                "block_type": "text",
+                "order_index": 0,
+                "content": "<p>Первый вариант текста урока.</p>",
+            },
+        )
+        block_id = resp.json()["id"]
+        original = _active_rows(db, block_id)[0]
+        resp = client.put(
+            f"/api/v1/blocks/{block_id}",
+            json={"content": "<p>Второй вариант текста урока.</p>"},
+        )
+        assert resp.status_code == 200, resp.text
+        active = _active_rows(db, block_id)
+        assert len(active) == 1
+        assert "Второй вариант" in active[0].text
+        db.refresh(original)
+        assert original.superseded_by == active[0].id
+
+    def test_non_content_patch_does_not_touch_content_versions(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={
+                "block_type": "text",
+                "order_index": 0,
+                "content": "<p>Стабильный текст.</p>",
+            },
+        )
+        block_id = resp.json()["id"]
+        ids_before = {r.id for r in _active_rows(db, block_id)}
+        # PATCH that only flips order_index — content_versions stays put.
+        resp = client.put(f"/api/v1/blocks/{block_id}", json={"order_index": 5})
+        assert resp.status_code == 200, resp.text
+        ids_after = {r.id for r in _active_rows(db, block_id)}
+        assert ids_before == ids_after
+
+    def test_identical_content_patch_is_idempotent(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={
+                "block_type": "text",
+                "order_index": 0,
+                "content": "<p>Текст урока.</p>",
+            },
+        )
+        block_id = resp.json()["id"]
+        original_id = _active_rows(db, block_id)[0].id
+        # Re-PUT identical content — no version churn.
+        resp = client.put(
+            f"/api/v1/blocks/{block_id}",
+            json={"content": "<p>Текст урока.</p>"},
+        )
+        assert resp.status_code == 200, resp.text
+        current = _active_rows(db, block_id)
+        assert len(current) == 1
+        assert current[0].id == original_id
+
+
+@pytest.fixture(autouse=True)
+def _isolate(db: Session):
+    """Make each test see a fresh ``content_versions`` slate for
+    the seeded chapter so tests don't bleed assertions into each
+    other when the same module/chapter ids reappear via the seed
+    helper."""
+    yield
+    db.query(ContentVersion).filter(ContentVersion.entity_type == "chapter_block").delete()
+    db.query(ChapterBlock).delete()
+    db.commit()

--- a/backend/tests/test_modules_chapters_dual_write.py
+++ b/backend/tests/test_modules_chapters_dual_write.py
@@ -1,0 +1,163 @@
+# ruff: noqa: RUF001
+"""Phase 1c integration tests: module / chapter create/update
+dual-writes into ``content_versions``.
+
+Pins behaviour parallel to ``test_courses_dual_write.py``:
+
+* Each create writes one ``content_versions`` row per translatable
+  field with per-field detected locale.
+* Each update supersedes only the fields the caller actually wrote.
+* Short titles that the detector can't classify fall back to the
+  parent course's ``source_locale``.
+
+Modules have (title, description); chapters have just (title,).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.content_version import ContentVersion
+from app.models.user import User, UserRole
+from app.schemas.course import (
+    ChapterCreate,
+    ChapterUpdate,
+    CourseCreate,
+    ModuleCreate,
+    ModuleUpdate,
+)
+from app.services.course_service._chapters import create_chapter, update_chapter
+from app.services.course_service._courses import create_course
+from app.services.course_service._modules import create_module, update_module
+
+
+@pytest.fixture
+def db():
+    from tests.conftest import test_engine
+
+    session = Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def teacher(db: Session) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email=f"mc-dw-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Module/Chapter Teacher",
+        role=UserRole.TEACHER.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _active_rows(db: Session, entity_type: str, entity_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .order_by(ContentVersion.field)
+        .all()
+    )
+
+
+def _make_course(db: Session, teacher: User, *, locale: str = "ru"):
+    title, desc = ("Учебник", "Курс.") if locale == "ru" else ("Textbook", "Course on scripture.")
+    return create_course(
+        db,
+        CourseCreate(title=title, description=desc),
+        user_id=teacher.id,
+        source_locale=locale,
+    )
+
+
+class TestModuleDualWrite:
+    def test_create_writes_title_and_description(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(
+            db,
+            course.id,
+            ModuleCreate(title="Модуль 1", description="О первой части."),
+        )
+        rows = {r.field: r for r in _active_rows(db, "module", module.id)}
+        assert set(rows.keys()) == {"title", "description"}
+        assert rows["title"].text == "Модуль 1"
+        assert rows["title"].locale == "ru"
+        assert rows["description"].locale == "ru"
+
+    def test_create_with_no_description_skips_description_row(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Модуль", description=None))
+        rows = _active_rows(db, "module", module.id)
+        assert [r.field for r in rows] == ["title"]
+
+    def test_short_title_falls_back_to_course_source_locale(self, db: Session, teacher: User):
+        # Title of just "1" — detector cannot classify; fallback is
+        # the parent course's source_locale ("ru" here).
+        course = _make_course(db, teacher, locale="ru")
+        module = create_module(db, course.id, ModuleCreate(title="1", description=None))
+        rows = _active_rows(db, "module", module.id)
+        assert len(rows) == 1
+        assert rows[0].locale == "ru"
+
+    def test_update_title_supersedes_old_title_only(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(
+            db,
+            course.id,
+            ModuleCreate(title="Старое", description="Описание."),
+        )
+        original_title = next(r for r in _active_rows(db, "module", module.id) if r.field == "title")
+        update_module(db, module, ModuleUpdate(title="Новое"))
+        active_title = next(r for r in _active_rows(db, "module", module.id) if r.field == "title")
+        assert active_title.text == "Новое"
+        db.refresh(original_title)
+        assert original_title.superseded_by == active_title.id
+        # description row is untouched (only one version of it).
+        desc_versions = (
+            db.query(ContentVersion)
+            .filter(ContentVersion.entity_id == module.id, ContentVersion.field == "description")
+            .count()
+        )
+        assert desc_versions == 1
+
+
+class TestChapterDualWrite:
+    def test_create_writes_title_row(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Раздел", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="Глава 1"))
+        rows = _active_rows(db, "chapter", chapter.id)
+        assert [r.field for r in rows] == ["title"]
+        assert rows[0].text == "Глава 1"
+        assert rows[0].locale == "ru"
+
+    def test_short_chapter_title_falls_back_to_course_source_locale(self, db: Session, teacher: User):
+        # English course → English fallback when title has no signal.
+        course = _make_course(db, teacher, locale="en")
+        module = create_module(db, course.id, ModuleCreate(title="Module", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="1"))
+        rows = _active_rows(db, "chapter", chapter.id)
+        assert len(rows) == 1
+        assert rows[0].locale == "en"
+
+    def test_update_title_supersedes(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Раздел", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="Глава первая"))
+        original = next(iter(_active_rows(db, "chapter", chapter.id)))
+        update_chapter(db, chapter, ChapterUpdate(title="Глава вторая"))
+        active = next(iter(_active_rows(db, "chapter", chapter.id)))
+        assert active.text == "Глава вторая"
+        db.refresh(original)
+        assert original.superseded_by == active.id

--- a/backend/tests/test_quizzes_dual_write.py
+++ b/backend/tests/test_quizzes_dual_write.py
@@ -1,0 +1,173 @@
+"""Phase 1e integration tests: quiz / question / option dual-writes.
+
+Quiz creation is one-shot — Quiz + Questions + Options all land in
+a single endpoint call. The dual-write fans out: one row per
+(quiz, field), one per (question, field), one per (option, field).
+``update_quiz`` only mutates the Quiz row itself.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.models.content_version import ContentVersion
+from app.models.course import Chapter, Course, Module
+from app.models.quiz import Quiz, QuizOption, QuizQuestion
+from tests.conftest import TEACHER_ID
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+def _seed_chapter(db: Session) -> str:
+    course = Course(
+        id="course-quiz-dw",
+        title="Учебник",
+        created_by=TEACHER_ID,
+        status="draft",
+        source_locale="ru",
+    )
+    module = Module(id="mod-quiz-dw", course_id=course.id, title="Раздел", order_index=0)
+    chapter = Chapter(
+        id="ch-quiz-dw",
+        module_id=module.id,
+        title="Глава",
+        order_index=0,
+        chapter_type="quiz",
+    )
+    db.add_all([course, module, chapter])
+    db.commit()
+    return chapter.id
+
+
+def _active(db: Session, entity_type: str, entity_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .order_by(ContentVersion.field)
+        .all()
+    )
+
+
+class TestCreateQuizDualWrite:
+    def test_writes_quiz_question_option_rows(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        payload = {
+            "chapter_id": chapter_id,
+            "title": "Тест по Бытию",
+            "description": "Краткий тест после первой главы.",
+            "quiz_type": "quiz",
+            "passing_score": 70,
+            "questions": [
+                {
+                    "question_text": "Кто создал небо и землю?",
+                    "question_type": "multiple_choice",
+                    "order_index": 0,
+                    "points": 1,
+                    "options": [
+                        {"option_text": "Бог", "is_correct": True, "order_index": 0},
+                        {"option_text": "Никто", "is_correct": False, "order_index": 1},
+                    ],
+                },
+            ],
+        }
+        resp = client.post("/api/v1/quizzes", json=payload)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        quiz_id = data["id"]
+        # Quiz: title + description rows.
+        quiz_rows = {r.field: r for r in _active(db, "quiz", quiz_id)}
+        assert set(quiz_rows.keys()) == {"title", "description"}
+        assert quiz_rows["title"].text == "Тест по Бытию"
+        assert quiz_rows["title"].locale == "ru"
+        assert quiz_rows["title"].authored_by == TEACHER_ID
+        # Question row.
+        question_id = data["questions"][0]["id"]
+        question_rows = _active(db, "quiz_question", question_id)
+        assert len(question_rows) == 1
+        assert question_rows[0].field == "question_text"
+        assert "Кто создал" in question_rows[0].text
+        # Option rows (one per option).
+        for opt in data["questions"][0]["options"]:
+            opt_rows = _active(db, "quiz_option", opt["id"])
+            assert len(opt_rows) == 1
+            assert opt_rows[0].field == "option_text"
+
+    def test_quiz_without_description_skips_description_row(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            "/api/v1/quizzes",
+            json={
+                "chapter_id": chapter_id,
+                "title": "Тест",
+                "description": None,
+                "quiz_type": "quiz",
+                "passing_score": 70,
+                "questions": [],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        quiz_id = resp.json()["id"]
+        rows = _active(db, "quiz", quiz_id)
+        assert [r.field for r in rows] == ["title"]
+
+
+class TestUpdateQuizDualWrite:
+    def test_title_change_supersedes_quiz_title_row(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            "/api/v1/quizzes",
+            json={
+                "chapter_id": chapter_id,
+                "title": "Старое",
+                "description": "Описание.",
+                "quiz_type": "quiz",
+                "passing_score": 70,
+                "questions": [],
+            },
+        )
+        quiz_id = resp.json()["id"]
+        original_title = next(r for r in _active(db, "quiz", quiz_id) if r.field == "title")
+        resp = client.put(f"/api/v1/quizzes/{quiz_id}", json={"title": "Новое"})
+        assert resp.status_code == 200, resp.text
+        active_title = next(r for r in _active(db, "quiz", quiz_id) if r.field == "title")
+        assert active_title.text == "Новое"
+        db.refresh(original_title)
+        assert original_title.superseded_by == active_title.id
+
+    def test_non_text_patch_does_not_touch_content_versions(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            "/api/v1/quizzes",
+            json={
+                "chapter_id": chapter_id,
+                "title": "Стабильный",
+                "description": "Описание.",
+                "quiz_type": "quiz",
+                "passing_score": 70,
+                "questions": [],
+            },
+        )
+        quiz_id = resp.json()["id"]
+        ids_before = {r.id for r in _active(db, "quiz", quiz_id)}
+        resp = client.put(f"/api/v1/quizzes/{quiz_id}", json={"passing_score": 80})
+        assert resp.status_code == 200, resp.text
+        ids_after = {r.id for r in _active(db, "quiz", quiz_id)}
+        assert ids_before == ids_after
+
+
+@pytest.fixture(autouse=True)
+def _isolate(db: Session):
+    yield
+    db.query(ContentVersion).filter(ContentVersion.entity_type.in_(("quiz", "quiz_question", "quiz_option"))).delete()
+    db.query(QuizOption).delete()
+    db.query(QuizQuestion).delete()
+    db.query(Quiz).delete()
+    db.commit()


### PR DESCRIPTION
## What

Phase 1e — wires the dual-write helper into quiz creation + update.

**Stacked on #534 / #535.** Auto-merges once those land.

## How

`create_quiz` is one-shot — Quiz + every Question + every Option lands in a single transaction. The dual-write fans out one row per `(entity, field)`:

| Entity | Fields |
|---|---|
| `quiz` | `title`, `description` |
| `quiz_question` | `question_text` |
| `quiz_option` | `option_text` |

`update_quiz` only mutates Quiz fields (questions/options have no per-entity update endpoint in the current API — they're immutable post-creation).

Fallback locale walks `Quiz → Chapter → Module → Course`.

## Tests (4 new, via TestClient)

| Test | Pins |
|---|---|
| `test_writes_quiz_question_option_rows` | Create writes `quiz` + `quiz_question` + `quiz_option` rows with detected locale + `authored_by` |
| `test_quiz_without_description_skips_description_row` | NULL description → no phantom row |
| `test_title_change_supersedes_quiz_title_row` | Title PATCH supersedes only the quiz title row |
| `test_non_text_patch_does_not_touch_content_versions` | `passing_score`-only PATCH leaves the table untouched |

**901/901 backend tests passing. Ruff + mypy clean.**

## Next

- **1f**: assignments + announcements + course_events + cohorts
- **1g**: MT pipeline dual-write

🤖 Generated with [Claude Code](https://claude.com/claude-code)
