### PR TITLE
feat(bilingual): V1 phase 5q — ?source=1 on list endpoints

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -109,12 +109,43 @@ def list_announcements(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    source: bool = Query(
+        False,
+        description=(
+            "Bypass the translation overlay and return source-language ``title`` "
+            "and ``content`` for the editor. Requires a ``course_id`` filter and "
+            "course ownership (or admin). Source-locale per row matches the row's "
+            "course ``source_locale``; ``prefer_human=True`` in the any-locale "
+            "fallback tier keeps MT rows out of the editor view."
+        ),
+    ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[AnnouncementResponse]:
     response.headers["Vary"] = "Accept-Language"
     query = db.query(Announcement)
     is_admin = current_user.role in (UserRole.ADMIN.value, "admin")
+    # ``?source=1`` is editor-only: it returns unredacted source text
+    # for the announcements of a specific course, so gate it to a
+    # course_id filter that the caller actually owns (or admin). A
+    # heterogeneous unfiltered list of source-locale rows would leak
+    # draft content across course boundaries.
+    if source:
+        if course_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="?source=1 requires a course_id filter",
+            )
+        if not is_admin:
+            owns = (
+                db.query(Course.id).filter(Course.id == course_id, Course.created_by == current_user.id).first()
+                is not None
+            )
+            if not owns:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Only the course owner or an admin can request source-language content",
+                )
 
     if global_only:
         # AnnouncementBanner asks for site-wide-only rows; previously it
@@ -164,6 +195,9 @@ def list_announcements(
     # Locale wins. Every reader — students, teachers, admins — gets the
     # locale overlay when one exists. Moderators who need raw source
     # content use the admin-only audit/edit surfaces, not this list.
+    # When ``?source=1`` was requested (gated to course owner + admin
+    # above), display_locale collapses to source_locale per row so the
+    # editor sees the teacher's own text.
     display_locale: LocaleCode = normalize_locale(accept_language)
     course_ids = [str(a.course_id) for a in rows if a.course_id]
     source_locales = _course_source_locale_map(db, course_ids)
@@ -173,7 +207,15 @@ def list_announcements(
         bucket = [a for a in rows if source_locales.get(str(a.course_id), normalize_locale(None)) == src]
         if not bucket:
             continue
-        out.extend(localize_announcement_rows(db, bucket, display_locale=display_locale, source_locale=src))
+        out.extend(
+            localize_announcement_rows(
+                db,
+                bucket,
+                display_locale=src if source else display_locale,
+                source_locale=src,
+                prefer_human=source,
+            )
+        )
     return out
 
 

--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -103,8 +103,12 @@ def list_chapter_assignments(
             )
         # Phase 5e3: title + description columns dropped — re-use the
         # localize path with display==source so the cv lookup populates
-        # the source-locale text.
-        return localize_assignment_rows(db, rows, display_locale=ctx.source_locale, source_locale=ctx.source_locale)
+        # the source-locale text. ``prefer_human=True`` makes the
+        # any-locale fallback skip MT rows so the editor never sees
+        # machine output as the "source" text.
+        return localize_assignment_rows(
+            db, rows, display_locale=ctx.source_locale, source_locale=ctx.source_locale, prefer_human=True
+        )
     display_locale: LocaleCode = normalize_locale(accept_language)
     return localize_assignment_rows(db, rows, display_locale=display_locale, source_locale=ctx.source_locale)
 

--- a/backend/app/api/v1/blocks.py
+++ b/backend/app/api/v1/blocks.py
@@ -116,8 +116,12 @@ def list_blocks(
         # Phase 5e2: chapter_blocks.content column dropped — build
         # source-locale responses by re-using the resolve layer that
         # already does the cv lookups (source==display when no
-        # localisation requested).
-        return localize_chapter_block_rows(db, rows, display_locale=ctx.source_locale, source_locale=ctx.source_locale)
+        # localisation requested). ``prefer_human=True`` ensures the
+        # editor never surfaces an MT row in the any-locale fallback
+        # tier — teachers edit human text, not machine output.
+        return localize_chapter_block_rows(
+            db, rows, display_locale=ctx.source_locale, source_locale=ctx.source_locale, prefer_human=True
+        )
     display_locale: LocaleCode = normalize_locale(accept_language)
     return localize_chapter_block_rows(db, rows, display_locale=display_locale, source_locale=ctx.source_locale)
 

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -332,6 +332,15 @@ def list_course_events(
     response: Response,
     course_id: str,
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    source: bool = Query(
+        False,
+        description=(
+            "Bypass the translation overlay and return source-language ``title`` "
+            "+ ``description``. Owner / admin only — used by the calendar event "
+            "editor. ``prefer_human=True`` keeps MT rows out of the any-locale "
+            "fallback tier."
+        ),
+    ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[CourseEventResponse]:
@@ -357,13 +366,25 @@ def list_course_events(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You must be enrolled in this course to view events",
             )
+    if source and not (is_owner or is_admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the course owner or an admin can request source-language content",
+        )
     rows = db.query(CourseEvent).filter(CourseEvent.course_id == course_id).order_by(CourseEvent.event_date).all()
     # Locale wins. Every reader — students, owners, admins — gets the locale
-    # overlay when one exists. Editors that need raw source must use dedicated
-    # authoring endpoints (the PUT/POST routes below operate on raw columns).
+    # overlay when one exists. ``?source=1`` collapses display_locale to
+    # source_locale and prefers human rows in the any-locale fallback tier
+    # so the editor never sees machine output as authoritative source.
     display_locale: LocaleCode = normalize_locale(accept_language)
     source_locale: LocaleCode = normalize_locale(course_row.source_locale)
-    return localize_course_event_rows(db, rows, display_locale=display_locale, source_locale=source_locale)
+    return localize_course_event_rows(
+        db,
+        rows,
+        display_locale=source_locale if source else display_locale,
+        source_locale=source_locale,
+        prefer_human=source,
+    )
 
 
 @event_router.put(

--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -97,9 +97,11 @@ def get_chapter_quiz(
             )
         # Phase 5f: title / question_text / option_text columns dropped.
         # The student response is the same shape source==display surfaces,
-        # so re-use the localize path with display=source.
+        # so re-use the localize path with display=source. ``prefer_human``
+        # makes the any-locale fallback prefer human rows so the editor
+        # never shows an MT row as authoritative source content.
         resp = build_localized_quiz_student_response(
-            db, quiz, display_locale=ctx.source_locale, source_locale=ctx.source_locale
+            db, quiz, display_locale=ctx.source_locale, source_locale=ctx.source_locale, prefer_human=True
         )
     else:
         display_locale: LocaleCode = normalize_locale(accept_language)

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -832,6 +832,7 @@ def localize_announcement_rows(
     *,
     display_locale: LocaleCode,
     source_locale: LocaleCode,
+    prefer_human: bool = False,
 ) -> list[AnnouncementResponse]:
     """Phase 5e5: ``announcements.title`` + ``content`` columns dropped.
     Both texts live in cv now. Resolve each via the three-tier fallback
@@ -847,6 +848,7 @@ def localize_announcement_rows(
         fields=["title", "content"],
         display_locale=display_locale,
         source_locale=source_locale,
+        prefer_human=prefer_human,
     )
     out: list[AnnouncementResponse] = []
     for a in announcements:
@@ -873,6 +875,7 @@ def localize_course_event_rows(
     *,
     display_locale: LocaleCode,
     source_locale: LocaleCode,
+    prefer_human: bool = False,
 ) -> list[CourseEventResponse]:
     """Phase 5e4: ``course_events.title`` + ``description`` columns dropped.
     Both texts live in cv now. Resolve each via the three-tier
@@ -888,6 +891,7 @@ def localize_course_event_rows(
         fields=["title", "description"],
         display_locale=display_locale,
         source_locale=source_locale,
+        prefer_human=prefer_human,
     )
     out: list[CourseEventResponse] = []
     for e in events:

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -507,6 +507,7 @@ def _fetch_quiz_tree_texts(
     *,
     display_locale: LocaleCode,
     source_locale: LocaleCode,
+    prefer_human: bool = False,
 ) -> tuple[dict[tuple[str, str], str | None], dict[tuple[str, str], str | None], dict[tuple[str, str], str | None]]:
     """Bulk-fetch every cv text for ``quiz`` + its questions + their options
     at display→source→any locale fallback. Returns three (entity_id, field)
@@ -517,6 +518,11 @@ def _fetch_quiz_tree_texts(
     were dropped, so cv is the only store. Three calls (one per
     entity_type) keeps the SQL tuple-IN clauses simple and lets each
     use its own ``fields=[]`` list.
+
+    ``prefer_human`` flows down into ``fetch_cv_entity_texts_with_fallback``
+    so the teacher editor (``?source=1``) prefers human rows in the
+    any-locale tier. See ``read.fetch_cv_entity_texts_with_fallback`` for
+    the semantics.
     """
     quiz_texts = fetch_cv_entity_texts_with_fallback(
         db,
@@ -525,6 +531,7 @@ def _fetch_quiz_tree_texts(
         fields=["title", "description"],
         display_locale=display_locale,
         source_locale=source_locale,
+        prefer_human=prefer_human,
     )
     question_ids = [str(qn.id) for qn in quiz.questions]
     question_texts = (
@@ -535,6 +542,7 @@ def _fetch_quiz_tree_texts(
             fields=["question_text"],
             display_locale=display_locale,
             source_locale=source_locale,
+            prefer_human=prefer_human,
         )
         if question_ids
         else {}
@@ -548,6 +556,7 @@ def _fetch_quiz_tree_texts(
             fields=["option_text"],
             display_locale=display_locale,
             source_locale=source_locale,
+            prefer_human=prefer_human,
         )
         if option_ids
         else {}
@@ -561,13 +570,14 @@ def build_localized_quiz_student_response(
     *,
     display_locale: LocaleCode,
     source_locale: LocaleCode,
+    prefer_human: bool = False,
 ) -> QuizStudentResponse:
     """Phase 5f: quiz tree text columns dropped — fetch every title /
     description / question_text / option_text from cv with three-tier
     fallback, then assemble the student-facing response.
     """
     quiz_texts, question_texts, option_texts = _fetch_quiz_tree_texts(
-        db, quiz, display_locale=display_locale, source_locale=source_locale
+        db, quiz, display_locale=display_locale, source_locale=source_locale, prefer_human=prefer_human
     )
     new_questions: list[dict] = []
     for qn in quiz.questions:
@@ -615,10 +625,12 @@ def build_quiz_response_from_cv(
 ) -> QuizResponse:
     """Teacher-facing quiz response with all texts pulled from cv at the
     course's source_locale (with any-locale fallback). Used by the
-    create / update / source=1 list routes.
+    create / update / source=1 list routes. Always prefers human-origin
+    rows in the any-locale tier — a teacher edit surface should never
+    surface MT output even if a localised MT row was created earlier.
     """
     quiz_texts, question_texts, option_texts = _fetch_quiz_tree_texts(
-        db, quiz, display_locale=source_locale, source_locale=source_locale
+        db, quiz, display_locale=source_locale, source_locale=source_locale, prefer_human=True
     )
     new_questions: list[dict] = []
     for qn in quiz.questions:
@@ -667,6 +679,7 @@ def localize_assignment_rows(
     *,
     display_locale: LocaleCode,
     source_locale: LocaleCode,
+    prefer_human: bool = False,
 ) -> list[AssignmentResponse]:
     """Phase 5e3: ``assignments.title`` + ``description`` columns dropped.
     Both texts live in ``content_versions`` now. Resolve each via a
@@ -682,6 +695,7 @@ def localize_assignment_rows(
         fields=["title", "description"],
         display_locale=display_locale,
         source_locale=source_locale,
+        prefer_human=prefer_human,
     )
     out: list[AssignmentResponse] = []
     for a in assignments:
@@ -709,6 +723,7 @@ def localize_chapter_block_rows(
     *,
     display_locale: LocaleCode,
     source_locale: LocaleCode,
+    prefer_human: bool = False,
 ) -> list[BlockResponse]:
     """Apply stored translations to TipTap HTML stored on chapter blocks.
 
@@ -720,7 +735,11 @@ def localize_chapter_block_rows(
     Three-tier fallback: display_locale → source_locale → any-locale.
     The any-locale tier rescues blocks whose content was authored in a
     locale that's neither display nor course-declared source (an edge
-    case from the per-field-detection world).
+    case from the per-field-detection world). When ``prefer_human`` is
+    set, the any-locale tier prefers human-authored rows over MT ones —
+    used by the ``?source=1`` editor view so a teacher never sees a
+    stale MT row as the "source" content for a block whose source-locale
+    row went missing.
     """
     if not blocks:
         return []
@@ -729,7 +748,7 @@ def localize_chapter_block_rows(
     # + any-locale tiers. Ordered by created_at so we deterministically
     # pick the earliest if multiple rows exist per block at a locale.
     rows = (
-        db.query(ContentVersion.entity_id, ContentVersion.locale, ContentVersion.text)
+        db.query(ContentVersion.entity_id, ContentVersion.locale, ContentVersion.text, ContentVersion.origin)
         .filter(
             ContentVersion.entity_type == "chapter_block",
             ContentVersion.entity_id.in_(block_ids),
@@ -742,17 +761,17 @@ def localize_chapter_block_rows(
     )
     by_block_locale: dict[tuple[str, str], str] = {}
     any_by_block: dict[str, str] = {}
-    for eid, locale, text in rows:
+    human_by_block: dict[str, str] = {}
+    for eid, locale, text, origin in rows:
         by_block_locale.setdefault((eid, locale), text)
         any_by_block.setdefault(eid, text)
+        if origin == "human":
+            human_by_block.setdefault(eid, text)
     out: list[BlockResponse] = []
     for b in blocks:
         bid = str(b.id)
-        content = (
-            by_block_locale.get((bid, display_locale))
-            or by_block_locale.get((bid, source_locale))
-            or any_by_block.get(bid)
-        )
+        any_tier = human_by_block.get(bid) or any_by_block.get(bid) if prefer_human else any_by_block.get(bid)
+        content = by_block_locale.get((bid, display_locale)) or by_block_locale.get((bid, source_locale)) or any_tier
         out.append(
             BlockResponse.model_validate(
                 {


### PR DESCRIPTION
## Summary

Adds the `?source=1` editor-mode query flag to two list endpoints that previously only served the localized overlay.

| Endpoint | Gating |
|---|---|
| `GET /api/v1/announcements` | Requires `course_id` filter + course ownership (or admin). Unfiltered source-locale lists would leak draft content across course boundaries. |
| `GET /api/v1/courses/{course_id}/events` | Owner / admin only, mirrors the per-course access semantics already on this route. |

The global `GET /api/v1/calendar/events` endpoint deliberately does **not** take a `source` flag — it's a student-facing union view across enrolled courses with no clean editor-mode access model.

Both endpoints route through `localize_announcement_rows` / `localize_course_event_rows`, which now accept `prefer_human: bool = False` and pass it through to `fetch_cv_entity_texts_with_fallback`. Matches the pattern from #564 (5p).

> Stacked on #564 (v1/phase5p-prefer-human). Will rebase to main once that auto-merges.

## Test plan

- [x] `pytest -q` → 903 passed
- [x] `mypy` clean
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)