### PR TITLE
feat(bilingual): V1 phase 4 — cv-primary read behind a feature flag

### DIFF
--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -24,6 +24,12 @@ from app.services.content_versions.compare import (
     set_compare_sample_rate,
 )
 from app.services.content_versions.dual_write import dual_write_entity_content
+from app.services.content_versions.read import (
+    fetch_cv_course_text_bulk,
+    fetch_cv_text_bulk,
+    read_from_content_versions,
+    set_read_primary,
+)
 from app.services.content_versions.write import (
     record_human_version,
     record_mt_failure,
@@ -36,10 +42,14 @@ __all__ = [
     "MismatchReport",
     "compare_resolved_text",
     "dual_write_entity_content",
+    "fetch_cv_course_text_bulk",
+    "fetch_cv_text_bulk",
     "get_compare_sample_rate",
     "maybe_compare_and_log",
+    "read_from_content_versions",
     "record_human_version",
     "record_mt_failure",
     "record_mt_version",
     "set_compare_sample_rate",
+    "set_read_primary",
 ]

--- a/backend/app/services/content_versions/read.py
+++ b/backend/app/services/content_versions/read.py
@@ -1,0 +1,124 @@
+"""Phase 4 cv-primary read helpers + env-flag gate.
+
+When ``CONTENT_VERSIONS_READ_PRIMARY=1``, the canonical overlay
+fetchers in ``resolve_for_display.py`` route through these helpers
+instead of querying the legacy ``content_translations`` table.
+Same dict shape returned either way — call sites stay untouched.
+
+Default: flag is OFF. Phase 4's first PR ships the new path dark;
+ops bumps the env var to enable. Rollback is one env-var flip + a
+redeploy (no code revert needed).
+
+The cv query mirrors the legacy one but hits ``content_versions``:
+
+    SELECT entity_type, entity_id, field, text
+    FROM content_versions
+    WHERE (entity_type, entity_id, field) IN :keys
+      AND locale = :display_locale
+      AND superseded_by IS NULL
+      AND status = 'ok'
+
+Uses ``uniq_content_versions_active`` directly (partial unique on
+``superseded_by IS NULL``). Same number of round-trips as the legacy
+fetcher — Phase 4 has zero N+1 risk.
+
+We do NOT re-detect per-field language on the read path: cv already
+has the detected locale recorded at write time (Phase 1 dual-write +
+Phase 3 backfill). The read trusts what's there.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from sqlalchemy import tuple_
+
+from app.models.content_version import ContentVersion
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+# Read once at import time — flag changes require a redeploy / worker
+# restart, which is fine for a phased migration. Tests override via
+# ``set_read_primary`` to flip behavior per-test without monkey-
+# patching the module constant directly.
+_READ_PRIMARY: bool = os.environ.get("CONTENT_VERSIONS_READ_PRIMARY", "0").strip() in ("1", "true", "True")
+
+
+def set_read_primary(value: bool) -> None:
+    """Test-only override for the cv-primary read flag.
+
+    Production code reads ``CONTENT_VERSIONS_READ_PRIMARY`` from the
+    environment at import time. Tests use this hook to flip the flag
+    per-test without monkey-patching the constant directly.
+    """
+    global _READ_PRIMARY
+    _READ_PRIMARY = bool(value)
+
+
+def read_from_content_versions() -> bool:
+    """Return True when the resolver should source overlay rows from
+    ``content_versions``. False = read from the legacy
+    ``content_translations`` table (Phase 0-3 behaviour)."""
+    return _READ_PRIMARY
+
+
+def fetch_cv_text_bulk(
+    db: Session,
+    keys: list[tuple[str, str, str]],
+    display_locale: str,
+) -> dict[tuple[str, str, str], str]:
+    """Bulk-fetch ``content_versions`` active+ok rows keyed by
+    ``(entity_type, entity_id, field)`` at the given display_locale.
+
+    Drop-in replacement for ``fetch_overlay_triples_bulk`` — returns
+    the same dict shape so the consumer (``pick_overlay_value``) is
+    locale- and store-agnostic.
+    """
+    if not keys:
+        return {}
+    uniq = list(dict.fromkeys(keys))
+    rows = (
+        db.query(ContentVersion)
+        .filter(
+            tuple_(
+                ContentVersion.entity_type,
+                ContentVersion.entity_id,
+                ContentVersion.field,
+            ).in_(uniq),
+            ContentVersion.locale == display_locale,
+            ContentVersion.superseded_by.is_(None),
+            ContentVersion.status == "ok",
+        )
+        .all()
+    )
+    return {(r.entity_type, r.entity_id, r.field): r.text for r in rows}
+
+
+def fetch_cv_course_text_bulk(
+    db: Session,
+    *,
+    course_ids: list[str],
+    display_locale: str,
+) -> dict[tuple[str, str], str]:
+    """Course-catalog bulk variant: returns ``(course_id, field) -> text``
+    for the course title + description overlay at display_locale.
+
+    Drop-in replacement for ``batch_fetch_course_translations``.
+    """
+    if not course_ids:
+        return {}
+    rows = (
+        db.query(ContentVersion)
+        .filter(
+            ContentVersion.entity_type == "course",
+            ContentVersion.entity_id.in_(course_ids),
+            ContentVersion.locale == display_locale,
+            ContentVersion.field.in_(("title", "description")),
+            ContentVersion.superseded_by.is_(None),
+            ContentVersion.status == "ok",
+        )
+        .all()
+    )
+    return {(r.entity_id, r.field): r.text for r in rows}

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -36,7 +36,12 @@ from app.schemas.chapter_block import BlockResponse
 from app.schemas.course import ChapterResponse, CourseResponse, CourseSummary, ModuleResponse
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.schemas.quiz import QuizOptionStudentResponse, QuizQuestionStudentResponse, QuizStudentResponse
-from app.services.content_versions import maybe_compare_and_log
+from app.services.content_versions import (
+    fetch_cv_course_text_bulk,
+    fetch_cv_text_bulk,
+    maybe_compare_and_log,
+    read_from_content_versions,
+)
 from app.services.language_detection import detect_locale
 
 
@@ -61,7 +66,14 @@ def batch_fetch_course_translations(
     course_ids: list[str],
     display_locale: LocaleCode,
 ) -> dict[tuple[str, str], str]:
-    """Return a map ``(entity_id, field) -> text`` for ok course-level rows."""
+    """Return a map ``(entity_id, field) -> text`` for ok course-level rows.
+
+    Phase 4: when ``CONTENT_VERSIONS_READ_PRIMARY=1``, sources rows from
+    ``content_versions`` instead of the legacy ``content_translations``
+    overlay. Same dict shape — call sites stay unchanged.
+    """
+    if read_from_content_versions():
+        return fetch_cv_course_text_bulk(db, course_ids=course_ids, display_locale=display_locale)
     if not course_ids:
         return {}
     rows = (
@@ -187,7 +199,14 @@ def fetch_overlay_triples_bulk(
     keys: list[tuple[str, str, str]],
     display_locale: LocaleCode,
 ) -> dict[tuple[str, str, str], str]:
-    """Bulk-fetch ``content_translations`` rows keyed by ``(entity_type, entity_id, field)``."""
+    """Bulk-fetch overlay rows keyed by ``(entity_type, entity_id, field)``.
+
+    Phase 4: when ``CONTENT_VERSIONS_READ_PRIMARY=1``, sources rows from
+    ``content_versions`` instead of the legacy ``content_translations``
+    table. Same dict shape — call sites stay unchanged.
+    """
+    if read_from_content_versions():
+        return fetch_cv_text_bulk(db, keys, display_locale)
     if not keys:
         return {}
     uniq = list(dict.fromkeys(keys))

--- a/backend/tests/test_cv_read_primary.py
+++ b/backend/tests/test_cv_read_primary.py
@@ -1,0 +1,282 @@
+"""Phase 4 tests: ``CONTENT_VERSIONS_READ_PRIMARY=1`` flips the
+overlay source from ``content_translations`` to ``content_versions``.
+
+Pins the contract:
+
+* With the flag OFF, ``fetch_overlay_triples_bulk`` /
+  ``batch_fetch_course_translations`` read from
+  ``content_translations`` exactly as before.
+* With the flag ON, the same functions return the same dict shape
+  but sourced from ``content_versions``.
+* The dict shape contract (``(entity_type, entity_id, field) ->
+  text`` and ``(entity_id, field) -> text``) is identical across
+  flag states — call sites stay byte-for-byte unchanged.
+* Cv-only data (no legacy row) becomes visible when flag is ON.
+* Cv-superseded rows are excluded.
+* Cv ``status='failed'`` rows are excluded (resolver falls back to
+  source via the upstream call site).
+* Flipping the flag mid-session takes effect immediately.
+
+The downstream consumer ``pick_overlay_value`` is unchanged in
+Phase 4 (its per-field detection logic still runs), so testing the
+fetchers in isolation is sufficient. Integration via Localizer is
+covered by ``test_localizer_dual_read.py``'s existing fixtures
+when re-run with the flag toggled.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.models.content_translation import ContentTranslation
+from app.services.content_versions import set_read_primary
+from app.services.content_versions.write import record_human_version, record_mt_version
+from app.services.translation.resolve_for_display import (
+    batch_fetch_course_translations,
+    fetch_overlay_triples_bulk,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+@pytest.fixture
+def db():
+    from sqlalchemy.orm import Session as _Session
+
+    from tests.conftest import test_engine
+
+    session = _Session(bind=test_engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def read_primary_on():
+    set_read_primary(True)
+    yield
+    set_read_primary(False)
+
+
+@pytest.fixture
+def read_primary_off():
+    # Explicit OFF — covers the case where the test runs under
+    # CI with ``CONTENT_VERSIONS_READ_PRIMARY=1`` in the env, which
+    # would otherwise leak the ON state into "flag OFF" tests.
+    set_read_primary(False)
+    yield
+    set_read_primary(False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(db: Session):
+    """Wipe both stores between tests so seed counts are predictable."""
+    from app.models.content_version import ContentVersion
+
+    yield
+    db.query(ContentVersion).delete()
+    db.query(ContentTranslation).delete()
+    db.commit()
+
+
+class TestFlagOffPreservesLegacyBehavior:
+    def test_overlay_triples_reads_from_content_translations(self, db: Session, read_primary_off: None):
+        # Flag default OFF; only the legacy store has a row.
+        db.add(
+            ContentTranslation(
+                entity_type="course",
+                entity_id="ct-only",
+                field="title",
+                locale="ru",
+                text="Из legacy",
+                origin="mt",
+                source_hash="h",
+                status="ok",
+                attempts=0,
+            )
+        )
+        db.commit()
+        result = fetch_overlay_triples_bulk(db, [("course", "ct-only", "title")], "ru")
+        assert result == {("course", "ct-only", "title"): "Из legacy"}
+
+    def test_overlay_triples_does_not_read_cv_when_flag_off(self, db: Session, read_primary_off: None):
+        # Cv has a row; legacy doesn't. With flag OFF the cv row is invisible.
+        record_human_version(db, entity_type="course", entity_id="cv-only", field="title", locale="ru", text="Из cv")
+        db.commit()
+        result = fetch_overlay_triples_bulk(db, [("course", "cv-only", "title")], "ru")
+        assert result == {}
+
+
+class TestFlagOnReadsFromCv:
+    def test_overlay_triples_reads_from_content_versions(self, db: Session, read_primary_on: None):
+        record_human_version(db, entity_type="course", entity_id="flip-1", field="title", locale="ru", text="Из cv")
+        db.commit()
+        result = fetch_overlay_triples_bulk(db, [("course", "flip-1", "title")], "ru")
+        assert result == {("course", "flip-1", "title"): "Из cv"}
+
+    def test_overlay_triples_ignores_legacy_when_flag_on(self, db: Session, read_primary_on: None):
+        # Legacy has a row; cv doesn't. With flag ON the legacy row is invisible.
+        db.add(
+            ContentTranslation(
+                entity_type="course",
+                entity_id="legacy-ignored",
+                field="title",
+                locale="ru",
+                text="Должно быть невидимым",
+                origin="mt",
+                source_hash="h",
+                status="ok",
+                attempts=0,
+            )
+        )
+        db.commit()
+        result = fetch_overlay_triples_bulk(db, [("course", "legacy-ignored", "title")], "ru")
+        assert result == {}
+
+    def test_overlay_triples_excludes_failed_status(self, db: Session, read_primary_on: None):
+        from app.services.content_versions.write import record_mt_failure
+
+        record_mt_failure(
+            db,
+            entity_type="course",
+            entity_id="failed-1",
+            field="title",
+            locale="ru",
+            source_locale="en",
+            source_hash="h",
+        )
+        db.commit()
+        result = fetch_overlay_triples_bulk(db, [("course", "failed-1", "title")], "ru")
+        assert result == {}
+
+    def test_overlay_triples_excludes_superseded_rows(self, db: Session, read_primary_on: None):
+        # v1 inserted then superseded by v2; only v2 should appear.
+        v1 = record_human_version(db, entity_type="course", entity_id="sup-1", field="title", locale="ru", text="v1")
+        db.commit()
+        v2 = record_human_version(db, entity_type="course", entity_id="sup-1", field="title", locale="ru", text="v2")
+        db.commit()
+        result = fetch_overlay_triples_bulk(db, [("course", "sup-1", "title")], "ru")
+        assert result == {("course", "sup-1", "title"): "v2"}
+        # v1 still exists in the table but is superseded.
+        db.refresh(v1)
+        assert v1.superseded_by == v2.id
+
+    def test_overlay_triples_handles_mt_origin_row(self, db: Session, read_primary_on: None):
+        record_mt_version(
+            db,
+            entity_type="course",
+            entity_id="mt-1",
+            field="title",
+            locale="ru",
+            text="Машинный",
+            source_locale="en",
+            source_hash="h",
+        )
+        db.commit()
+        result = fetch_overlay_triples_bulk(db, [("course", "mt-1", "title")], "ru")
+        assert result == {("course", "mt-1", "title"): "Машинный"}
+
+
+class TestCourseBulkFetchHonorsFlag:
+    def test_course_bulk_reads_legacy_when_flag_off(self, db: Session, read_primary_off: None):
+        db.add(
+            ContentTranslation(
+                entity_type="course",
+                entity_id="course-flag-off",
+                field="title",
+                locale="ru",
+                text="Из legacy",
+                origin="mt",
+                source_hash="h",
+                status="ok",
+                attempts=0,
+            )
+        )
+        db.commit()
+        result = batch_fetch_course_translations(db, course_ids=["course-flag-off"], display_locale="ru")
+        assert result == {("course-flag-off", "title"): "Из legacy"}
+
+    def test_course_bulk_reads_cv_when_flag_on(self, db: Session, read_primary_on: None):
+        record_human_version(
+            db, entity_type="course", entity_id="course-flag-on", field="title", locale="ru", text="Из cv"
+        )
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id="course-flag-on",
+            field="description",
+            locale="ru",
+            text="Описание cv",
+        )
+        db.commit()
+        result = batch_fetch_course_translations(db, course_ids=["course-flag-on"], display_locale="ru")
+        assert result == {
+            ("course-flag-on", "title"): "Из cv",
+            ("course-flag-on", "description"): "Описание cv",
+        }
+
+    def test_course_bulk_filters_to_title_and_description_only(self, db: Session, read_primary_on: None):
+        # Imagine a stray field somehow landed in cv; the catalog
+        # bulk fetcher must only return title + description (the
+        # course-summary contract).
+        record_human_version(db, entity_type="course", entity_id="catalog", field="title", locale="ru", text="Title")
+        record_human_version(
+            db,
+            entity_type="course",
+            entity_id="catalog",
+            field="instructions",
+            locale="ru",
+            text="Лишнее",
+        )
+        db.commit()
+        result = batch_fetch_course_translations(db, course_ids=["catalog"], display_locale="ru")
+        assert "title" in {k[1] for k in result}
+        assert "instructions" not in {k[1] for k in result}
+
+
+class TestFlagFlipMidSession:
+    def test_flipping_flag_changes_result_immediately(self, db: Session):
+        # Same key in both stores with different text. Flipping the
+        # flag toggles which store wins on the very next call.
+        record_human_version(db, entity_type="course", entity_id="both", field="title", locale="ru", text="Из cv")
+        db.add(
+            ContentTranslation(
+                entity_type="course",
+                entity_id="both",
+                field="title",
+                locale="ru",
+                text="Из legacy",
+                origin="mt",
+                source_hash="h",
+                status="ok",
+                attempts=0,
+            )
+        )
+        db.commit()
+
+        # Flag OFF (default) → legacy
+        set_read_primary(False)
+        result_off = fetch_overlay_triples_bulk(db, [("course", "both", "title")], "ru")
+        assert result_off == {("course", "both", "title"): "Из legacy"}
+
+        # Flag ON → cv
+        try:
+            set_read_primary(True)
+            result_on = fetch_overlay_triples_bulk(db, [("course", "both", "title")], "ru")
+            assert result_on == {("course", "both", "title"): "Из cv"}
+        finally:
+            set_read_primary(False)
+
+
+class TestBulkFetchersHandleEmptyKeys:
+    """Cosmetic invariant: passing empty input returns an empty dict
+    without hitting the DB. Important for catalog routes that pass
+    empty course_ids when no courses match a filter."""
+
+    def test_empty_keys_short_circuits(self, db: Session, read_primary_on: None):
+        assert fetch_overlay_triples_bulk(db, [], "ru") == {}
+        assert batch_fetch_course_translations(db, course_ids=[], display_locale="ru") == {}


### PR DESCRIPTION
## What

Phase 4 flips the read path from the legacy `content_translations` table to `content_versions`. **Ships dark behind `CONTENT_VERSIONS_READ_PRIMARY=1`** (default OFF) — this PR can land without any user-visible change. Ops flips the env var when ready; rollback is one env-var change + redeploy.

**Stacked on #543.**

## Why this is safe to ship (per three parallel audits)

**Agent A — boundary spec:** Minimal switch surface. Two bulk fetchers (`fetch_overlay_triples_bulk`, `batch_fetch_course_translations`) gain a one-line flag branch. Downstream `pick_overlay_value` is unchanged — its per-field detection logic still produces correct answers. Owner-bypass paths untouched.

**Agent B — empirical drift audit against prod:** ZERO bugs found.
- 526/529 shared keys between cv and content_translations are byte-equal
- 3 differing cases are all human corrections of MT (quality improvements, not regressions)
- 429 cv-only rows are all `origin='human'` source rows (cv MT invariant holds)
- 12 CT-only rows are orphans of hard-deleted entities (safe to ignore)
- "Тайтл" tree resolves identically across both stores
- 0 soft-deleted entities with active cv rows

**Agent C — rollout strategy:** Single feature-flag PR. Flag-OFF preserves byte-for-byte existing behavior; flag-ON sources from cv. cv-exclusive on miss (no legacy fallback) since cv is now a superset post Phase 3 backfill. Rollback = env var flip + 30s redeploy.

## How

```
GET /api/v1/courses
  → batch_fetch_course_translations()
    → if CONTENT_VERSIONS_READ_PRIMARY:
        fetch_cv_course_text_bulk()   ← Phase 4 path
      else:
        SELECT FROM content_translations ...   ← legacy
```

Same dict shape (`(entity_id, field) -> text` or `(entity_type, entity_id, field) -> text`) on both branches. 20+ read call sites stay unchanged — the flag check is internal to the two bulk fetchers.

## Tests (12 new, all green)

| Test | Pins |
|---|---|
| `test_overlay_triples_reads_from_content_translations` | Flag OFF reads legacy |
| `test_overlay_triples_does_not_read_cv_when_flag_off` | Flag OFF ignores cv even with rows present |
| `test_overlay_triples_reads_from_content_versions` | Flag ON reads cv |
| `test_overlay_triples_ignores_legacy_when_flag_on` | Flag ON ignores legacy |
| `test_overlay_triples_excludes_failed_status` | Flag ON skips cv `status=failed` |
| `test_overlay_triples_excludes_superseded_rows` | Flag ON skips superseded |
| `test_overlay_triples_handles_mt_origin_row` | Flag ON reads MT rows |
| `test_course_bulk_reads_legacy_when_flag_off` | Course-summary variant flag-aware |
| `test_course_bulk_reads_cv_when_flag_on` | Course-summary variant cv variant |
| `test_course_bulk_filters_to_title_and_description_only` | Catalog contract preserved |
| `test_flipping_flag_changes_result_immediately` | Flag flips take effect per-call |
| `test_empty_keys_short_circuits` | Empty input doesn't hit DB |

**973/973 backend tests passing with default flag OFF (zero regression).** All 12 new tests pass under `CONTENT_VERSIONS_READ_PRIMARY=1` env override. Ruff + mypy clean.

## Operational sequence (Vadym's checklist)

1. **Bump `CONTENT_VERSIONS_COMPARE_RATE=1.0` in prod for 24h** (Vercel env, no deploy).
2. **Review Datadog**: search `cv_compare_reason in (text_differs, locale_diverged, new_only, entity_deleted)`. Expected: zero or known-benign-only.
3. **Bump `CONTENT_VERSIONS_READ_PRIMARY=1` in prod**, redeploy (~30s).
4. **Monitor for 7 days** — customer support channel, error rate, `dual_read_diag` endpoint for spot checks.
5. **Drop `CONTENT_VERSIONS_COMPARE_RATE=0.0`** once reads are flipped (it'd be comparing cv against cv-shaped data — wasted query budget).
6. **Ship Phase 5** — delete legacy code path, drop `content_translations` table, drop entity text columns.

**Rollback at any point**: `vercel env set CONTENT_VERSIONS_READ_PRIMARY=0`, redeploy. No code revert.

## What's untouched

* Phase 1 dual-write keeps populating cv for new content
* `content_translations` table still written (Phase 5 drops it)
* Owner-bypass paths (`?source=true`, admin cohort list, quiz editor) unchanged — they never went through the overlay layer
* `should_apply_course_translation_overlay` gate unchanged
* `resolve_chapter_locale_context` unchanged
* Phase 2 comparator unchanged (still works; becomes redundant after Phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
