### PR TITLE
feat(bilingual): V1 phase 1f — dual-write assignments/announcements/events/cohorts

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -1,4 +1,5 @@
 import uuid
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
@@ -21,11 +22,44 @@ from app.schemas.announcement import (
     AnnouncementUpdate,
 )
 from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.content_versions import dual_write_entity_content
 from app.services.notification_service import create_notifications_bulk
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import localize_announcement_rows
 
 router = APIRouter(prefix="/announcements", tags=["announcements"])
+
+
+_TRANSLATABLE_ANNOUNCEMENT_FIELDS = ("title", "content")
+
+
+def _dual_write_announcement(
+    db: Session,
+    announcement: Announcement,
+    *,
+    teacher: User,
+    course: Course | None,
+    only_fields: set[str] | None = None,
+) -> None:
+    """Dual-write an announcement's title + content to content_versions.
+
+    Course-scoped announcements use the course's source_locale as the
+    detector fallback. Global announcements (no course context) fall
+    back to the author's preferred_locale — never a hard-coded default
+    so a Russian admin writing a Russian announcement from an English
+    UI still lands in 'ru'.
+    """
+    fallback = course.source_locale if course is not None else teacher.preferred_locale
+    dual_write_entity_content(
+        db,
+        entity_type="announcement",
+        entity_id=str(announcement.id),
+        entity=announcement,
+        fields=_TRANSLATABLE_ANNOUNCEMENT_FIELDS,
+        fallback_locale=fallback,
+        authored_by=teacher.id,
+        only_fields=only_fields,
+    )
 
 
 def _course_source_locale_map(db: Session, course_ids: list[str]) -> dict[str, LocaleCode]:
@@ -212,6 +246,13 @@ def create_announcement(
             metadata={"course_id": data.course_id, "announcement_id": str(announcement.id)},
         )
 
+    # Dual-write to content_versions. Global announcements (no
+    # course_id) fall back to the author's preferred_locale because
+    # they have no course context. The detector still runs per-field
+    # on the actual text so a Russian-authored announcement from an
+    # English-UI admin lands in 'ru'.
+    _dual_write_announcement(db, announcement, teacher=teacher, course=course)
+
     db.commit()
     db.refresh(announcement)
     if data.course_id:
@@ -221,7 +262,7 @@ def create_announcement(
 
 @router.put("/{announcement_id}", response_model=AnnouncementResponse)
 def update_announcement(
-    announcement_id: str,
+    announcement_id: UUID,
     data: AnnouncementUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
@@ -238,10 +279,17 @@ def update_announcement(
             detail="You can only edit your own announcements",
         )
 
+    touched: set[str] = set()
     if data.title is not None:
         announcement.title = sanitize_string(data.title)
+        touched.add("title")
     if data.content is not None:
         announcement.content = sanitize_string(data.content)
+        touched.add("content")
+
+    course = db.query(Course).filter(Course.id == announcement.course_id).first() if announcement.course_id else None
+    db.flush()
+    _dual_write_announcement(db, announcement, teacher=teacher, course=course, only_fields=touched)
 
     db.commit()
     db.refresh(announcement)
@@ -252,7 +300,7 @@ def update_announcement(
 
 @router.delete("/{announcement_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_announcement(
-    announcement_id: str,
+    announcement_id: UUID,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> None:

--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -15,6 +15,7 @@ from app.api.dependencies import (
 from app.core.database import get_db
 from app.models.assignment import Assignment, AssignmentSubmission
 from app.models.chapter_progress import ChapterProgress
+from app.models.course import Chapter, Course, Module
 from app.models.enrollment import Enrollment
 from app.models.user import User, UserRole
 from app.schemas.assignment import (
@@ -27,6 +28,7 @@ from app.schemas.assignment import (
 )
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.audit_service import log_action
+from app.services.content_versions import dual_write_entity_content
 from app.services.course_service import sync_enrollment_progress
 from app.services.notification_service import create_notification
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
@@ -74,6 +76,20 @@ def list_chapter_assignments(
     return rows
 
 
+_TRANSLATABLE_ASSIGNMENT_FIELDS = ("title", "description")
+
+
+def _course_source_locale_for_chapter(db: Session, chapter_id: str) -> str | None:
+    """Walk Assignment -> Chapter -> Module -> Course."""
+    return (
+        db.query(Course.source_locale)
+        .join(Module, Module.course_id == Course.id)
+        .join(Chapter, Chapter.module_id == Module.id)
+        .filter(Chapter.id == chapter_id)
+        .scalar()
+    )
+
+
 @router.post("", response_model=AssignmentResponse, status_code=status.HTTP_201_CREATED)
 def create_assignment(
     data: AssignmentCreate,
@@ -83,6 +99,16 @@ def create_assignment(
     verify_chapter_owner(db, data.chapter_id, teacher)
     assignment = Assignment(**data.model_dump())
     db.add(assignment)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="assignment",
+        entity_id=str(assignment.id),
+        entity=assignment,
+        fields=_TRANSLATABLE_ASSIGNMENT_FIELDS,
+        fallback_locale=_course_source_locale_for_chapter(db, data.chapter_id),
+        authored_by=teacher.id,
+    )
     db.commit()
     db.refresh(assignment)
     reconcile_entity_if_course_published(db, "assignment", assignment)
@@ -101,9 +127,21 @@ def update_assignment(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Assignment not found")
     verify_chapter_owner(db, assignment.chapter_id, teacher)
 
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(assignment, field, value)
 
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="assignment",
+        entity_id=str(assignment.id),
+        entity=assignment,
+        fields=_TRANSLATABLE_ASSIGNMENT_FIELDS,
+        fallback_locale=_course_source_locale_for_chapter(db, assignment.chapter_id),
+        authored_by=teacher.id,
+        only_fields={f for f in _TRANSLATABLE_ASSIGNMENT_FIELDS if f in patch},
+    )
     db.commit()
     db.refresh(assignment)
     reconcile_entity_if_course_published(db, "assignment", assignment)

--- a/backend/app/api/v1/blocks.py
+++ b/backend/app/api/v1/blocks.py
@@ -8,9 +8,11 @@ from app.api.dependencies import get_current_user, require_teacher, verify_chapt
 from app.core.database import get_db
 from app.core.sanitize import sanitize_string
 from app.models.chapter_block import ChapterBlock
+from app.models.course import Chapter, Course, Module
 from app.models.user import User
 from app.schemas.chapter_block import BlockCreate, BlockReorderItem, BlockResponse, BlockUpdate
 from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.content_versions import dual_write_entity_content
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
     localize_chapter_block_rows,
@@ -18,6 +20,24 @@ from app.services.translation.resolve_for_display import (
 )
 
 router = APIRouter(prefix="/blocks", tags=["blocks"])
+
+
+_TRANSLATABLE_BLOCK_FIELDS = ("content",)
+
+
+def _course_source_locale_for_chapter(db: Session, chapter_id: str) -> str | None:
+    """Walk ``ChapterBlock -> Chapter -> Module -> Course`` to find the
+    parent course's source locale for use as the dual-write fallback
+    when block ``content`` is too short or non-letter for the
+    detector to classify on its own.
+    """
+    return (
+        db.query(Course.source_locale)
+        .join(Module, Module.course_id == Course.id)
+        .join(Chapter, Chapter.module_id == Module.id)
+        .filter(Chapter.id == chapter_id)
+        .scalar()
+    )
 
 
 @router.get("/chapter/{chapter_id}", response_model=list[BlockResponse])
@@ -101,6 +121,16 @@ def create_block(
     )
     db.add(block)
     try:
+        db.flush()
+        dual_write_entity_content(
+            db,
+            entity_type="chapter_block",
+            entity_id=str(block.id),
+            entity=block,
+            fields=_TRANSLATABLE_BLOCK_FIELDS,
+            fallback_locale=_course_source_locale_for_chapter(db, chapter_id),
+            authored_by=teacher.id,
+        )
         db.commit()
     except IntegrityError as exc:
         # quiz_id / assignment_id are FKs — a stale client can pass an id
@@ -143,11 +173,23 @@ def update_block(
     if not block:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Block not found")
     verify_chapter_owner(db, block.chapter_id, teacher)
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         if field == "content" and value:
             value = sanitize_string(value)
         setattr(block, field, value)
     try:
+        db.flush()
+        dual_write_entity_content(
+            db,
+            entity_type="chapter_block",
+            entity_id=str(block.id),
+            entity=block,
+            fields=_TRANSLATABLE_BLOCK_FIELDS,
+            fallback_locale=_course_source_locale_for_chapter(db, block.chapter_id),
+            authored_by=teacher.id,
+            only_fields={f for f in _TRANSLATABLE_BLOCK_FIELDS if f in patch},
+        )
         db.commit()
     except IntegrityError as exc:
         db.rollback()

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
@@ -16,6 +18,7 @@ from app.schemas.calendar import (
     CourseEventUpdate,
 )
 from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.content_versions import dual_write_entity_content
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import (
     fetch_overlay_triples_bulk,
@@ -219,6 +222,16 @@ def create_course_event(
         created_by=teacher.id,
     )
     db.add(event)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="course_event",
+        entity_id=str(event.id),
+        entity=event,
+        fields=("title", "description"),
+        fallback_locale=db.query(Course.source_locale).filter(Course.id == course_id).scalar(),
+        authored_by=teacher.id,
+    )
     db.commit()
     db.refresh(event)
     reconcile_entity_if_course_published(db, "course_event", event)
@@ -273,7 +286,7 @@ def list_course_events(
 )
 def update_course_event(
     course_id: str,
-    event_id: str,
+    event_id: UUID,
     data: CourseEventUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
@@ -302,6 +315,17 @@ def update_course_event(
         updates["description"] = sanitize_string(updates["description"])
     for field, value in updates.items():
         setattr(event, field, value)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="course_event",
+        entity_id=str(event.id),
+        entity=event,
+        fields=("title", "description"),
+        fallback_locale=db.query(Course.source_locale).filter(Course.id == course_id).scalar(),
+        authored_by=teacher.id,
+        only_fields={f for f in ("title", "description") if f in updates},
+    )
     db.commit()
     db.refresh(event)
     reconcile_entity_if_course_published(db, "course_event", event)
@@ -314,7 +338,7 @@ def update_course_event(
 )
 def delete_course_event(
     course_id: str,
-    event_id: str,
+    event_id: UUID,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> None:

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -44,10 +44,40 @@ from app.schemas.cohort import (
 )
 from app.schemas.locale import normalize_locale
 from app.services.audit_service import log_action
+from app.services.content_versions import record_human_version
+from app.services.language_detection import detect_locale
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import Localizer
 
 router = APIRouter(prefix="/cohorts", tags=["cohorts"])
+
+
+def _dual_write_cohort_name(db: Session, cohort: Cohort, *, admin: User) -> None:
+    """Dual-write Cohort.name to content_versions.field='title'.
+
+    Cohorts don't have an entity-level attribute named ``title`` —
+    the registry maps ``Cohort.name`` to ``field='title'`` so this
+    helper inlines the call rather than using the shared
+    ``dual_write_entity_content`` (which keys on attribute name).
+
+    Cohorts have no parent course (they're M2M with courses) so
+    the detector fallback is the admin's preferred_locale.
+    """
+    if not cohort.name or not cohort.name.strip():
+        return
+    detected = detect_locale(cohort.name)
+    locale = detected or admin.preferred_locale
+    if locale is None:
+        return
+    record_human_version(
+        db,
+        entity_type="cohort",
+        entity_id=str(cohort.id),
+        field="title",
+        locale=locale,
+        text=cohort.name,
+        authored_by=admin.id,
+    )
 
 
 # ----------------------------- helpers --------------------------------
@@ -159,6 +189,8 @@ def create_cohort(
         created_by=admin.id,
     )
     db.add(cohort)
+    db.flush()
+    _dual_write_cohort_name(db, cohort, admin=admin)
     db.commit()
     db.refresh(cohort)
     log_action(
@@ -210,11 +242,20 @@ def update_cohort(
     # flip like ``upcoming -> active`` is fully traceable: the row holds
     # both ends of the transition.
     changes: dict[str, dict[str, object]] = {}
+    name_changed = False
     for field, value in patch.items():
         before = getattr(cohort, field)
         if before != value:
             changes[field] = {"from": before, "to": value}
         setattr(cohort, field, value)
+        if field == "name":
+            name_changed = True
+    db.flush()
+    if name_changed:
+        # Cohort.name maps to content_versions.field='title' (see the
+        # translation registry). Re-record so the dual-write store
+        # stays in sync with the entity column.
+        _dual_write_cohort_name(db, cohort, admin=admin)
     db.commit()
     db.refresh(cohort)
     # Translation reconcile reads the attached-course set internally and

--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -16,6 +16,7 @@ from app.api.dependencies import (
     verify_chapter_owner,
 )
 from app.core.database import get_db
+from app.models.course import Chapter, Course, Module
 from app.models.quiz import Quiz, QuizExtraAttempt, QuizOption, QuizQuestion
 from app.models.user import User
 from app.schemas.locale import LocaleCode, normalize_locale
@@ -25,6 +26,7 @@ from app.schemas.quiz import (
     QuizStudentResponse,
     QuizUpdate,
 )
+from app.services.content_versions import dual_write_entity_content
 from app.services.translation.pipeline_hooks import (
     reconcile_entity_if_course_published,
     run_course_translation_pipeline_if_published,
@@ -36,6 +38,24 @@ from app.services.translation.resolve_for_display import (
 
 from ._deps import verify_quiz_owner
 from ._router import router
+
+_TRANSLATABLE_QUIZ_FIELDS = ("title", "description")
+_TRANSLATABLE_QUESTION_FIELDS = ("question_text",)
+_TRANSLATABLE_OPTION_FIELDS = ("option_text",)
+
+
+def _course_source_locale_for_chapter(db: Session, chapter_id: str) -> str | None:
+    """Walk ``Quiz -> Chapter -> Module -> Course`` to find the parent
+    course's source locale for use as the dual-write fallback when a
+    short / non-letter field can't be classified by the detector.
+    """
+    return (
+        db.query(Course.source_locale)
+        .join(Module, Module.course_id == Course.id)
+        .join(Chapter, Chapter.module_id == Module.id)
+        .filter(Chapter.id == chapter_id)
+        .scalar()
+    )
 
 
 @router.get("/chapter/{chapter_id}", response_model=QuizStudentResponse | None)
@@ -139,32 +159,67 @@ def create_quiz(
     )
     db.add(quiz)
 
+    questions_to_dual_write: list[tuple[QuizQuestion, list[QuizOption]]] = []
     for q_data in data.questions:
         question_id = uuid.uuid4()
-        db.add(
-            QuizQuestion(
-                id=question_id,
-                quiz_id=quiz_id_val,
-                question_text=q_data.question_text,
-                question_type=q_data.question_type,
-                order_index=q_data.order_index,
-                points=q_data.points,
-                # ``min_words`` is only meaningful for ``essay``; it's
-                # intentionally persisted as-is for every type so that
-                # switching a question to ``essay`` later keeps the hint.
-                min_words=q_data.min_words,
-            )
+        question = QuizQuestion(
+            id=question_id,
+            quiz_id=quiz_id_val,
+            question_text=q_data.question_text,
+            question_type=q_data.question_type,
+            order_index=q_data.order_index,
+            points=q_data.points,
+            # ``min_words`` is only meaningful for ``essay``; it's
+            # intentionally persisted as-is for every type so that
+            # switching a question to ``essay`` later keeps the hint.
+            min_words=q_data.min_words,
         )
+        db.add(question)
+        question_options: list[QuizOption] = []
         for o_data in q_data.options:
-            db.add(
-                QuizOption(
-                    question_id=question_id,
-                    option_text=o_data.option_text,
-                    is_correct=o_data.is_correct,
-                    order_index=o_data.order_index,
-                )
+            opt = QuizOption(
+                question_id=question_id,
+                option_text=o_data.option_text,
+                is_correct=o_data.is_correct,
+                order_index=o_data.order_index,
             )
+            db.add(opt)
+            question_options.append(opt)
+        questions_to_dual_write.append((question, question_options))
 
+    # Flush so child ids (options have server-side defaults) are
+    # populated before dual-write reads them.
+    db.flush()
+    fallback_locale = _course_source_locale_for_chapter(db, data.chapter_id)
+    dual_write_entity_content(
+        db,
+        entity_type="quiz",
+        entity_id=str(quiz.id),
+        entity=quiz,
+        fields=_TRANSLATABLE_QUIZ_FIELDS,
+        fallback_locale=fallback_locale,
+        authored_by=teacher.id,
+    )
+    for question, options in questions_to_dual_write:
+        dual_write_entity_content(
+            db,
+            entity_type="quiz_question",
+            entity_id=str(question.id),
+            entity=question,
+            fields=_TRANSLATABLE_QUESTION_FIELDS,
+            fallback_locale=fallback_locale,
+            authored_by=teacher.id,
+        )
+        for opt in options:
+            dual_write_entity_content(
+                db,
+                entity_type="quiz_option",
+                entity_id=str(opt.id),
+                entity=opt,
+                fields=_TRANSLATABLE_OPTION_FIELDS,
+                fallback_locale=fallback_locale,
+                authored_by=teacher.id,
+            )
     db.commit()
     reloaded = (
         db.query(Quiz)
@@ -193,12 +248,24 @@ def update_quiz(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
     verify_quiz_owner(db, quiz, teacher.id)
 
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(quiz, field, value)
 
     if quiz.quiz_type == "exam" and quiz.max_attempts is None:
         quiz.max_attempts = 1
 
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="quiz",
+        entity_id=str(quiz.id),
+        entity=quiz,
+        fields=_TRANSLATABLE_QUIZ_FIELDS,
+        fallback_locale=_course_source_locale_for_chapter(db, quiz.chapter_id),
+        authored_by=teacher.id,
+        only_fields={f for f in _TRANSLATABLE_QUIZ_FIELDS if f in patch},
+    )
     db.commit()
     reloaded = (
         db.query(Quiz)

--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -7,6 +7,7 @@ all funnel through ``record_human_version`` / ``record_mt_version``
 / ``record_mt_failure``.
 """
 
+from app.services.content_versions.dual_write import dual_write_entity_content
 from app.services.content_versions.write import (
     record_human_version,
     record_mt_failure,
@@ -14,6 +15,7 @@ from app.services.content_versions.write import (
 )
 
 __all__ = [
+    "dual_write_entity_content",
     "record_human_version",
     "record_mt_failure",
     "record_mt_version",

--- a/backend/app/services/content_versions/dual_write.py
+++ b/backend/app/services/content_versions/dual_write.py
@@ -1,0 +1,98 @@
+"""Shared per-field dual-write helper used by every entity write
+path during Phase 1.
+
+The pattern repeats for every translatable entity:
+
+1. Read each translatable field's text from the entity.
+2. Detect that field's language (or fall back to a caller-supplied
+   locale when the detector has no signal).
+3. Call ``record_human_version`` once per field.
+
+Centralising it here keeps every call site to a 4-line invocation,
+and means a future change to language-detection / fallback strategy
+edits ONE function instead of N.
+
+Reads still go to entity columns. Phase 2 introduces the dual-read
+layer; Phase 4 flips reads exclusive.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from app.services.content_versions.write import record_human_version
+from app.services.language_detection import detect_locale
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sqlalchemy.orm import Session
+
+
+def dual_write_entity_content(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    entity: object,
+    fields: Iterable[str],
+    fallback_locale: str | None,
+    authored_by: str | uuid.UUID | None = None,
+    only_fields: set[str] | None = None,
+) -> None:
+    """Write a ``content_versions`` human row for every translatable
+    field on ``entity`` that the caller wrote.
+
+    Per-field detection: each field's locale is decided from its own
+    text. Two fields on the same entity can land in different locales
+    (an EN title and a RU description are normal). Detection falls
+    back to ``fallback_locale`` when the field text is too short to
+    classify or has no language signal.
+
+    ``only_fields`` filters to the fields the caller actually wrote
+    (used on UPDATE so a description-only PATCH doesn't supersede
+    the title row). ``None`` means "every field in ``fields``".
+
+    ``authored_by`` is stored on the row when known. Accepts a UUID
+    or a string-coerceable id.
+    """
+    if only_fields is None:
+        target_fields: list[str] = list(fields)
+    else:
+        target_fields = [f for f in fields if f in only_fields]
+
+    if not target_fields:
+        return
+
+    author_uuid = _coerce_uuid(authored_by)
+
+    for field in target_fields:
+        text = getattr(entity, field, None)
+        if not text or not str(text).strip():
+            continue
+        text_str = str(text)
+        detected = detect_locale(text_str)
+        locale = detected or fallback_locale
+        if locale is None:
+            # No signal AND no fallback — skip. The field re-enters
+            # this path the next time the entity is saved with
+            # enough surrounding context to resolve a fallback.
+            continue
+        record_human_version(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            locale=locale,
+            text=text_str,
+            authored_by=author_uuid,
+        )
+
+
+def _coerce_uuid(value: str | uuid.UUID | None) -> uuid.UUID | None:
+    if value is None:
+        return None
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))

--- a/backend/app/services/course_service/_chapters.py
+++ b/backend/app/services/course_service/_chapters.py
@@ -8,12 +8,16 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import func
 
-from app.models.course import Chapter
+from app.models.course import Chapter, Course, Module
+from app.services.content_versions import dual_write_entity_content
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from app.schemas.course import ChapterCreate, ChapterUpdate
+
+
+_TRANSLATABLE_CHAPTER_FIELDS = ("title",)
 
 
 def _next_chapter_order(db: Session, module_id: str) -> int:
@@ -24,6 +28,19 @@ def _next_chapter_order(db: Session, module_id: str) -> int:
         .scalar()
     )
     return 0 if current_max is None else current_max + 1
+
+
+def _course_source_locale_for_module(db: Session, module_id: str) -> str | None:
+    """Walk ``Chapter -> Module -> Course`` to find the parent course's
+    source locale. Used as the fallback when a chapter title alone
+    can't be classified by the language detector.
+    """
+    return (
+        db.query(Course.source_locale)
+        .join(Module, Module.course_id == Course.id)
+        .filter(Module.id == module_id)
+        .scalar()
+    )
 
 
 def create_chapter(db: Session, module_id: str, data: ChapterCreate) -> Chapter:
@@ -40,14 +57,34 @@ def create_chapter(db: Session, module_id: str, data: ChapterCreate) -> Chapter:
         is_locked=data.is_locked,
     )
     db.add(chapter)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="chapter",
+        entity_id=str(chapter.id),
+        entity=chapter,
+        fields=_TRANSLATABLE_CHAPTER_FIELDS,
+        fallback_locale=_course_source_locale_for_module(db, module_id),
+    )
     db.commit()
     db.refresh(chapter)
     return chapter
 
 
 def update_chapter(db: Session, chapter: Chapter, data: ChapterUpdate) -> Chapter:
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(chapter, field, value)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="chapter",
+        entity_id=str(chapter.id),
+        entity=chapter,
+        fields=_TRANSLATABLE_CHAPTER_FIELDS,
+        fallback_locale=_course_source_locale_for_module(db, chapter.module_id),
+        only_fields={f for f in _TRANSLATABLE_CHAPTER_FIELDS if f in patch},
+    )
     db.commit()
     db.refresh(chapter)
     return chapter

--- a/backend/app/services/course_service/_courses.py
+++ b/backend/app/services/course_service/_courses.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 
 from app.models.course import Chapter, Course, Module
-from app.services.content_versions import record_human_version
+from app.services.content_versions import dual_write_entity_content
 from app.services.language_detection import detect_locale
 
 if TYPE_CHECKING:
@@ -21,64 +21,6 @@ if TYPE_CHECKING:
 
 
 _TRANSLATABLE_COURSE_FIELDS = ("title", "description")
-
-
-def _dual_write_course_content(
-    db: Session,
-    course: Course,
-    *,
-    authored_by: str | UUID | None,
-    course_fallback: str | None,
-    only_fields: set[str] | None = None,
-) -> None:
-    """Write a ``content_versions`` row for every translatable field
-    on ``course`` that the caller wrote.
-
-    Each field's locale is detected from its own text (so a course
-    with an English title and Russian description gets two rows with
-    different ``locale`` values). Detection falls back to the course
-    source locale when the field's text is too short or has no
-    language signal.
-
-    ``only_fields`` is the set of fields the caller actually wrote;
-    ``None`` means "every translatable field" (used on create).
-    Filtering is important on PATCH so a description-only update
-    doesn't supersede the title row.
-
-    ``authored_by`` is the user id the route layer attributes the
-    write to (course owner on create, owner on update). Stored on
-    the row so the future preacher-style audit UI can show who
-    wrote what.
-    """
-    fields: tuple[str, ...]
-    if only_fields is None:
-        fields = _TRANSLATABLE_COURSE_FIELDS
-    else:
-        fields = tuple(f for f in _TRANSLATABLE_COURSE_FIELDS if f in only_fields)
-    author_uuid: UUID | None = None
-    if authored_by is not None:
-        author_uuid = authored_by if isinstance(authored_by, uuid.UUID) else uuid.UUID(str(authored_by))
-    for field in fields:
-        text = getattr(course, field, None)
-        if not text or not str(text).strip():
-            continue
-        detected = detect_locale(str(text))
-        locale = detected or course_fallback
-        if locale is None:
-            # No signal AND no course-level fallback — skip. Dual-write
-            # without a locale would be nonsensical and the field will
-            # come back through this path the next time the entity is
-            # saved with enough context.
-            continue
-        record_human_version(
-            db,
-            entity_type="course",
-            entity_id=str(course.id),
-            field=field,
-            locale=locale,
-            text=str(text),
-            authored_by=author_uuid,
-        )
 
 
 def _resolve_source_locale(
@@ -138,7 +80,15 @@ def create_course(
         course.source_locale = resolved_locale
     db.add(course)
     db.flush()
-    _dual_write_course_content(db, course, authored_by=user_id, course_fallback=resolved_locale)
+    dual_write_entity_content(
+        db,
+        entity_type="course",
+        entity_id=str(course.id),
+        entity=course,
+        fields=_TRANSLATABLE_COURSE_FIELDS,
+        fallback_locale=resolved_locale,
+        authored_by=user_id,
+    )
     db.commit()
     db.refresh(course)
     return course
@@ -165,12 +115,15 @@ def update_course(db: Session, course: Course, data: CourseUpdate) -> Course:
     # Dual-write to content_versions only for fields the caller actually
     # touched — a PATCH that didn't include ``description`` mustn't
     # supersede the existing description row.
-    _dual_write_course_content(
+    dual_write_entity_content(
         db,
-        course,
+        entity_type="course",
+        entity_id=str(course.id),
+        entity=course,
+        fields=_TRANSLATABLE_COURSE_FIELDS,
+        fallback_locale=course.source_locale,
         authored_by=course.created_by,
-        course_fallback=course.source_locale,
-        only_fields={f for f in ("title", "description") if f in patch},
+        only_fields={f for f in _TRANSLATABLE_COURSE_FIELDS if f in patch},
     )
     db.commit()
     db.refresh(course)

--- a/backend/app/services/course_service/_modules.py
+++ b/backend/app/services/course_service/_modules.py
@@ -8,12 +8,16 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import func
 
-from app.models.course import Chapter, Module
+from app.models.course import Chapter, Course, Module
+from app.services.content_versions import dual_write_entity_content
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from app.schemas.course import ModuleCreate, ModuleUpdate
+
+
+_TRANSLATABLE_MODULE_FIELDS = ("title", "description")
 
 
 def _next_module_order(db: Session, course_id: str) -> int:
@@ -24,6 +28,16 @@ def _next_module_order(db: Session, course_id: str) -> int:
         .scalar()
     )
     return 0 if current_max is None else current_max + 1
+
+
+def _course_source_locale(db: Session, course_id: str) -> str | None:
+    """Cheap single-column lookup of the parent course's source locale.
+
+    Used as the per-field detection fallback when a module / chapter
+    title can't be classified on its own (short titles like "1" or
+    "Часть 1" often can't).
+    """
+    return db.query(Course.source_locale).filter(Course.id == course_id).scalar()
 
 
 def create_module(db: Session, course_id: str, data: ModuleCreate) -> Module:
@@ -41,14 +55,34 @@ def create_module(db: Session, course_id: str, data: ModuleCreate) -> Module:
         due_date=data.due_date,
     )
     db.add(module)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="module",
+        entity_id=str(module.id),
+        entity=module,
+        fields=_TRANSLATABLE_MODULE_FIELDS,
+        fallback_locale=_course_source_locale(db, course_id),
+    )
     db.commit()
     db.refresh(module)
     return module
 
 
 def update_module(db: Session, module: Module, data: ModuleUpdate) -> Module:
-    for field, value in data.model_dump(exclude_unset=True).items():
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
         setattr(module, field, value)
+    db.flush()
+    dual_write_entity_content(
+        db,
+        entity_type="module",
+        entity_id=str(module.id),
+        entity=module,
+        fields=_TRANSLATABLE_MODULE_FIELDS,
+        fallback_locale=_course_source_locale(db, module.course_id),
+        only_fields={f for f in _TRANSLATABLE_MODULE_FIELDS if f in patch},
+    )
     db.commit()
     db.refresh(module)
     return module

--- a/backend/tests/test_blocks_dual_write.py
+++ b/backend/tests/test_blocks_dual_write.py
@@ -1,0 +1,184 @@
+# ruff: noqa: RUF001
+"""Phase 1d integration tests: chapter_block create/update dual-writes
+into ``content_versions``.
+
+Block content is HTML — the language detector ignores tag chars by
+construction, so per-field detection works directly on the stored
+markup without a pre-strip step. Pins the same supersession +
+idempotency contract as courses / modules / chapters.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.models.chapter_block import ChapterBlock
+from app.models.content_version import ContentVersion
+from app.models.course import Chapter, Course, Module
+from tests.conftest import TEACHER_ID
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+def _seed_chapter(db: Session, *, course_locale: str = "ru") -> str:
+    """Course → module → chapter; return chapter id."""
+    course = Course(
+        id="course-blocks-dw",
+        title="Учебник" if course_locale == "ru" else "Textbook",
+        created_by=TEACHER_ID,
+        status="draft",
+        source_locale=course_locale,
+    )
+    module = Module(id="mod-blocks-dw", course_id=course.id, title="Раздел", order_index=0)
+    chapter = Chapter(
+        id="ch-blocks-dw",
+        module_id=module.id,
+        title="Глава",
+        order_index=0,
+        chapter_type="text",
+    )
+    db.add_all([course, module, chapter])
+    db.commit()
+    return chapter.id
+
+
+def _active_rows(db: Session, block_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == "chapter_block",
+            ContentVersion.entity_id == block_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .all()
+    )
+
+
+class TestCreateBlockDualWrite:
+    def test_text_block_writes_content_row(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={
+                "block_type": "text",
+                "order_index": 0,
+                "content": "<p>Урок о первой главе книги Бытия.</p>",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        block_id = resp.json()["id"]
+        rows = _active_rows(db, block_id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.field == "content"
+        assert "Урок о первой главе" in row.text
+        assert row.locale == "ru"
+        assert row.origin == "human"
+        assert row.authored_by == TEACHER_ID
+
+    def test_quiz_block_with_no_content_skips_dual_write(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        # Quiz blocks reference a quiz_id and have NULL content; nothing
+        # to write into content_versions.
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={"block_type": "file", "order_index": 0, "file_name": "syllabus.pdf"},
+        )
+        assert resp.status_code == 201, resp.text
+        block_id = resp.json()["id"]
+        assert _active_rows(db, block_id) == []
+
+    def test_html_only_falls_back_to_course_source_locale(self, client: TestClient, db: Session):
+        # ASCII non-letter content — detector returns None; falls back
+        # to the parent course's source_locale (en here).
+        chapter_id = _seed_chapter(db, course_locale="en")
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={"block_type": "text", "order_index": 0, "content": "<p>12345</p>"},
+        )
+        assert resp.status_code == 201, resp.text
+        block_id = resp.json()["id"]
+        rows = _active_rows(db, block_id)
+        assert len(rows) == 1
+        assert rows[0].locale == "en"
+
+
+class TestUpdateBlockDualWrite:
+    def test_content_change_supersedes_old_row(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={
+                "block_type": "text",
+                "order_index": 0,
+                "content": "<p>Первый вариант текста урока.</p>",
+            },
+        )
+        block_id = resp.json()["id"]
+        original = _active_rows(db, block_id)[0]
+        resp = client.put(
+            f"/api/v1/blocks/{block_id}",
+            json={"content": "<p>Второй вариант текста урока.</p>"},
+        )
+        assert resp.status_code == 200, resp.text
+        active = _active_rows(db, block_id)
+        assert len(active) == 1
+        assert "Второй вариант" in active[0].text
+        db.refresh(original)
+        assert original.superseded_by == active[0].id
+
+    def test_non_content_patch_does_not_touch_content_versions(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={
+                "block_type": "text",
+                "order_index": 0,
+                "content": "<p>Стабильный текст.</p>",
+            },
+        )
+        block_id = resp.json()["id"]
+        ids_before = {r.id for r in _active_rows(db, block_id)}
+        # PATCH that only flips order_index — content_versions stays put.
+        resp = client.put(f"/api/v1/blocks/{block_id}", json={"order_index": 5})
+        assert resp.status_code == 200, resp.text
+        ids_after = {r.id for r in _active_rows(db, block_id)}
+        assert ids_before == ids_after
+
+    def test_identical_content_patch_is_idempotent(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            f"/api/v1/blocks/chapter/{chapter_id}",
+            json={
+                "block_type": "text",
+                "order_index": 0,
+                "content": "<p>Текст урока.</p>",
+            },
+        )
+        block_id = resp.json()["id"]
+        original_id = _active_rows(db, block_id)[0].id
+        # Re-PUT identical content — no version churn.
+        resp = client.put(
+            f"/api/v1/blocks/{block_id}",
+            json={"content": "<p>Текст урока.</p>"},
+        )
+        assert resp.status_code == 200, resp.text
+        current = _active_rows(db, block_id)
+        assert len(current) == 1
+        assert current[0].id == original_id
+
+
+@pytest.fixture(autouse=True)
+def _isolate(db: Session):
+    """Make each test see a fresh ``content_versions`` slate for
+    the seeded chapter so tests don't bleed assertions into each
+    other when the same module/chapter ids reappear via the seed
+    helper."""
+    yield
+    db.query(ContentVersion).filter(ContentVersion.entity_type == "chapter_block").delete()
+    db.query(ChapterBlock).delete()
+    db.commit()

--- a/backend/tests/test_modules_chapters_dual_write.py
+++ b/backend/tests/test_modules_chapters_dual_write.py
@@ -1,0 +1,163 @@
+# ruff: noqa: RUF001
+"""Phase 1c integration tests: module / chapter create/update
+dual-writes into ``content_versions``.
+
+Pins behaviour parallel to ``test_courses_dual_write.py``:
+
+* Each create writes one ``content_versions`` row per translatable
+  field with per-field detected locale.
+* Each update supersedes only the fields the caller actually wrote.
+* Short titles that the detector can't classify fall back to the
+  parent course's ``source_locale``.
+
+Modules have (title, description); chapters have just (title,).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.content_version import ContentVersion
+from app.models.user import User, UserRole
+from app.schemas.course import (
+    ChapterCreate,
+    ChapterUpdate,
+    CourseCreate,
+    ModuleCreate,
+    ModuleUpdate,
+)
+from app.services.course_service._chapters import create_chapter, update_chapter
+from app.services.course_service._courses import create_course
+from app.services.course_service._modules import create_module, update_module
+
+
+@pytest.fixture
+def db():
+    from tests.conftest import test_engine
+
+    session = Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def teacher(db: Session) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email=f"mc-dw-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Module/Chapter Teacher",
+        role=UserRole.TEACHER.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _active_rows(db: Session, entity_type: str, entity_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .order_by(ContentVersion.field)
+        .all()
+    )
+
+
+def _make_course(db: Session, teacher: User, *, locale: str = "ru"):
+    title, desc = ("Учебник", "Курс.") if locale == "ru" else ("Textbook", "Course on scripture.")
+    return create_course(
+        db,
+        CourseCreate(title=title, description=desc),
+        user_id=teacher.id,
+        source_locale=locale,
+    )
+
+
+class TestModuleDualWrite:
+    def test_create_writes_title_and_description(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(
+            db,
+            course.id,
+            ModuleCreate(title="Модуль 1", description="О первой части."),
+        )
+        rows = {r.field: r for r in _active_rows(db, "module", module.id)}
+        assert set(rows.keys()) == {"title", "description"}
+        assert rows["title"].text == "Модуль 1"
+        assert rows["title"].locale == "ru"
+        assert rows["description"].locale == "ru"
+
+    def test_create_with_no_description_skips_description_row(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Модуль", description=None))
+        rows = _active_rows(db, "module", module.id)
+        assert [r.field for r in rows] == ["title"]
+
+    def test_short_title_falls_back_to_course_source_locale(self, db: Session, teacher: User):
+        # Title of just "1" — detector cannot classify; fallback is
+        # the parent course's source_locale ("ru" here).
+        course = _make_course(db, teacher, locale="ru")
+        module = create_module(db, course.id, ModuleCreate(title="1", description=None))
+        rows = _active_rows(db, "module", module.id)
+        assert len(rows) == 1
+        assert rows[0].locale == "ru"
+
+    def test_update_title_supersedes_old_title_only(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(
+            db,
+            course.id,
+            ModuleCreate(title="Старое", description="Описание."),
+        )
+        original_title = next(r for r in _active_rows(db, "module", module.id) if r.field == "title")
+        update_module(db, module, ModuleUpdate(title="Новое"))
+        active_title = next(r for r in _active_rows(db, "module", module.id) if r.field == "title")
+        assert active_title.text == "Новое"
+        db.refresh(original_title)
+        assert original_title.superseded_by == active_title.id
+        # description row is untouched (only one version of it).
+        desc_versions = (
+            db.query(ContentVersion)
+            .filter(ContentVersion.entity_id == module.id, ContentVersion.field == "description")
+            .count()
+        )
+        assert desc_versions == 1
+
+
+class TestChapterDualWrite:
+    def test_create_writes_title_row(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Раздел", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="Глава 1"))
+        rows = _active_rows(db, "chapter", chapter.id)
+        assert [r.field for r in rows] == ["title"]
+        assert rows[0].text == "Глава 1"
+        assert rows[0].locale == "ru"
+
+    def test_short_chapter_title_falls_back_to_course_source_locale(self, db: Session, teacher: User):
+        # English course → English fallback when title has no signal.
+        course = _make_course(db, teacher, locale="en")
+        module = create_module(db, course.id, ModuleCreate(title="Module", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="1"))
+        rows = _active_rows(db, "chapter", chapter.id)
+        assert len(rows) == 1
+        assert rows[0].locale == "en"
+
+    def test_update_title_supersedes(self, db: Session, teacher: User):
+        course = _make_course(db, teacher)
+        module = create_module(db, course.id, ModuleCreate(title="Раздел", description=None))
+        chapter = create_chapter(db, module.id, ChapterCreate(title="Глава первая"))
+        original = next(iter(_active_rows(db, "chapter", chapter.id)))
+        update_chapter(db, chapter, ChapterUpdate(title="Глава вторая"))
+        active = next(iter(_active_rows(db, "chapter", chapter.id)))
+        assert active.text == "Глава вторая"
+        db.refresh(original)
+        assert original.superseded_by == active.id

--- a/backend/tests/test_others_dual_write.py
+++ b/backend/tests/test_others_dual_write.py
@@ -1,0 +1,248 @@
+# ruff: noqa: RUF001
+"""Phase 1f integration tests: assignment / announcement /
+course_event / cohort dual-writes.
+
+Pins the same supersession + idempotency contract as the rest of
+Phase 1 across the remaining translatable entity types.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.models.announcement import Announcement
+from app.models.assignment import Assignment
+from app.models.cohort import Cohort
+from app.models.content_version import ContentVersion
+from app.models.course import Chapter, Course, Module
+from app.models.course_event import CourseEvent
+from tests.conftest import ADMIN_ID, TEACHER_ID
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+def _seed_chapter(db: Session) -> str:
+    course = Course(
+        id="course-others-dw",
+        title="Учебник",
+        created_by=TEACHER_ID,
+        status="draft",
+        source_locale="ru",
+    )
+    module = Module(id="mod-others-dw", course_id=course.id, title="Раздел", order_index=0)
+    chapter = Chapter(
+        id="ch-others-dw",
+        module_id=module.id,
+        title="Глава",
+        order_index=0,
+        chapter_type="assignment",
+    )
+    db.add_all([course, module, chapter])
+    db.commit()
+    return chapter.id
+
+
+def _seed_course(db: Session) -> str:
+    course = Course(
+        id="course-others-dw-bare",
+        title="Учебник",
+        created_by=TEACHER_ID,
+        status="draft",
+        source_locale="ru",
+    )
+    db.add(course)
+    db.commit()
+    return course.id
+
+
+def _active(db: Session, entity_type: str, entity_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .order_by(ContentVersion.field)
+        .all()
+    )
+
+
+class TestAssignmentDualWrite:
+    def test_create_writes_title_and_description(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            "/api/v1/assignments",
+            json={
+                "chapter_id": chapter_id,
+                "title": "Эссе о Бытии",
+                "description": "Напишите 500 слов о первой главе.",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        ass_id = resp.json()["id"]
+        rows = {r.field: r for r in _active(db, "assignment", ass_id)}
+        assert set(rows.keys()) == {"title", "description"}
+        assert rows["title"].locale == "ru"
+
+    def test_update_title_supersedes(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            "/api/v1/assignments",
+            json={"chapter_id": chapter_id, "title": "Старое", "description": "Описание."},
+        )
+        ass_id = resp.json()["id"]
+        original = next(r for r in _active(db, "assignment", ass_id) if r.field == "title")
+        resp = client.put(f"/api/v1/assignments/{ass_id}", json={"title": "Новое"})
+        assert resp.status_code == 200, resp.text
+        active = next(r for r in _active(db, "assignment", ass_id) if r.field == "title")
+        assert active.text == "Новое"
+        db.refresh(original)
+        assert original.superseded_by == active.id
+
+
+class TestAnnouncementDualWrite:
+    def test_course_announcement_writes_title_and_content(self, client: TestClient, db: Session):
+        course_id = _seed_course(db)
+        resp = client.post(
+            "/api/v1/announcements",
+            json={
+                "title": "Объявление о вебинаре",
+                "content": "Завтра в 19:00 встречаемся в Zoom.",
+                "course_id": course_id,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        ann_id = resp.json()["id"]
+        rows = {r.field: r for r in _active(db, "announcement", ann_id)}
+        assert set(rows.keys()) == {"title", "content"}
+        assert rows["title"].locale == "ru"
+        assert rows["title"].authored_by == TEACHER_ID
+
+    def test_global_announcement_falls_back_to_admin_preferred_locale(self, admin_client: TestClient, db: Session):
+        resp = admin_client.post(
+            "/api/v1/announcements",
+            json={"title": "Notice", "content": "Maintenance tonight.", "course_id": None},
+        )
+        assert resp.status_code == 201, resp.text
+        ann_id = resp.json()["id"]
+        rows = _active(db, "announcement", ann_id)
+        assert len(rows) == 2
+        # Detector sees Latin → 'en' for both fields.
+        assert {r.locale for r in rows} == {"en"}
+
+    def test_update_title_supersedes(self, client: TestClient, db: Session):
+        course_id = _seed_course(db)
+        resp = client.post(
+            "/api/v1/announcements",
+            json={"title": "Старое", "content": "Текст.", "course_id": course_id},
+        )
+        ann_id = resp.json()["id"]
+        original = next(r for r in _active(db, "announcement", ann_id) if r.field == "title")
+        resp = client.put(f"/api/v1/announcements/{ann_id}", json={"title": "Новое"})
+        assert resp.status_code == 200, resp.text
+        active = next(r for r in _active(db, "announcement", ann_id) if r.field == "title")
+        assert active.text == "Новое"
+        db.refresh(original)
+        assert original.superseded_by == active.id
+
+
+class TestCourseEventDualWrite:
+    def test_create_writes_title_and_description(self, client: TestClient, db: Session):
+        course_id = _seed_course(db)
+        resp = client.post(
+            f"/api/v1/courses/{course_id}/events",
+            json={
+                "title": "Вебинар",
+                "description": "Обсуждение глав 1-3.",
+                "event_type": "live_session",
+                "event_date": "2026-06-01T19:00:00Z",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        ev_id = resp.json()["id"]
+        rows = {r.field: r for r in _active(db, "course_event", ev_id)}
+        assert set(rows.keys()) == {"title", "description"}
+        assert rows["title"].locale == "ru"
+
+    def test_update_title_supersedes(self, client: TestClient, db: Session):
+        course_id = _seed_course(db)
+        resp = client.post(
+            f"/api/v1/courses/{course_id}/events",
+            json={
+                "title": "Старое",
+                "description": "Описание.",
+                "event_type": "live_session",
+                "event_date": "2026-06-01T19:00:00Z",
+            },
+        )
+        ev_id = resp.json()["id"]
+        original = next(r for r in _active(db, "course_event", ev_id) if r.field == "title")
+        resp = client.put(
+            f"/api/v1/courses/{course_id}/events/{ev_id}",
+            json={"title": "Новое"},
+        )
+        assert resp.status_code == 200, resp.text
+        active = next(r for r in _active(db, "course_event", ev_id) if r.field == "title")
+        assert active.text == "Новое"
+        db.refresh(original)
+        assert original.superseded_by == active.id
+
+
+class TestCohortDualWrite:
+    def test_create_writes_title_row_from_name(self, admin_client: TestClient, db: Session):
+        resp = admin_client.post(
+            "/api/v1/cohorts",
+            json={
+                "name": "Когорта весна 2026",
+                "start_date": "2026-03-01T00:00:00Z",
+                "end_date": "2026-06-01T00:00:00Z",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        cohort_id = resp.json()["id"]
+        rows = _active(db, "cohort", cohort_id)
+        # Cohort.name -> content_versions.field='title' per registry mapping.
+        assert len(rows) == 1
+        assert rows[0].field == "title"
+        assert rows[0].text == "Когорта весна 2026"
+        assert rows[0].locale == "ru"
+        assert rows[0].authored_by == ADMIN_ID
+
+    def test_update_name_supersedes(self, admin_client: TestClient, db: Session):
+        resp = admin_client.post(
+            "/api/v1/cohorts",
+            json={
+                "name": "Старая когорта",
+                "start_date": "2026-03-01T00:00:00Z",
+                "end_date": "2026-06-01T00:00:00Z",
+            },
+        )
+        cohort_id = resp.json()["id"]
+        original = _active(db, "cohort", cohort_id)[0]
+        resp = admin_client.patch(
+            f"/api/v1/cohorts/{cohort_id}",
+            json={"name": "Новая когорта"},
+        )
+        assert resp.status_code == 200, resp.text
+        active = _active(db, "cohort", cohort_id)[0]
+        assert active.text == "Новая когорта"
+        db.refresh(original)
+        assert original.superseded_by == active.id
+
+
+@pytest.fixture(autouse=True)
+def _isolate(db: Session):
+    yield
+    db.query(ContentVersion).filter(
+        ContentVersion.entity_type.in_(("assignment", "announcement", "course_event", "cohort"))
+    ).delete()
+    db.query(Assignment).delete()
+    db.query(Announcement).delete()
+    db.query(CourseEvent).delete()
+    db.query(Cohort).delete()
+    db.commit()

--- a/backend/tests/test_quizzes_dual_write.py
+++ b/backend/tests/test_quizzes_dual_write.py
@@ -1,0 +1,173 @@
+"""Phase 1e integration tests: quiz / question / option dual-writes.
+
+Quiz creation is one-shot — Quiz + Questions + Options all land in
+a single endpoint call. The dual-write fans out: one row per
+(quiz, field), one per (question, field), one per (option, field).
+``update_quiz`` only mutates the Quiz row itself.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.models.content_version import ContentVersion
+from app.models.course import Chapter, Course, Module
+from app.models.quiz import Quiz, QuizOption, QuizQuestion
+from tests.conftest import TEACHER_ID
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+def _seed_chapter(db: Session) -> str:
+    course = Course(
+        id="course-quiz-dw",
+        title="Учебник",
+        created_by=TEACHER_ID,
+        status="draft",
+        source_locale="ru",
+    )
+    module = Module(id="mod-quiz-dw", course_id=course.id, title="Раздел", order_index=0)
+    chapter = Chapter(
+        id="ch-quiz-dw",
+        module_id=module.id,
+        title="Глава",
+        order_index=0,
+        chapter_type="quiz",
+    )
+    db.add_all([course, module, chapter])
+    db.commit()
+    return chapter.id
+
+
+def _active(db: Session, entity_type: str, entity_id: str) -> list[ContentVersion]:
+    return (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .order_by(ContentVersion.field)
+        .all()
+    )
+
+
+class TestCreateQuizDualWrite:
+    def test_writes_quiz_question_option_rows(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        payload = {
+            "chapter_id": chapter_id,
+            "title": "Тест по Бытию",
+            "description": "Краткий тест после первой главы.",
+            "quiz_type": "quiz",
+            "passing_score": 70,
+            "questions": [
+                {
+                    "question_text": "Кто создал небо и землю?",
+                    "question_type": "multiple_choice",
+                    "order_index": 0,
+                    "points": 1,
+                    "options": [
+                        {"option_text": "Бог", "is_correct": True, "order_index": 0},
+                        {"option_text": "Никто", "is_correct": False, "order_index": 1},
+                    ],
+                },
+            ],
+        }
+        resp = client.post("/api/v1/quizzes", json=payload)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        quiz_id = data["id"]
+        # Quiz: title + description rows.
+        quiz_rows = {r.field: r for r in _active(db, "quiz", quiz_id)}
+        assert set(quiz_rows.keys()) == {"title", "description"}
+        assert quiz_rows["title"].text == "Тест по Бытию"
+        assert quiz_rows["title"].locale == "ru"
+        assert quiz_rows["title"].authored_by == TEACHER_ID
+        # Question row.
+        question_id = data["questions"][0]["id"]
+        question_rows = _active(db, "quiz_question", question_id)
+        assert len(question_rows) == 1
+        assert question_rows[0].field == "question_text"
+        assert "Кто создал" in question_rows[0].text
+        # Option rows (one per option).
+        for opt in data["questions"][0]["options"]:
+            opt_rows = _active(db, "quiz_option", opt["id"])
+            assert len(opt_rows) == 1
+            assert opt_rows[0].field == "option_text"
+
+    def test_quiz_without_description_skips_description_row(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            "/api/v1/quizzes",
+            json={
+                "chapter_id": chapter_id,
+                "title": "Тест",
+                "description": None,
+                "quiz_type": "quiz",
+                "passing_score": 70,
+                "questions": [],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        quiz_id = resp.json()["id"]
+        rows = _active(db, "quiz", quiz_id)
+        assert [r.field for r in rows] == ["title"]
+
+
+class TestUpdateQuizDualWrite:
+    def test_title_change_supersedes_quiz_title_row(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            "/api/v1/quizzes",
+            json={
+                "chapter_id": chapter_id,
+                "title": "Старое",
+                "description": "Описание.",
+                "quiz_type": "quiz",
+                "passing_score": 70,
+                "questions": [],
+            },
+        )
+        quiz_id = resp.json()["id"]
+        original_title = next(r for r in _active(db, "quiz", quiz_id) if r.field == "title")
+        resp = client.put(f"/api/v1/quizzes/{quiz_id}", json={"title": "Новое"})
+        assert resp.status_code == 200, resp.text
+        active_title = next(r for r in _active(db, "quiz", quiz_id) if r.field == "title")
+        assert active_title.text == "Новое"
+        db.refresh(original_title)
+        assert original_title.superseded_by == active_title.id
+
+    def test_non_text_patch_does_not_touch_content_versions(self, client: TestClient, db: Session):
+        chapter_id = _seed_chapter(db)
+        resp = client.post(
+            "/api/v1/quizzes",
+            json={
+                "chapter_id": chapter_id,
+                "title": "Стабильный",
+                "description": "Описание.",
+                "quiz_type": "quiz",
+                "passing_score": 70,
+                "questions": [],
+            },
+        )
+        quiz_id = resp.json()["id"]
+        ids_before = {r.id for r in _active(db, "quiz", quiz_id)}
+        resp = client.put(f"/api/v1/quizzes/{quiz_id}", json={"passing_score": 80})
+        assert resp.status_code == 200, resp.text
+        ids_after = {r.id for r in _active(db, "quiz", quiz_id)}
+        assert ids_before == ids_after
+
+
+@pytest.fixture(autouse=True)
+def _isolate(db: Session):
+    yield
+    db.query(ContentVersion).filter(ContentVersion.entity_type.in_(("quiz", "quiz_question", "quiz_option"))).delete()
+    db.query(QuizOption).delete()
+    db.query(QuizQuestion).delete()
+    db.query(Quiz).delete()
+    db.commit()


### PR DESCRIPTION
## What

Phase 1f wraps up entity-side dual-write. Wires `dual_write_entity_content` into the remaining four translatable entity types — **Phase 1 is now complete across every entity the translation registry covers** (11 entity types: course, module, chapter, chapter_block, quiz, quiz_question, quiz_option, assignment, announcement, course_event, cohort).

**Stacked on #536.** Auto-merges once 1e lands.

## How

| Entity | Fields | Fallback locale |
|---|---|---|
| Assignment | title, description | walk Assignment → Chapter → Module → Course |
| Announcement (course-scoped) | title, content | course.source_locale |
| Announcement (global) | title, content | author's preferred_locale |
| CourseEvent | title, description | parent course |
| Cohort | name → field='title' | admin's preferred_locale |

Cohorts use an inline helper because the model attribute (`name`) doesn't match the registry field name (`title`); every other entity uses the shared `dual_write_entity_content`.

## Latent bug fixed in passing

`update_announcement` and `update_course_event` route signatures took `announcement_id: str` and `event_id: str`, but the model ids are UUID — any real PUT request returned 503 (`'str' object has no attribute 'hex'` from the UUID column processor). No existing tests exercised the PUT, so this had never been caught. Type-changed both to `UUID` — FastAPI auto-converts path params, and the existing tests in this PR now exercise the path.

## Tests (9 new, via TestClient)

* `TestAssignmentDualWrite::test_create_writes_title_and_description`
* `TestAssignmentDualWrite::test_update_title_supersedes`
* `TestAnnouncementDualWrite::test_course_announcement_writes_title_and_content`
* `TestAnnouncementDualWrite::test_global_announcement_falls_back_to_admin_preferred_locale`
* `TestAnnouncementDualWrite::test_update_title_supersedes`
* `TestCourseEventDualWrite::test_create_writes_title_and_description`
* `TestCourseEventDualWrite::test_update_title_supersedes`
* `TestCohortDualWrite::test_create_writes_title_row_from_name`
* `TestCohortDualWrite::test_update_name_supersedes`

**910/910 backend tests passing. Ruff + mypy clean.**

## Phase 1 status

| Sub-PR | Scope | Status |
|---|---|---|
| 1a #532 | write helpers + supersession FK migration | merged |
| 1b #533 | courses | merged |
| 1c #534 | modules + chapters + shared helper | merged |
| 1d #535 | chapter_blocks | merged |
| 1e #536 | quizzes + questions + options | open |
| **1f (this)** | **assignments + announcements + events + cohorts** | **open** |
| 1g | MT pipeline dual-write (record_mt_version + record_mt_failure) | next |

Once 1g lands, every write into the system — human-typed and machine-translated — flows into `content_versions` in parallel with the legacy stores. Phase 2 (dual-read with mismatch logging) is then ready to begin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
