### PR TITLE
feat(diag): unauthenticated translation-status probe

### DIFF
--- a/backend/app/api/v1/courses/translate.py
+++ b/backend/app/api/v1/courses/translate.py
@@ -32,6 +32,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@router.get("/_diag/translation-status")
+def translation_status() -> dict:
+    """Anonymous diagnostic: is the translation provider configured?
+
+    Returns ``{"enabled": true/false, "provider": "gemini"}``. Doesn't
+    expose the API key or any other secrets — only the boolean result of
+    the env-var check that gates every translation entry point. Used to
+    confirm prod has the env wired correctly after a deploy without
+    having to authenticate as a teacher and POST against a real course.
+    """
+    return {"enabled": is_translation_enabled(), "provider": "gemini"}
+
+
 @router.post("/{course_id}/translate", response_model=CourseTranslationResponse)
 def trigger_course_translation(
     course_id: str,


### PR DESCRIPTION
Adds GET `/api/v1/courses/_diag/translation-status` that returns `{enabled: bool, provider: 'gemini'}`. Lets a smoke test confirm prod has `GEMINI_API_KEY` wired without going through teacher auth.

Returns only the boolean from `is_translation_enabled()` — no key material exposed.