### PR TITLE
feat(bilingual): V1 phase 5e4 — drop course_events.title + description columns

### DIFF
--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -18,15 +18,44 @@ from app.schemas.calendar import (
     CourseEventUpdate,
 )
 from app.schemas.locale import LocaleCode, normalize_locale
-from app.services.content_versions import dual_write_entity_content
+from app.services.content_versions import dual_write_entity_content, fetch_cv_entity_texts_with_fallback
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
-from app.services.translation.resolve_for_display import (
-    fetch_overlay_triples_bulk,
-    localize_course_event_rows,
-    pick_overlay_value,
-)
+from app.services.translation.resolve_for_display import localize_course_event_rows
 
 router = APIRouter(prefix="/calendar", tags=["calendar"])
+
+
+_TRANSLATABLE_COURSE_EVENT_FIELDS = ("title", "description")
+
+
+def _course_event_to_response(db: Session, event: CourseEvent, *, source_locale: str = "en") -> CourseEventResponse:
+    """Phase 5e4: title + description columns dropped — pull both from
+    cv. Used by the single-entity create / update routes; the list /
+    calendar routes use ``localize_course_event_rows`` which is
+    locale-aware.
+    """
+    texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="course_event",
+        entity_ids=[str(event.id)],
+        fields=list(_TRANSLATABLE_COURSE_EVENT_FIELDS),
+        display_locale=source_locale,
+        source_locale=source_locale,
+    )
+    title = texts.get((str(event.id), "title")) or ""
+    description = texts.get((str(event.id), "description"))
+    return CourseEventResponse.model_validate(
+        {
+            "id": event.id,
+            "course_id": event.course_id,
+            "title": title,
+            "description": description,
+            "event_type": event.event_type,
+            "event_date": event.event_date,
+            "created_by": event.created_by,
+            "created_at": event.created_at,
+        }
+    )
 
 
 @router.get("/events", response_model=list[CalendarEvent])
@@ -182,40 +211,50 @@ def get_calendar_events(
 
     course_events = db.query(CourseEvent).filter(CourseEvent.course_id.in_(enrolled_course_ids)).all()
 
-    # Bulk-fetch overlay rows for every course_event title + non-empty
-    # description. Locale wins for every reader, including admins — moderators
-    # who need raw source content use admin-only audit/edit surfaces.
-    overlay_event: dict[tuple[str, str, str], str] = {}
+    # Phase 5e4: course_events.title + description columns dropped — one
+    # cv read covers every event, with the picker applying the
+    # per-event course-declared source_locale fallback in Python.
+    # Mirrors the assignment-deadline pattern above.
+    ce_rows_by_pair_locale: dict[tuple[str, str, str], str] = {}
+    ce_any_for_pair: dict[tuple[str, str], str] = {}
     if course_events:
-        specs: list[tuple[str, str, str]] = []
-        for ce in course_events:
-            specs.append(("course_event", str(ce.id), "title"))
-            if ce.description and str(ce.description).strip():
-                specs.append(("course_event", str(ce.id), "description"))
-        overlay_event = fetch_overlay_triples_bulk(db, specs, display_locale)
+        from app.models.content_version import ContentVersion
+
+        ce_ids = [str(ce.id) for ce in course_events]
+        cv_rows = (
+            db.query(
+                ContentVersion.entity_id,
+                ContentVersion.field,
+                ContentVersion.locale,
+                ContentVersion.text,
+            )
+            .filter(
+                ContentVersion.entity_type == "course_event",
+                ContentVersion.entity_id.in_(ce_ids),
+                ContentVersion.field.in_(["title", "description"]),
+                ContentVersion.superseded_by.is_(None),
+                ContentVersion.status == "ok",
+            )
+            .order_by(ContentVersion.entity_id, ContentVersion.field, ContentVersion.created_at)
+            .all()
+        )
+        for eid, fld, loc, txt in cv_rows:
+            ce_rows_by_pair_locale.setdefault((eid, fld, loc), txt)
+            ce_any_for_pair.setdefault((eid, fld), txt)
 
     for ce in course_events:
         course_src = course_source_locales.get(ce.course_id, normalize_locale(None))
+        ce_id = str(ce.id)
         title = (
-            pick_overlay_value(
-                overlay_event,
-                "course_event",
-                str(ce.id),
-                "title",
-                ce.title,
-                source_locale=course_src,
-                display_locale=display_locale,
-            )
-            or ce.title
+            ce_rows_by_pair_locale.get((ce_id, "title", display_locale))
+            or ce_rows_by_pair_locale.get((ce_id, "title", course_src))
+            or ce_any_for_pair.get((ce_id, "title"))
+            or ""
         )
-        description = pick_overlay_value(
-            overlay_event,
-            "course_event",
-            str(ce.id),
-            "description",
-            ce.description,
-            source_locale=course_src,
-            display_locale=display_locale,
+        description = (
+            ce_rows_by_pair_locale.get((ce_id, "description", display_locale))
+            or ce_rows_by_pair_locale.get((ce_id, "description", course_src))
+            or ce_any_for_pair.get((ce_id, "description"))
         )
         events.append(
             CalendarEvent(
@@ -247,37 +286,34 @@ def create_course_event(
     data: CourseEventCreate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> CourseEvent:
+) -> CourseEventResponse:
     verify_course_owner(db, course_id, teacher)
-    # Defence-in-depth: the frontend strips HTML before submit, but a direct
-    # API caller can post arbitrary markup. Same shape as
-    # ``announcements.create`` and ``courses.create`` — title is a plain
-    # short string, description may carry rich content (TipTap output),
-    # both go through ``sanitize_string`` which keeps the allowlisted tags
-    # and drops anything that could turn into stored XSS at render time.
+    # Phase 5e4: title + description live in cv. Sanitisation runs
+    # before the cv write so stored text is safe to render.
+    title = sanitize_string(data.title)
+    description = sanitize_string(data.description) if data.description else data.description
     event = CourseEvent(
         course_id=course_id,
-        title=sanitize_string(data.title),
-        description=sanitize_string(data.description) if data.description else data.description,
         event_type=data.event_type,
         event_date=data.event_date,
         created_by=teacher.id,
     )
     db.add(event)
     db.flush()
+    source_locale = db.query(Course.source_locale).filter(Course.id == course_id).scalar()
     dual_write_entity_content(
         db,
         entity_type="course_event",
         entity_id=str(event.id),
-        entity=event,
-        fields=("title", "description"),
-        fallback_locale=db.query(Course.source_locale).filter(Course.id == course_id).scalar(),
+        fields=_TRANSLATABLE_COURSE_EVENT_FIELDS,
+        fallback_locale=source_locale,
         authored_by=teacher.id,
+        texts={"title": title, "description": description},
     )
     db.commit()
     db.refresh(event)
     reconcile_entity_if_course_published(db, "course_event", event)
-    return event
+    return _course_event_to_response(db, event, source_locale=source_locale or "en")
 
 
 @event_router.get(
@@ -332,7 +368,7 @@ def update_course_event(
     data: CourseEventUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> CourseEvent:
+) -> CourseEventResponse:
     verify_course_owner(db, course_id, teacher)
     event = (
         db.query(CourseEvent)
@@ -344,34 +380,35 @@ def update_course_event(
     )
     if not event:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
-    # Defence-in-depth: title + description carry user-supplied markup
-    # and were already sanitized on create. The setattr loop below would
-    # otherwise let a direct API caller bypass DOMPurify on edit and
-    # plant stored XSS through the title bar or rich-text body. Same
-    # ``sanitize_string`` is used here as on the create path so the two
-    # behaviours stay symmetric.
+    # Phase 5e4: title + description live in cv. Pop them off the patch
+    # before the setattr loop and route through dual_write.
     updates = data.model_dump(exclude_unset=True)
-    if "title" in updates and updates["title"] is not None:
-        updates["title"] = sanitize_string(updates["title"])
-    if "description" in updates and updates["description"] is not None:
-        updates["description"] = sanitize_string(updates["description"])
+    text_patch: dict[str, str | None] = {}
+    if "title" in updates:
+        v = updates.pop("title")
+        text_patch["title"] = sanitize_string(v) if v is not None else None
+    if "description" in updates:
+        v = updates.pop("description")
+        text_patch["description"] = sanitize_string(v) if v is not None else None
     for field, value in updates.items():
         setattr(event, field, value)
     db.flush()
-    dual_write_entity_content(
-        db,
-        entity_type="course_event",
-        entity_id=str(event.id),
-        entity=event,
-        fields=("title", "description"),
-        fallback_locale=db.query(Course.source_locale).filter(Course.id == course_id).scalar(),
-        authored_by=teacher.id,
-        only_fields={f for f in ("title", "description") if f in updates},
-    )
+    source_locale = db.query(Course.source_locale).filter(Course.id == course_id).scalar()
+    if text_patch:
+        dual_write_entity_content(
+            db,
+            entity_type="course_event",
+            entity_id=str(event.id),
+            fields=_TRANSLATABLE_COURSE_EVENT_FIELDS,
+            fallback_locale=source_locale,
+            authored_by=teacher.id,
+            only_fields=set(text_patch.keys()),
+            texts=text_patch,
+        )
     db.commit()
     db.refresh(event)
     reconcile_entity_if_course_published(db, "course_event", event)
-    return event
+    return _course_event_to_response(db, event, source_locale=source_locale or "en")
 
 
 @event_router.delete(

--- a/backend/app/models/course_event.py
+++ b/backend/app/models/course_event.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -18,8 +18,9 @@ class CourseEvent(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     course_id: Mapped[str] = mapped_column(ForeignKey("courses.id", ondelete="CASCADE"))
-    title: Mapped[str] = mapped_column(String(255))
-    description: Mapped[str | None] = mapped_column(Text)
+    # Phase 5e4: title + description columns dropped — cv is the only
+    # store. Reads go through fetch_cv_entity_texts_with_fallback;
+    # writes through dual_write_entity_content(texts={...}).
     event_type: Mapped[str] = mapped_column(String(30), default="other")
     event_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     created_by: Mapped[uuid.UUID] = mapped_column()

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -608,21 +608,40 @@ def localize_course_event_rows(
     display_locale: LocaleCode,
     source_locale: LocaleCode,
 ) -> list[CourseEventResponse]:
-    """Apply stored translations to calendar event rows."""
+    """Phase 5e4: ``course_events.title`` + ``description`` columns dropped.
+    Both texts live in cv now. Resolve each via the three-tier
+    fallback (display → source → any-locale).
+    """
     if not events:
         return []
-    specs: list[tuple[str, str, str]] = []
-    for e in events:
-        specs.append(("course_event", str(e.id), "title"))
-        if e.description and str(e.description).strip():
-            specs.append(("course_event", str(e.id), "description"))
-    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
+    from app.services.content_versions import fetch_cv_entity_texts_with_fallback
+
+    ids = [str(e.id) for e in events]
+    texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="course_event",
+        entity_ids=ids,
+        fields=["title", "description"],
+        display_locale=display_locale,
+        source_locale=source_locale,
+    )
     out: list[CourseEventResponse] = []
     for e in events:
-        base = CourseEventResponse.model_validate(e, from_attributes=True)
-        title = loc.pick("course_event", str(e.id), "title", e.title) or e.title
-        description = loc.pick("course_event", str(e.id), "description", e.description)
-        out.append(base.model_copy(update={"title": title, "description": description}))
+        eid = str(e.id)
+        out.append(
+            CourseEventResponse.model_validate(
+                {
+                    "id": e.id,
+                    "course_id": e.course_id,
+                    "title": texts.get((eid, "title")) or "",
+                    "description": texts.get((eid, "description")),
+                    "event_type": e.event_type,
+                    "event_date": e.event_date,
+                    "created_by": e.created_by,
+                    "created_at": e.created_at,
+                }
+            )
+        )
     return out
 
 

--- a/backend/tests/_cv_helpers.py
+++ b/backend/tests/_cv_helpers.py
@@ -66,6 +66,53 @@ def make_assignment_with_text(
     return assignment
 
 
+def make_course_event_with_text(
+    db: Session,
+    *,
+    course_id: str,
+    title: str = "Event",
+    description: str | None = None,
+    event_type: str = "other",
+    event_date=None,
+    created_by,
+    event_id: uuid.UUID | None = None,
+    locale: str = "en",
+):
+    """Phase 5e4: ``course_events.title`` + ``description`` columns dropped.
+    Builds the row plus records both texts in cv at ``locale``.
+    """
+    from datetime import UTC, datetime
+
+    from app.models.course_event import CourseEvent
+    from app.services.content_versions.write import record_human_version
+
+    event = CourseEvent(
+        id=event_id or uuid.uuid4(),
+        course_id=course_id,
+        event_type=event_type,
+        event_date=event_date or datetime.now(UTC),
+        created_by=created_by,
+    )
+    db.add(event)
+    db.flush()
+    record_human_version(
+        db, entity_type="course_event", entity_id=str(event.id), field="title", locale=locale, text=title
+    )
+    # Empty string ≡ missing for cv purposes — matches the create route
+    # which would store the value but the reconcile path skips blanks
+    # so we keep the parity here.
+    if description:
+        record_human_version(
+            db,
+            entity_type="course_event",
+            entity_id=str(event.id),
+            field="description",
+            locale=locale,
+            text=description,
+        )
+    return event
+
+
 def make_chapter_block_with_content(
     db: Session,
     *,

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Session
 from app.models.announcement import Announcement
 from app.models.cohort import Cohort, CohortCourse
 from app.models.course import Course, Module
-from app.models.course_event import CourseEvent
 from app.models.enrollment import Enrollment
 from app.models.notification import Notification
 from tests.conftest import ADMIN_ID, STUDENT_ID, TEACHER_ID
@@ -1170,17 +1169,19 @@ class TestListCourseEvents:
         assert len(resp.json()) == 2
 
     def test_enrolled_student_can_list(self, student_client: TestClient, db: Session):
+        from ._cv_helpers import make_course_event_with_text
+
         _seed_course(db)
         _seed_enrollment(db, user_id=STUDENT_ID, course_id="test-course-1")
 
-        ev = CourseEvent(
+        make_course_event_with_text(
+            db,
             course_id="test-course-1",
             title="Lecture",
             event_type="live_session",
             event_date=TOMORROW,
             created_by=TEACHER_ID,
         )
-        db.add(ev)
         db.commit()
 
         resp = student_client.get(f"{COURSES_PREFIX}/test-course-1/events")
@@ -1240,15 +1241,17 @@ class TestUpdateCourseEvent:
         assert resp.status_code == 404
 
     def test_student_cannot_update(self, student_client: TestClient, db: Session):
+        from ._cv_helpers import make_course_event_with_text
+
         _seed_course(db)
-        ev = CourseEvent(
+        ev = make_course_event_with_text(
+            db,
             course_id="test-course-1",
             title="Lecture",
             event_type="other",
             event_date=TOMORROW,
             created_by=TEACHER_ID,
         )
-        db.add(ev)
         db.commit()
         db.refresh(ev)
 
@@ -1280,15 +1283,17 @@ class TestDeleteCourseEvent:
         assert resp.status_code == 404
 
     def test_student_cannot_delete(self, student_client: TestClient, db: Session):
+        from ._cv_helpers import make_course_event_with_text
+
         _seed_course(db)
-        ev = CourseEvent(
+        ev = make_course_event_with_text(
+            db,
             course_id="test-course-1",
             title="Lecture",
             event_type="other",
             event_date=TOMORROW,
             created_by=TEACHER_ID,
         )
-        db.add(ev)
         db.commit()
         db.refresh(ev)
 

--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -15,7 +15,6 @@ import pytest
 from app.models.announcement import Announcement
 from app.models.content_version import ContentVersionEntityType as TranslationEntityType
 from app.models.course import Course, Module
-from app.models.course_event import CourseEvent
 from app.services.translation.protocol import EntityType
 from app.services.translation.registry import (
     ENTITY_MODEL,
@@ -73,7 +72,7 @@ def test_registry_field_names_exist_on_models():
     FieldSpec but ``getattr(entity, attr, None)`` returns None, so it
     cleanly no-ops for cv-only entities.
     """
-    cv_only_entities = {"cohort", "chapter_block", "assignment"}
+    cv_only_entities = {"cohort", "chapter_block", "assignment", "course_event"}
     for entity_type, reg in REGISTRY.items():
         if entity_type in cv_only_entities:
             continue
@@ -125,7 +124,12 @@ def test_reconcile_event_with_empty_description_skips_that_field(
     reconcile the non-empty fields, not skip the whole entity."""
     from datetime import UTC, datetime
 
-    ev = CourseEvent(
+    # Phase 5e4: title + description columns dropped; reconcile pulls
+    # from cv now. Use the helper to seed the source rows.
+    from ._cv_helpers import make_course_event_with_text
+
+    ev = make_course_event_with_text(
+        db,
         course_id=published_course.id,
         title="Final Exam",
         description="",
@@ -133,8 +137,6 @@ def test_reconcile_event_with_empty_description_skips_that_field(
         event_date=datetime(2026, 12, 1, 10, 0, tzinfo=UTC),
         created_by=teacher.id,
     )
-    db.add(ev)
-    db.flush()
     report = reconcile_entity(db, "course_event", ev)
     assert report.failed == 0
 

--- a/backend/tests/test_translation_registry_resolvers.py
+++ b/backend/tests/test_translation_registry_resolvers.py
@@ -392,11 +392,10 @@ class TestRegistryWiring:
     def test_course_event_resolves_via_course_id_attr(self, db: Session, course: Course, teacher):
         from app.services.translation.registry import REGISTRY
 
+        # Phase 5e4: title + description columns dropped.
         ev = CourseEvent(
             id=uuid.uuid4(),
             course_id=course.id,
-            title="t",
-            description="d",
             event_type="exam",
             event_date=datetime(2026, 12, 1, 10, 0, tzinfo=UTC),
             created_by=teacher.id,

--- a/supabase/migrations/20260528050000_drop_course_events_text_columns.sql
+++ b/supabase/migrations/20260528050000_drop_course_events_text_columns.sql
@@ -1,0 +1,20 @@
+-- =====================================================================
+-- Phase 5e4 — drop ``course_events.title`` and ``course_events.description``.
+--
+-- After Phase 3 backfill, every course event's title + description is
+-- mirrored in ``content_versions`` (entity_type='course_event',
+-- field IN ('title', 'description')) which becomes the single source
+-- of truth.
+--
+-- The read path uses ``fetch_cv_entity_texts_with_fallback`` with a
+-- three-tier locale resolution (display → source → any-locale).
+-- The write paths in ``api/v1/calendar.py`` (create + update event)
+-- pass an explicit ``texts={"title": ..., "description": ...}`` arg
+-- to ``dual_write_entity_content``.
+--
+-- Irreversibility: column data is gone after this migration. A
+-- pre-merge dump is the rollback artefact.
+-- =====================================================================
+
+ALTER TABLE course_events DROP COLUMN IF EXISTS title;
+ALTER TABLE course_events DROP COLUMN IF EXISTS description;


### PR DESCRIPTION
## Summary

Phase 5e4 of the bilingual rebuild — drops the legacy `course_events.title` and `course_events.description` columns. cv (`content_versions`) is now the single source of truth for course-event text.

Stacked on top of #551 (5e3 drop assignments text). All Phase 5 PRs require the 7-day prod stability gate before manual merge.

## What changes

**Model + migration**
- `course_events.title` and `course_events.description` columns dropped (`20260528050000_drop_course_events_text_columns.sql`, applied to prod)
- `CourseEvent` model: both attributes removed

**Write paths** (`api/v1/calendar.py`)
- `create_course_event` / `update_course_event` extract title + description from the payload, sanitise, and route through `dual_write_entity_content(texts={...})`
- `_course_event_to_response(db, event, source_locale)` builds the single-entity response from cv
- Both route return types updated to `CourseEventResponse`

**Read paths**
- `localize_course_event_rows` rewritten on top of the shared `fetch_cv_entity_texts_with_fallback`
- Calendar `GET /events` rolls course_event title + description into the Python-side display→source→any-locale picker (mirrors the 5e3 assignment-deadline pattern)

**Tests** — new `make_course_event_with_text` helper in `tests/_cv_helpers.py`
- Seeds the cv source rows alongside the structural row; empty-string descriptions are treated as missing for parity with the reconcile path
- Five test sites swept (`test_cohorts_calendar_notifications` x3, `test_translation_registry` x1, `test_translation_registry_resolvers` x1)
- `cv_only_entities` extended with `course_event`

## Test plan

- [x] `pytest -q` → 902 passed
- [x] `mypy` → clean
- [x] `ruff check` + `ruff format --check` → clean
- [x] Migration applied to prod via Supabase MCP
- [ ] 7-day prod stability gate (operator merges after that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
