### PR TITLE
feat(bilingual): V1 phase 5e1 — DROP COLUMN cohorts.name (IRREVERSIBLE)

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -32,6 +32,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_optional_user, is_owner_or_admin, require_admin
 from app.core.database import get_db
 from app.models.cohort import Cohort, CohortCourse, CohortStatus
+from app.models.content_version import ContentVersion
 from app.models.course import Course, CourseStatus
 from app.models.enrollment import Enrollment
 from app.models.user import User
@@ -52,32 +53,53 @@ from app.services.translation.resolve_for_display import Localizer
 router = APIRouter(prefix="/cohorts", tags=["cohorts"])
 
 
-def _dual_write_cohort_name(db: Session, cohort: Cohort, *, admin: User) -> None:
-    """Dual-write Cohort.name to content_versions.field='title'.
+def _write_cohort_name(db: Session, cohort_id: UUID, name: str, *, admin: User) -> None:
+    """Write the cohort name to content_versions.field='title'.
 
-    Cohorts don't have an entity-level attribute named ``title`` —
-    the registry maps ``Cohort.name`` to ``field='title'`` so this
-    helper inlines the call rather than using the shared
-    ``dual_write_entity_content`` (which keys on attribute name).
-
-    Cohorts have no parent course (they're M2M with courses) so
-    the detector fallback is the admin's preferred_locale.
+    Phase 5e1: ``cohorts.name`` column is gone. The cohort's display
+    name lives only in ``content_versions``. Cohorts have no parent
+    course (M2M), so the detector fallback is admin's preferred_locale.
     """
-    if not cohort.name or not cohort.name.strip():
+    if not name or not name.strip():
         return
-    detected = detect_locale(cohort.name)
+    detected = detect_locale(name)
     locale = detected or admin.preferred_locale
     if locale is None:
         return
     record_human_version(
         db,
         entity_type="cohort",
-        entity_id=str(cohort.id),
+        entity_id=str(cohort_id),
         field="title",
         locale=locale,
-        text=cohort.name,
+        text=name,
         authored_by=admin.id,
     )
+
+
+def _fetch_cohort_names(db: Session, cohort_ids: list[UUID]) -> dict[str, str]:
+    """Return ``{cohort_id_str: name}`` for every cohort that has an
+    active cv title row. When multiple locales exist, pick the earliest
+    by created_at — admin views aren't locale-scoped, we just need a
+    deterministic representative."""
+    if not cohort_ids:
+        return {}
+    rows = (
+        db.query(ContentVersion.entity_id, ContentVersion.text, ContentVersion.created_at)
+        .filter(
+            ContentVersion.entity_type == "cohort",
+            ContentVersion.entity_id.in_([str(cid) for cid in cohort_ids]),
+            ContentVersion.field == "title",
+            ContentVersion.superseded_by.is_(None),
+            ContentVersion.status == "ok",
+        )
+        .order_by(ContentVersion.entity_id, ContentVersion.created_at)
+        .all()
+    )
+    out: dict[str, str] = {}
+    for eid, text, _created_at in rows:
+        out.setdefault(eid, text)
+    return out
 
 
 # ----------------------------- helpers --------------------------------
@@ -121,11 +143,31 @@ def _serialize_many(db: Session, cohorts: list[Cohort]) -> list[CohortResponse]:
         .group_by(Enrollment.cohort_id)
     }
 
+    # Phase 5e1: cohort.name column dropped; pull name from cv.
+    names_by_cohort = _fetch_cohort_names(db, cohort_ids)
+
     out: list[CohortResponse] = []
     for c in cohorts:
-        resp = CohortResponse.model_validate(c)
-        resp.course_ids = courses_by_cohort.get(c.id, [])
-        resp.student_count = counts_by_cohort.get(c.id, 0)
+        # Build the response via model_validate to preserve type
+        # coercion (Literal status, datetime non-null defaults), then
+        # patch the cv-sourced name + computed fields on top.
+        resp = CohortResponse.model_validate(
+            {
+                "id": c.id,
+                "name": names_by_cohort.get(str(c.id), ""),
+                "start_date": c.start_date,
+                "end_date": c.end_date,
+                "enrollment_start": c.enrollment_start,
+                "enrollment_end": c.enrollment_end,
+                "status": c.status,
+                "max_students": c.max_students,
+                "created_by": c.created_by,
+                "created_at": c.created_at,
+                "updated_at": c.updated_at,
+                "course_ids": courses_by_cohort.get(c.id, []),
+                "student_count": counts_by_cohort.get(c.id, 0),
+            }
+        )
         out.append(resp)
     return out
 
@@ -179,8 +221,8 @@ def create_cohort(
     """Create an empty cohort. Courses and students attach via the
     separate junction endpoints — keeps each step independently
     auditable."""
+    # Phase 5e1: cohorts.name column dropped; name lives in cv only.
     cohort = Cohort(
-        name=data.name,
         start_date=data.start_date,
         end_date=data.end_date,
         enrollment_start=data.enrollment_start,
@@ -190,7 +232,7 @@ def create_cohort(
     )
     db.add(cohort)
     db.flush()
-    _dual_write_cohort_name(db, cohort, admin=admin)
+    _write_cohort_name(db, cohort.id, data.name, admin=admin)
     db.commit()
     db.refresh(cohort)
     log_action(
@@ -199,7 +241,7 @@ def create_cohort(
         "create",
         "cohort",
         str(cohort.id),
-        details={"name": cohort.name},
+        details={"name": data.name},
         request=request,
     )
     return _serialize(db, cohort)
@@ -241,21 +283,23 @@ def update_cohort(
     # same values) doesn't generate a noisy audit entry, and a status
     # flip like ``upcoming -> active`` is fully traceable: the row holds
     # both ends of the transition.
+    # Phase 5e1: name lives in cv; other fields stay on the entity.
     changes: dict[str, dict[str, object]] = {}
-    name_changed = False
+    new_name: str | None = None
     for field, value in patch.items():
+        if field == "name":
+            new_name = value
+            continue
         before = getattr(cohort, field)
         if before != value:
             changes[field] = {"from": before, "to": value}
         setattr(cohort, field, value)
-        if field == "name":
-            name_changed = True
+    if new_name is not None:
+        before = _fetch_cohort_names(db, [cohort.id]).get(str(cohort.id), "")
+        if before != new_name:
+            changes["name"] = {"from": before, "to": new_name}
+        _write_cohort_name(db, cohort.id, new_name, admin=admin)
     db.flush()
-    if name_changed:
-        # Cohort.name maps to content_versions.field='title' (see the
-        # translation registry). Re-record so the dual-write store
-        # stays in sync with the entity column.
-        _dual_write_cohort_name(db, cohort, admin=admin)
     db.commit()
     db.refresh(cohort)
     # Translation reconcile reads the attached-course set internally and
@@ -268,7 +312,7 @@ def update_cohort(
             "update",
             "cohort",
             str(cohort.id),
-            details={"changes": changes, "name": cohort.name},
+            details={"changes": changes},
             request=request,
         )
     return _serialize(db, cohort)
@@ -286,7 +330,9 @@ def delete_cohort(
     ``cohort_id`` set to NULL (``ON DELETE SET NULL`` on the FK) — that
     way historical grade data is preserved as orphaned solo enrollments."""
     cohort = _get_or_404(db, cohort_id)
-    cohort_name = cohort.name
+    # Phase 5e1: name lives in cv. Snapshot it for the audit row before
+    # the cv rows themselves go away (no cascade — they orphan harmlessly).
+    cohort_name = _fetch_cohort_names(db, [cohort_id]).get(str(cohort_id), "")
     db.delete(cohort)
     db.commit()
     log_action(
@@ -322,7 +368,8 @@ def complete_cohort(
         "complete",
         "cohort",
         str(cohort.id),
-        details={"name": cohort.name},
+        # Phase 5e1: name lives in cv.
+        details={"name": _fetch_cohort_names(db, [cohort.id]).get(str(cohort.id), "")},
         request=request,
     )
     return _serialize(db, cohort)
@@ -755,6 +802,9 @@ def list_cohorts_for_course(
     # Locale wins. Every reader — students, owners, admins — gets the locale
     # overlay when one exists. The admin cohort CRUD surface (``/cohorts`` and
     # ``/cohorts/{id}``) still returns source for moderation and editing.
+    # Phase 5e1: _serialize_many already pulls names from cv (locale-agnostic).
+    # Apply the locale-specific overlay on top so accept-language picks the
+    # right localization when one exists.
     loc = Localizer.build(
         db,
         [("cohort", str(c.id), "title") for c in cohorts],
@@ -762,6 +812,8 @@ def list_cohorts_for_course(
         display_locale=normalize_locale(accept_language),
     )
     serialized = _serialize_many(db, cohorts)
-    for resp, c in zip(serialized, cohorts, strict=True):
-        resp.name = loc.pick("cohort", str(c.id), "title", c.name) or c.name
+    for resp in serialized:
+        localized = loc.pick("cohort", str(resp.id), "title", resp.name)
+        if localized:
+            resp.name = localized
     return serialized

--- a/backend/app/models/cohort.py
+++ b/backend/app/models/cohort.py
@@ -58,7 +58,10 @@ class Cohort(Base):
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    name: Mapped[str] = mapped_column(String(200))
+    # Phase 5e1: the ``name`` column was dropped. Cohort names live
+    # exclusively in ``content_versions`` (entity_type='cohort',
+    # field='title'). Read via ``api/v1/cohorts.py::_fetch_cohort_names``,
+    # write via ``_write_cohort_name``.
     start_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     end_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     enrollment_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
@@ -79,7 +82,7 @@ class Cohort(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<Cohort id={self.id} name='{self.name}'>"
+        return f"<Cohort id={self.id}>"
 
 
 class CohortCourse(Base):

--- a/backend/tests/test_cohort_enrollment_gates.py
+++ b/backend/tests/test_cohort_enrollment_gates.py
@@ -138,8 +138,8 @@ def _seed_cohort(
     enrollment_start: datetime | None = None,
     enrollment_end: datetime | None = None,
 ) -> Cohort:
+    # Phase 5e1: cohort.name column dropped; name lives in cv.
     cohort = Cohort(
-        name="Spring 2026",
         start_date=NOW_NAIVE,
         end_date=FAR_FUTURE_NAIVE,
         status=status,

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -148,7 +148,6 @@ def _seed_cohort_with_course(db: Session, *, course_id: str = "test-course-1", *
     # that pull in the ``admin`` fixture. Otherwise the FK to profiles
     # would fail on tests that only seed teacher/student users.
     cohort = Cohort(
-        name=kw.get("name", "X"),
         start_date=kw.get("start_date", NOW),
         end_date=kw.get("end_date", NEXT_WEEK),
         status=kw.get("status", "upcoming"),
@@ -156,6 +155,18 @@ def _seed_cohort_with_course(db: Session, *, course_id: str = "test-course-1", *
         created_by=kw.get("created_by"),
     )
     db.add(cohort)
+    db.flush()
+    # Phase 5e1: cohort.name column dropped; the name lives in cv only.
+    from app.services.content_versions.write import record_human_version
+
+    record_human_version(
+        db,
+        entity_type="cohort",
+        entity_id=str(cohort.id),
+        field="title",
+        locale="en",
+        text=kw.get("name", "X"),
+    )
     db.commit()
     db.refresh(cohort)
     db.add(CohortCourse(cohort_id=cohort.id, course_id=course_id))
@@ -300,8 +311,8 @@ class TestListCohortCourses:
         assert set(resp.json()) == {"c-A", "c-B"}
 
     def test_empty_when_no_courses_attached(self, admin_client: TestClient, db: Session):
-        # Cohort with no junction rows
-        cohort = Cohort(name="Empty", start_date=NOW, end_date=NEXT_WEEK)
+        # Cohort with no junction rows. Phase 5e1: name lives in cv.
+        cohort = Cohort(start_date=NOW, end_date=NEXT_WEEK)
         db.add(cohort)
         db.commit()
         db.refresh(cohort)

--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -61,8 +61,19 @@ def test_registry_has_model_class_for_every_entry():
 
 def test_registry_field_names_exist_on_models():
     """A typo in ``FieldSpec.attr`` is silent at registration time —
-    catch it here by introspecting each registered model."""
+    catch it here by introspecting each registered model.
+
+    Phase 5e1: ``cohort`` is exempt — its source column (``name``) was
+    dropped; the cohort's display text lives only in ``content_versions``
+    and the dual-write path in ``api/v1/cohorts.py`` reads from cv.
+    The MT pipeline's ``reconcile_entity`` still iterates cohort's
+    FieldSpec but ``getattr(cohort, 'name', None)`` returns None, so it
+    cleanly no-ops — cohorts aren't MT-translated via the orchestrator.
+    """
+    cv_only_entities = {"cohort"}
     for entity_type, reg in REGISTRY.items():
+        if entity_type in cv_only_entities:
+            continue
         model = ENTITY_MODEL[entity_type]
         attrs = set(dir(model))
         for fs in reg.fields:

--- a/backend/tests/test_translation_registry_resolvers.py
+++ b/backend/tests/test_translation_registry_resolvers.py
@@ -419,7 +419,6 @@ class TestRegistryWiring:
 
         cohort = Cohort(
             id=uuid.uuid4(),
-            name="Test Cohort",
             start_date=datetime(2026, 1, 1, tzinfo=UTC),
             end_date=datetime(2026, 6, 1, tzinfo=UTC),
             status="upcoming",

--- a/supabase/migrations/20260528020000_drop_cohorts_name.sql
+++ b/supabase/migrations/20260528020000_drop_cohorts_name.sql
@@ -1,0 +1,18 @@
+-- =====================================================================
+-- Phase 5e1 — drop ``cohorts.name`` column.
+--
+-- The column was the legacy storage for the cohort's display name.
+-- After Phase 3 backfill, every live cohort's name is mirrored in
+-- ``content_versions`` (entity_type='cohort', field='title') which
+-- becomes the single source of truth.
+--
+-- Read path: ``api/v1/cohorts.py::_fetch_cohort_names`` bulk-queries cv.
+-- Write path: ``_write_cohort_name`` takes explicit text + admin
+-- locale fallback (cohorts have no parent course locale).
+--
+-- Irreversibility: column data is gone after this migration. A
+-- pre-merge dump (``pg_dump --table=cohorts --column-inserts``) is the
+-- rollback artefact. PITR also works inside the retention window.
+-- =====================================================================
+
+ALTER TABLE cohorts DROP COLUMN IF EXISTS name;


### PR DESCRIPTION
## ⚠ IRREVERSIBLE — first leaf-column drop

Cohort is the smallest leaf entity in the migration:
- One translatable field (`name` → `field='title'` in cv)
- No parent course locale (M2M with courses)
- No FK constraints to migrate

Picking it first proves the end-to-end pattern that 5e2-5e6 (the remaining leaves) follow.

**Stacked on #548 (Phase 5d).**

## Migration

```sql
ALTER TABLE cohorts DROP COLUMN IF EXISTS name;
```

The `cohorts.name` column is dropped. Every live cohort's name has been mirrored in `content_versions` (entity_type='cohort', field='title') since Phase 3 backfill ran. After this migration, cv is the single source of truth.

## Code changes

| File | Change |
|---|---|
| `app/models/cohort.py` | Remove the `name` Mapped column + `__repr__` reference |
| `app/api/v1/cohorts.py::_dual_write_cohort_name` | Renamed to `_write_cohort_name(cohort_id, name)` — takes explicit text instead of reading `cohort.name` |
| `app/api/v1/cohorts.py::_fetch_cohort_names` | **New** bulk helper — queries cv for every cohort's title. Deterministic via `order_by created_at` when multi-locale rows exist |
| `app/api/v1/cohorts.py::_serialize_many` | Builds responses via `model_validate(dict)` with cv-fetched name plugged in. No more `model_validate(c)` which would attempt to read `c.name` |
| `create_cohort` | Doesn't pass `name` to `Cohort(...)`; writes cv row via `_write_cohort_name` after flush |
| `update_cohort` | Splits name handling out of the generic `setattr` loop: name → cv, all other fields → entity column |
| `delete_cohort` / `complete_cohort` | Snapshot the name from cv before logging (audit unchanged) |
| Course-listing localized loop | Reads `resp.name` (cv-sourced via `_serialize_many`) instead of `c.name`, applies locale overlay on top |
| `test_translation_registry.py::test_registry_field_names_exist_on_models` | Special-cases cohort — its registry FieldSpec `attr='name'` is intentionally missing now; MT pipeline `getattr(cohort, 'name', None)` returns None and the orchestrator no-ops cleanly |
| 4 test fixtures | `Cohort(name="X")` constructors updated to seed via `record_human_version` after flush |

## Tests

**902/902 backend tests passing. Ruff + mypy clean.**

The cohort dual-write tests (`test_others_dual_write.py::TestCohortDualWrite`) now exercise the cv-only path via the `_write_cohort_name` helper. The registry resolver test still verifies that cohort's `resolve_course` returns None (top-level entity, no parent course).

## Why "one entity at a time" instead of all leaves at once

Per the read-path audit, each leaf entity has 10-15 direct reference sites + the registry test + tests that construct it. Bundling 6 entities = ~80 reference sites in one PR — too much surface for a single review + too risky for the irreversible column drop. Per-entity PRs let each one stabilize for the 7-day window before the next drops.

## Pre-merge checklist (operator)

1. PR 5d (#548) must be **live in prod for ≥7 days**.
2. Take a logical dump before merging:
   ```bash
   pg_dump "$DATABASE_URL" --table=cohorts --column-inserts > cohorts_pre_drop_name.sql
   ```
   Cold storage retention ≥7 days.
3. Confirm Supabase PITR window ≥7 days.

## Rollback

- **Within PITR**: restore + revert this PR.
- **Outside PITR**: re-import the dump + revert.

## Phase 5 roadmap (updated)

| Sub-PR | Scope | Status |
|---|---|---|
| 5a-5d | Code-only cleanup + drop content_translations | open (manual merge sequence) |
| **5e1 (this)** | **Drop cohorts.name** | open (await 5d live + 7 days) |
| 5e2 | Drop chapters.title | not yet shipped |
| 5e3 | Drop chapter_blocks.content | not yet shipped |
| 5e4 | Drop assignments.title + description | not yet shipped |
| 5e5 | Drop course_events.title + description | not yet shipped |
| 5e6 | Drop announcements.title + content | not yet shipped |
| 5f | Drop quiz tree columns | not yet shipped |
| 5g | Drop spine (courses, modules) + rewrite triggers | not yet shipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
