### PR TITLE
docs(diag): V1 phase 5t — keep translation-status diag endpoint public

### DIFF
--- a/backend/app/api/v1/courses/translate.py
+++ b/backend/app/api/v1/courses/translate.py
@@ -41,6 +41,13 @@ def translation_status() -> dict:
     the env-var check that gates every translation entry point. Used to
     confirm prod has the env wired correctly after a deploy without
     having to authenticate as a teacher and POST against a real course.
+
+    **Visibility decision (Phase 5t):** kept public. The response surface
+    is two static keys; an authenticated teacher can already infer the
+    same boolean from the ``enabled`` field of any ``POST /translate``
+    response, so gating this would not actually reduce information
+    disclosure and would only break the post-deploy smoke-test workflow
+    (``curl api.equipbible.com/...`` from any laptop).
     """
     return {"enabled": is_translation_enabled(), "provider": "gemini"}
 


### PR DESCRIPTION
## Summary

The unauthenticated diagnostic endpoint at `GET /api/v1/courses/_diag/translation-status` returns a two-key status object (`enabled` + `provider`). After reviewing the threat model:

- An authenticated teacher can already infer the `enabled` boolean from any `POST /translate` response, so gating this endpoint would not actually reduce information disclosure.
- The provider name is a static `gemini` literal — not a configuration leak.
- Removing public access would break the post-deploy smoke-test workflow (curl from any laptop, no JWT needed).

So: **keep it public, document the rationale in the docstring**. No behavioural change, just an in-code decision record.

## Test plan

- [x] `ruff check` clean — docstring-only diff
- [x] `pytest -q` — no functional change

🤖 Generated with [Claude Code](https://claude.com/claude-code)