### PR TITLE
feat(bilingual): V1 phase 2b — wire dual-read into Localizer

### DIFF
--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -19,6 +19,9 @@ from app.services.content_versions.compare import (
     MismatchReason,
     MismatchReport,
     compare_resolved_text,
+    get_compare_sample_rate,
+    maybe_compare_and_log,
+    set_compare_sample_rate,
 )
 from app.services.content_versions.dual_write import dual_write_entity_content
 from app.services.content_versions.write import (
@@ -33,7 +36,10 @@ __all__ = [
     "MismatchReport",
     "compare_resolved_text",
     "dual_write_entity_content",
+    "get_compare_sample_rate",
+    "maybe_compare_and_log",
     "record_human_version",
     "record_mt_failure",
     "record_mt_version",
+    "set_compare_sample_rate",
 ]

--- a/backend/app/services/content_versions/compare.py
+++ b/backend/app/services/content_versions/compare.py
@@ -51,6 +51,9 @@ would otherwise dominate the mismatch counts.
 
 from __future__ import annotations
 
+import logging
+import os
+import random
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -60,6 +63,36 @@ from app.services.translation.hash import _normalize as _normalize_whitespace
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# Sampling rate for the dual-read comparator, 0.0 to 1.0. The comparator
+# adds two single-row indexed SELECTs per call (active-at-display-locale
+# + any-active-for-field) so even at rate=1.0 the overhead is small,
+# but in prod we'll start at a low rate to confirm the wiring works
+# without risk of log spam.
+#
+# Read once at import time — the env var changes a deploy. Tests that
+# need to override use ``set_compare_sample_rate`` (a deliberate
+# escape hatch; production code must not call it).
+_DEFAULT_SAMPLE_RATE: float = float(os.environ.get("CONTENT_VERSIONS_COMPARE_RATE", "0.0") or "0.0")
+_sample_rate: float = max(0.0, min(1.0, _DEFAULT_SAMPLE_RATE))
+
+
+def set_compare_sample_rate(rate: float) -> None:
+    """Test-only: override the dual-read comparator sampling rate.
+
+    Production code reads ``CONTENT_VERSIONS_COMPARE_RATE`` from the
+    environment at import time. This hook exists so per-test fixtures
+    can flip the rate to 1.0 without monkey-patching the module
+    constant directly.
+    """
+    global _sample_rate
+    _sample_rate = max(0.0, min(1.0, rate))
+
+
+def get_compare_sample_rate() -> float:
+    return _sample_rate
 
 
 class MismatchReason(StrEnum):
@@ -418,3 +451,67 @@ def compare_resolved_text(
         new_status="ok",
         new_recorded_locale=new_recorded_locale,
     )
+
+
+def maybe_compare_and_log(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: str,
+    field: str,
+    source_locale: str,
+    display_locale: str,
+    base_source_text: str | None,
+    legacy_text: str | None,
+    entity_deleted: bool = False,
+) -> None:
+    """Sample-gated wrapper around ``compare_resolved_text``.
+
+    Production read sites call THIS instead of the bare comparator.
+    Three responsibilities, in order:
+
+    1. Sampling — skip cleanly when the env-controlled sample rate
+       says this call shouldn't compare. Default rate is 0.0, so the
+       function is a no-op until ops flip the dial. Compared rows pay
+       two indexed SELECTs, so even at 1.0 the overhead is small, but
+       starting low gives us a safe rollout.
+    2. Comparator — call the pure ``compare_resolved_text`` with the
+       same args.
+    3. Logging — emit a structured ``warning`` for INTERESTING reasons.
+       Benign reasons (OK / no-backfill / fallback agreement / failed
+       status / locale at source) are silently dropped so we don't
+       drown the log feed during the unbackfilled-prod phase.
+
+    Wraps every call in a ``try / except`` because Phase 2's whole
+    contract is "comparison MUST NOT affect the user's response".
+    A bug in the comparator (or a flaky DB read) should never bubble
+    up to the read endpoint that called us.
+    """
+    if _sample_rate <= 0.0:
+        return
+    if _sample_rate < 1.0 and random.random() >= _sample_rate:
+        return
+    try:
+        report = compare_resolved_text(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            source_locale=source_locale,
+            display_locale=display_locale,
+            base_source_text=base_source_text,
+            legacy_text=legacy_text,
+            entity_deleted=entity_deleted,
+        )
+    except Exception:
+        # The comparator does only reads, but if a DB hiccup throws we
+        # silently swallow and move on. Phase 2 is observation, not a
+        # correctness path.
+        logger.exception("content_versions dual-read comparator raised; swallowing")
+        return
+    if report.is_interesting:
+        logger.warning(
+            "content_versions dual-read mismatch: %s",
+            report.reason.value,
+            extra=report.to_log_fields(),
+        )

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -36,6 +36,7 @@ from app.schemas.chapter_block import BlockResponse
 from app.schemas.course import ChapterResponse, CourseResponse, CourseSummary, ModuleResponse
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.schemas.quiz import QuizOptionStudentResponse, QuizQuestionStudentResponse, QuizStudentResponse
+from app.services.content_versions import maybe_compare_and_log
 from app.services.language_detection import detect_locale
 
 
@@ -216,14 +217,22 @@ class Localizer:
     actually varies between rows.
 
     Construct one per response; pass it down to inner row-builders.
+
+    Phase 2 dual-read: when constructed with ``Localizer.build`` the
+    instance holds a reference to the session, and every ``pick`` call
+    fires the sample-gated dual-read comparator behind the legacy
+    return value. Legacy direct construction (``Localizer(overlay,
+    source, display)``) leaves ``db=None`` and the comparator never
+    fires — keeps the existing tests unchanged.
     """
 
     overlay: dict[tuple[str, str, str], str]
     source_locale: LocaleCode
     display_locale: LocaleCode
+    db: Session | None = None
 
     def pick(self, entity_type: str, entity_id: str, field: str, base: str | None) -> str | None:
-        return pick_overlay_value(
+        result = pick_overlay_value(
             self.overlay,
             entity_type,
             entity_id,
@@ -232,6 +241,23 @@ class Localizer:
             source_locale=self.source_locale,
             display_locale=self.display_locale,
         )
+        if self.db is not None:
+            # Side-effect-only: log a structured warning when the new
+            # store would have returned something different. Sampled at
+            # the env-controlled rate (default 0.0 / disabled). Wrapped
+            # internally with broad except so a comparator failure
+            # never affects the user's response.
+            maybe_compare_and_log(
+                self.db,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                field=field,
+                source_locale=self.source_locale,
+                display_locale=self.display_locale,
+                base_source_text=base,
+                legacy_text=result,
+            )
+        return result
 
     @classmethod
     def build(
@@ -245,11 +271,15 @@ class Localizer:
         """Bulk-fetch the overlay rows for ``specs`` and wrap them in a
         ``Localizer``. Convenience constructor for the common pattern of
         ``Localizer(fetch_overlay_triples_bulk(...), source, display)``.
+
+        Hooks the session into the returned instance so ``pick`` can
+        fire the Phase 2 dual-read comparator on each call.
         """
         return cls(
             overlay=fetch_overlay_triples_bulk(db, specs, display_locale),
             source_locale=source_locale,
             display_locale=display_locale,
+            db=db,
         )
 
 

--- a/backend/tests/test_localizer_dual_read.py
+++ b/backend/tests/test_localizer_dual_read.py
@@ -1,0 +1,195 @@
+"""Phase 2b tests: ``Localizer.pick`` fires the dual-read comparator.
+
+Pins the wiring contract:
+
+* When ``Localizer`` is built via ``Localizer.build(db, ...)``, every
+  ``pick`` call fires ``maybe_compare_and_log`` behind the legacy
+  return value.
+* When ``Localizer`` is constructed directly (without ``db``), the
+  comparator is never called — preserves the existing test surface.
+* The sampler gate works: rate=0.0 short-circuits without touching
+  the DB; rate=1.0 always fires.
+* INTERESTING reasons produce a structured warning log; benign
+  reasons are silent.
+* A comparator exception NEVER bubbles out of ``pick``.
+* The legacy return value is unchanged regardless of comparator
+  outcome.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.services.content_versions import set_compare_sample_rate
+from app.services.content_versions.write import record_human_version
+from app.services.translation.resolve_for_display import Localizer
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+@pytest.fixture
+def db():
+    from sqlalchemy.orm import Session as _Session
+
+    from tests.conftest import test_engine
+
+    session = _Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def sample_rate_one():
+    """Force the comparator to always fire for this test."""
+    set_compare_sample_rate(1.0)
+    yield
+    set_compare_sample_rate(0.0)
+
+
+class TestLocalizerWithoutDb:
+    """Constructing Localizer directly (no db) keeps it as a pure
+    in-memory helper — comparator never fires. Lets existing tests
+    and any inline helper that builds its own overlay map continue
+    working unchanged."""
+
+    def test_pick_returns_overlay_value_when_no_db(self, sample_rate_one: None):
+        loc = Localizer(
+            overlay={("course", "c1", "title"): "Заголовок"},
+            source_locale="en",
+            display_locale="ru",
+        )
+        result = loc.pick("course", "c1", "title", "Title")
+        assert result == "Заголовок"
+        # No db ⇒ comparator never called; no failure even though
+        # the rate is 1.0.
+
+    def test_pick_falls_back_to_base_when_no_overlay(self):
+        loc = Localizer(overlay={}, source_locale="en", display_locale="ru")
+        assert loc.pick("course", "c1", "title", "Title") == "Title"
+
+
+class TestLocalizerWithDbAndSamplerOff:
+    """db is held but rate=0.0 — comparator must not run. Confirms
+    the sampler gate is the actual gate."""
+
+    def test_pick_works_normally_when_sample_rate_zero(self, db: Session, caplog: pytest.LogCaptureFixture):
+        set_compare_sample_rate(0.0)
+        loc = Localizer.build(db, [], source_locale="en", display_locale="ru")
+        with caplog.at_level(logging.WARNING, logger="app.services.content_versions.compare"):
+            result = loc.pick("course", "unsampled-1", "title", "Title")
+        assert result == "Title"
+        assert "content_versions dual-read" not in caplog.text
+
+
+class TestLocalizerFiresInterestingMismatch:
+    """When the new store has a translation the legacy missed
+    (``NEW_ONLY``), the comparator fires and a structured warning
+    lands in the log."""
+
+    def test_new_only_mismatch_is_logged(
+        self,
+        db: Session,
+        sample_rate_one: None,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        # Pre-seed cv with both source and translation.
+        record_human_version(
+            db, entity_type="course", entity_id="cv-new-only", field="title", locale="en", text="Title"
+        )
+        record_human_version(
+            db, entity_type="course", entity_id="cv-new-only", field="title", locale="ru", text="Заголовок"
+        )
+        db.commit()
+        # Build Localizer with an empty overlay (legacy will fall back
+        # to source) but db hooked in so comparator runs.
+        loc = Localizer.build(db, [], source_locale="en", display_locale="ru")
+        with caplog.at_level(logging.WARNING, logger="app.services.content_versions.compare"):
+            result = loc.pick("course", "cv-new-only", "title", "Title")
+        # Legacy return unchanged.
+        assert result == "Title"
+        # Structured warning fired with NEW_ONLY reason.
+        records = [r for r in caplog.records if "content_versions dual-read" in r.message]
+        assert len(records) == 1
+        assert getattr(records[0], "cv_compare_reason", None) == "new_only"
+        assert getattr(records[0], "cv_compare_entity_type", None) == "course"
+        assert getattr(records[0], "cv_compare_entity_id", None) == "cv-new-only"
+        # Lengths surface for triage but the full text is never dumped.
+        assert "Заголовок" not in caplog.text
+        assert "Title" not in caplog.text
+
+
+class TestLocalizerSilentOnBenignReasons:
+    """``LEGACY_ONLY_NO_BACKFILL`` (the pre-Phase-3 expected state)
+    must NOT fire a warning even when the sampler is wide open."""
+
+    def test_no_cv_rows_is_silent(
+        self,
+        db: Session,
+        sample_rate_one: None,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        # No cv rows for this entity.
+        loc = Localizer.build(db, [], source_locale="en", display_locale="ru")
+        with caplog.at_level(logging.WARNING, logger="app.services.content_versions.compare"):
+            result = loc.pick("course", "cv-silent-1", "title", "Title")
+        assert result == "Title"
+        assert "content_versions dual-read" not in caplog.text
+
+
+class TestLocalizerExceptionsAreSwallowed:
+    """A bug in the comparator (or a flaky DB read) must NEVER affect
+    the response. The pick return value depends only on the legacy
+    overlay map."""
+
+    def test_comparator_exception_does_not_propagate(
+        self,
+        db: Session,
+        sample_rate_one: None,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Replace compare_resolved_text with a function that raises.
+        def boom(*args: object, **kwargs: object):
+            raise RuntimeError("simulated comparator failure")
+
+        monkeypatch.setattr("app.services.content_versions.compare.compare_resolved_text", boom)
+        loc = Localizer.build(db, [], source_locale="en", display_locale="ru")
+        with caplog.at_level(logging.ERROR, logger="app.services.content_versions.compare"):
+            # Should not raise.
+            result = loc.pick("course", "cv-err-1", "title", "Title")
+        assert result == "Title"
+        # The swallowed exception logged at ERROR with a traceable message.
+        assert any("dual-read comparator raised" in r.message for r in caplog.records)
+
+
+class TestLocalizerPicksUpSamplerAtCallTime:
+    """The sampler rate is consulted on every call, so flipping it
+    mid-test takes effect immediately for the next pick."""
+
+    def test_flipping_rate_to_one_starts_firing(
+        self,
+        db: Session,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        record_human_version(db, entity_type="course", entity_id="cv-flip", field="title", locale="en", text="Title")
+        record_human_version(
+            db, entity_type="course", entity_id="cv-flip", field="title", locale="ru", text="Заголовок"
+        )
+        db.commit()
+        loc = Localizer.build(db, [], source_locale="en", display_locale="ru")
+        with caplog.at_level(logging.WARNING, logger="app.services.content_versions.compare"):
+            set_compare_sample_rate(0.0)
+            loc.pick("course", "cv-flip", "title", "Title")  # silent
+            assert "content_versions dual-read" not in caplog.text
+            set_compare_sample_rate(1.0)
+            try:
+                loc.pick("course", "cv-flip", "title", "Title")  # fires
+                assert "content_versions dual-read" in caplog.text
+            finally:
+                set_compare_sample_rate(0.0)


### PR DESCRIPTION
## What

Wires the Phase 2a comparator into the canonical translation read helper. Every read path that goes through `Localizer` now fires the sample-gated dual-read comparator behind the legacy return value.

**Stacked on #539.** Auto-merges after 2a lands.

## How

`Localizer.build(db, ...)` now holds the session reference; every `loc.pick(...)` call passes through `maybe_compare_and_log` which:

1. **Sample-gates** on env var `CONTENT_VERSIONS_COMPARE_RATE` (0.0–1.0, default 0.0). At 0.0 the wrapper short-circuits before hitting the DB.
2. Runs `compare_resolved_text` (two indexed single-row SELECTs).
3. Emits a structured `warning` log when the reason is INTERESTING (`TEXT_DIFFERS`, `LOCALE_DIVERGED`, `NEW_ONLY`, `ENTITY_DELETED`).
4. Wrapped in `try/except` — a comparator failure NEVER affects the user's response.

Legacy direct construction `Localizer(overlay, source, display)` leaves `db=None` — comparator never fires. Preserves the existing test surface and any inline helper that builds its own overlay map.

## Why this covers most of the inventory in one shot

The read-path audit found 20 read paths across 11 entity types. ~95% of them flow through `Localizer.pick` (course detail, module detail, quiz student, assignment list, block list, cohort list, course event list). The remaining inline paths (calendar event composition, announcement source-locale grouping, prerequisites title map) get wired in sub-PR 2c.

## Production rollout

Sample rate stays at **0.0** in prod by default. Zero behavior change. Once Phase 1 fires in prod (smoke test pending — see 2e), ops bumps `CONTENT_VERSIONS_COMPARE_RATE` to a small value (e.g. 0.05) and we watch the structured warning stream.

## Tests (7 new, all green)

| Test | Pins |
|---|---|
| `test_pick_returns_overlay_value_when_no_db` | Legacy construction leaves comparator inert even at rate=1.0 |
| `test_pick_falls_back_to_base_when_no_overlay` | Pure overlay-miss path unchanged |
| `test_pick_works_normally_when_sample_rate_zero` | `db` present + rate=0.0 ⇒ silent (sample gate is the gate) |
| `test_new_only_mismatch_is_logged` | INTERESTING reason → structured warning with full triage fields, no full text in log |
| `test_no_cv_rows_is_silent` | `LEGACY_ONLY_NO_BACKFILL` never logged (expected pre-Phase-3 state) |
| `test_comparator_exception_does_not_propagate` | Comparator failures swallowed; ERROR logged; pick returns legacy result |
| `test_flipping_rate_to_one_starts_firing` | Sample rate consulted on every call, not cached |

**940/940 backend tests passing. Ruff + mypy clean.**

## Next

- **2c**: Wire inline read paths (calendar event composition, announcement grouping, prerequisites)
- **2d**: Telemetry — Datadog metric + MCP query helper for inspecting current mismatches
- **2e**: Smoke recipe — manual prod check that Phase 1 dual-write actually fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)
