### PR TITLE
fix(bilingual): V1 phase 5r — cohort translation resolver via cohort_courses junction

### DIFF
--- a/backend/app/services/translation/registry.py
+++ b/backend/app/services/translation/registry.py
@@ -165,6 +165,33 @@ def _resolve_course_via_question(db: Session, entity: Any) -> Course | None:
     return _resolve_course_via_quiz_chapter(db, quiz)
 
 
+def _resolve_course_via_cohort_courses(db: Session, entity: Any) -> Course | None:
+    """ADR-010: cohorts attach to courses via the ``cohort_courses``
+    junction table, not via a ``course_id`` FK column. Pick any course
+    the cohort is linked to so ``reconcile_entity`` can derive a
+    source_locale + build a prompt context. A cohort attached to
+    multiple courses with different source_locales is a rare edge —
+    the first-link choice is deterministic (created_at ordering on the
+    junction) and the cohort name is short, so re-translating against
+    a different locale costs little.
+    """
+    from app.models.cohort import CohortCourse
+
+    cohort_id = getattr(entity, "id", None)
+    if cohort_id is None:
+        return None
+    course_id = (
+        db.query(CohortCourse.course_id)
+        .filter(CohortCourse.cohort_id == cohort_id)
+        .order_by(CohortCourse.added_at)
+        .limit(1)
+        .scalar()
+    )
+    if not course_id:
+        return None
+    return db.query(Course).filter(Course.id == course_id).first()
+
+
 def _resolve_course_via_option(db: Session, entity: Any) -> Course | None:
     """QuizOption -> question -> quiz -> chapter -> ... -> course."""
     question_id = getattr(entity, "question_id", None)
@@ -245,7 +272,7 @@ REGISTRY: dict[EntityType, EntityRegistration] = {
     "cohort": EntityRegistration(
         entity_type="cohort",
         fields=(FieldSpec("title", "title", model_attr="name"),),
-        resolve_course=_resolve_course_via_attr("course_id"),
+        resolve_course=_resolve_course_via_cohort_courses,
         build_context=lambda _co, c: f"Student cohort name in course «{c.title}»",
     ),
 }

--- a/backend/tests/test_translation_registry_resolvers.py
+++ b/backend/tests/test_translation_registry_resolvers.py
@@ -394,13 +394,13 @@ class TestRegistryWiring:
         assert resolved is not None
         assert resolved.id == course.id
 
-    def test_cohort_resolves_via_course_id_attr_and_is_none_for_top_level_cohort(self, db: Session):
-        """The cohort entry uses ``_resolve_course_via_attr('course_id')``
-        but Cohort is a top-level admin entity (ADR-010) that doesn't HAVE
-        a ``course_id`` column. The resolver therefore returns None for
-        every cohort — which is exactly what makes cohort name reconciliation
-        a no-op until ADR-010 evolves. Lock the current behavior in so a
-        future schema change is forced through this test."""
+    def test_cohort_resolves_via_cohort_courses_junction(self, db: Session, course: Course):
+        """ADR-010: cohorts attach to courses via ``cohort_courses``, not
+        a ``course_id`` column. The resolver walks the junction and
+        returns the first linked course so ``reconcile_entity`` can pull
+        a source_locale + run translation. A cohort with no junction
+        row is genuinely orphaned and returns None."""
+        from app.models.cohort import CohortCourse
         from app.services.translation.registry import REGISTRY
 
         cohort = Cohort(
@@ -411,7 +411,14 @@ class TestRegistryWiring:
         )
         db.add(cohort)
         db.flush()
+        # No linked course → None (orphan).
         assert REGISTRY["cohort"].resolve_course(db, cohort) is None
+        # Linked course → resolver returns it.
+        db.add(CohortCourse(cohort_id=cohort.id, course_id=course.id))
+        db.flush()
+        resolved = REGISTRY["cohort"].resolve_course(db, cohort)
+        assert resolved is not None
+        assert resolved.id == course.id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The cohort entry in `REGISTRY` pointed at `_resolve_course_via_attr("course_id")` — but ADR-010 moved cohort ↔ course linkage to the `cohort_courses` junction. Cohorts have no `course_id` column. So the resolver returned `None` for every cohort, `reconcile_entity` skipped them, and every cohort row's non-source-locale translation never materialised.

**Concrete symptom on prod course `Тайтл`:** cohort `тест` had only an `ru` row in `content_versions`; an EN student saw the raw RU name in the cohort filter dropdown.

This PR:
- adds `_resolve_course_via_cohort_courses` which walks the junction and returns the first-linked course (ordered by `added_at` so the choice is deterministic);
- updates the registry wiring for `cohort` to point at the new resolver;
- replaces the old resolver test (which explicitly locked the broken `None`-return behaviour) with one that asserts both the junction-walk happy path and the orphan case.

After deploy, calling `POST /api/v1/courses/{id}/translate` for a course with attached cohorts will materialise the missing EN rows on the next pass.

## Test plan

- [x] `pytest -q` → 903 passed
- [x] `mypy` clean
- [x] `ruff check` clean
- [ ] After merge: re-trigger `/api/v1/courses/fce3337a-…/translate`, verify `cohort:69f9bde6-9ef0-4553-bb13-b72c030893db` field=`title` locale=`en` row appears with English text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)