### PR TITLE
fix(bilingual): V1 phase 5j — ?source=1 returns human-authored text

### DIFF
--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -182,13 +182,14 @@ def get_module_detail(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only the course owner or an admin can request source-language content",
             )
-        # Phase 5g: ``?source=1`` returns the earliest-authored cv row
-        # for the module (the source language, regardless of overlay)
-        # — bypasses the per-display-locale lookup.
+        # ``?source=1`` returns the teacher-authored source text regardless
+        # of overlay locale. Read the earliest active human-origin row
+        # per field; fall back to the earliest of any origin so a content
+        # row written by an importer still surfaces.
         from app.models.content_version import ContentVersion
 
-        rows = (
-            db.query(ContentVersion.field, ContentVersion.text)
+        cv_rows = (
+            db.query(ContentVersion.field, ContentVersion.text, ContentVersion.origin)
             .filter(
                 ContentVersion.entity_type == "module",
                 ContentVersion.entity_id == str(module.id),
@@ -199,12 +200,14 @@ def get_module_detail(
             .order_by(ContentVersion.created_at)
             .all()
         )
-        text_by_field: dict[str, str] = {}
-        for field, text in rows:
-            text_by_field.setdefault(field, text)
-        module.title = text_by_field.get("title") or module.title or ""
-        if "description" in text_by_field:
-            module.description = text_by_field["description"]
+        human_by_field: dict[str, str] = {}
+        any_by_field: dict[str, str] = {}
+        for field, text, origin in cv_rows:
+            any_by_field.setdefault(field, text)
+            if origin == "human":
+                human_by_field.setdefault(field, text)
+        module.title = human_by_field.get("title") or any_by_field.get("title") or ""
+        module.description = human_by_field.get("description") or any_by_field.get("description")
         return ModuleResponse.model_validate(module, from_attributes=True)
 
     # Owner + admin always see source for editorial accuracy (matches the

--- a/backend/app/services/content_versions/read.py
+++ b/backend/app/services/content_versions/read.py
@@ -74,6 +74,7 @@ def fetch_cv_entity_texts_with_fallback(
     fields: list[str],
     display_locale: str,
     source_locale: str,
+    prefer_human: bool = False,
 ) -> dict[tuple[str, str], str | None]:
     """Read every active+ok ``content_versions`` row for the given
     entities + fields, then resolve each (entity, field) to a single
@@ -83,15 +84,29 @@ def fetch_cv_entity_texts_with_fallback(
     Returns a map ``(entity_id, field) -> text or None``. ``None`` only
     appears when no active+ok row exists at any locale.
 
+    When ``prefer_human`` is set, the any-locale tier prefers
+    human-authored rows (``origin='human'``) over MT ones. The
+    display-locale and source-locale tiers ignore the flag — the
+    overlay system intentionally serves MT text in those locales
+    when that's what's authoritative. The flag matters only for the
+    ``?source=1`` editor view, where a teacher wants to see THEIR
+    typed text in its source language even if an MT row at that
+    locale was created earlier.
+
     Phase 5e-series: entities whose source columns are dropped need
     one indexed lookup per request to materialise responses; this is
-    that lookup. Same code path for the locale-aware list endpoints
-    and the single-entity GET/POST/PUT returns.
+    that lookup.
     """
     if not entity_ids or not fields:
         return {}
     rows = (
-        db.query(ContentVersion.entity_id, ContentVersion.field, ContentVersion.locale, ContentVersion.text)
+        db.query(
+            ContentVersion.entity_id,
+            ContentVersion.field,
+            ContentVersion.locale,
+            ContentVersion.text,
+            ContentVersion.origin,
+        )
         .filter(
             ContentVersion.entity_type == entity_type,
             ContentVersion.entity_id.in_(entity_ids),
@@ -104,16 +119,22 @@ def fetch_cv_entity_texts_with_fallback(
     )
     by_locale: dict[tuple[str, str, str], str] = {}
     any_for_pair: dict[tuple[str, str], str] = {}
-    for eid, field, locale, text in rows:
+    human_for_pair: dict[tuple[str, str], str] = {}
+    for eid, field, locale, text, origin in rows:
         by_locale.setdefault((eid, field, locale), text)
         any_for_pair.setdefault((eid, field), text)
+        if origin == "human":
+            human_for_pair.setdefault((eid, field), text)
     resolved: dict[tuple[str, str], str | None] = {}
     for eid in entity_ids:
         for field in fields:
+            any_tier = (
+                human_for_pair.get((eid, field)) or any_for_pair.get((eid, field))
+                if prefer_human
+                else any_for_pair.get((eid, field))
+            )
             resolved[(eid, field)] = (
-                by_locale.get((eid, field, display_locale))
-                or by_locale.get((eid, field, source_locale))
-                or any_for_pair.get((eid, field))
+                by_locale.get((eid, field, display_locale)) or by_locale.get((eid, field, source_locale)) or any_tier
             )
     return resolved
 

--- a/backend/tests/test_courses.py
+++ b/backend/tests/test_courses.py
@@ -465,12 +465,6 @@ class TestCatalogLocalizedMetadata:
         )
         assert resp.status_code == 403
 
-    @pytest.mark.skip(
-        reason="Phase 5g: ?source=1 semantics for modules with cv-only text "
-        "need a separate followup — when course.source_locale != module text "
-        "actual language, the earliest-created cv row may not match the "
-        "teacher's authored source. Tracked separately; not blocking the column drop."
-    )
     def test_get_module_detail_source_param_returns_raw_columns_for_owner(
         self,
         client: TestClient,


### PR DESCRIPTION
## Summary

Closes the skipped test from Phase 5g: `?source=1` for module-detail now correctly returns the teacher's authored source text instead of an MT translation that happened to be written at the viewer's display locale.

## Repro of the bug

Teacher authors a module titled `"Модуль RU"` (Russian). Auto-translator writes `content_versions(module, title, en, "Module title EN", origin=mt)`. The editor opens the module in EN UI and hits `?source=1` to see the source text, expecting `"Модуль RU"`. **Old behaviour:** returns `"Module title EN"` — the EN locale lookup hits the MT row before the source-locale fallback ever fires.

## What changes

1. **`fetch_cv_entity_texts_with_fallback`** gains a `prefer_human=False` keyword. When set, the any-locale fallback tier prefers `origin='human'` rows over MT ones. The display- and source-locale tiers ignore the flag — normal overlay reads serve MT text in those locales when that's authoritative, which is the desired behaviour for non-editor surfaces.

2. **`?source=1` branch in `get_module_detail`** rewritten to bypass the locale tiers entirely. The editor scans cv rows ordered by `created_at` and picks the earliest `origin='human'` row per field, falling back to the earliest of any origin. The viewer's `Accept-Language` is irrelevant when the explicit `?source=1` flag is set — the editor wants the teacher's typed text, regardless of UI language.

3. **Unskip** `test_get_module_detail_source_param_returns_raw_columns_for_owner`.

## Test plan

- [x] `pytest -q` → 903 passed, 0 skipped (was 902 + 1)
- [x] `mypy` → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
