### PR TITLE
feat(bilingual): V1 phase 5e3 — drop assignments.title + description columns

### DIFF
--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -28,7 +28,7 @@ from app.schemas.assignment import (
 )
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.services.audit_service import log_action
-from app.services.content_versions import dual_write_entity_content
+from app.services.content_versions import dual_write_entity_content, fetch_cv_entity_texts_with_fallback
 from app.services.course_service import sync_enrollment_progress
 from app.services.notification_service import create_notification
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
@@ -38,6 +38,39 @@ from app.services.translation.resolve_for_display import (
 )
 
 router = APIRouter(prefix="/assignments", tags=["assignments"])
+
+
+_TRANSLATABLE_ASSIGNMENT_FIELDS = ("title", "description")
+
+
+def _assignment_to_response(db: Session, assignment: Assignment, *, source_locale: str = "en") -> AssignmentResponse:
+    """Phase 5e3: title + description columns dropped — pull both from
+    cv (preferring source_locale, falling back to any active locale).
+    Used by the single-entity routes (create / update); list / source
+    routes use ``localize_assignment_rows`` which is locale-aware.
+    """
+    texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="assignment",
+        entity_ids=[str(assignment.id)],
+        fields=list(_TRANSLATABLE_ASSIGNMENT_FIELDS),
+        display_locale=source_locale,
+        source_locale=source_locale,
+    )
+    title = texts.get((str(assignment.id), "title")) or ""
+    description = texts.get((str(assignment.id), "description"))
+    return AssignmentResponse.model_validate(
+        {
+            "id": assignment.id,
+            "chapter_id": assignment.chapter_id,
+            "title": title,
+            "description": description,
+            "max_score": assignment.max_score,
+            "due_date": assignment.due_date,
+            "created_at": assignment.created_at,
+            "updated_at": assignment.updated_at,
+        }
+    )
 
 
 @router.get("/chapter/{chapter_id}", response_model=list[AssignmentResponse])
@@ -60,8 +93,7 @@ def list_chapter_assignments(
     response.headers["Vary"] = "Accept-Language"
     rows = db.query(Assignment).filter(Assignment.chapter_id == chapter_id).order_by(Assignment.created_at).all()
     # One chapter→module→course join covers the locale + access decisions
-    # below. Previously this paid 2 round-trips for the common non-source
-    # path.
+    # below.
     ctx = resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=current_user)
     if source:
         if not ctx.is_owner_or_admin:
@@ -69,14 +101,12 @@ def list_chapter_assignments(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only the course owner or an admin can request source-language content",
             )
-        return rows
+        # Phase 5e3: title + description columns dropped — re-use the
+        # localize path with display==source so the cv lookup populates
+        # the source-locale text.
+        return localize_assignment_rows(db, rows, display_locale=ctx.source_locale, source_locale=ctx.source_locale)
     display_locale: LocaleCode = normalize_locale(accept_language)
-    if ctx.apply_overlay:
-        return localize_assignment_rows(db, rows, display_locale=display_locale, source_locale=ctx.source_locale)
-    return rows
-
-
-_TRANSLATABLE_ASSIGNMENT_FIELDS = ("title", "description")
+    return localize_assignment_rows(db, rows, display_locale=display_locale, source_locale=ctx.source_locale)
 
 
 def _course_source_locale_for_chapter(db: Session, chapter_id: str) -> str | None:
@@ -97,22 +127,28 @@ def create_assignment(
     db: Session = Depends(get_db),
 ):
     verify_chapter_owner(db, data.chapter_id, teacher)
-    assignment = Assignment(**data.model_dump())
+    # Phase 5e3: title + description go to cv; only structural fields
+    # land on the Assignment row.
+    payload = data.model_dump()
+    title = payload.pop("title")
+    description = payload.pop("description", None)
+    assignment = Assignment(**payload)
     db.add(assignment)
     db.flush()
+    source_locale = _course_source_locale_for_chapter(db, data.chapter_id)
     dual_write_entity_content(
         db,
         entity_type="assignment",
         entity_id=str(assignment.id),
-        entity=assignment,
         fields=_TRANSLATABLE_ASSIGNMENT_FIELDS,
-        fallback_locale=_course_source_locale_for_chapter(db, data.chapter_id),
+        fallback_locale=source_locale,
         authored_by=teacher.id,
+        texts={"title": title, "description": description},
     )
     db.commit()
     db.refresh(assignment)
     reconcile_entity_if_course_published(db, "assignment", assignment)
-    return assignment
+    return _assignment_to_response(db, assignment, source_locale=source_locale or "en")
 
 
 @router.put("/{assignment_id}", response_model=AssignmentResponse)
@@ -128,24 +164,33 @@ def update_assignment(
     verify_chapter_owner(db, assignment.chapter_id, teacher)
 
     patch = data.model_dump(exclude_unset=True)
+    # Phase 5e3: title + description live in cv. Pop them off the patch
+    # so they don't try to setattr on the (now-text-less) ORM row.
+    text_patch: dict[str, str | None] = {}
+    if "title" in patch:
+        text_patch["title"] = patch.pop("title")
+    if "description" in patch:
+        text_patch["description"] = patch.pop("description")
     for field, value in patch.items():
         setattr(assignment, field, value)
 
     db.flush()
-    dual_write_entity_content(
-        db,
-        entity_type="assignment",
-        entity_id=str(assignment.id),
-        entity=assignment,
-        fields=_TRANSLATABLE_ASSIGNMENT_FIELDS,
-        fallback_locale=_course_source_locale_for_chapter(db, assignment.chapter_id),
-        authored_by=teacher.id,
-        only_fields={f for f in _TRANSLATABLE_ASSIGNMENT_FIELDS if f in patch},
-    )
+    source_locale = _course_source_locale_for_chapter(db, assignment.chapter_id)
+    if text_patch:
+        dual_write_entity_content(
+            db,
+            entity_type="assignment",
+            entity_id=str(assignment.id),
+            fields=_TRANSLATABLE_ASSIGNMENT_FIELDS,
+            fallback_locale=source_locale,
+            authored_by=teacher.id,
+            only_fields=set(text_patch.keys()),
+            texts=text_patch,
+        )
     db.commit()
     db.refresh(assignment)
     reconcile_entity_if_course_published(db, "assignment", assignment)
-    return assignment
+    return _assignment_to_response(db, assignment, source_locale=source_locale or "en")
 
 
 @router.delete("/{assignment_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -343,12 +388,25 @@ def grade_submission(
     submission.graded_by = teacher.id
     submission.graded_at = datetime.now(UTC)
 
+    # Phase 5e3: assignment.title moved to cv — fetch the source-locale
+    # title for the notification message (any locale fallback covers
+    # edge cases where the source row hasn't been recorded yet).
+    source_locale_for_msg = _course_source_locale_for_chapter(db, assignment.chapter_id) or "en"
+    assignment_texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="assignment",
+        entity_ids=[str(assignment.id)],
+        fields=["title"],
+        display_locale=source_locale_for_msg,
+        source_locale=source_locale_for_msg,
+    )
+    assignment_title = assignment_texts.get((str(assignment.id), "title")) or "your assignment"
     create_notification(
         db,
         user_id=submission.student_id,
         type="assignment_graded",
         title="Assignment Graded",
-        message=f'Your submission for "{assignment.title}" has been graded: {data.grade}/{assignment.max_score}.',
+        message=f'Your submission for "{assignment_title}" has been graded: {data.grade}/{assignment.max_score}.',
         link=None,
         metadata={"assignment_id": str(assignment.id), "submission_id": str(submission.id)},
     )

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -122,14 +122,56 @@ def get_calendar_events(
             )
             .all()
         )
+        # Phase 5e3: assignments.title + description columns dropped —
+        # one cv read covers every assignment, with the picker applying
+        # the per-assignment course-declared source_locale fallback.
+        asg_rows_by_pair_locale: dict[tuple[str, str, str], str] = {}
+        any_for_pair: dict[tuple[str, str], str] = {}
+        if assignments:
+            from app.models.content_version import ContentVersion
+
+            asg_ids = [str(a.id) for a in assignments]
+            cv_rows = (
+                db.query(
+                    ContentVersion.entity_id,
+                    ContentVersion.field,
+                    ContentVersion.locale,
+                    ContentVersion.text,
+                )
+                .filter(
+                    ContentVersion.entity_type == "assignment",
+                    ContentVersion.entity_id.in_(asg_ids),
+                    ContentVersion.field.in_(["title", "description"]),
+                    ContentVersion.superseded_by.is_(None),
+                    ContentVersion.status == "ok",
+                )
+                .order_by(ContentVersion.entity_id, ContentVersion.field, ContentVersion.created_at)
+                .all()
+            )
+            for eid, fld, loc, txt in cv_rows:
+                asg_rows_by_pair_locale.setdefault((eid, fld, loc), txt)
+                any_for_pair.setdefault((eid, fld), txt)
         for a in assignments:
             assert a.due_date is not None
             crs_id = ch_to_course.get(a.chapter_id, "")
+            aid = str(a.id)
+            asg_source = course_source_locales.get(crs_id, display_locale)
+            asg_title = (
+                asg_rows_by_pair_locale.get((aid, "title", display_locale))
+                or asg_rows_by_pair_locale.get((aid, "title", asg_source))
+                or any_for_pair.get((aid, "title"))
+                or ""
+            )
+            asg_description = (
+                asg_rows_by_pair_locale.get((aid, "description", display_locale))
+                or asg_rows_by_pair_locale.get((aid, "description", asg_source))
+                or any_for_pair.get((aid, "description"))
+            )
             events.append(
                 CalendarEvent(
                     id=f"assignment-{a.id}",
-                    title=a.title,
-                    description=a.description,
+                    title=asg_title,
+                    description=asg_description,
                     event_type="deadline",
                     event_date=a.due_date,
                     course_id=crs_id,

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -13,8 +13,9 @@ class Assignment(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     chapter_id: Mapped[str] = mapped_column(ForeignKey("chapters.id", ondelete="CASCADE"))
-    title: Mapped[str] = mapped_column(String(255))
-    description: Mapped[str | None] = mapped_column(Text)
+    # Phase 5e3: title + description columns dropped — cv is the only
+    # store. Reads go through fetch_cv_entity_texts_with_fallback;
+    # writes through dual_write_entity_content(texts={...}).
     max_score: Mapped[int] = mapped_column(default=100)
     due_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -10,6 +10,7 @@ all funnel through these helpers.
 from app.services.content_versions.dual_write import dual_write_entity_content
 from app.services.content_versions.read import (
     fetch_cv_course_text_bulk,
+    fetch_cv_entity_texts_with_fallback,
     fetch_cv_text_bulk,
 )
 from app.services.content_versions.write import (
@@ -21,6 +22,7 @@ from app.services.content_versions.write import (
 __all__ = [
     "dual_write_entity_content",
     "fetch_cv_course_text_bulk",
+    "fetch_cv_entity_texts_with_fallback",
     "fetch_cv_text_bulk",
     "record_human_version",
     "record_mt_failure",

--- a/backend/app/services/content_versions/read.py
+++ b/backend/app/services/content_versions/read.py
@@ -66,6 +66,58 @@ def fetch_cv_text_bulk(
     return {(r.entity_type, r.entity_id, r.field): r.text for r in rows}
 
 
+def fetch_cv_entity_texts_with_fallback(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_ids: list[str],
+    fields: list[str],
+    display_locale: str,
+    source_locale: str,
+) -> dict[tuple[str, str], str | None]:
+    """Read every active+ok ``content_versions`` row for the given
+    entities + fields, then resolve each (entity, field) to a single
+    text using a three-tier fallback: ``display_locale`` first, then
+    ``source_locale``, then any-locale-with-earliest-created_at.
+
+    Returns a map ``(entity_id, field) -> text or None``. ``None`` only
+    appears when no active+ok row exists at any locale.
+
+    Phase 5e-series: entities whose source columns are dropped need
+    one indexed lookup per request to materialise responses; this is
+    that lookup. Same code path for the locale-aware list endpoints
+    and the single-entity GET/POST/PUT returns.
+    """
+    if not entity_ids or not fields:
+        return {}
+    rows = (
+        db.query(ContentVersion.entity_id, ContentVersion.field, ContentVersion.locale, ContentVersion.text)
+        .filter(
+            ContentVersion.entity_type == entity_type,
+            ContentVersion.entity_id.in_(entity_ids),
+            ContentVersion.field.in_(fields),
+            ContentVersion.superseded_by.is_(None),
+            ContentVersion.status == "ok",
+        )
+        .order_by(ContentVersion.entity_id, ContentVersion.field, ContentVersion.created_at)
+        .all()
+    )
+    by_locale: dict[tuple[str, str, str], str] = {}
+    any_for_pair: dict[tuple[str, str], str] = {}
+    for eid, field, locale, text in rows:
+        by_locale.setdefault((eid, field, locale), text)
+        any_for_pair.setdefault((eid, field), text)
+    resolved: dict[tuple[str, str], str | None] = {}
+    for eid in entity_ids:
+        for field in fields:
+            resolved[(eid, field)] = (
+                by_locale.get((eid, field, display_locale))
+                or by_locale.get((eid, field, source_locale))
+                or any_for_pair.get((eid, field))
+            )
+    return resolved
+
+
 def fetch_cv_course_text_bulk(
     db: Session,
     *,

--- a/backend/app/services/course_readiness.py
+++ b/backend/app/services/course_readiness.py
@@ -306,6 +306,29 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
         for loaded_assignment in db.query(Assignment).filter(Assignment.chapter_id.in_(all_chapter_ids)).all():
             assignments_by_chapter[loaded_assignment.chapter_id] = loaded_assignment
 
+    # Phase 5e3: ``assignments.description`` column dropped. Bulk-fetch
+    # the set of assignment ids with a non-blank cv description row at
+    # any locale (same pattern as ``blocks_with_cv_content`` above) so
+    # the per-chapter check can answer "has brief?" in O(1).
+    assignments_with_cv_brief: set[str] = set()
+    if assignments_by_chapter:
+        from app.models.content_version import ContentVersion
+
+        assignment_ids = [str(a.id) for a in assignments_by_chapter.values()]
+        assignments_with_cv_brief = {
+            eid
+            for (eid, text) in db.query(ContentVersion.entity_id, ContentVersion.text)
+            .filter(
+                ContentVersion.entity_type == "assignment",
+                ContentVersion.entity_id.in_(assignment_ids),
+                ContentVersion.field == "description",
+                ContentVersion.superseded_by.is_(None),
+                ContentVersion.status == "ok",
+            )
+            .all()
+            if text and text.strip()
+        }
+
     has_any_quiz_chapter = False
     has_any_assignment_chapter = False
 
@@ -360,11 +383,12 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
             elif ctype == "assignment":
                 has_any_assignment_chapter = True
                 assignment = assignments_by_chapter.get(chapter.id)
+                has_brief = assignment is not None and str(assignment.id) in assignments_with_cv_brief
                 checks.append(
                     ReadinessCheck(
                         id=f"assignment_has_brief:{chapter.id}",
                         severity="critical",
-                        passed=assignment is not None and bool((assignment.description or "").strip()),
+                        passed=has_brief,
                         message_key="courseReadiness.checks.assignmentHasBrief",
                         subject=_make_chapter_subject(chapter),
                         action=_open_assignment_action(chapter),

--- a/backend/app/services/course_service/_clone.py
+++ b/backend/app/services/course_service/_clone.py
@@ -174,12 +174,14 @@ def clone_course(db: Session, course_id: str, teacher_id: str | uuid.UUID) -> Co
             for assignment in assignments_by_chapter.get(chapter.id, []):
                 new_assignment_id = uuid.uuid4()
                 assignment_id_map[str(assignment.id)] = new_assignment_id
+                # Phase 5e3: assignment title + description columns
+                # dropped. The clone copies structural fields; cv text
+                # rows are NOT cloned (clones land as drafts and the
+                # teacher edits text post-clone, same as 5e2 blocks).
                 db.add(
                     Assignment(
                         id=new_assignment_id,
                         chapter_id=new_chapter_id,
-                        title=assignment.title,
-                        description=assignment.description,
                         max_score=assignment.max_score,
                         due_date=None,
                     )

--- a/backend/app/services/student_progress_service.py
+++ b/backend/app/services/student_progress_service.py
@@ -252,6 +252,25 @@ def build_course_student_progress(db: Session, course: Course, course_id: str) -
         db, assignment_map
     )
 
+    # Phase 5e3: assignments.title column dropped — bulk-fetch the
+    # source-language title from cv for the dashboard rendering below.
+    # Any-locale fallback keeps the lookup defensive against missing
+    # rows (the dashboard prefers showing *something* over crashing).
+    assignment_title_by_id: dict[str, str] = {}
+    if assignment_by_id_str:
+        from app.services.content_versions import fetch_cv_entity_texts_with_fallback
+
+        source_locale = course.source_locale or "en"
+        cv_titles = fetch_cv_entity_texts_with_fallback(
+            db,
+            entity_type="assignment",
+            entity_ids=list(assignment_by_id_str.keys()),
+            fields=["title"],
+            display_locale=source_locale,
+            source_locale=source_locale,
+        )
+        assignment_title_by_id = {aid: (cv_titles.get((aid, "title")) or "") for aid in assignment_by_id_str}
+
     progress_by_user = _load_completed_progress(db, chapter_ids)
 
     enrollments = (
@@ -300,7 +319,7 @@ def build_course_student_progress(db: Session, course: Course, course_id: str) -
                     {
                         "chapter_title": chapter_title_map.get(str(ch_id), ""),
                         "chapter_id": str(ch_id),
-                        "title": a.title,
+                        "title": assignment_title_by_id.get(str(a.id), ""),
                         "status": latest["status"],
                         "grade": latest["grade"],
                         "max_score": a.max_score or 0,

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -435,23 +435,40 @@ def localize_assignment_rows(
     display_locale: LocaleCode,
     source_locale: LocaleCode,
 ) -> list[AssignmentResponse]:
+    """Phase 5e3: ``assignments.title`` + ``description`` columns dropped.
+    Both texts live in ``content_versions`` now. Resolve each via a
+    three-tier fallback (display → source → any-locale).
+    """
     if not assignments:
         return []
-    specs: list[tuple[str, str, str]] = []
-    for a in assignments:
-        specs.extend(
-            [
-                ("assignment", str(a.id), "title"),
-                ("assignment", str(a.id), "description"),
-            ]
-        )
-    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
+    from app.services.content_versions import fetch_cv_entity_texts_with_fallback
+
+    ids = [str(a.id) for a in assignments]
+    texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="assignment",
+        entity_ids=ids,
+        fields=["title", "description"],
+        display_locale=display_locale,
+        source_locale=source_locale,
+    )
     out: list[AssignmentResponse] = []
     for a in assignments:
-        base = AssignmentResponse.model_validate(a, from_attributes=True)
-        t = loc.pick("assignment", str(a.id), "title", a.title) or a.title
-        d = loc.pick("assignment", str(a.id), "description", a.description)
-        out.append(base.model_copy(update={"title": t, "description": d}))
+        aid = str(a.id)
+        out.append(
+            AssignmentResponse.model_validate(
+                {
+                    "id": a.id,
+                    "chapter_id": a.chapter_id,
+                    "title": texts.get((aid, "title")) or "",
+                    "description": texts.get((aid, "description")),
+                    "max_score": a.max_score,
+                    "due_date": a.due_date,
+                    "created_at": a.created_at,
+                    "updated_at": a.updated_at,
+                }
+            )
+        )
     return out
 
 

--- a/backend/tests/_cv_helpers.py
+++ b/backend/tests/_cv_helpers.py
@@ -1,0 +1,102 @@
+"""Test helpers for entities whose text columns were moved to ``content_versions``.
+
+Phase 5e dropped source columns on several entities (cohort.name, chapter_block.content,
+assignment.title + description, …). Tests that previously did
+``Assignment(title=..., description=...)`` need to create the structural row and
+then record the text in cv. These helpers keep that one-step.
+
+Default locale is ``"en"``; the read path's three-tier fallback (display → source →
+any-locale) means tests don't have to track the parent course's source_locale.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from app.models.assignment import Assignment as AssignmentModel
+    from app.models.chapter_block import ChapterBlock as ChapterBlockModel
+
+
+def make_assignment_with_text(
+    db: Session,
+    *,
+    chapter_id: str,
+    title: str = "Assignment",
+    description: str | None = None,
+    max_score: int = 100,
+    due_date=None,
+    assignment_id: uuid.UUID | None = None,
+    locale: str = "en",
+) -> AssignmentModel:
+    """Phase 5e3: ``assignments.title`` + ``description`` columns dropped.
+    Builds the row plus records both texts in cv at ``locale``.
+    """
+    from app.models.assignment import Assignment
+    from app.services.content_versions.write import record_human_version
+
+    assignment = Assignment(
+        id=assignment_id or uuid.uuid4(),
+        chapter_id=chapter_id,
+        max_score=max_score,
+        due_date=due_date,
+    )
+    db.add(assignment)
+    db.flush()
+    record_human_version(
+        db,
+        entity_type="assignment",
+        entity_id=str(assignment.id),
+        field="title",
+        locale=locale,
+        text=title,
+    )
+    if description is not None:
+        record_human_version(
+            db,
+            entity_type="assignment",
+            entity_id=str(assignment.id),
+            field="description",
+            locale=locale,
+            text=description,
+        )
+    return assignment
+
+
+def make_chapter_block_with_content(
+    db: Session,
+    *,
+    chapter_id: str,
+    block_type: str = "text",
+    order_index: int = 0,
+    content: str | None = None,
+    block_id: uuid.UUID | None = None,
+    locale: str = "en",
+) -> ChapterBlockModel:
+    """Phase 5e2: ``chapter_blocks.content`` column dropped. Builds the
+    row plus records ``content`` in cv at ``locale`` (skipped if None).
+    """
+    from app.models.chapter_block import ChapterBlock
+    from app.services.content_versions.write import record_human_version
+
+    block = ChapterBlock(
+        id=block_id or uuid.uuid4(),
+        chapter_id=chapter_id,
+        block_type=block_type,
+        order_index=order_index,
+    )
+    db.add(block)
+    db.flush()
+    if content is not None:
+        record_human_version(
+            db,
+            entity_type="chapter_block",
+            entity_id=str(block.id),
+            field="content",
+            locale=locale,
+            text=content,
+        )
+    return block

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -1014,11 +1014,11 @@ def _seed_teacher_progress_dashboard(db: Session) -> tuple[str, uuid.UUID, uuid.
         completed_at=t1,
     )
     asg_id = uuid.uuid4()
+    # Phase 5e3: title + description moved to cv. Build the structural
+    # row here (so we can keep the explicit id) and seed cv after flush.
     assignment = Assignment(
         id=asg_id,
         chapter_id=ch_asg_id,
-        title="Essay",
-        description="Write",
         max_score=100,
     )
     sub = AssignmentSubmission(
@@ -1052,6 +1052,15 @@ def _seed_teacher_progress_dashboard(db: Session) -> tuple[str, uuid.UUID, uuid.
             enrollment,
             cp,
         ]
+    )
+    db.flush()
+    # Phase 5e3: seed the cv title + description for the assignment now
+    # that the structural row exists.
+    from app.services.content_versions.write import record_human_version
+
+    record_human_version(db, entity_type="assignment", entity_id=str(asg_id), field="title", locale="en", text="Essay")
+    record_human_version(
+        db, entity_type="assignment", entity_id=str(asg_id), field="description", locale="en", text="Write"
     )
     db.commit()
     return course_id, quiz_id, asg_id, ch_quiz_id, ch_asg_id, ch_read_id

--- a/backend/tests/test_course_readiness.py
+++ b/backend/tests/test_course_readiness.py
@@ -14,7 +14,7 @@ import uuid
 import pytest
 from sqlalchemy.orm import Session  # noqa: TC002  (used at runtime by fixtures)
 
-from app.models.assignment import Assignment
+from app.models.assignment import Assignment  # noqa: TC001  (used as return-type annotation)
 from app.models.chapter_block import ChapterBlock
 from app.models.course import Chapter, Course, CourseStatus, Module
 from app.models.quiz import Quiz, QuizOption, QuizQuestion
@@ -128,10 +128,10 @@ def _add_quiz_with_question(
 
 
 def _add_assignment(db: Session, chapter: Chapter, *, description: str | None = None) -> Assignment:
-    assignment = Assignment(chapter_id=chapter.id, title="Assignment", description=description)
-    db.add(assignment)
-    db.flush()
-    return assignment
+    # Phase 5e3: assignments.title + description columns dropped; both live in cv.
+    from ._cv_helpers import make_assignment_with_text
+
+    return make_assignment_with_text(db, chapter_id=chapter.id, title="Assignment", description=description)
 
 
 def _check(report: ReadinessReport, check_id_prefix: str):

--- a/backend/tests/test_progress_and_assignments.py
+++ b/backend/tests/test_progress_and_assignments.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, get_optional_user
 from app.main import app
-from app.models.assignment import Assignment
 from app.models.chapter_progress import ChapterProgress
 from app.models.course import Chapter, Course, Module
 from app.models.enrollment import Enrollment
@@ -145,22 +144,23 @@ class TestListChapterAssignmentsSourceParam:
     def _seed_with_translation(self, db: Session, chapter_id: str) -> str:
         from app.services.content_versions.write import record_mt_version
 
-        asg_id = uuid.uuid4()
-        db.add(
-            Assignment(
-                id=asg_id,
-                chapter_id=chapter_id,
-                title="RU задание",
-                description="Описание RU",
-                max_score=10,
-            )
+        from ._cv_helpers import make_assignment_with_text
+
+        # Phase 5e3: source row recorded in cv at the RU source locale.
+        assignment = make_assignment_with_text(
+            db,
+            chapter_id=chapter_id,
+            title="RU задание",
+            description="Описание RU",
+            max_score=10,
+            locale="ru",
         )
-        db.flush()
-        # Phase 5d: cv is the only translation store.
+        # EN translation overlay (the test verifies ?source=1 still
+        # serves the RU source even with an EN row present).
         record_mt_version(
             db,
             entity_type="assignment",
-            entity_id=str(asg_id),
+            entity_id=str(assignment.id),
             field="title",
             locale="en",
             text="EN translation title",
@@ -168,7 +168,7 @@ class TestListChapterAssignmentsSourceParam:
             source_hash="ah1",
         )
         db.commit()
-        return str(asg_id)
+        return str(assignment.id)
 
     def test_owner_with_source_param_gets_raw_columns(self, client: TestClient, db: Session):
         _course, _mod, chapter = _seed_course_graph(db)
@@ -270,14 +270,10 @@ class TestUpdateAssignment:
         assert r.status_code == 404
 
     def test_not_chapter_owner(self, client: TestClient, db: Session):
+        from ._cv_helpers import make_assignment_with_text
+
         foreign = _seed_foreign_teacher_chapter(db)
-        asg = Assignment(
-            id=uuid.uuid4(),
-            chapter_id=foreign.id,
-            title="Other",
-            max_score=10,
-        )
-        db.add(asg)
+        asg = make_assignment_with_text(db, chapter_id=foreign.id, title="Other", max_score=10)
         db.commit()
         r = client.put(
             f"/api/v1/assignments/{asg.id}",
@@ -316,16 +312,11 @@ class TestListAssignmentSubmissions:
         db: Session,
         teacher: User,
     ):
+        from ._cv_helpers import make_assignment_with_text
+
         _course, _mod, chapter = _seed_course_graph(db)
-        aid = uuid.uuid4()
-        db.add(
-            Assignment(
-                id=aid,
-                chapter_id=chapter.id,
-                title="Sub test",
-                max_score=10,
-            )
-        )
+        asg = make_assignment_with_text(db, chapter_id=chapter.id, title="Sub test", max_score=10)
+        aid = asg.id
         db.commit()
         sub = student_client.post(
             f"/api/v1/assignments/{aid}/submit",
@@ -345,11 +336,12 @@ class TestListAssignmentSubmissions:
         assert r.status_code == 404
 
     def test_student_forbidden(self, student_client: TestClient, db: Session):
+        from ._cv_helpers import make_assignment_with_text
+
         _course, _mod, chapter = _seed_course_graph(db)
-        aid = uuid.uuid4()
-        db.add(Assignment(id=aid, chapter_id=chapter.id, title="T", max_score=10))
+        asg = make_assignment_with_text(db, chapter_id=chapter.id, title="T", max_score=10)
         db.commit()
-        r = student_client.get(f"/api/v1/assignments/{aid}/submissions")
+        r = student_client.get(f"/api/v1/assignments/{asg.id}/submissions")
         assert r.status_code == 403
 
 
@@ -363,16 +355,11 @@ class TestGradeSubmission:
         db: Session,
         teacher: User,
     ):
+        from ._cv_helpers import make_assignment_with_text
+
         _course, _mod, chapter = _seed_course_graph(db)
-        aid = uuid.uuid4()
-        db.add(
-            Assignment(
-                id=aid,
-                chapter_id=chapter.id,
-                title="Grade me",
-                max_score=10,
-            )
-        )
+        asg = make_assignment_with_text(db, chapter_id=chapter.id, title="Grade me", max_score=10)
+        aid = asg.id
         db.commit()
         sub_resp = student_client.post(
             f"/api/v1/assignments/{aid}/submit",
@@ -399,9 +386,11 @@ class TestGradeSubmission:
         db: Session,
         teacher: User,
     ):
+        from ._cv_helpers import make_assignment_with_text
+
         _course, _mod, chapter = _seed_course_graph(db)
-        aid = uuid.uuid4()
-        db.add(Assignment(id=aid, chapter_id=chapter.id, title="Cap", max_score=10))
+        asg = make_assignment_with_text(db, chapter_id=chapter.id, title="Cap", max_score=10)
+        aid = asg.id
         db.commit()
         sub_resp = student_client.post(
             f"/api/v1/assignments/{aid}/submit",
@@ -476,14 +465,10 @@ def test_submit_assignment_survives_concurrent_chapter_progress_insert(student_c
     """
     from sqlalchemy.orm import Query
 
+    from ._cv_helpers import make_assignment_with_text
+
     _course, _module, chapter = _seed_course_graph(db)
-    assignment = Assignment(
-        id=uuid.uuid4(),
-        chapter_id=chapter.id,
-        title="Reflection",
-        max_score=10,
-    )
-    db.add(assignment)
+    assignment = make_assignment_with_text(db, chapter_id=chapter.id, title="Reflection", max_score=10)
     db.add(
         ChapterProgress(
             user_id=STUDENT_ID,
@@ -536,15 +521,16 @@ def test_submit_assignment_survives_concurrent_chapter_progress_insert(student_c
 
 
 def test_student_can_fetch_own_assignment_submissions(student_client: TestClient, db: Session):
+    from ._cv_helpers import make_assignment_with_text
+
     course, _module, chapter = _seed_course_graph(db)
-    assignment = Assignment(
-        id=uuid.uuid4(),
+    assignment = make_assignment_with_text(
+        db,
         chapter_id=chapter.id,
         title="Reflection",
         description="Write a reflection",
         max_score=10,
     )
-    db.add(assignment)
     db.commit()
 
     submit_response = student_client.post(

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -591,7 +591,6 @@ def test_walker_finds_quizzes_attached_via_chapter_id_only(db: Session):
 def test_walker_finds_assignments_attached_via_chapter_id_only(db: Session):
     """Same regression shape for assignments — they also attach via
     ``Assignment.chapter_id`` directly without a chapter_block bridge."""
-    from app.models.assignment import Assignment
     from app.models.course import Chapter, Module
 
     course = _make_course(db, status="published")
@@ -607,12 +606,16 @@ def test_walker_finds_assignments_attached_via_chapter_id_only(db: Session):
     )
     db.add(chapter)
     db.flush()
-    assignment = Assignment(
+    # Phase 5e3: title + description live in cv. Use the helper so the
+    # cv source rows are seeded for the orchestrator to translate.
+    from ._cv_helpers import make_assignment_with_text
+
+    assignment = make_assignment_with_text(
+        db,
         chapter_id=chapter.id,
         title="Reflection",
         description="Write 500 words on the chapter.",
     )
-    db.add(assignment)
     db.commit()
 
     provider = _RecordingProvider()

--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -73,7 +73,7 @@ def test_registry_field_names_exist_on_models():
     FieldSpec but ``getattr(entity, attr, None)`` returns None, so it
     cleanly no-ops for cv-only entities.
     """
-    cv_only_entities = {"cohort", "chapter_block"}
+    cv_only_entities = {"cohort", "chapter_block", "assignment"}
     for entity_type, reg in REGISTRY.items():
         if entity_type in cv_only_entities:
             continue

--- a/backend/tests/test_translation_registry_resolvers.py
+++ b/backend/tests/test_translation_registry_resolvers.py
@@ -268,11 +268,10 @@ class TestResolveCourseViaChapter:
         assert _resolve_course_via_chapter(db, block).id == course.id
 
     def test_resolves_assignment_to_course(self, db: Session, course: Course, chapter: Chapter):
+        # Phase 5e3: title + description columns dropped.
         asgn = Assignment(
             id=uuid.uuid4(),
             chapter_id=chapter.id,
-            title="A1",
-            description="d",
             max_score=10,
         )
         db.add(asgn)

--- a/supabase/migrations/20260528040000_drop_assignments_text_columns.sql
+++ b/supabase/migrations/20260528040000_drop_assignments_text_columns.sql
@@ -1,0 +1,20 @@
+-- =====================================================================
+-- Phase 5e3 — drop ``assignments.title`` and ``assignments.description``.
+--
+-- After Phase 3 backfill, every assignment's title + description is
+-- mirrored in ``content_versions`` (entity_type='assignment',
+-- field IN ('title', 'description')) which becomes the single source
+-- of truth.
+--
+-- The read path uses ``fetch_cv_entity_texts_with_fallback`` with a
+-- three-tier locale resolution (display → source → any-locale).
+-- The write paths in ``api/v1/assignments.py`` pass an explicit
+-- ``texts={"title": ..., "description": ...}`` arg to
+-- ``dual_write_entity_content``.
+--
+-- Irreversibility: column data is gone after this migration. A
+-- pre-merge dump is the rollback artefact.
+-- =====================================================================
+
+ALTER TABLE assignments DROP COLUMN IF EXISTS title;
+ALTER TABLE assignments DROP COLUMN IF EXISTS description;


### PR DESCRIPTION
## Summary

Phase 5e3 of the bilingual rebuild — drops the legacy `assignments.title` and `assignments.description` columns. cv (`content_versions`) is now the single source of truth for assignment text.

Stacked on top of #550 (5e2 drop chapter_blocks.content). Both require the 7-day prod stability gate before manual merge.

## What changes

**Model + migration**
- `assignments.title` and `assignments.description` columns dropped (`20260528040000_drop_assignments_text_columns.sql`, applied to prod)
- `Assignment` model: both attributes removed

**Shared cv-resolver helper** (`services/content_versions/read.py`)
- New `fetch_cv_entity_texts_with_fallback(entity_type, entity_ids, fields, display_locale, source_locale)` — one indexed bulk read that resolves each `(entity, field)` pair with display → source → any-locale fallback
- Replaces the ad-hoc resolver pattern from 5e2

**Write paths** (`api/v1/assignments.py`)
- `create_assignment` / `update_assignment` extract title + description from the payload and pass them via `texts={"title": ..., "description": ...}` to `dual_write_entity_content`
- `_assignment_to_response(db, assignment, source_locale)` builds the single-entity response from cv
- `grade_submission` resolves the title from cv for the student notification message

**Read paths**
- `localize_assignment_rows` rewritten on top of the shared helper
- Calendar route bulk-fetches every assignment's cv title + description for `assignment_deadline` events (per-assignment source_locale fallback applied in Python)
- Student-progress dashboard pre-fetches assignment titles before per-student rendering

**Clone path** drops the title/description args from the new-Assignment constructor (same pattern as 5e2 chapter blocks)

**Course readiness** "assignment has brief" check pre-fetches the set of assignment ids with a non-blank cv description row at any locale, preserving whitespace-only semantics

**Tests** — new shared module `tests/_cv_helpers.py`
- `make_assignment_with_text` and `make_chapter_block_with_content` build structural row + cv source rows in one call
- Replaces repeated boilerplate across 5 test files (`test_progress_and_assignments`, `test_certificates_and_grades`, `test_course_readiness`, `test_translation_orchestrator`, `test_translation_registry_resolvers`)
- `cv_only_entities` set in the registry-attr test extended with `assignment`

## Test plan

- [x] `pytest -q` → 902 passed
- [x] `mypy` → clean
- [x] `ruff check` + `ruff format --check` → clean
- [x] Migration applied to prod via Supabase MCP
- [ ] 7-day prod stability gate (operator merges after that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
