### PR TITLE
feat(bilingual): V1 phase 5f — drop quiz tree text columns

### DIFF
--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -33,6 +33,7 @@ from app.services.translation.pipeline_hooks import (
 )
 from app.services.translation.resolve_for_display import (
     build_localized_quiz_student_response,
+    build_quiz_response_from_cv,
     resolve_chapter_locale_context,
 )
 
@@ -86,8 +87,7 @@ def get_chapter_quiz(
         return None
 
     # One chapter→module→course join covers the locale + access decisions
-    # below. Previously source=true paid 1 round-trip and source=false
-    # paid 2, all to the same join.
+    # below.
     ctx = resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=current_user)
     if source:
         if not ctx.is_owner_or_admin:
@@ -95,15 +95,17 @@ def get_chapter_quiz(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only the course owner or an admin can request source-language content",
             )
-        resp = QuizStudentResponse.model_validate(quiz)
+        # Phase 5f: title / question_text / option_text columns dropped.
+        # The student response is the same shape source==display surfaces,
+        # so re-use the localize path with display=source.
+        resp = build_localized_quiz_student_response(
+            db, quiz, display_locale=ctx.source_locale, source_locale=ctx.source_locale
+        )
     else:
         display_locale: LocaleCode = normalize_locale(accept_language)
-        if ctx.apply_overlay:
-            resp = build_localized_quiz_student_response(
-                db, quiz, display_locale=display_locale, source_locale=ctx.source_locale
-            )
-        else:
-            resp = QuizStudentResponse.model_validate(quiz)
+        resp = build_localized_quiz_student_response(
+            db, quiz, display_locale=display_locale, source_locale=ctx.source_locale
+        )
     if resp.max_attempts is not None:
         extra = (
             db.query(QuizExtraAttempt)
@@ -133,7 +135,10 @@ def get_quiz_detail(
     if not quiz:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
     verify_quiz_owner(db, quiz, teacher.id)
-    return quiz
+    # Phase 5f: text columns dropped — build response from cv.
+    return build_quiz_response_from_cv(
+        db, quiz, source_locale=normalize_locale(_course_source_locale_for_chapter(db, quiz.chapter_id))
+    )
 
 
 @router.post("", response_model=QuizResponse, status_code=status.HTTP_201_CREATED)
@@ -148,77 +153,69 @@ def create_quiz(
         max_attempts = 1
 
     quiz_id_val = uuid.uuid4()
+    # Phase 5f: title + description live in cv; only structural fields on the row.
     quiz = Quiz(
         id=quiz_id_val,
         chapter_id=data.chapter_id,
-        title=data.title,
-        description=data.description,
         quiz_type=data.quiz_type,
         max_attempts=max_attempts,
         passing_score=data.passing_score,
     )
     db.add(quiz)
 
-    questions_to_dual_write: list[tuple[QuizQuestion, list[QuizOption]]] = []
+    questions_with_options: list[tuple[QuizQuestion, str, list[tuple[QuizOption, str]]]] = []
     for q_data in data.questions:
         question_id = uuid.uuid4()
         question = QuizQuestion(
             id=question_id,
             quiz_id=quiz_id_val,
-            question_text=q_data.question_text,
             question_type=q_data.question_type,
             order_index=q_data.order_index,
             points=q_data.points,
-            # ``min_words`` is only meaningful for ``essay``; it's
-            # intentionally persisted as-is for every type so that
-            # switching a question to ``essay`` later keeps the hint.
             min_words=q_data.min_words,
         )
         db.add(question)
-        question_options: list[QuizOption] = []
+        question_options: list[tuple[QuizOption, str]] = []
         for o_data in q_data.options:
             opt = QuizOption(
                 question_id=question_id,
-                option_text=o_data.option_text,
                 is_correct=o_data.is_correct,
                 order_index=o_data.order_index,
             )
             db.add(opt)
-            question_options.append(opt)
-        questions_to_dual_write.append((question, question_options))
+            question_options.append((opt, o_data.option_text))
+        questions_with_options.append((question, q_data.question_text, question_options))
 
-    # Flush so child ids (options have server-side defaults) are
-    # populated before dual-write reads them.
     db.flush()
     fallback_locale = _course_source_locale_for_chapter(db, data.chapter_id)
     dual_write_entity_content(
         db,
         entity_type="quiz",
         entity_id=str(quiz.id),
-        entity=quiz,
         fields=_TRANSLATABLE_QUIZ_FIELDS,
         fallback_locale=fallback_locale,
         authored_by=teacher.id,
+        texts={"title": data.title, "description": data.description},
     )
-    for question, options in questions_to_dual_write:
+    for question, q_text, options in questions_with_options:
         dual_write_entity_content(
             db,
             entity_type="quiz_question",
             entity_id=str(question.id),
-            entity=question,
             fields=_TRANSLATABLE_QUESTION_FIELDS,
             fallback_locale=fallback_locale,
             authored_by=teacher.id,
+            texts={"question_text": q_text},
         )
-        for opt in options:
+        for opt, o_text in options:
             dual_write_entity_content(
                 db,
                 entity_type="quiz_option",
                 entity_id=str(opt.id),
-                entity=opt,
                 fields=_TRANSLATABLE_OPTION_FIELDS,
                 fallback_locale=fallback_locale,
                 authored_by=teacher.id,
+                texts={"option_text": o_text},
             )
     db.commit()
     reloaded = (
@@ -229,11 +226,8 @@ def create_quiz(
     )
     if reloaded is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
-    # Create flow seeds the quiz + every question + every option in one go.
-    # Full-tree pipeline is cheaper here than N+1 per-entity reconcile calls
-    # because the course gets loaded once and every child re-walks once.
     run_course_translation_pipeline_if_published(db, course_id)
-    return reloaded
+    return build_quiz_response_from_cv(db, reloaded, source_locale=normalize_locale(fallback_locale))
 
 
 @router.put("/{quiz_id}", response_model=QuizResponse)
@@ -249,6 +243,13 @@ def update_quiz(
     verify_quiz_owner(db, quiz, teacher.id)
 
     patch = data.model_dump(exclude_unset=True)
+    # Phase 5f: title + description live in cv. Pop them off the patch
+    # so they don't try to setattr on the (now-text-less) ORM row.
+    text_patch: dict[str, str | None] = {}
+    if "title" in patch:
+        text_patch["title"] = patch.pop("title")
+    if "description" in patch:
+        text_patch["description"] = patch.pop("description")
     for field, value in patch.items():
         setattr(quiz, field, value)
 
@@ -256,16 +257,18 @@ def update_quiz(
         quiz.max_attempts = 1
 
     db.flush()
-    dual_write_entity_content(
-        db,
-        entity_type="quiz",
-        entity_id=str(quiz.id),
-        entity=quiz,
-        fields=_TRANSLATABLE_QUIZ_FIELDS,
-        fallback_locale=_course_source_locale_for_chapter(db, quiz.chapter_id),
-        authored_by=teacher.id,
-        only_fields={f for f in _TRANSLATABLE_QUIZ_FIELDS if f in patch},
-    )
+    source_locale = _course_source_locale_for_chapter(db, quiz.chapter_id)
+    if text_patch:
+        dual_write_entity_content(
+            db,
+            entity_type="quiz",
+            entity_id=str(quiz.id),
+            fields=_TRANSLATABLE_QUIZ_FIELDS,
+            fallback_locale=source_locale,
+            authored_by=teacher.id,
+            only_fields=set(text_patch.keys()),
+            texts=text_patch,
+        )
     db.commit()
     reloaded = (
         db.query(Quiz)
@@ -275,10 +278,8 @@ def update_quiz(
     )
     if reloaded is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
-    # ``update_quiz`` only mutates the quiz row itself; questions + options
-    # have their own endpoints. Per-entity reconcile is enough.
     reconcile_entity_if_course_published(db, "quiz", reloaded)
-    return reloaded
+    return build_quiz_response_from_cv(db, reloaded, source_locale=normalize_locale(source_locale))
 
 
 @router.delete("/{quiz_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/quizzes/grading.py
+++ b/backend/app/api/v1/quizzes/grading.py
@@ -16,6 +16,7 @@ from app.schemas.quiz import (
     QuizAnswerResult,
 )
 from app.services import quiz_service
+from app.services.content_versions import fetch_cv_entity_texts_with_fallback
 
 from ._deps import verify_quiz_owner
 from ._router import router
@@ -74,14 +75,32 @@ def list_pending_answers(
         # comment — the row would re-appear on every page reload.
         query = query.filter(QuizAnswer.graded_at.is_(None))
 
+    pending_rows = query.offset(skip).limit(limit).all()
+    # Phase 5f: ``quiz_questions.question_text`` column dropped — bulk-fetch
+    # from cv for the rendering pass (any-locale fallback covers source-only
+    # rows from a non-default course locale).
+    question_ids = list({str(q.id) for _, q, _, _ in pending_rows})
+    question_texts = (
+        fetch_cv_entity_texts_with_fallback(
+            db,
+            entity_type="quiz_question",
+            entity_ids=question_ids,
+            fields=["question_text"],
+            display_locale="en",
+            source_locale="en",
+        )
+        if question_ids
+        else {}
+    )
+
     results: list[PendingAnswerInfo] = []
-    for answer, question, attempt, student in query.offset(skip).limit(limit).all():
+    for answer, question, attempt, student in pending_rows:
         results.append(
             PendingAnswerInfo(
                 answer_id=answer.id,
                 attempt_id=attempt.id,
                 question_id=question.id,
-                question_text=question.question_text,
+                question_text=question_texts.get((str(question.id), "question_text")) or "",
                 question_type=question.question_type,
                 max_points=int(question.points),
                 min_words=question.min_words,

--- a/backend/app/models/quiz.py
+++ b/backend/app/models/quiz.py
@@ -13,8 +13,7 @@ class Quiz(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     chapter_id: Mapped[str] = mapped_column(ForeignKey("chapters.id", ondelete="CASCADE"))
-    title: Mapped[str] = mapped_column(String(255))
-    description: Mapped[str | None] = mapped_column(Text)
+    # Phase 5f: title + description columns dropped — cv is the only store.
     quiz_type: Mapped[str] = mapped_column(String(20), default="quiz", server_default="quiz")
     max_attempts: Mapped[int | None] = mapped_column()
     passing_score: Mapped[int] = mapped_column(default=70)
@@ -36,7 +35,7 @@ class QuizQuestion(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     quiz_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("quizzes.id", ondelete="CASCADE"))
-    question_text: Mapped[str] = mapped_column(Text)
+    # Phase 5f: question_text column dropped — cv is the only store.
     question_type: Mapped[str] = mapped_column(String(20), default="multiple_choice")
     order_index: Mapped[int] = mapped_column(default=0)
     points: Mapped[int] = mapped_column(default=1)
@@ -58,7 +57,7 @@ class QuizOption(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     question_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("quiz_questions.id", ondelete="CASCADE"))
-    option_text: Mapped[str] = mapped_column(Text)
+    # Phase 5f: option_text column dropped — cv is the only store.
     is_correct: Mapped[bool] = mapped_column(default=False)
     order_index: Mapped[int] = mapped_column(default=0)
 

--- a/backend/app/services/course_service/_clone.py
+++ b/backend/app/services/course_service/_clone.py
@@ -128,12 +128,14 @@ def clone_course(db: Session, course_id: str, teacher_id: str | uuid.UUID) -> Co
             for quiz in quizzes_by_chapter.get(chapter.id, []):
                 new_quiz_id = uuid.uuid4()
                 quiz_id_map[str(quiz.id)] = new_quiz_id
+                # Phase 5f: title + description + question_text + option_text
+                # columns dropped. Clone copies structural rows only; cv text
+                # rows are NOT cloned (clones land as drafts and the teacher
+                # edits text post-clone, same as 5e2 blocks / 5e3 assignments).
                 db.add(
                     Quiz(
                         id=new_quiz_id,
                         chapter_id=new_chapter_id,
-                        title=quiz.title,
-                        description=quiz.description,
                         quiz_type=quiz.quiz_type or "quiz",
                         max_attempts=quiz.max_attempts,
                         passing_score=quiz.passing_score,
@@ -149,7 +151,6 @@ def clone_course(db: Session, course_id: str, teacher_id: str | uuid.UUID) -> Co
                         QuizQuestion(
                             id=new_question_id,
                             quiz_id=new_quiz_id,
-                            question_text=question.question_text,
                             question_type=question.question_type,
                             order_index=question.order_index,
                             points=question.points,
@@ -165,7 +166,6 @@ def clone_course(db: Session, course_id: str, teacher_id: str | uuid.UUID) -> Co
                             QuizOption(
                                 id=uuid.uuid4(),
                                 question_id=new_question_id,
-                                option_text=option.option_text,
                                 is_correct=option.is_correct,
                                 order_index=option.order_index,
                             )

--- a/backend/app/services/translation/registry.py
+++ b/backend/app/services/translation/registry.py
@@ -300,9 +300,36 @@ def reconcile_entity(
         return OrchestratorReport()
     course_source: LocaleCode = normalize_locale(course.source_locale)
 
+    # Phase 5e/5f: source text columns are dropped on several entities
+    # (cohort, chapter_block, assignment, course_event, announcement,
+    # quiz, quiz_question, quiz_option). ``getattr`` returns None for
+    # those fields, so we fetch the source from cv as a fallback before
+    # falling back to "no source → skip". One bulk query covers every
+    # field on the entity at the course's declared source_locale (with
+    # any-locale fallback for entities authored in a non-default locale).
+    cv_source_texts: dict[str, str | None] = {}
+    field_names_needing_cv: list[str] = [fs.name for fs in reg.fields if getattr(entity, fs.attr, None) is None]
+    if field_names_needing_cv:
+        from app.services.content_versions import fetch_cv_entity_texts_with_fallback
+
+        bulk = fetch_cv_entity_texts_with_fallback(
+            db,
+            entity_type=entity_type,
+            entity_ids=[str(entity.id)],  # type: ignore[attr-defined]
+            fields=field_names_needing_cv,
+            display_locale=course_source,
+            source_locale=course_source,
+        )
+        cv_source_texts = {
+            field: bulk.get((str(entity.id), field))  # type: ignore[attr-defined]
+            for field in field_names_needing_cv
+        }
+
     fields: list[TranslationFieldSpec] = []
     for fs in reg.fields:
         text = getattr(entity, fs.attr, None)
+        if text is None:
+            text = cv_source_texts.get(fs.name)
         if text is None or not str(text).strip():
             continue
         # Per-field language detection: the entity's actual content

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -34,7 +34,7 @@ from app.schemas.calendar import CourseEventResponse
 from app.schemas.chapter_block import BlockResponse
 from app.schemas.course import ChapterResponse, CourseResponse, CourseSummary, ModuleResponse
 from app.schemas.locale import LocaleCode, normalize_locale
-from app.schemas.quiz import QuizOptionStudentResponse, QuizQuestionStudentResponse, QuizStudentResponse
+from app.schemas.quiz import QuizResponse, QuizStudentResponse
 from app.services.content_versions import (
     fetch_cv_course_text_bulk,
     fetch_cv_text_bulk,
@@ -394,6 +394,62 @@ def build_localized_course_response_with_tree(
     return base.model_copy(update={"title": ct, "description": cd, "modules": new_modules})
 
 
+def _fetch_quiz_tree_texts(
+    db: Session,
+    quiz: Quiz,
+    *,
+    display_locale: LocaleCode,
+    source_locale: LocaleCode,
+) -> tuple[dict[tuple[str, str], str | None], dict[tuple[str, str], str | None], dict[tuple[str, str], str | None]]:
+    """Bulk-fetch every cv text for ``quiz`` + its questions + their options
+    at display→source→any locale fallback. Returns three (entity_id, field)
+    → text dicts so callers can build whichever response shape they need.
+
+    Phase 5f: ``quizzes.title``, ``quizzes.description``,
+    ``quiz_questions.question_text`` and ``quiz_options.option_text``
+    were dropped, so cv is the only store. Three calls (one per
+    entity_type) keeps the SQL tuple-IN clauses simple and lets each
+    use its own ``fields=[]`` list.
+    """
+    from app.services.content_versions import fetch_cv_entity_texts_with_fallback
+
+    quiz_texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="quiz",
+        entity_ids=[str(quiz.id)],
+        fields=["title", "description"],
+        display_locale=display_locale,
+        source_locale=source_locale,
+    )
+    question_ids = [str(qn.id) for qn in quiz.questions]
+    question_texts = (
+        fetch_cv_entity_texts_with_fallback(
+            db,
+            entity_type="quiz_question",
+            entity_ids=question_ids,
+            fields=["question_text"],
+            display_locale=display_locale,
+            source_locale=source_locale,
+        )
+        if question_ids
+        else {}
+    )
+    option_ids = [str(opt.id) for qn in quiz.questions for opt in qn.options]
+    option_texts = (
+        fetch_cv_entity_texts_with_fallback(
+            db,
+            entity_type="quiz_option",
+            entity_ids=option_ids,
+            fields=["option_text"],
+            display_locale=display_locale,
+            source_locale=source_locale,
+        )
+        if option_ids
+        else {}
+    )
+    return quiz_texts, question_texts, option_texts
+
+
 def build_localized_quiz_student_response(
     db: Session,
     quiz: Quiz,
@@ -401,31 +457,103 @@ def build_localized_quiz_student_response(
     display_locale: LocaleCode,
     source_locale: LocaleCode,
 ) -> QuizStudentResponse:
-    """Apply ``content_translations`` to a quiz payload shown to students."""
-    specs: list[tuple[str, str, str]] = [
-        ("quiz", str(quiz.id), "title"),
-        ("quiz", str(quiz.id), "description"),
-    ]
+    """Phase 5f: quiz tree text columns dropped — fetch every title /
+    description / question_text / option_text from cv with three-tier
+    fallback, then assemble the student-facing response.
+    """
+    quiz_texts, question_texts, option_texts = _fetch_quiz_tree_texts(
+        db, quiz, display_locale=display_locale, source_locale=source_locale
+    )
+    new_questions: list[dict] = []
     for qn in quiz.questions:
-        specs.append(("quiz_question", str(qn.id), "question_text"))
+        qid = str(qn.id)
+        new_opts: list[dict] = []
         for opt in qn.options:
-            specs.append(("quiz_option", str(opt.id), "option_text"))
-    loc = Localizer.build(db, specs, source_locale=source_locale, display_locale=display_locale)
+            oid = str(opt.id)
+            new_opts.append(
+                {
+                    "id": opt.id,
+                    "option_text": option_texts.get((oid, "option_text")) or "",
+                    "order_index": opt.order_index,
+                }
+            )
+        new_questions.append(
+            {
+                "id": qn.id,
+                "question_text": question_texts.get((qid, "question_text")) or "",
+                "question_type": qn.question_type,
+                "order_index": qn.order_index,
+                "points": qn.points,
+                "min_words": qn.min_words,
+                "options": new_opts,
+            }
+        )
+    return QuizStudentResponse.model_validate(
+        {
+            "id": quiz.id,
+            "chapter_id": quiz.chapter_id,
+            "title": quiz_texts.get((str(quiz.id), "title")) or "",
+            "description": quiz_texts.get((str(quiz.id), "description")),
+            "quiz_type": quiz.quiz_type,
+            "max_attempts": quiz.max_attempts,
+            "passing_score": quiz.passing_score,
+            "questions": new_questions,
+        }
+    )
 
-    new_title = loc.pick("quiz", str(quiz.id), "title", quiz.title) or quiz.title
-    new_desc = loc.pick("quiz", str(quiz.id), "description", quiz.description)
-    new_questions: list[QuizQuestionStudentResponse] = []
+
+def build_quiz_response_from_cv(
+    db: Session,
+    quiz: Quiz,
+    *,
+    source_locale: LocaleCode,
+) -> QuizResponse:
+    """Teacher-facing quiz response with all texts pulled from cv at the
+    course's source_locale (with any-locale fallback). Used by the
+    create / update / source=1 list routes.
+    """
+    quiz_texts, question_texts, option_texts = _fetch_quiz_tree_texts(
+        db, quiz, display_locale=source_locale, source_locale=source_locale
+    )
+    new_questions: list[dict] = []
     for qn in quiz.questions:
-        qt = loc.pick("quiz_question", str(qn.id), "question_text", qn.question_text) or qn.question_text
-        new_opts: list[QuizOptionStudentResponse] = []
+        qid = str(qn.id)
+        new_opts: list[dict] = []
         for opt in qn.options:
-            ot = loc.pick("quiz_option", str(opt.id), "option_text", opt.option_text) or opt.option_text
-            ob = QuizOptionStudentResponse.model_validate(opt, from_attributes=True)
-            new_opts.append(ob.model_copy(update={"option_text": ot}))
-        qb = QuizQuestionStudentResponse.model_validate(qn, from_attributes=True)
-        new_questions.append(qb.model_copy(update={"question_text": qt, "options": new_opts}))
-    base = QuizStudentResponse.model_validate(quiz, from_attributes=True)
-    return base.model_copy(update={"title": new_title, "description": new_desc, "questions": new_questions})
+            oid = str(opt.id)
+            new_opts.append(
+                {
+                    "id": opt.id,
+                    "option_text": option_texts.get((oid, "option_text")) or "",
+                    "is_correct": opt.is_correct,
+                    "order_index": opt.order_index,
+                }
+            )
+        new_questions.append(
+            {
+                "id": qn.id,
+                "question_text": question_texts.get((qid, "question_text")) or "",
+                "question_type": qn.question_type,
+                "order_index": qn.order_index,
+                "points": qn.points,
+                "min_words": qn.min_words,
+                "options": new_opts,
+            }
+        )
+    return QuizResponse.model_validate(
+        {
+            "id": quiz.id,
+            "chapter_id": quiz.chapter_id,
+            "title": quiz_texts.get((str(quiz.id), "title")) or "",
+            "description": quiz_texts.get((str(quiz.id), "description")),
+            "quiz_type": quiz.quiz_type,
+            "max_attempts": quiz.max_attempts,
+            "passing_score": quiz.passing_score,
+            "created_at": quiz.created_at,
+            "updated_at": quiz.updated_at,
+            "questions": new_questions,
+        }
+    )
 
 
 def localize_assignment_rows(

--- a/backend/tests/_cv_helpers.py
+++ b/backend/tests/_cv_helpers.py
@@ -146,6 +146,114 @@ def make_announcement_with_text(
     return ann
 
 
+def make_quiz_with_text(
+    db: Session,
+    *,
+    chapter_id: str,
+    title: str = "Quiz",
+    description: str | None = None,
+    quiz_type: str = "quiz",
+    max_attempts: int | None = None,
+    passing_score: int = 70,
+    quiz_id: uuid.UUID | None = None,
+    locale: str = "en",
+):
+    """Phase 5f: ``quizzes.title`` + ``description`` columns dropped."""
+    from app.models.quiz import Quiz
+    from app.services.content_versions.write import record_human_version
+
+    quiz = Quiz(
+        id=quiz_id or uuid.uuid4(),
+        chapter_id=chapter_id,
+        quiz_type=quiz_type,
+        max_attempts=max_attempts,
+        passing_score=passing_score,
+    )
+    db.add(quiz)
+    db.flush()
+    record_human_version(db, entity_type="quiz", entity_id=str(quiz.id), field="title", locale=locale, text=title)
+    if description:
+        record_human_version(
+            db,
+            entity_type="quiz",
+            entity_id=str(quiz.id),
+            field="description",
+            locale=locale,
+            text=description,
+        )
+    return quiz
+
+
+def make_quiz_question_with_text(
+    db: Session,
+    *,
+    quiz_id,
+    question_text: str = "Q?",
+    question_type: str = "multiple_choice",
+    order_index: int = 0,
+    points: int = 1,
+    min_words: int | None = None,
+    question_id: uuid.UUID | None = None,
+    locale: str = "en",
+):
+    """Phase 5f: ``quiz_questions.question_text`` column dropped."""
+    from app.models.quiz import QuizQuestion
+    from app.services.content_versions.write import record_human_version
+
+    question = QuizQuestion(
+        id=question_id or uuid.uuid4(),
+        quiz_id=quiz_id,
+        question_type=question_type,
+        order_index=order_index,
+        points=points,
+        min_words=min_words,
+    )
+    db.add(question)
+    db.flush()
+    record_human_version(
+        db,
+        entity_type="quiz_question",
+        entity_id=str(question.id),
+        field="question_text",
+        locale=locale,
+        text=question_text,
+    )
+    return question
+
+
+def make_quiz_option_with_text(
+    db: Session,
+    *,
+    question_id,
+    option_text: str = "A",
+    is_correct: bool = False,
+    order_index: int = 0,
+    option_id: uuid.UUID | None = None,
+    locale: str = "en",
+):
+    """Phase 5f: ``quiz_options.option_text`` column dropped."""
+    from app.models.quiz import QuizOption
+    from app.services.content_versions.write import record_human_version
+
+    option = QuizOption(
+        id=option_id or uuid.uuid4(),
+        question_id=question_id,
+        is_correct=is_correct,
+        order_index=order_index,
+    )
+    db.add(option)
+    db.flush()
+    record_human_version(
+        db,
+        entity_type="quiz_option",
+        entity_id=str(option.id),
+        field="option_text",
+        locale=locale,
+        text=option_text,
+    )
+    return option
+
+
 def make_chapter_block_with_content(
     db: Session,
     *,

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -989,11 +989,11 @@ def _seed_teacher_progress_dashboard(db: Session) -> tuple[str, uuid.UUID, uuid.
         chapter_type="reading",
     )
     quiz_id = uuid.uuid4()
+    # Phase 5f: title + description moved to cv. Structural row only here;
+    # cv text rows seeded after flush below.
     quiz = Quiz(
         id=quiz_id,
         chapter_id=ch_quiz_id,
-        title="Unit quiz",
-        description=None,
     )
     t0 = datetime(2024, 1, 10, 12, 0, tzinfo=UTC)
     t1 = datetime(2024, 1, 11, 12, 0, tzinfo=UTC)
@@ -1062,6 +1062,8 @@ def _seed_teacher_progress_dashboard(db: Session) -> tuple[str, uuid.UUID, uuid.
     record_human_version(
         db, entity_type="assignment", entity_id=str(asg_id), field="description", locale="en", text="Write"
     )
+    # Phase 5f: quiz title moved to cv.
+    record_human_version(db, entity_type="quiz", entity_id=str(quiz_id), field="title", locale="en", text="Unit quiz")
     db.commit()
     return course_id, quiz_id, asg_id, ch_quiz_id, ch_asg_id, ch_read_id
 

--- a/backend/tests/test_course_readiness.py
+++ b/backend/tests/test_course_readiness.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session  # noqa: TC002  (used at runtime by fixtures)
 from app.models.assignment import Assignment  # noqa: TC001  (used as return-type annotation)
 from app.models.chapter_block import ChapterBlock
 from app.models.course import Chapter, Course, CourseStatus, Module
-from app.models.quiz import Quiz, QuizOption, QuizQuestion
+from app.models.quiz import Quiz  # noqa: TC001  (used as return-type annotation)
 from app.models.user import User
 from app.services.course_readiness import (
     ReadinessReport,
@@ -108,22 +108,19 @@ def _add_quiz_with_question(
     options: int = 2,
     correct: int = 1,
 ) -> Quiz:
-    quiz = Quiz(chapter_id=chapter.id, title="Quiz")
-    db.add(quiz)
-    db.flush()
-    question = QuizQuestion(quiz_id=quiz.id, question_text="Q?", question_type=qtype, order_index=0)
-    db.add(question)
-    db.flush()
+    # Phase 5f: quiz tree text columns dropped; use the cv helpers.
+    from ._cv_helpers import make_quiz_option_with_text, make_quiz_question_with_text, make_quiz_with_text
+
+    quiz = make_quiz_with_text(db, chapter_id=chapter.id, title="Quiz")
+    question = make_quiz_question_with_text(db, quiz_id=quiz.id, question_text="Q?", question_type=qtype, order_index=0)
     for i in range(options):
-        db.add(
-            QuizOption(
-                question_id=question.id,
-                option_text=f"Option {i}",
-                is_correct=(i < correct),
-                order_index=i,
-            )
+        make_quiz_option_with_text(
+            db,
+            question_id=question.id,
+            option_text=f"Option {i}",
+            is_correct=(i < correct),
+            order_index=i,
         )
-    db.flush()
     return quiz
 
 

--- a/backend/tests/test_quizzes_and_blocks.py
+++ b/backend/tests/test_quizzes_and_blocks.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from app.models.chapter_block import ChapterBlock
 from app.models.course import Chapter, Course, Module
 from app.models.enrollment import Enrollment
-from app.models.quiz import Quiz, QuizAttempt, QuizOption, QuizQuestion
+from app.models.quiz import Quiz, QuizAttempt
 from app.models.user import User, UserRole
 from tests.conftest import STUDENT_ID, TEACHER_ID
 
@@ -96,57 +96,30 @@ def _seed_course_with_enrollment(db: Session):
 
 
 def _seed_quiz_with_questions(db: Session, chapter_id: str = "ch-1"):
-    """Create a quiz with two MC questions, each with two options (one correct)."""
-    quiz_id = uuid.uuid4()
-    quiz = Quiz(
-        id=quiz_id,
+    """Phase 5f: quiz tree text columns dropped — use the cv helpers."""
+    from ._cv_helpers import make_quiz_option_with_text, make_quiz_question_with_text, make_quiz_with_text
+
+    quiz = make_quiz_with_text(
+        db,
         chapter_id=chapter_id,
         title="Test Quiz",
         description="A quiz for testing",
-        quiz_type="quiz",
         max_attempts=3,
         passing_score=50,
     )
-    db.add(quiz)
-    db.flush()
-
-    q1_id, q2_id = uuid.uuid4(), uuid.uuid4()
-    q1 = QuizQuestion(
-        id=q1_id,
-        quiz_id=quiz_id,
-        question_text="What is 2+2?",
-        question_type="multiple_choice",
-        order_index=0,
-        points=1,
-    )
-    q2 = QuizQuestion(
-        id=q2_id,
-        quiz_id=quiz_id,
-        question_text="Capital of France?",
-        question_type="multiple_choice",
-        order_index=1,
-        points=1,
-    )
-    db.add_all([q1, q2])
-    db.flush()
-
-    o1_wrong, o1_right = uuid.uuid4(), uuid.uuid4()
-    o2_wrong, o2_right = uuid.uuid4(), uuid.uuid4()
-    db.add_all(
-        [
-            QuizOption(id=o1_wrong, question_id=q1_id, option_text="3", is_correct=False, order_index=0),
-            QuizOption(id=o1_right, question_id=q1_id, option_text="4", is_correct=True, order_index=1),
-            QuizOption(id=o2_wrong, question_id=q2_id, option_text="London", is_correct=False, order_index=0),
-            QuizOption(id=o2_right, question_id=q2_id, option_text="Paris", is_correct=True, order_index=1),
-        ]
-    )
+    q1 = make_quiz_question_with_text(db, quiz_id=quiz.id, question_text="What is 2+2?", order_index=0, points=1)
+    q2 = make_quiz_question_with_text(db, quiz_id=quiz.id, question_text="Capital of France?", order_index=1, points=1)
+    o1_wrong = make_quiz_option_with_text(db, question_id=q1.id, option_text="3", is_correct=False, order_index=0)
+    o1_right = make_quiz_option_with_text(db, question_id=q1.id, option_text="4", is_correct=True, order_index=1)
+    o2_wrong = make_quiz_option_with_text(db, question_id=q2.id, option_text="London", is_correct=False, order_index=0)
+    o2_right = make_quiz_option_with_text(db, question_id=q2.id, option_text="Paris", is_correct=True, order_index=1)
     db.commit()
 
     opts = {
-        "q1_correct": o1_right,
-        "q1_wrong": o1_wrong,
-        "q2_correct": o2_right,
-        "q2_wrong": o2_wrong,
+        "q1_correct": o1_right.id,
+        "q1_wrong": o1_wrong.id,
+        "q2_correct": o2_right.id,
+        "q2_wrong": o2_wrong.id,
     }
     return quiz, [q1, q2], opts
 
@@ -590,16 +563,27 @@ def test_get_chapter_quiz_anon_unauthorized(anon_client: TestClient):
 
 
 def _seed_quiz_with_en_translations(db: Session):
-    """Seed an RU-source quiz plus an EN ``content_translations`` overlay."""
+    """Seed an RU-source quiz plus an EN cv overlay. Phase 5f: quiz tree
+    texts live in cv only, so the RU source rows go through record_human_version
+    and the EN overlay via record_mt_version (matching the orchestrator's
+    write shape)."""
     quiz, questions, _opts = _seed_quiz_with_questions(db)
     q1, q2 = questions
-    quiz.title = "RU тест"
-    quiz.description = "Описание"
-    q1.question_text = "Вопрос 1"
-    q2.question_text = "Вопрос 2"
-    from app.services.content_versions.write import record_mt_version
+    from app.services.content_versions.write import record_human_version, record_mt_version
 
-    # Phase 5d: cv is the only translation store.
+    # Overwrite the helper's default ``en`` source rows with the RU source
+    # text by recording a newer human version (record_human_version
+    # supersedes the previous active row).
+    record_human_version(db, entity_type="quiz", entity_id=str(quiz.id), field="title", locale="ru", text="RU тест")
+    record_human_version(
+        db, entity_type="quiz", entity_id=str(quiz.id), field="description", locale="ru", text="Описание"
+    )
+    record_human_version(
+        db, entity_type="quiz_question", entity_id=str(q1.id), field="question_text", locale="ru", text="Вопрос 1"
+    )
+    record_human_version(
+        db, entity_type="quiz_question", entity_id=str(q2.id), field="question_text", locale="ru", text="Вопрос 2"
+    )
     record_mt_version(
         db,
         entity_type="quiz",
@@ -1352,9 +1336,10 @@ def test_list_extra_attempts_anon_unauthorized(anon_client: TestClient):
 
 def _seed_essay_quiz(db: Session):
     """Seed a mixed quiz: one 1-point MCQ + one 20-point essay, passing=70."""
-    quiz_id = uuid.uuid4()
-    quiz = Quiz(
-        id=quiz_id,
+    from ._cv_helpers import make_quiz_option_with_text, make_quiz_question_with_text, make_quiz_with_text
+
+    quiz = make_quiz_with_text(
+        db,
         chapter_id="ch-1",
         title="Midterm",
         description="MCQ + essay",
@@ -1362,39 +1347,22 @@ def _seed_essay_quiz(db: Session):
         max_attempts=2,
         passing_score=70,
     )
-    db.add(quiz)
-    db.flush()
-
-    mcq_id, essay_id = uuid.uuid4(), uuid.uuid4()
-    mcq = QuizQuestion(
-        id=mcq_id,
-        quiz_id=quiz_id,
-        question_text="2+2?",
-        question_type="multiple_choice",
-        order_index=0,
-        points=1,
+    mcq = make_quiz_question_with_text(
+        db, quiz_id=quiz.id, question_text="2+2?", question_type="multiple_choice", order_index=0, points=1
     )
-    essay = QuizQuestion(
-        id=essay_id,
-        quiz_id=quiz_id,
+    essay = make_quiz_question_with_text(
+        db,
+        quiz_id=quiz.id,
         question_text="Reflect on the book of Acts (≥300 words).",
         question_type="essay",
         order_index=1,
         points=20,
         min_words=300,
     )
-    db.add_all([mcq, essay])
-    db.flush()
-
-    o_wrong, o_right = uuid.uuid4(), uuid.uuid4()
-    db.add_all(
-        [
-            QuizOption(id=o_wrong, question_id=mcq_id, option_text="3", is_correct=False, order_index=0),
-            QuizOption(id=o_right, question_id=mcq_id, option_text="4", is_correct=True, order_index=1),
-        ]
-    )
+    make_quiz_option_with_text(db, question_id=mcq.id, option_text="3", is_correct=False, order_index=0)
+    o_right = make_quiz_option_with_text(db, question_id=mcq.id, option_text="4", is_correct=True, order_index=1)
     db.commit()
-    return quiz, mcq, essay, o_right
+    return quiz, mcq, essay, o_right.id
 
 
 def test_create_essay_question_accepted(client: TestClient, db: Session):

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -521,7 +521,6 @@ def test_walker_finds_quizzes_attached_via_chapter_id_only(db: Session):
     Regression for 2026-05-16: see commit message.
     """
     from app.models.course import Chapter, Module
-    from app.models.quiz import Quiz, QuizOption, QuizQuestion
 
     course = _make_course(db, status="published")
     module = Module(id=str(uuid.uuid4()), course_id=course.id, title="M1", order_index=0)
@@ -542,25 +541,34 @@ def test_walker_finds_quizzes_attached_via_chapter_id_only(db: Session):
     # finds the quiz* (not about translation direction), seed Russian
     # text so the detector agrees with the course's source and the
     # original ``[en]`` assertion stays meaningful.
-    quiz = Quiz(chapter_id=chapter.id, title="Контрольная работа", description="Проверка знаний")
-    db.add(quiz)
-    db.flush()
-    question = QuizQuestion(
+    # Phase 5f: quiz tree text columns dropped — use the cv helpers
+    # so the orchestrator finds source rows to translate.
+    from ._cv_helpers import make_quiz_option_with_text, make_quiz_question_with_text, make_quiz_with_text
+
+    quiz = make_quiz_with_text(
+        db,
+        chapter_id=chapter.id,
+        title="Контрольная работа",
+        description="Проверка знаний",
+        locale="ru",
+    )
+    question = make_quiz_question_with_text(
+        db,
         quiz_id=quiz.id,
         question_text="Какой правильный ответ на этот вопрос?",
         question_type="multiple_choice",
         order_index=0,
         points=1,
+        locale="ru",
     )
-    db.add(question)
-    db.flush()
-    option = QuizOption(
+    option = make_quiz_option_with_text(
+        db,
         question_id=question.id,
         option_text="Правильный ответ номер один",
         is_correct=True,
         order_index=0,
+        locale="ru",
     )
-    db.add(option)
     db.commit()
 
     provider = _RecordingProvider()

--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -71,7 +71,16 @@ def test_registry_field_names_exist_on_models():
     FieldSpec but ``getattr(entity, attr, None)`` returns None, so it
     cleanly no-ops for cv-only entities.
     """
-    cv_only_entities = {"cohort", "chapter_block", "assignment", "course_event", "announcement"}
+    cv_only_entities = {
+        "cohort",
+        "chapter_block",
+        "assignment",
+        "course_event",
+        "announcement",
+        "quiz",
+        "quiz_question",
+        "quiz_option",
+    }
     for entity_type, reg in REGISTRY.items():
         if entity_type in cv_only_entities:
             continue

--- a/backend/tests/test_translation_registry_resolvers.py
+++ b/backend/tests/test_translation_registry_resolvers.py
@@ -126,12 +126,9 @@ def chapter(db: Session, module: Module) -> Chapter:
 
 @pytest.fixture
 def quiz(db: Session, chapter: Chapter) -> Quiz:
-    q = Quiz(
-        id=uuid.uuid4(),
-        chapter_id=chapter.id,
-        title="Q1",
-        description="d",
-    )
+    # Phase 5f: title + description columns dropped. Structural row only —
+    # cv text rows are unnecessary for resolver tests (they only walk FKs).
+    q = Quiz(id=uuid.uuid4(), chapter_id=chapter.id)
     db.add(q)
     db.flush()
     return q
@@ -139,10 +136,10 @@ def quiz(db: Session, chapter: Chapter) -> Quiz:
 
 @pytest.fixture
 def quiz_question(db: Session, quiz: Quiz) -> QuizQuestion:
+    # Phase 5f: question_text column dropped.
     qq = QuizQuestion(
         id=uuid.uuid4(),
         quiz_id=quiz.id,
-        question_text="t?",
         question_type="multiple_choice",
         order_index=0,
         points=1,
@@ -154,10 +151,10 @@ def quiz_question(db: Session, quiz: Quiz) -> QuizQuestion:
 
 @pytest.fixture
 def quiz_option(db: Session, quiz_question: QuizQuestion) -> QuizOption:
+    # Phase 5f: option_text column dropped.
     qo = QuizOption(
         id=uuid.uuid4(),
         question_id=quiz_question.id,
-        option_text="A",
         is_correct=True,
         order_index=0,
     )

--- a/supabase/migrations/20260528070000_drop_quiz_tree_text_columns.sql
+++ b/supabase/migrations/20260528070000_drop_quiz_tree_text_columns.sql
@@ -1,0 +1,23 @@
+-- =====================================================================
+-- Phase 5f — drop the entire quiz-tree text columns:
+--   * ``quizzes.title`` and ``quizzes.description``
+--   * ``quiz_questions.question_text``
+--   * ``quiz_options.option_text``
+--
+-- After Phase 3 backfill, all four texts are mirrored in
+-- ``content_versions`` keyed by (entity_type, entity_id, field, locale)
+-- which becomes the single source of truth.
+--
+-- The read path uses ``fetch_cv_entity_texts_with_fallback`` with a
+-- three-tier locale resolution (display → source → any-locale).
+-- The write path in ``api/v1/quizzes/crud.py`` passes ``texts={...}``
+-- dicts to ``dual_write_entity_content`` for each entity in the tree.
+--
+-- Irreversibility: column data is gone after this migration. A
+-- pre-merge dump is the rollback artefact.
+-- =====================================================================
+
+ALTER TABLE quizzes DROP COLUMN IF EXISTS title;
+ALTER TABLE quizzes DROP COLUMN IF EXISTS description;
+ALTER TABLE quiz_questions DROP COLUMN IF EXISTS question_text;
+ALTER TABLE quiz_options DROP COLUMN IF EXISTS option_text;


### PR DESCRIPTION
## Summary

Phase 5f — drops the four legacy text columns in the quiz subtree:

- `quizzes.title` and `quizzes.description`
- `quiz_questions.question_text`
- `quiz_options.option_text`

After Phase 3 backfill, all four texts live in `content_versions`. This makes cv the single source of truth for the entire quiz subtree.

## What changes

**Read paths**
- New `_fetch_quiz_tree_texts` — three bulk `fetch_cv_entity_texts_with_fallback` calls (quiz / question / option) returning three (id, field) → text dicts
- `build_localized_quiz_student_response` rebuilt on top of the helper
- `build_quiz_response_from_cv` is the teacher-facing equivalent used by `get_quiz_detail`, `create_quiz`, `update_quiz`, and the `?source=1` editor path

**Write paths** (`api/v1/quizzes/crud.py`)
- `create_quiz` builds structural rows (no `title` / `question_text` / `option_text` args) and dispatches texts through `dual_write_entity_content` using the `texts={...}` dict variant for each of the three entity types
- `update_quiz` pops title + description off the patch before the setattr loop, routes through dual-write

**Grading** — `list_pending_answers` bulk-fetches every question's `question_text` from cv before assembling the response

**Translation orchestrator** — `reconcile_entity` now reads source text from cv as a fallback when `getattr(entity, attr)` returns None. Without this, every cv-only entity (cohort + the 5e leaf entities + the 5f quiz tree) silently skips MT translation after its column drop. Fixes an existing gap in addition to the new one.

**Clone** — Quiz / QuizQuestion / QuizOption constructors lose the text args (clones land as drafts; teacher edits text post-clone, same as 5e2 chapter blocks)

**Tests**
- `tests/_cv_helpers.py` gains `make_quiz_with_text`, `make_quiz_question_with_text`, `make_quiz_option_with_text`
- Shared seed helpers swept (`_seed_quiz_with_questions`, `_seed_essay_quiz`, `_seed_quiz_with_en_translations`, `_add_quiz_with_question`)
- `_seed_quiz_with_en_translations` writes RU source rows via `record_human_version` (which supersedes the helper's default `en` row) plus the EN overlay via `record_mt_version`
- `cv_only_entities` set extended with `quiz`, `quiz_question`, `quiz_option`

## Test plan

- [x] `pytest -q` → 902 passed
- [x] `mypy` → clean
- [x] `ruff check` + `ruff format --check` → clean
- [ ] Migration applied to prod via Supabase MCP **after** merge (per the new `feedback-migrations-merge-atomically` lesson — don't drop columns before the deployed code stops referencing them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
