### PR TITLE
refactor(bilingual): V1 phase 5l — collapse course-summary helper chain

### DIFF
--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -16,9 +16,8 @@ from app.services.course_service import (
     get_teacher_courses,
 )
 from app.services.translation.resolve_for_display import (
-    batch_fetch_course_translations,
     build_localized_course_response_with_tree,
-    build_localized_course_summary,
+    build_localized_course_summaries,
     build_localized_module_response,
     should_apply_course_translation_overlay,
 )
@@ -48,12 +47,7 @@ def list_courses(
     courses = get_courses(db, skip=skip, limit=limit, search=search)
     if not courses:
         return []
-    overlay = batch_fetch_course_translations(
-        db,
-        course_ids=[c.id for c in courses],
-        display_locale=display_locale,
-    )
-    return [build_localized_course_summary(c, overlay, display_locale) for c in courses]
+    return build_localized_course_summaries(db, courses, display_locale)
 
 
 @router.get("/my", response_model=list[CourseSummary])

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -25,8 +25,7 @@ from app.schemas.user import PreferredLocaleUpdate, UserResponse
 from app.services.audit_service import log_action
 from app.services.course_service import get_user_courses
 from app.services.translation.resolve_for_display import (
-    batch_fetch_course_translations,
-    build_localized_course_summary,
+    build_localized_course_summaries,
     populate_spine_texts,
     should_apply_course_translation_overlay,
 )
@@ -68,18 +67,29 @@ def get_my_courses(
     courses = [e.course for e in rows if e.course is not None]
     if not courses:
         return [EnrollmentSummaryResponse.model_validate(e, from_attributes=True) for e in rows]
+    # Pre-hydrate at the source locale for the owner / admin path. The
+    # student / non-owner path uses a localized summary; per-course
+    # overlay choice depends on the caller's role.
     populate_spine_texts(db, courses)
-    overlay = batch_fetch_course_translations(db, course_ids=[c.id for c in courses], display_locale=display_locale)
+    localized = {
+        c.id: s
+        for c, s in zip(
+            courses,
+            build_localized_course_summaries(db, courses, display_locale),
+            strict=True,
+        )
+    }
     out: list[EnrollmentSummaryResponse] = []
     for e in rows:
         if e.course is None:
             out.append(EnrollmentSummaryResponse.model_validate(e, from_attributes=True))
             continue
         c = e.course
-        if should_apply_course_translation_overlay(course=c, current_user=current_user):
-            summary = build_localized_course_summary(c, overlay, display_locale)
-        else:
-            summary = CourseSummary.model_validate(c, from_attributes=True)
+        summary = (
+            localized[c.id]
+            if should_apply_course_translation_overlay(course=c, current_user=current_user)
+            else CourseSummary.model_validate(c, from_attributes=True)
+        )
         base = EnrollmentSummaryResponse.model_validate(e, from_attributes=True)
         out.append(base.model_copy(update={"course": summary}))
     return out

--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -9,7 +9,6 @@ all funnel through these helpers.
 
 from app.services.content_versions.dual_write import dual_write_entity_content
 from app.services.content_versions.read import (
-    fetch_cv_course_text_bulk,
     fetch_cv_entity_texts_with_fallback,
     fetch_cv_text_bulk,
 )
@@ -21,7 +20,6 @@ from app.services.content_versions.write import (
 
 __all__ = [
     "dual_write_entity_content",
-    "fetch_cv_course_text_bulk",
     "fetch_cv_entity_texts_with_fallback",
     "fetch_cv_text_bulk",
     "record_human_version",

--- a/backend/app/services/content_versions/read.py
+++ b/backend/app/services/content_versions/read.py
@@ -137,28 +137,3 @@ def fetch_cv_entity_texts_with_fallback(
                 by_locale.get((eid, field, display_locale)) or by_locale.get((eid, field, source_locale)) or any_tier
             )
     return resolved
-
-
-def fetch_cv_course_text_bulk(
-    db: Session,
-    *,
-    course_ids: list[str],
-    display_locale: str,
-) -> dict[tuple[str, str], str]:
-    """Course-catalog bulk variant: returns ``(course_id, field) -> text``
-    for the course title + description overlay at display_locale."""
-    if not course_ids:
-        return {}
-    rows = (
-        db.query(ContentVersion)
-        .filter(
-            ContentVersion.entity_type == "course",
-            ContentVersion.entity_id.in_(course_ids),
-            ContentVersion.locale == display_locale,
-            ContentVersion.field.in_(("title", "description")),
-            ContentVersion.superseded_by.is_(None),
-            ContentVersion.status == "ok",
-        )
-        .all()
-    )
-    return {(r.entity_id, r.field): r.text for r in rows}

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from typing import cast
 
 from sqlalchemy.orm import Session  # noqa: TC002
 
@@ -36,7 +35,6 @@ from app.schemas.course import ChapterResponse, CourseResponse, CourseSummary, M
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.schemas.quiz import QuizResponse, QuizStudentResponse
 from app.services.content_versions import (
-    fetch_cv_course_text_bulk,
     fetch_cv_entity_texts_with_fallback,
     fetch_cv_text_bulk,
 )
@@ -96,81 +94,44 @@ def fetch_course_titles_by_id(
     return out
 
 
-def batch_fetch_course_translations(
+def build_localized_course_summaries(
     db: Session,
-    *,
-    course_ids: list[str],
+    courses: list[Course],
     display_locale: LocaleCode,
-) -> dict[tuple[str, str], str]:
-    """Return a map ``(entity_id, field) -> text`` for ok course-level rows.
+) -> list[CourseSummary]:
+    """Build ``CourseSummary`` for every course, resolving title +
+    description against ``content_versions`` at the requested
+    ``display_locale`` with per-course source_locale fallback.
 
-    Sourced exclusively from ``content_versions`` (Phase 4 made cv the
-    primary read store; Phase 5a removed the legacy fallback branch).
+    One bulk cv read covers every course (grouped by source_locale).
+    Caller doesn't have to pre-populate spine texts — this function
+    drives its own hydration.
     """
-    return fetch_cv_course_text_bulk(db, course_ids=course_ids, display_locale=display_locale)
-
-
-def pick_localized_text(
-    course: Course,
-    field: str,
-    base: str,
-    overlay: dict[tuple[str, str], str],
-    display_locale: LocaleCode,
-) -> str:
-    key = (course.id, field)
-    if key in overlay:
-        return overlay[key]
-    if normalize_locale(course.source_locale) == display_locale:
-        return base
-    return overlay.get(key, base)
-
-
-def _localize_optional_description(
-    course: Course,
-    base: str | None,
-    overlay: dict[tuple[str, str], str],
-    display_locale: LocaleCode,
-) -> str | None:
-    dkey = (course.id, "description")
-    if dkey in overlay:
-        return overlay[dkey]
-    if base is not None:
-        return pick_localized_text(course, "description", base, overlay, display_locale)
-    if normalize_locale(course.source_locale) == display_locale:
-        return None
-    return overlay.get(dkey)
-
-
-def _build_localized_course[T: CourseSummary | CourseResponse](
-    schema_cls: type[T],
-    course: Course,
-    overlay: dict[tuple[str, str], str],
-    display_locale: LocaleCode,
-) -> T:
-    """Shared body for ``build_localized_course_summary`` /
-    ``_response``. The two were byte-for-byte identical except for the
-    return-type / ``model_validate`` target — this collapses them.
-
-    Phase 5g: ``course.title`` / ``course.description`` columns dropped.
-    Read path callers MUST call ``populate_spine_texts`` (or its bulk
-    cousin) on the course before invoking this — it sets ``.title`` and
-    ``.description`` as runtime attributes from cv, so the rest of the
-    serialization pipeline keeps working unchanged.
-    """
-    title = pick_localized_text(course, "title", course.title, overlay, display_locale)
-    desc = _localize_optional_description(course, course.description, overlay, display_locale)
-    base = schema_cls.model_validate(course, from_attributes=True)
-    if title == base.title and desc == base.description:
-        return cast("T", base)
-    return cast("T", base.model_copy(update={"title": title, "description": desc}))
-
-
-def build_localized_course_summary(
-    course: Course,
-    overlay: dict[tuple[str, str], str],
-    display_locale: LocaleCode,
-) -> CourseSummary:
-    return _build_localized_course(CourseSummary, course, overlay, display_locale)
+    if not courses:
+        return []
+    by_src: dict[str, list[str]] = {}
+    for c in courses:
+        by_src.setdefault(normalize_locale(c.source_locale), []).append(c.id)
+    texts: dict[tuple[str, str], str | None] = {}
+    for src_locale, ids in by_src.items():
+        texts.update(
+            fetch_cv_entity_texts_with_fallback(
+                db,
+                entity_type="course",
+                entity_ids=ids,
+                fields=["title", "description"],
+                display_locale=display_locale,
+                source_locale=src_locale,
+            )
+        )
+    out: list[CourseSummary] = []
+    for c in courses:
+        # Set runtime attrs so ``model_validate(course, from_attributes=True)``
+        # picks them up via Pydantic's attribute reader.
+        c.title = texts.get((c.id, "title")) or ""
+        c.description = texts.get((c.id, "description"))
+        out.append(CourseSummary.model_validate(c, from_attributes=True))
+    return out
 
 
 def populate_spine_texts(
@@ -930,9 +891,8 @@ def localize_course_event_rows(
 
 
 __all__ = [
-    "batch_fetch_course_translations",
     "build_localized_course_response_with_tree",
-    "build_localized_course_summary",
+    "build_localized_course_summaries",
     "build_localized_module_response",
     "build_localized_quiz_student_response",
     "fetch_course_titles_by_id",


### PR DESCRIPTION
## Summary

Collapses a five-helper chain on the catalog hot path into a single function.

## Before

```
catalog.list_courses
  → batch_fetch_course_translations
    → fetch_cv_course_text_bulk
      → ContentVersion query at display_locale (no source-locale fallback!)

  per course:
    → build_localized_course_summary
      → _build_localized_course
        → pick_localized_text + _localize_optional_description
        → CourseSummary.model_validate + model_copy
```

Three thin wrappers and two private picker helpers. None survived 5g cleanly: `pick_localized_text` reads `course.title` which has been a runtime attribute since 5g; `_build_localized_course` re-wraps that string into Pydantic just to overwrite it on the next line; the cv read tier ignored per-course source_locale fallback (display-locale only).

## After

```python
build_localized_course_summaries(db, courses, display_locale) -> list[CourseSummary]
```

- Groups courses by their declared `source_locale`
- One `fetch_cv_entity_texts_with_fallback` call per group (display → source → any-locale; same resolver every other 5e/f entity uses)
- Attaches resolved text as runtime `.title` / `.description`
- Returns `CourseSummary.model_validate(course, from_attributes=True)` in one pass

## Deletions

- `batch_fetch_course_translations` (resolve_for_display.py)
- `fetch_cv_course_text_bulk` (content_versions/read.py)
- `build_localized_course_summary` (resolve_for_display.py)
- `_build_localized_course` (resolve_for_display.py)
- `pick_localized_text` (only used by deleted helper)
- `_localize_optional_description` (same)

## Call-site rewrites

- `api/v1/courses/catalog.py::list_courses` — one-line return
- `api/v1/users.py::get_my_courses` — bulk builder once, dict lookup per enrollment

## Net change

-117 lines / +54 lines = **63 fewer lines of code**, one less indirection level on the catalog hot path, and correct per-course source_locale fallback on the catalog list (which the old code silently lacked).

## Test plan

- [x] `pytest -q` → 903 passed, 0 skipped
- [x] `mypy` clean
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
