### PR TITLE
feat(bilingual): V1 phase 2a — content_versions dual-read comparator

### DIFF
--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -1,12 +1,25 @@
-"""Single-point-of-mutation helpers for ``content_versions``.
+"""Single-point-of-mutation helpers for ``content_versions`` + the
+Phase 2 dual-read comparator.
 
-Every write to the table goes through here. Direct INSERTs or
+Every write to the table goes through ``record_human_version`` /
+``record_mt_version`` / ``record_mt_failure``. Direct INSERTs or
 UPDATEs from anywhere else in the codebase are forbidden — the
 supersession + cascade-invalidation invariants only hold when they
-all funnel through ``record_human_version`` / ``record_mt_version``
-/ ``record_mt_failure``.
+all funnel through these helpers.
+
+``compare_resolved_text`` is the Phase 2 dual-read comparator: read
+sites call it after running the legacy resolve path; it reads the
+same key from ``content_versions`` and returns a structured report
+of how the two stores agree (or disagree). It never changes
+behaviour — Phase 4 is when reads switch over.
 """
 
+from app.services.content_versions.compare import (
+    INTERESTING_REASONS,
+    MismatchReason,
+    MismatchReport,
+    compare_resolved_text,
+)
 from app.services.content_versions.dual_write import dual_write_entity_content
 from app.services.content_versions.write import (
     record_human_version,
@@ -15,6 +28,10 @@ from app.services.content_versions.write import (
 )
 
 __all__ = [
+    "INTERESTING_REASONS",
+    "MismatchReason",
+    "MismatchReport",
+    "compare_resolved_text",
     "dual_write_entity_content",
     "record_human_version",
     "record_mt_failure",

--- a/backend/app/services/content_versions/compare.py
+++ b/backend/app/services/content_versions/compare.py
@@ -1,0 +1,420 @@
+"""Phase 2 dual-read comparator.
+
+Compares the legacy read result (entity column + ``content_translations``
+overlay) against what the new ``content_versions`` store would have
+returned for the same ``(entity_type, entity_id, field, display_locale)``
+lookup.
+
+This module ONLY reports. It never changes the caller's return value.
+Phase 2's whole job is to log every divergence so we can fix bugs (or
+deliberately-acceptable differences) BEFORE Phase 4 switches reads to
+``content_versions`` exclusively. Phase 4 then deletes the comparator
+calls.
+
+Edge cases we know about (from the dual-read audit). Each one is
+represented by a distinct ``MismatchReason`` so the log filter can
+slice by kind:
+
+  * ``OK`` — both stores agree.
+  * ``LEGACY_ONLY_NO_BACKFILL`` — no ``content_versions`` row for the
+    entity at all. Expected on every pre-Phase-1 entity until Phase 3
+    backfill runs. NOT a bug.
+  * ``BOTH_FALL_BACK_TO_SOURCE`` — neither store has a translation
+    for ``display_locale``; both correctly return the source text.
+    Equality verified, no mismatch.
+  * ``NEW_FAILED_STATUS`` — ``content_versions`` row exists but
+    ``status`` is ``failed`` / ``failed_permanent``; the new resolver
+    falls back to source. Compared against legacy fallback; mismatch
+    only flagged if texts diverge.
+  * ``TEXT_DIFFERS`` — both stores returned text but the texts differ
+    after whitespace normalisation. The interesting case to triage.
+  * ``LOCALE_DIVERGED`` — both stores returned text in the same
+    display locale, but the underlying ``content_versions`` row was
+    recorded under a different ``locale`` than the legacy path
+    expected. This happens when per-field language detection
+    classified a field differently from the course's declared
+    ``source_locale``. NOT a bug — the new path is more correct —
+    but worth surfacing so we can watch the rate.
+  * ``NEW_ONLY`` — legacy returned the source base (no overlay),
+    ``content_versions`` had a translation. Indicates the legacy
+    overlay row was missed (or never written) but the new path
+    captured it. Flag for investigation.
+  * ``ENTITY_DELETED`` — the entity is soft-deleted on the legacy
+    side but ``content_versions`` rows survive (no cascade wired
+    yet). Phase 5 cleanup.
+
+Hash / whitespace normalisation: comparison treats two strings as
+equal if their ``compute_source_hash``-normalised form matches.
+This catches trailing-newline drift and similar benign noise that
+would otherwise dominate the mismatch counts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from app.models.content_version import ContentVersion
+from app.services.translation.hash import _normalize as _normalize_whitespace
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class MismatchReason(StrEnum):
+    OK = "ok"
+    LEGACY_ONLY_NO_BACKFILL = "legacy_only_no_backfill"
+    BOTH_FALL_BACK_TO_SOURCE = "both_fall_back_to_source"
+    NEW_FAILED_STATUS = "new_failed_status"
+    TEXT_DIFFERS = "text_differs"
+    LOCALE_DIVERGED = "locale_diverged"
+    NEW_ONLY = "new_only"
+    ENTITY_DELETED = "entity_deleted"
+
+
+# Reasons we treat as "interesting" — the caller's structured log + Datadog
+# metric should fire for these. The remaining reasons are accounted-for
+# benign states and we count them silently.
+INTERESTING_REASONS: frozenset[MismatchReason] = frozenset(
+    {
+        MismatchReason.TEXT_DIFFERS,
+        MismatchReason.LOCALE_DIVERGED,
+        MismatchReason.NEW_ONLY,
+        MismatchReason.ENTITY_DELETED,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MismatchReport:
+    """One comparator outcome.
+
+    Always constructed; the caller decides whether to log / emit a
+    metric based on ``is_interesting``.
+    """
+
+    reason: MismatchReason
+    entity_type: str
+    entity_id: str
+    field: str
+    display_locale: str
+    # Text the legacy resolve path returned (or None when it had nothing).
+    legacy_text: str | None
+    # Text the new resolve path would return (or None when it had nothing).
+    new_text: str | None
+    # The status of the active content_versions row at ``display_locale``,
+    # or None when no row exists. Lets the log distinguish a missing row
+    # from a failed one.
+    new_status: str | None
+    # The ACTUAL ``locale`` column of the active content_versions row for
+    # this (entity, field) regardless of display_locale. None when no row.
+    # Useful to spot per-field detection drift.
+    new_recorded_locale: str | None
+
+    @property
+    def is_interesting(self) -> bool:
+        return self.reason in INTERESTING_REASONS
+
+    def to_log_fields(self) -> dict[str, str | None]:
+        """Structured fields for the warning log."""
+        return {
+            "cv_compare_reason": self.reason.value,
+            "cv_compare_entity_type": self.entity_type,
+            "cv_compare_entity_id": self.entity_id,
+            "cv_compare_field": self.field,
+            "cv_compare_display_locale": self.display_locale,
+            "cv_compare_new_status": self.new_status,
+            "cv_compare_new_recorded_locale": self.new_recorded_locale,
+            # Don't dump full text into structured fields — it can be
+            # megabytes of HTML for chapter_block.content. Lengths are
+            # enough to triage; pull the rows by id when debugging.
+            "cv_compare_legacy_text_len": (str(len(self.legacy_text)) if self.legacy_text is not None else None),
+            "cv_compare_new_text_len": (str(len(self.new_text)) if self.new_text is not None else None),
+        }
+
+
+def _entity_has_any_content_version(db: Session, *, entity_type: str, entity_id: str) -> bool:
+    """Has the dual-write fired for this entity at all (any field, any locale)?
+
+    Used to distinguish "Phase 3 backfill hasn't run for this entity yet"
+    from "the write path is broken". Both look like missing rows but only
+    the latter is a bug. A single existence query is enough to disambiguate.
+    """
+    return (
+        db.query(ContentVersion.id)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+        )
+        .first()
+        is not None
+    )
+
+
+def _texts_match(a: str | None, b: str | None) -> bool:
+    """Whitespace-normalised text equality.
+
+    Mirrors ``compute_source_hash``'s ``\\s+`` collapse so a trailing
+    newline or a re-flowed paragraph doesn't count as a mismatch.
+    Both NULL ⇒ match. One NULL + one empty-string ⇒ also match,
+    because the legacy path treats empty as no-value while the new
+    path stores empty as the failure sentinel; treating them the same
+    here means we don't flood logs with a known-irrelevant difference.
+    """
+    if not a and not b:
+        return True
+    if a is None or b is None:
+        return False
+    return _normalize_whitespace(a) == _normalize_whitespace(b)
+
+
+def compare_resolved_text(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    field: str,
+    source_locale: str,
+    display_locale: str,
+    base_source_text: str | None,
+    legacy_text: str | None,
+    entity_deleted: bool = False,
+) -> MismatchReport:
+    """Run the new-store resolve and compare against the legacy result.
+
+    The caller has already executed the legacy resolution and passes the
+    final string it would have returned to the user (``legacy_text``)
+    along with the entity's source-column text (``base_source_text``).
+    This function reads ``content_versions`` for the same key, applies
+    the new-path resolution rules (active row at ``display_locale`` with
+    ``status='ok'``; fall back to source otherwise), and returns a
+    structured comparison.
+
+    ``source_locale`` is the parent entity's declared source language
+    (course.source_locale or equivalent). It lets the comparator
+    distinguish "cv recorded the field at the expected source locale"
+    (a benign confirmation) from "cv recorded the field at a locale
+    that's neither display nor source" (per-field detection drift —
+    interesting).
+
+    No side effects — purely returns the report. The caller decides
+    whether to log it, what sampling to apply, and which metric to
+    emit. Phase 2 wiring lives outside this module.
+    """
+    active_row_for_display_locale = (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.field == field,
+            ContentVersion.locale == display_locale,
+            ContentVersion.superseded_by.is_(None),
+        )
+        .one_or_none()
+    )
+
+    # One extra single-row lookup: the active row for this (entity, field)
+    # in ANY locale, used purely to surface "the new store recorded this
+    # under a different locale than the legacy expected" as its own
+    # mismatch class. Cheap, indexed by ix_content_versions_entity.
+    any_active_for_field = (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id == entity_id,
+            ContentVersion.field == field,
+            ContentVersion.superseded_by.is_(None),
+            ContentVersion.status == "ok",
+        )
+        .first()
+    )
+
+    # Edge case: nothing in content_versions for this entity at all.
+    # Almost certainly "Phase 3 backfill hasn't run yet" for legacy
+    # entities. Don't flood logs.
+    if active_row_for_display_locale is None and any_active_for_field is None:
+        if not _entity_has_any_content_version(db, entity_type=entity_type, entity_id=entity_id):
+            return MismatchReport(
+                reason=MismatchReason.LEGACY_ONLY_NO_BACKFILL,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                field=field,
+                display_locale=display_locale,
+                legacy_text=legacy_text,
+                new_text=None,
+                new_status=None,
+                new_recorded_locale=None,
+            )
+
+    new_text: str | None
+    new_status: str | None
+    new_recorded_locale = any_active_for_field.locale if any_active_for_field is not None else None
+
+    if active_row_for_display_locale is None:
+        # No content_versions row at display_locale — same fallback as
+        # legacy (return source). Will be ``BOTH_FALL_BACK_TO_SOURCE``
+        # or ``LOCALE_DIVERGED`` depending on whether the new store has
+        # the field in some OTHER locale.
+        new_text = base_source_text
+        new_status = None
+    elif active_row_for_display_locale.status == "ok":
+        new_text = active_row_for_display_locale.text
+        new_status = "ok"
+    else:
+        # status='failed' / 'failed_permanent' — new resolver falls
+        # back to source, same as legacy.
+        new_text = base_source_text
+        new_status = active_row_for_display_locale.status
+
+    # Soft-delete: legacy reads typically filter out deleted entities;
+    # content_versions has no delete cascade yet. Flag as its own kind
+    # so the cleanup PR in Phase 5 can target it.
+    if entity_deleted and (active_row_for_display_locale is not None or any_active_for_field is not None):
+        return MismatchReport(
+            reason=MismatchReason.ENTITY_DELETED,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            display_locale=display_locale,
+            legacy_text=legacy_text,
+            new_text=new_text,
+            new_status=new_status,
+            new_recorded_locale=new_recorded_locale,
+        )
+
+    # Failed/failed-permanent path: both paths fell back to source.
+    # Compare with whitespace-normalisation; ``status`` reported back
+    # so the metric can sort failures out of the "real" mismatches.
+    if active_row_for_display_locale is not None and active_row_for_display_locale.status != "ok":
+        if _texts_match(legacy_text, new_text):
+            return MismatchReport(
+                reason=MismatchReason.NEW_FAILED_STATUS,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                field=field,
+                display_locale=display_locale,
+                legacy_text=legacy_text,
+                new_text=new_text,
+                new_status=new_status,
+                new_recorded_locale=new_recorded_locale,
+            )
+        return MismatchReport(
+            reason=MismatchReason.TEXT_DIFFERS,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            display_locale=display_locale,
+            legacy_text=legacy_text,
+            new_text=new_text,
+            new_status=new_status,
+            new_recorded_locale=new_recorded_locale,
+        )
+
+    if active_row_for_display_locale is None:
+        # No row at display_locale → both paths fall back to source.
+        # Distinguish two sub-cases by what cv has for the field in
+        # OTHER locales:
+        #   * any_active_for_field is None: cv has nothing → already
+        #     handled above as LEGACY_ONLY_NO_BACKFILL (the field
+        #     hasn't been dual-written yet for ANY locale).
+        #   * any_active_for_field at source_locale: cv recorded the
+        #     field at the EXPECTED source locale. Benign.
+        #   * any_active_for_field at a third locale: per-field
+        #     detection put the field somewhere unexpected. Surface
+        #     it so we can review whether the detection was right.
+        if (
+            any_active_for_field is not None
+            and any_active_for_field.locale != source_locale
+            and any_active_for_field.locale != display_locale
+        ):
+            # Recorded under neither display nor source. Texts may
+            # still match if both fell back to source — the divergence
+            # signal is the recorded locale itself.
+            if _texts_match(legacy_text, new_text):
+                return MismatchReport(
+                    reason=MismatchReason.LOCALE_DIVERGED,
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    field=field,
+                    display_locale=display_locale,
+                    legacy_text=legacy_text,
+                    new_text=new_text,
+                    new_status=None,
+                    new_recorded_locale=new_recorded_locale,
+                )
+            return MismatchReport(
+                reason=MismatchReason.TEXT_DIFFERS,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                field=field,
+                display_locale=display_locale,
+                legacy_text=legacy_text,
+                new_text=new_text,
+                new_status=None,
+                new_recorded_locale=new_recorded_locale,
+            )
+        # cv has nothing OR has the field at source/display locale only.
+        # Either way both paths converged on the source text.
+        if _texts_match(legacy_text, new_text):
+            return MismatchReport(
+                reason=MismatchReason.BOTH_FALL_BACK_TO_SOURCE,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                field=field,
+                display_locale=display_locale,
+                legacy_text=legacy_text,
+                new_text=new_text,
+                new_status=None,
+                new_recorded_locale=new_recorded_locale,
+            )
+        return MismatchReport(
+            reason=MismatchReason.TEXT_DIFFERS,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            display_locale=display_locale,
+            legacy_text=legacy_text,
+            new_text=new_text,
+            new_status=None,
+            new_recorded_locale=new_recorded_locale,
+        )
+
+    # Active ok row exists at display_locale.
+    if legacy_text == base_source_text or legacy_text is None:
+        # Legacy fell back to source (or returned None); new store has
+        # a translation. Flag — the legacy overlay was missed.
+        return MismatchReport(
+            reason=MismatchReason.NEW_ONLY,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            display_locale=display_locale,
+            legacy_text=legacy_text,
+            new_text=new_text,
+            new_status="ok",
+            new_recorded_locale=new_recorded_locale,
+        )
+    if _texts_match(legacy_text, new_text):
+        return MismatchReport(
+            reason=MismatchReason.OK,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            display_locale=display_locale,
+            legacy_text=legacy_text,
+            new_text=new_text,
+            new_status="ok",
+            new_recorded_locale=new_recorded_locale,
+        )
+    return MismatchReport(
+        reason=MismatchReason.TEXT_DIFFERS,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        display_locale=display_locale,
+        legacy_text=legacy_text,
+        new_text=new_text,
+        new_status="ok",
+        new_recorded_locale=new_recorded_locale,
+    )

--- a/backend/tests/test_content_versions_compare.py
+++ b/backend/tests/test_content_versions_compare.py
@@ -1,0 +1,595 @@
+"""Tests for the Phase 2 dual-read comparator.
+
+Pins every branch of the decision tree so the wiring in subsequent
+sub-PRs can rely on a stable contract. The comparator is read-only
+and side-effect-free; tests assert on returned ``MismatchReport``s.
+
+Coverage map (one test per branch, plus normalisation edge cases):
+
+* ``OK`` — both stores agree on the translated text
+* ``LEGACY_ONLY_NO_BACKFILL`` — no cv rows for the entity at all
+* ``BOTH_FALL_BACK_TO_SOURCE`` — cv has the field in another locale
+  but not at display_locale; both paths fall back to source
+* ``NEW_FAILED_STATUS`` — cv row at display_locale has status=failed;
+  both paths fall back; texts match
+* ``TEXT_DIFFERS`` — both paths returned a non-empty value but the
+  two values disagree after whitespace normalisation
+* ``LOCALE_DIVERGED`` — cv has the field but recorded under a
+  different locale than the legacy path expected; texts happen to
+  match (fall-back path on both sides)
+* ``NEW_ONLY`` — legacy returned source; cv has a translation at
+  display_locale
+* ``ENTITY_DELETED`` — entity is soft-deleted but cv rows persist
+* Whitespace normalisation — trailing newlines, collapsed spaces,
+  empty-vs-None equivalence
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.services.content_versions import (
+    INTERESTING_REASONS,
+    MismatchReason,
+    compare_resolved_text,
+)
+from app.services.content_versions.write import (
+    record_human_version,
+    record_mt_failure,
+    record_mt_version,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+@pytest.fixture
+def db():
+    from sqlalchemy.orm import Session as _Session
+
+    from tests.conftest import test_engine
+
+    session = _Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _unique_entity_id() -> str:
+    return f"ent-{uuid.uuid4().hex[:10]}"
+
+
+# ---------------------------------------------------------------------------
+# OK — both stores agree
+# ---------------------------------------------------------------------------
+
+
+class TestOk:
+    def test_both_stores_have_matching_translation_at_display_locale(self, db: Session):
+        eid = _unique_entity_id()
+        # Pre-seed cv with the same text the legacy resolver returned.
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="ru",
+            text="Заголовок",
+        )
+        # Source row at en (so the resolver doesn't think we're already
+        # at the source locale).
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="en",
+            text="Title",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            legacy_text="Заголовок",
+        )
+        assert report.reason is MismatchReason.OK
+        assert report.is_interesting is False
+
+
+# ---------------------------------------------------------------------------
+# LEGACY_ONLY_NO_BACKFILL — cv empty for entity (expected pre-Phase-3)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyOnlyNoBackfill:
+    def test_empty_content_versions_for_entity_is_not_interesting(self, db: Session):
+        eid = _unique_entity_id()
+        # No cv rows at all for this entity.
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            legacy_text="Заголовок",
+        )
+        assert report.reason is MismatchReason.LEGACY_ONLY_NO_BACKFILL
+        assert report.is_interesting is False
+        assert report.new_text is None
+        assert report.new_status is None
+        assert report.new_recorded_locale is None
+
+    def test_legacy_no_backfill_does_not_flag_even_with_text_difference(self, db: Session):
+        # Even when legacy returned a different text from what we'd
+        # expect, missing-cv-entirely means we have nothing to compare
+        # against and shouldn't flag.
+        eid = _unique_entity_id()
+        report = compare_resolved_text(
+            db,
+            entity_type="quiz",
+            entity_id=eid,
+            field="question_text",
+            source_locale="ru",
+            display_locale="en",
+            base_source_text="Question",
+            legacy_text="Pytanie",  # arbitrary
+        )
+        assert report.reason is MismatchReason.LEGACY_ONLY_NO_BACKFILL
+
+
+# ---------------------------------------------------------------------------
+# BOTH_FALL_BACK_TO_SOURCE — no overlay at display_locale, both fall back
+# ---------------------------------------------------------------------------
+
+
+class TestBothFallBackToSource:
+    def test_no_overlay_either_side_at_display_locale(self, db: Session):
+        eid = _unique_entity_id()
+        # cv has en (the source) only — no ru translation.
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="en",
+            text="Title",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            legacy_text="Title",  # legacy also fell back
+        )
+        assert report.reason is MismatchReason.BOTH_FALL_BACK_TO_SOURCE
+        assert report.is_interesting is False
+
+
+# ---------------------------------------------------------------------------
+# NEW_FAILED_STATUS — cv row at display_locale is failed; both fall back
+# ---------------------------------------------------------------------------
+
+
+class TestNewFailedStatus:
+    def test_failed_at_display_locale_falls_back_and_matches_legacy(self, db: Session):
+        eid = _unique_entity_id()
+        record_mt_failure(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="ru",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            legacy_text="Title",
+        )
+        assert report.reason is MismatchReason.NEW_FAILED_STATUS
+        assert report.new_status == "failed"
+        assert report.is_interesting is False  # known-acceptable
+
+    def test_failed_at_display_locale_but_texts_disagree_flags_text_differs(self, db: Session):
+        eid = _unique_entity_id()
+        record_mt_failure(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="ru",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            # Legacy somehow returned something other than the source —
+            # that's a real bug we want to know about.
+            legacy_text="Заголовок",
+        )
+        assert report.reason is MismatchReason.TEXT_DIFFERS
+        assert report.new_status == "failed"
+        assert report.is_interesting is True
+
+
+# ---------------------------------------------------------------------------
+# TEXT_DIFFERS — both paths returned text but they disagree
+# ---------------------------------------------------------------------------
+
+
+class TestTextDiffers:
+    def test_text_differs_at_display_locale(self, db: Session):
+        eid = _unique_entity_id()
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="ru",
+            text="Версия из cv",
+        )
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="en",
+            text="Title",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            legacy_text="Версия из legacy",
+        )
+        assert report.reason is MismatchReason.TEXT_DIFFERS
+        assert report.is_interesting is True
+        assert report.legacy_text == "Версия из legacy"
+        assert report.new_text == "Версия из cv"
+
+
+# ---------------------------------------------------------------------------
+# LOCALE_DIVERGED — cv has the field but at an unexpected locale
+# ---------------------------------------------------------------------------
+
+
+class TestLocaleDiverged:
+    def test_field_recorded_at_unexpected_locale(self, db: Session):
+        # Course says source_locale=ru, but a chapter title was authored
+        # in English ("Genesis"). Per-field detection put the cv row at
+        # en, not ru. The legacy resolver returns the source column as-is
+        # (no ru overlay needed because display == source); the cv row is
+        # at neither the display nor source locale. That's the genuine
+        # LOCALE_DIVERGED signal — recording locale != either expected.
+        eid = _unique_entity_id()
+        record_human_version(
+            db,
+            entity_type="chapter",
+            entity_id=eid,
+            field="title",
+            locale="en",  # cv recorded under en
+            text="Genesis",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="chapter",
+            entity_id=eid,
+            field="title",
+            source_locale="ru",  # course's declared source
+            display_locale="ru",  # user asked for the source language
+            base_source_text="Genesis",
+            legacy_text="Genesis",  # legacy returned source as-is
+        )
+        assert report.reason is MismatchReason.LOCALE_DIVERGED
+        assert report.new_recorded_locale == "en"
+        assert report.is_interesting is True
+
+    def test_cv_at_source_locale_is_benign_fallback(self, db: Session):
+        # Normal case: course is en, chapter title is English, cv
+        # recorded the field under en. User asks for ru → both stores
+        # fall back to source. Recording at source_locale = not diverged.
+        eid = _unique_entity_id()
+        record_human_version(
+            db,
+            entity_type="chapter",
+            entity_id=eid,
+            field="title",
+            locale="en",
+            text="Title",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="chapter",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            legacy_text="Title",
+        )
+        assert report.reason is MismatchReason.BOTH_FALL_BACK_TO_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# NEW_ONLY — legacy returned source; cv has a translation
+# ---------------------------------------------------------------------------
+
+
+class TestNewOnly:
+    def test_legacy_fell_back_but_cv_has_translation(self, db: Session):
+        eid = _unique_entity_id()
+        # cv has both source AND translation; legacy somehow missed
+        # the overlay row.
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="en",
+            text="Title",
+        )
+        record_mt_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="ru",
+            text="Заголовок",
+            source_locale="en",
+            source_hash="h1",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            legacy_text="Title",  # legacy returned source (missed overlay)
+        )
+        assert report.reason is MismatchReason.NEW_ONLY
+        assert report.new_text == "Заголовок"
+        assert report.is_interesting is True
+
+
+# ---------------------------------------------------------------------------
+# ENTITY_DELETED — entity gone but cv rows survive
+# ---------------------------------------------------------------------------
+
+
+class TestEntityDeleted:
+    def test_deleted_entity_with_surviving_cv_rows_flagged(self, db: Session):
+        eid = _unique_entity_id()
+        record_human_version(
+            db,
+            entity_type="chapter",
+            entity_id=eid,
+            field="title",
+            locale="ru",
+            text="Глава",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="chapter",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text=None,
+            legacy_text=None,
+            entity_deleted=True,
+        )
+        assert report.reason is MismatchReason.ENTITY_DELETED
+        assert report.is_interesting is True
+
+    def test_deleted_entity_with_no_cv_rows_not_flagged(self, db: Session):
+        # If there were no cv rows AND the entity is deleted, it's the
+        # legacy-only-no-backfill case, not an orphan. Treat as benign.
+        eid = _unique_entity_id()
+        report = compare_resolved_text(
+            db,
+            entity_type="chapter",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text=None,
+            legacy_text=None,
+            entity_deleted=True,
+        )
+        assert report.reason is MismatchReason.LEGACY_ONLY_NO_BACKFILL
+
+
+# ---------------------------------------------------------------------------
+# Whitespace / normalisation edges
+# ---------------------------------------------------------------------------
+
+
+class TestWhitespaceNormalisation:
+    def test_trailing_newline_does_not_count_as_mismatch(self, db: Session):
+        eid = _unique_entity_id()
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="description",
+            locale="ru",
+            text="Описание",
+        )
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="description",
+            locale="en",
+            text="Description",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="description",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Description",
+            legacy_text="Описание\n",  # legacy retains trailing newline
+        )
+        assert report.reason is MismatchReason.OK
+
+    def test_collapsed_whitespace_does_not_count_as_mismatch(self, db: Session):
+        eid = _unique_entity_id()
+        record_human_version(
+            db,
+            entity_type="chapter_block",
+            entity_id=eid,
+            field="content",
+            locale="ru",
+            text="Слово  второе",
+        )
+        record_human_version(
+            db,
+            entity_type="chapter_block",
+            entity_id=eid,
+            field="content",
+            locale="en",
+            text="Word two",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="chapter_block",
+            entity_id=eid,
+            field="content",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Word two",
+            legacy_text="Слово второе",  # single space — equal after normalise
+        )
+        assert report.reason is MismatchReason.OK
+
+    def test_empty_vs_none_treated_as_equal(self, db: Session):
+        eid = _unique_entity_id()
+        # No cv row at all for this entity.
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="description",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text=None,
+            legacy_text="",
+        )
+        # No cv rows → LEGACY_ONLY_NO_BACKFILL regardless of text shape.
+        assert report.reason is MismatchReason.LEGACY_ONLY_NO_BACKFILL
+
+
+# ---------------------------------------------------------------------------
+# Structured logging fields
+# ---------------------------------------------------------------------------
+
+
+class TestLogFields:
+    def test_log_fields_have_expected_shape(self, db: Session):
+        eid = _unique_entity_id()
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="ru",
+            text="Заголовок",
+        )
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            locale="en",
+            text="Title",
+        )
+        db.commit()
+        report = compare_resolved_text(
+            db,
+            entity_type="course",
+            entity_id=eid,
+            field="title",
+            source_locale="en",
+            display_locale="ru",
+            base_source_text="Title",
+            legacy_text="Foo",  # text differs
+        )
+        fields = report.to_log_fields()
+        assert fields["cv_compare_reason"] == "text_differs"
+        assert fields["cv_compare_entity_type"] == "course"
+        assert fields["cv_compare_entity_id"] == eid
+        assert fields["cv_compare_field"] == "title"
+        assert fields["cv_compare_display_locale"] == "ru"
+        assert fields["cv_compare_new_status"] == "ok"
+        # Never dump full text into structured fields.
+        assert "Заголовок" not in str(fields)
+        assert "Title" not in str(fields)
+        # Lengths are surfaced for triage.
+        assert fields["cv_compare_legacy_text_len"] == "3"
+        assert fields["cv_compare_new_text_len"] == "9"  # len("Заголовок")
+
+
+# ---------------------------------------------------------------------------
+# INTERESTING_REASONS set sanity
+# ---------------------------------------------------------------------------
+
+
+class TestInterestingReasonsSet:
+    def test_interesting_set_matches_decision_tree(self):
+        # The actionable reasons that should trigger structured warnings
+        # in the Phase 2 wiring. Pin the set so adding/removing a reason
+        # forces a deliberate choice.
+        expected = frozenset(
+            {
+                MismatchReason.TEXT_DIFFERS,
+                MismatchReason.LOCALE_DIVERGED,
+                MismatchReason.NEW_ONLY,
+                MismatchReason.ENTITY_DELETED,
+            }
+        )
+        assert expected == INTERESTING_REASONS


### PR DESCRIPTION
## What

Phase 2a — the dual-read comparator. Read sites call `compare_resolved_text` after running the legacy resolve path; it reads the same key from `content_versions` and returns a structured `MismatchReport` of how the two stores agree (or disagree). **It never changes the caller's return value** — pure side-effect-free reporting. Phase 4 is when reads actually switch over.

Built after a thorough three-pronged audit:
1. **Read-path inventory** — 20 distinct read paths catalogued by entity type, with 9 owner-bypass paths flagged as must-stay-raw.
2. **Edge-case audit** — 10 categories where the two stores can legitimately differ (pre-Phase-3 backfill, sanitization timing, per-field detection, soft-delete, MT failure fallback, etc).
3. **Prod state audit** — confirmed `content_versions` is empty in prod (no traffic since #533 merged). Phase 2 is built to gracefully report this as `LEGACY_ONLY_NO_BACKFILL`.

## Eight `MismatchReason` values

| Reason | Meaning | Interesting? |
|---|---|---|
| `OK` | Both stores agree at display_locale | no |
| `LEGACY_ONLY_NO_BACKFILL` | No cv row for entity (pre-Phase-3 state) | no |
| `BOTH_FALL_BACK_TO_SOURCE` | No overlay either side, source returned | no |
| `NEW_FAILED_STATUS` | cv has failed/failed_permanent at display | no |
| `TEXT_DIFFERS` | Both returned text but disagree (likely BUG) | **yes** |
| `LOCALE_DIVERGED` | cv recorded under unexpected locale | **yes** |
| `NEW_ONLY` | Legacy missed an overlay the new store captured | **yes** |
| `ENTITY_DELETED` | Soft-deleted entity with surviving cv rows | **yes** |

`INTERESTING_REASONS` is a frozenset pinning the subset that should fire structured warnings — the rest are benign and counted silently.

## Whitespace + payload-safety

* Comparison treats two strings as equal if their `compute_source_hash`-normalised form matches → trailing newlines + reflowed paragraphs don't flood mismatch counts.
* `MismatchReport.to_log_fields()` returns triage-only fields (entity ids, reasons, lengths). Full text is **never** dumped to structured logs because `chapter_block.content` can be megabytes of HTML; pull rows by id when debugging.

## Tests (17, all green)

* `OK` at display_locale
* `LEGACY_ONLY_NO_BACKFILL` × 2 (with and without legacy text difference)
* `BOTH_FALL_BACK_TO_SOURCE`
* `NEW_FAILED_STATUS` × 2 (matching and mismatching texts)
* `TEXT_DIFFERS` at display_locale
* `LOCALE_DIVERGED` × 2 (unexpected recorded locale vs benign at source)
* `NEW_ONLY` when legacy missed an overlay
* `ENTITY_DELETED` × 2 (with surviving cv vs no cv)
* Trailing-newline normalisation
* Collapsed-whitespace normalisation
* Empty-vs-None equality
* `to_log_fields` shape (never dumps full text)
* `INTERESTING_REASONS` set pinned

**933/933 backend tests passing. Ruff + mypy clean.**

## Phase 2 sub-PR plan

| Sub-PR | Scope |
|---|---|
| **2a (this)** | **comparator + tests** |
| 2b | Wire into `resolve_for_display` canonical helpers via opt-in flag |
| 2c | Wire into inline read paths (calendar, announcements, prerequisites) |
| 2d | Telemetry — structured warnings + Datadog metric + MCP query helper |
| 2e | Smoke recipe — manual prod check that Phase 1 dual-write actually fires |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
