### PR TITLE
feat(bilingual): V1 phase 2d — admin diag endpoint + comparator fix

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -10,6 +10,7 @@ from app.api.v1 import (
     certificates,
     cohorts,
     courses,
+    dual_read_diag,
     grades,
     health,
     notifications,
@@ -43,3 +44,4 @@ api_router.include_router(audit.router)
 api_router.include_router(calendar_mod.router)
 api_router.include_router(calendar_mod.event_router)
 api_router.include_router(verse_of_the_day.router)
+api_router.include_router(dual_read_diag.router)

--- a/backend/app/api/v1/dual_read_diag.py
+++ b/backend/app/api/v1/dual_read_diag.py
@@ -1,0 +1,267 @@
+"""Admin diagnostic endpoint for Phase 2 dual-read mismatches.
+
+When a structured warning fires in production (Datadog log search
+for ``cv_compare_reason:text_differs`` or similar), ops needs to
+inspect what the two stores actually have for that specific entity.
+This endpoint does the comparison on demand for every translatable
+field of one entity across all supported locales, returning the
+full ``MismatchReport`` per (field, locale).
+
+Admin-only. Does NOT mutate. Reads from both stores.
+
+Example query:
+    GET /api/v1/dual-read-diag/course/fce3337a-231f-4d21-a977-905bd6a2cc07
+
+Returns one block per (field, locale) showing the comparator's
+verdict plus both stores' current state. Useful for triaging
+``TEXT_DIFFERS``, ``LOCALE_DIVERGED``, and ``NEW_ONLY`` alerts.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from app.api.dependencies import require_admin
+from app.core.database import get_db
+from app.models.announcement import Announcement
+from app.models.assignment import Assignment
+from app.models.chapter_block import ChapterBlock
+from app.models.cohort import Cohort
+from app.models.course import Chapter, Course, Module
+from app.models.course_event import CourseEvent
+from app.models.quiz import Quiz, QuizOption, QuizQuestion
+from app.schemas.locale import LOCALE_CODES, normalize_locale
+from app.services.content_versions import compare_resolved_text
+from app.services.translation.resolve_for_display import fetch_overlay_triples_bulk
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from app.models.user import User
+
+router = APIRouter(prefix="/dual-read-diag", tags=["admin-diagnostics"])
+
+
+_EntityType = Literal[
+    "course",
+    "module",
+    "chapter",
+    "chapter_block",
+    "quiz",
+    "quiz_question",
+    "quiz_option",
+    "assignment",
+    "announcement",
+    "course_event",
+    "cohort",
+]
+
+
+class FieldDiag(BaseModel):
+    field: str
+    display_locale: str
+    reason: str
+    legacy_text_preview: str | None
+    new_text_preview: str | None
+    new_status: str | None
+    new_recorded_locale: str | None
+
+
+class EntityDiag(BaseModel):
+    entity_type: str
+    entity_id: str
+    source_locale: str | None
+    base_text_per_field: dict[str, str | None]
+    diagnostics: list[FieldDiag]
+
+
+# Map of (entity_type, translatable_field, model_attr) tuples. Cohort
+# is the one entity where the cv-field name (`title`) doesn't equal
+# the attribute name (`name`).
+_FIELDS_BY_TYPE: dict[str, list[tuple[str, str]]] = {
+    "course": [("title", "title"), ("description", "description")],
+    "module": [("title", "title"), ("description", "description")],
+    "chapter": [("title", "title")],
+    "chapter_block": [("content", "content")],
+    "quiz": [("title", "title"), ("description", "description")],
+    "quiz_question": [("question_text", "question_text")],
+    "quiz_option": [("option_text", "option_text")],
+    "assignment": [("title", "title"), ("description", "description")],
+    "announcement": [("title", "title"), ("content", "content")],
+    "course_event": [("title", "title"), ("description", "description")],
+    "cohort": [("title", "name")],
+}
+
+
+def _load_entity_and_source_locale(db: Session, entity_type: str, entity_id: str) -> tuple[object, str | None]:
+    """Load the entity row + figure out its parent course source_locale.
+
+    Returns (entity_object, source_locale). Source locale resolution
+    walks the same path the registry uses — course owns its own, every
+    other entity walks up to its parent course.
+    """
+    model_map: dict[str, type] = {
+        "course": Course,
+        "module": Module,
+        "chapter": Chapter,
+        "chapter_block": ChapterBlock,
+        "quiz": Quiz,
+        "quiz_question": QuizQuestion,
+        "quiz_option": QuizOption,
+        "assignment": Assignment,
+        "announcement": Announcement,
+        "course_event": CourseEvent,
+        "cohort": Cohort,
+    }
+    model_cls = model_map.get(entity_type)
+    if model_cls is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown entity_type {entity_type!r}")
+    entity = db.query(model_cls).filter(model_cls.id == entity_id).one_or_none()  # type: ignore[attr-defined]
+    if entity is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Entity {entity_type}:{entity_id} not found",
+        )
+    # Resolve source_locale via parent course walk.
+    if entity_type == "course":
+        return entity, getattr(entity, "source_locale", None)
+    course_id: str | None = None
+    if entity_type == "module":
+        course_id = getattr(entity, "course_id", None)
+    elif entity_type == "chapter":
+        module = db.query(Module).filter(Module.id == entity.module_id).one_or_none()
+        course_id = module.course_id if module else None
+    elif entity_type in ("chapter_block", "quiz"):
+        chapter = db.query(Chapter).filter(Chapter.id == entity.chapter_id).one_or_none()
+        if chapter is not None:
+            module = db.query(Module).filter(Module.id == chapter.module_id).one_or_none()
+            course_id = module.course_id if module else None
+    elif entity_type == "quiz_question":
+        quiz = db.query(Quiz).filter(Quiz.id == entity.quiz_id).one_or_none()
+        if quiz is not None:
+            chapter = db.query(Chapter).filter(Chapter.id == quiz.chapter_id).one_or_none()
+            if chapter is not None:
+                module = db.query(Module).filter(Module.id == chapter.module_id).one_or_none()
+                course_id = module.course_id if module else None
+    elif entity_type == "quiz_option":
+        question = db.query(QuizQuestion).filter(QuizQuestion.id == entity.question_id).one_or_none()
+        if question is not None:
+            quiz = db.query(Quiz).filter(Quiz.id == question.quiz_id).one_or_none()
+            if quiz is not None:
+                chapter = db.query(Chapter).filter(Chapter.id == quiz.chapter_id).one_or_none()
+                if chapter is not None:
+                    module = db.query(Module).filter(Module.id == chapter.module_id).one_or_none()
+                    course_id = module.course_id if module else None
+    elif entity_type == "assignment":
+        chapter = db.query(Chapter).filter(Chapter.id == entity.chapter_id).one_or_none()
+        if chapter is not None:
+            module = db.query(Module).filter(Module.id == chapter.module_id).one_or_none()
+            course_id = module.course_id if module else None
+    elif entity_type in ("announcement", "course_event"):
+        course_id = getattr(entity, "course_id", None)
+    # cohort: no parent course (M2M); source_locale stays None.
+    source_locale = None
+    if course_id:
+        source_locale = db.query(Course.source_locale).filter(Course.id == course_id).scalar()
+    return entity, source_locale
+
+
+def _preview(text: str | None, *, limit: int = 200) -> str | None:
+    """Trim long text to a previewable size for the response payload."""
+    if text is None:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"…[truncated, total {len(text)} chars]"
+
+
+@router.get(
+    "/{entity_type}/{entity_id}",
+    response_model=EntityDiag,
+    summary="Diagnose dual-read mismatches for one entity (admin-only)",
+    responses={
+        200: {"description": "Per-(field, locale) comparator verdict and both stores' state"},
+        403: {"description": "Caller is not an admin"},
+        404: {"description": "Entity not found"},
+    },
+)
+def diagnose_entity(
+    entity_type: _EntityType,
+    entity_id: str,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> EntityDiag:
+    """Run the dual-read comparator for every translatable field of
+    one entity across every supported locale and return the verdicts.
+
+    Use after a Datadog alert fires for an interesting mismatch:
+    paste the entity_type + entity_id from the log, hit this endpoint,
+    inspect what cv vs ct actually have. Helps decide whether the
+    mismatch is a bug to fix or a benign edge case to allow-list.
+    """
+    fields = _FIELDS_BY_TYPE.get(entity_type)
+    if fields is None:  # pragma: no cover — Literal type already restricts callers
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown entity_type {entity_type!r}")
+
+    entity, source_locale = _load_entity_and_source_locale(db, entity_type, entity_id)
+    base_text_per_field: dict[str, str | None] = {}
+    for cv_field, model_attr in fields:
+        base_text_per_field[cv_field] = getattr(entity, model_attr, None)
+
+    # Pre-fetch the legacy overlay rows in one query per field to mirror
+    # the resolver's real behaviour. The diagnostic isn't on a hot path
+    # — clarity beats batching.
+    diagnostics: list[FieldDiag] = []
+    for cv_field, _model_attr in fields:
+        base = base_text_per_field[cv_field]
+        for locale in LOCALE_CODES:
+            display_locale = normalize_locale(locale)
+            overlay = fetch_overlay_triples_bulk(
+                db,
+                [(entity_type, str(entity_id), cv_field)],
+                display_locale,
+            )
+            # Reproduce ``pick_overlay_value``'s fallback semantics
+            # without re-importing it (would create a circular module
+            # dep — diag → resolve_for_display → diag if anyone ever
+            # imports diag from resolve).
+            overlay_text = overlay.get((entity_type, str(entity_id), cv_field))
+            legacy_text: str | None
+            entity_source: str = source_locale or "en"
+            if overlay_text is not None:
+                legacy_text = overlay_text
+            elif entity_source == display_locale:
+                legacy_text = base
+            else:
+                legacy_text = base
+            report = compare_resolved_text(
+                db,
+                entity_type=entity_type,
+                entity_id=str(entity_id),
+                field=cv_field,
+                source_locale=entity_source,
+                display_locale=display_locale,
+                base_source_text=base,
+                legacy_text=legacy_text,
+            )
+            diagnostics.append(
+                FieldDiag(
+                    field=cv_field,
+                    display_locale=display_locale,
+                    reason=report.reason.value,
+                    legacy_text_preview=_preview(report.legacy_text),
+                    new_text_preview=_preview(report.new_text),
+                    new_status=report.new_status,
+                    new_recorded_locale=report.new_recorded_locale,
+                )
+            )
+    return EntityDiag(
+        entity_type=entity_type,
+        entity_id=str(entity_id),
+        source_locale=source_locale,
+        base_text_per_field={k: _preview(v) for k, v in base_text_per_field.items()},
+        diagnostics=diagnostics,
+    )

--- a/backend/app/services/content_versions/compare.py
+++ b/backend/app/services/content_versions/compare.py
@@ -282,7 +282,16 @@ def compare_resolved_text(
 
     new_text: str | None
     new_status: str | None
-    new_recorded_locale = any_active_for_field.locale if any_active_for_field is not None else None
+    # ``new_recorded_locale`` reports the locale of the row that
+    # actually drove the new-store resolution. When the display-locale
+    # row exists it's that one (and equals display_locale by
+    # construction); when it doesn't, fall back to the first active
+    # row for the field — the "what locale did cv actually file this
+    # under?" signal.
+    if active_row_for_display_locale is not None:
+        new_recorded_locale: str | None = active_row_for_display_locale.locale
+    else:
+        new_recorded_locale = any_active_for_field.locale if any_active_for_field is not None else None
 
     if active_row_for_display_locale is None:
         # No content_versions row at display_locale — same fallback as

--- a/backend/tests/test_dual_read_diag_endpoint.py
+++ b/backend/tests/test_dual_read_diag_endpoint.py
@@ -1,0 +1,119 @@
+"""Phase 2d tests: the admin dual-read diagnostic endpoint.
+
+``GET /api/v1/dual-read-diag/{entity_type}/{entity_id}`` runs the
+comparator for every translatable field of one entity across every
+supported locale and returns the verdicts. Used to triage a mismatch
+alert without round-tripping through Datadog logs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.services.content_versions.write import record_human_version
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+def _seed_course(db: Session, *, course_id: str = "diag-course-1") -> str:
+    from app.models.course import Course
+    from tests.conftest import TEACHER_ID
+
+    course = Course(
+        id=course_id,
+        title="Source Title",
+        description="Source description.",
+        created_by=TEACHER_ID,
+        status="published",
+        source_locale="en",
+    )
+    db.add(course)
+    db.commit()
+    return course_id
+
+
+class TestDiagEndpointAuth:
+    def test_non_admin_gets_403(self, client: TestClient, db: Session):
+        # client fixture is logged in as the teacher; teacher is not admin.
+        course_id = _seed_course(db)
+        resp = client.get(f"/api/v1/dual-read-diag/course/{course_id}")
+        assert resp.status_code == 403
+
+
+class TestDiagEndpointResults:
+    def test_returns_one_block_per_field_locale_pair(self, admin_client: TestClient, db: Session):
+        course_id = _seed_course(db, course_id="diag-locales")
+        # cv: english source row + russian translation for title
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=course_id,
+            field="title",
+            locale="en",
+            text="Source Title",
+        )
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=course_id,
+            field="title",
+            locale="ru",
+            text="Заголовок",
+        )
+        db.commit()
+        resp = admin_client.get(f"/api/v1/dual-read-diag/course/{course_id}")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["entity_type"] == "course"
+        assert data["entity_id"] == course_id
+        assert data["source_locale"] == "en"
+        # course has 2 fields (title, description) by 2 locales = 4 rows.
+        assert len(data["diagnostics"]) == 4
+        # Title at ru: cv has it but legacy is empty (overlay not seeded
+        # in content_translations) → NEW_ONLY.
+        ru_title = next(d for d in data["diagnostics"] if d["field"] == "title" and d["display_locale"] == "ru")
+        assert ru_title["reason"] == "new_only"
+        assert ru_title["new_recorded_locale"] == "ru"
+
+    def test_returns_legacy_only_no_backfill_when_cv_empty(self, admin_client: TestClient, db: Session):
+        course_id = _seed_course(db, course_id="diag-empty")
+        # No cv rows for this entity.
+        resp = admin_client.get(f"/api/v1/dual-read-diag/course/{course_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        for d in data["diagnostics"]:
+            assert d["reason"] == "legacy_only_no_backfill"
+
+    def test_returns_404_for_missing_entity(self, admin_client: TestClient, db: Session):
+        resp = admin_client.get("/api/v1/dual-read-diag/course/does-not-exist")
+        assert resp.status_code == 404
+
+    def test_long_text_is_truncated_in_preview(self, admin_client: TestClient, db: Session):
+        course_id = _seed_course(db, course_id="diag-long")
+        long_text = "x" * 1000
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=course_id,
+            field="title",
+            locale="ru",
+            text=long_text,
+        )
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id=course_id,
+            field="title",
+            locale="en",
+            text="Source Title",
+        )
+        db.commit()
+        resp = admin_client.get(f"/api/v1/dual-read-diag/course/{course_id}")
+        data = resp.json()
+        ru_title = next(d for d in data["diagnostics"] if d["field"] == "title" and d["display_locale"] == "ru")
+        # Preview kept under the truncation limit + a hint.
+        assert ru_title["new_text_preview"] is not None
+        assert "truncated" in ru_title["new_text_preview"]
+        assert len(ru_title["new_text_preview"]) < 300


### PR DESCRIPTION
## What

Phase 2 final sub-PR — admin diagnostic endpoint that runs the comparator on demand for any entity, plus a comparator bug fix discovered while writing the tests.

**Stacked on #541.**

## Why diag endpoint and not just logs

When a Datadog alert fires for `cv_compare_reason:text_differs`, ops needs to inspect what cv vs ct currently have for the offending entity to triage bug-vs-benign. The log carries triage-safe fields (entity ids, lengths, reason) but no payloads — pulling the full state from logs would require correlating multiple sources. This endpoint folds that triage into one HTTP call.

```
GET /api/v1/dual-read-diag/course/fce3337a-231f-4d21-a977-905bd6a2cc07
```

Returns one block per `(field, display_locale)` showing:
- The comparator's reason
- A preview (≤200 chars + truncation hint) of legacy vs new text
- The cv row's `status` and `locale`

Long text auto-truncates so a chapter_block with megabytes of HTML doesn't blow the JSON.

## Comparator bug fix in passing

`MismatchReport.new_recorded_locale` previously returned the first-active cv row across all locales (non-deterministic across SQLite vs Postgres ordering). Now correctly returns:
- The locale of the active row at `display_locale` when one exists
- Else the first active row for the field (the original intent)

Caught by a 2d test that seeded both en and ru rows for the same field — the previous logic showed "en" when display was "ru" and the ru row existed.

## Telemetry approach (no new code)

`DatadogHTTPHandler` (already in `app/core/logging.py`) ships structured warnings to Datadog. Ops builds log-based metrics on `cv_compare_reason` to slice by mismatch kind. No statsd / metric SDK call needed.

Alerting recipe:
1. Watch `status:warn message:"content_versions dual-read"` in Datadog Log Explorer.
2. Aggregate by `cv_compare_reason` to see which class is firing.
3. Hit `/api/v1/dual-read-diag/{entity_type}/{entity_id}` for one offending row.
4. Decide: bug to fix, or benign edge case to allow-list (extend `INTERESTING_REASONS`).

## Tests (5 new, all green)

| Test | Pins |
|---|---|
| `test_non_admin_gets_403` | Teacher-level access denied |
| `test_returns_one_block_per_field_locale_pair` | 2 fields × 2 locales = 4 verdicts, with correct cv state |
| `test_returns_legacy_only_no_backfill_when_cv_empty` | Pre-Phase-3 state surfaces cleanly |
| `test_returns_404_for_missing_entity` | Missing entity → 404 |
| `test_long_text_is_truncated_in_preview` | 1000-char text → preview ≤ 300 chars + "truncated" hint |

**948/948 backend tests passing (943 + 5 new). Ruff + mypy clean.**

## Phase 2 complete

| Sub-PR | Scope |
|---|---|
| 2a #539 | Comparator + 17 tests + sampler/logger wrapper |
| 2b #540 | Wire into `Localizer.pick` (covers ~95% of read paths) |
| 2c #541 | Wire into inline read paths (calendar / prereq / cert / catalog summary) |
| **2d (this)** | **Admin diag endpoint + comparator bug fix** |

Sample rate remains `0.0` in prod by default. Once Phase 3 backfill runs and Phase 1 dual-write fires in prod, ops bumps `CONTENT_VERSIONS_COMPARE_RATE` to start collecting signal.

Phase 3 (backfill) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
