### PR TITLE
feat(bilingual): V1 phase 5e5 — drop announcements.title + content columns

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -22,7 +22,7 @@ from app.schemas.announcement import (
     AnnouncementUpdate,
 )
 from app.schemas.locale import LocaleCode, normalize_locale
-from app.services.content_versions import dual_write_entity_content
+from app.services.content_versions import dual_write_entity_content, fetch_cv_entity_texts_with_fallback
 from app.services.notification_service import create_notifications_bulk
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
 from app.services.translation.resolve_for_display import localize_announcement_rows
@@ -39,9 +39,13 @@ def _dual_write_announcement(
     *,
     teacher: User,
     course: Course | None,
+    texts: dict[str, str | None],
     only_fields: set[str] | None = None,
 ) -> None:
     """Dual-write an announcement's title + content to content_versions.
+
+    Phase 5e5: title + content columns dropped — both texts live in cv
+    and arrive via the explicit ``texts`` dict.
 
     Course-scoped announcements use the course's source_locale as the
     detector fallback. Global announcements (no course context) fall
@@ -54,11 +58,39 @@ def _dual_write_announcement(
         db,
         entity_type="announcement",
         entity_id=str(announcement.id),
-        entity=announcement,
         fields=_TRANSLATABLE_ANNOUNCEMENT_FIELDS,
         fallback_locale=fallback,
         authored_by=teacher.id,
         only_fields=only_fields,
+        texts=texts,
+    )
+
+
+def _announcement_to_response(
+    db: Session, announcement: Announcement, *, source_locale: str = "en"
+) -> AnnouncementResponse:
+    """Phase 5e5: title + content columns dropped — pull both from cv.
+    Used by the single-entity routes (create / update); the list route
+    uses ``localize_announcement_rows`` which is locale-aware.
+    """
+    texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="announcement",
+        entity_ids=[str(announcement.id)],
+        fields=list(_TRANSLATABLE_ANNOUNCEMENT_FIELDS),
+        display_locale=source_locale,
+        source_locale=source_locale,
+    )
+    return AnnouncementResponse.model_validate(
+        {
+            "id": announcement.id,
+            "title": texts.get((str(announcement.id), "title")) or "",
+            "content": texts.get((str(announcement.id), "content")) or "",
+            "course_id": announcement.course_id,
+            "created_by": announcement.created_by,
+            "created_at": announcement.created_at,
+            "updated_at": announcement.updated_at,
+        }
     )
 
 
@@ -164,7 +196,7 @@ def create_announcement(
     data: AnnouncementCreate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> Announcement:
+) -> AnnouncementResponse:
     """Two flavors, picked by ``data.course_id``:
 
     - **Course-scoped** (``course_id`` set): only the course owner can
@@ -219,8 +251,6 @@ def create_announcement(
     safe_content = sanitize_string(data.content)
     announcement = Announcement(
         id=uuid.uuid4(),
-        title=safe_title,
-        content=safe_content,
         course_id=data.course_id,
         created_by=teacher.id,
     )
@@ -251,13 +281,16 @@ def create_announcement(
     # they have no course context. The detector still runs per-field
     # on the actual text so a Russian-authored announcement from an
     # English-UI admin lands in 'ru'.
-    _dual_write_announcement(db, announcement, teacher=teacher, course=course)
+    _dual_write_announcement(
+        db, announcement, teacher=teacher, course=course, texts={"title": safe_title, "content": safe_content}
+    )
 
     db.commit()
     db.refresh(announcement)
     if data.course_id:
         reconcile_entity_if_course_published(db, "announcement", announcement)
-    return announcement
+    fallback = course.source_locale if course is not None else (teacher.preferred_locale or "en")
+    return _announcement_to_response(db, announcement, source_locale=fallback)
 
 
 @router.put("/{announcement_id}", response_model=AnnouncementResponse)
@@ -266,7 +299,7 @@ def update_announcement(
     data: AnnouncementUpdate,
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
-) -> Announcement:
+) -> AnnouncementResponse:
     announcement = db.query(Announcement).filter(Announcement.id == announcement_id).first()
     if not announcement:
         raise HTTPException(
@@ -279,23 +312,30 @@ def update_announcement(
             detail="You can only edit your own announcements",
         )
 
-    touched: set[str] = set()
+    text_patch: dict[str, str | None] = {}
     if data.title is not None:
-        announcement.title = sanitize_string(data.title)
-        touched.add("title")
+        text_patch["title"] = sanitize_string(data.title)
     if data.content is not None:
-        announcement.content = sanitize_string(data.content)
-        touched.add("content")
+        text_patch["content"] = sanitize_string(data.content)
 
     course = db.query(Course).filter(Course.id == announcement.course_id).first() if announcement.course_id else None
     db.flush()
-    _dual_write_announcement(db, announcement, teacher=teacher, course=course, only_fields=touched)
+    if text_patch:
+        _dual_write_announcement(
+            db,
+            announcement,
+            teacher=teacher,
+            course=course,
+            only_fields=set(text_patch.keys()),
+            texts=text_patch,
+        )
 
     db.commit()
     db.refresh(announcement)
     if announcement.course_id:
         reconcile_entity_if_course_published(db, "announcement", announcement)
-    return announcement
+    fallback = course.source_locale if course is not None else (teacher.preferred_locale or "en")
+    return _announcement_to_response(db, announcement, source_locale=fallback)
 
 
 @router.delete("/{announcement_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/models/announcement.py
+++ b/backend/app/models/announcement.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -15,8 +15,7 @@ class Announcement(Base):
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    title: Mapped[str] = mapped_column(String(255))
-    content: Mapped[str] = mapped_column(Text)
+    # Phase 5e5: title + content columns dropped — cv is the only store.
     course_id: Mapped[str | None] = mapped_column(ForeignKey("courses.id", ondelete="CASCADE"))
     created_by: Mapped[uuid.UUID] = mapped_column()
     created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
@@ -25,4 +24,4 @@ class Announcement(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<Announcement id={self.id} title='{self.title}'>"
+        return f"<Announcement id={self.id}>"

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -583,21 +583,39 @@ def localize_announcement_rows(
     display_locale: LocaleCode,
     source_locale: LocaleCode,
 ) -> list[AnnouncementResponse]:
-    """Apply stored translations to teacher-authored announcement rows."""
+    """Phase 5e5: ``announcements.title`` + ``content`` columns dropped.
+    Both texts live in cv now. Resolve each via the three-tier fallback
+    (display → source → any-locale).
+    """
     if not announcements:
         return []
-    specs: list[tuple[str, str, str]] = []
-    for a in announcements:
-        specs.append(("announcement", str(a.id), "title"))
-        if a.content and str(a.content).strip():
-            specs.append(("announcement", str(a.id), "content"))
-    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
+    from app.services.content_versions import fetch_cv_entity_texts_with_fallback
+
+    ids = [str(a.id) for a in announcements]
+    texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="announcement",
+        entity_ids=ids,
+        fields=["title", "content"],
+        display_locale=display_locale,
+        source_locale=source_locale,
+    )
     out: list[AnnouncementResponse] = []
     for a in announcements:
-        base = AnnouncementResponse.model_validate(a, from_attributes=True)
-        title = loc.pick("announcement", str(a.id), "title", a.title) or a.title
-        content = loc.pick("announcement", str(a.id), "content", a.content) or a.content
-        out.append(base.model_copy(update={"title": title, "content": content}))
+        aid = str(a.id)
+        out.append(
+            AnnouncementResponse.model_validate(
+                {
+                    "id": a.id,
+                    "title": texts.get((aid, "title")) or "",
+                    "content": texts.get((aid, "content")) or "",
+                    "course_id": a.course_id,
+                    "created_by": a.created_by,
+                    "created_at": a.created_at,
+                    "updated_at": a.updated_at,
+                }
+            )
+        )
     return out
 
 

--- a/backend/tests/_cv_helpers.py
+++ b/backend/tests/_cv_helpers.py
@@ -113,6 +113,39 @@ def make_course_event_with_text(
     return event
 
 
+def make_announcement_with_text(
+    db: Session,
+    *,
+    title: str = "Announcement",
+    content: str = "Body",
+    course_id: str | None = None,
+    created_by,
+    announcement_id: uuid.UUID | None = None,
+    locale: str = "en",
+):
+    """Phase 5e5: ``announcements.title`` + ``content`` columns dropped.
+    Builds the row plus records both texts in cv at ``locale``.
+    """
+    from app.models.announcement import Announcement
+    from app.services.content_versions.write import record_human_version
+
+    ann = Announcement(
+        id=announcement_id or uuid.uuid4(),
+        course_id=course_id,
+        created_by=created_by,
+    )
+    db.add(ann)
+    db.flush()
+    record_human_version(
+        db, entity_type="announcement", entity_id=str(ann.id), field="title", locale=locale, text=title
+    )
+    if content:
+        record_human_version(
+            db, entity_type="announcement", entity_id=str(ann.id), field="content", locale=locale, text=content
+        )
+    return ann
+
+
 def make_chapter_block_with_content(
     db: Session,
     *,

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -8,7 +8,6 @@ import sqlalchemy.types as _sa_types
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.models.announcement import Announcement
 from app.models.cohort import Cohort, CohortCourse
 from app.models.course import Course, Module
 from app.models.enrollment import Enrollment
@@ -1658,13 +1657,9 @@ class TestUpdateAnnouncement:
         assert resp.status_code == 404
 
     def test_student_cannot_update(self, student_client: TestClient, db: Session):
-        ann = Announcement(
-            id=uuid.uuid4(),
-            title="Teacher Ann",
-            content="Some content",
-            created_by=TEACHER_ID,
-        )
-        db.add(ann)
+        from ._cv_helpers import make_announcement_with_text
+
+        ann = make_announcement_with_text(db, title="Teacher Ann", content="Some content", created_by=TEACHER_ID)
         db.commit()
         db.refresh(ann)
 
@@ -1697,13 +1692,9 @@ class TestDeleteAnnouncement:
         assert resp.status_code == 404
 
     def test_student_cannot_delete(self, student_client: TestClient, db: Session):
-        ann = Announcement(
-            id=uuid.uuid4(),
-            title="Teacher Ann",
-            content="Some content",
-            created_by=TEACHER_ID,
-        )
-        db.add(ann)
+        from ._cv_helpers import make_announcement_with_text
+
+        ann = make_announcement_with_text(db, title="Teacher Ann", content="Some content", created_by=TEACHER_ID)
         db.commit()
         db.refresh(ann)
 
@@ -1723,13 +1714,11 @@ class TestDeleteAnnouncement:
         db.add(other)
         db.commit()
 
-        ann = Announcement(
-            id=uuid.uuid4(),
-            title="Other's Announcement",
-            content="Other content",
-            created_by=other_teacher_id,
+        from ._cv_helpers import make_announcement_with_text
+
+        ann = make_announcement_with_text(
+            db, title="Other's Announcement", content="Other content", created_by=other_teacher_id
         )
-        db.add(ann)
         db.commit()
         db.refresh(ann)
 

--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from app.models.announcement import Announcement
 from app.models.content_version import ContentVersionEntityType as TranslationEntityType
 from app.models.course import Course, Module
 from app.services.translation.protocol import EntityType
@@ -72,7 +71,7 @@ def test_registry_field_names_exist_on_models():
     FieldSpec but ``getattr(entity, attr, None)`` returns None, so it
     cleanly no-ops for cv-only entities.
     """
-    cv_only_entities = {"cohort", "chapter_block", "assignment", "course_event"}
+    cv_only_entities = {"cohort", "chapter_block", "assignment", "course_event", "announcement"}
     for entity_type, reg in REGISTRY.items():
         if entity_type in cv_only_entities:
             continue
@@ -108,9 +107,10 @@ def published_course(db: Session, teacher) -> Course:
 def test_reconcile_orphan_announcement_is_noop(db: Session, teacher):
     """An announcement with no ``course_id`` has no source locale to
     translate from. Should silently no-op, not raise."""
-    ann = Announcement(title="Orphan", content="No course", course_id=None, created_by=teacher.id)
-    db.add(ann)
-    db.flush()
+    # Phase 5e5: title + content columns dropped; use the helper.
+    from ._cv_helpers import make_announcement_with_text
+
+    ann = make_announcement_with_text(db, title="Orphan", content="No course", course_id=None, created_by=teacher.id)
     report = reconcile_entity(db, "announcement", ann)
     assert (report.translated, report.skipped, report.failed) == (0, 0, 0)
 

--- a/backend/tests/test_translation_registry_resolvers.py
+++ b/backend/tests/test_translation_registry_resolvers.py
@@ -204,7 +204,8 @@ class TestResolveCourseViaAttr:
         resolver = _resolve_course_via_attr("course_id")
         # Announcement without course_id is the canonical "orphan" — the
         # comment on the resolver explicitly says this returns None.
-        orphan = Announcement(title="Orphan", content="x", course_id=None, created_by=TEACHER_ID)
+        # Phase 5e5: title + content columns dropped.
+        orphan = Announcement(course_id=None, created_by=TEACHER_ID)
         db.add(orphan)
         db.flush()
         assert resolver(db, orphan) is None
@@ -376,10 +377,9 @@ class TestRegistryWiring:
     def test_announcement_resolves_via_course_id_attr(self, db: Session, course: Course, teacher):
         from app.services.translation.registry import REGISTRY
 
+        # Phase 5e5: title + content columns dropped.
         ann = Announcement(
             id=uuid.uuid4(),
-            title="t",
-            content="c",
             course_id=course.id,
             created_by=teacher.id,
         )

--- a/supabase/migrations/20260528060000_drop_announcements_text_columns.sql
+++ b/supabase/migrations/20260528060000_drop_announcements_text_columns.sql
@@ -1,0 +1,20 @@
+-- =====================================================================
+-- Phase 5e5 — drop ``announcements.title`` and ``announcements.content``.
+--
+-- After Phase 3 backfill, every announcement's title + content is
+-- mirrored in ``content_versions`` (entity_type='announcement',
+-- field IN ('title', 'content')) which becomes the single source of
+-- truth.
+--
+-- The read path uses ``fetch_cv_entity_texts_with_fallback`` with a
+-- three-tier locale resolution (display → source → any-locale).
+-- The write paths in ``api/v1/announcements.py`` pass an explicit
+-- ``texts={"title": ..., "content": ...}`` arg to
+-- ``dual_write_entity_content``.
+--
+-- Irreversibility: column data is gone after this migration. A
+-- pre-merge dump is the rollback artefact.
+-- =====================================================================
+
+ALTER TABLE announcements DROP COLUMN IF EXISTS title;
+ALTER TABLE announcements DROP COLUMN IF EXISTS content;


### PR DESCRIPTION
## Summary

Phase 5e5 of the bilingual rebuild — drops the legacy `announcements.title` and `announcements.content` columns. cv (`content_versions`) is now the single source of truth for announcement text.

**Last leaf-entity column drop in the 5e series.** After this PR's 7-day stability gate plus its predecessors (#549, #550, #551, #552), the leaf cleanup is complete and 5f (quiz tree) can begin.

Stacked on top of #552 (5e4 drop course_events text).

## What changes

**Model + migration**
- `announcements.title` and `announcements.content` columns dropped (`20260528060000_drop_announcements_text_columns.sql`, applied to prod)
- `Announcement` model: both attributes removed; `__repr__` updated

**Write paths** (`api/v1/announcements.py`)
- `_dual_write_announcement` now requires an explicit `texts={...}` arg (no more `entity=getattr`)
- `create_announcement` and `update_announcement` sanitise their inputs, build the structural row, and route texts through that helper
- Both routes return `_announcement_to_response(db, announcement, source_locale=fallback)` which materialises the response from cv at the fallback source_locale (course's locale, or author's `preferred_locale` for global announcements)

**Read path** (`localize_announcement_rows`) rewritten on top of the shared `fetch_cv_entity_texts_with_fallback`. The list route's per-source-locale grouping stays intact — it just feeds cv-only buckets through the helper instead of doing entity-getattr fallback.

**Tests** — new `make_announcement_with_text` helper in `tests/_cv_helpers.py`
- Seeds cv source rows alongside the structural row
- Five test sites swept (`test_cohorts_calendar_notifications` x3, `test_translation_registry` x1, `test_translation_registry_resolvers` x2)
- `cv_only_entities` extended with `announcement`

## Test plan

- [x] `pytest -q` → 902 passed
- [x] `mypy` → clean
- [x] `ruff check` + `ruff format --check` → clean
- [x] Migration applied to prod via Supabase MCP
- [ ] 7-day prod stability gate (operator merges after that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
