### PR TITLE
feat(bilingual): V1 phase 5s — dedupe MT writes by source_hash

### DIFF
--- a/backend/app/services/translation/orchestrator.py
+++ b/backend/app/services/translation/orchestrator.py
@@ -378,6 +378,41 @@ def _translate_one_field(
     if existing is not None and existing.status == "failed_permanent":
         return "skipped"
 
+    # Phase 5s: duplicate-source dedupe. Gemini at temperature=0 is
+    # not strictly deterministic — identical RU source text can render
+    # to "Do not move..." 4x and "Don't move..." 1x across a quiz's
+    # answer options. Before paying a Gemini call, look for any other
+    # active+ok row with the same (target_locale, source_hash) and
+    # reuse its text. This costs one indexed query but eliminates an
+    # entire class of intra-question inconsistency (and one Gemini
+    # call per duplicate). Same-entity rows are excluded so we don't
+    # collide with the in-place ``existing`` branch above.
+    twin = (
+        db.query(ContentVersion.text)
+        .filter(
+            ContentVersion.locale == target_locale,
+            ContentVersion.source_hash == source_hash,
+            ContentVersion.status == "ok",
+            ContentVersion.superseded_by.is_(None),
+            ~((ContentVersion.entity_type == entity_type) & (ContentVersion.entity_id == entity_id)),
+        )
+        .order_by(ContentVersion.created_at)
+        .limit(1)
+        .scalar()
+    )
+    if twin is not None:
+        _dual_write_mt_success(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            field=field,
+            target_locale=target_locale,
+            text=twin,
+            source_locale=source_locale,
+            source_hash=source_hash,
+        )
+        return "translated"
+
     request = TranslationRequest(
         text=text,
         source_locale=source_locale,

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -168,6 +168,64 @@ def test_translate_course_metadata_skips_unchanged_source(db: Session):
     assert report.translated == 0
 
 
+def test_translate_entity_fields_reuses_existing_translation_for_identical_source(db: Session):
+    """Phase 5s: identical source text (same source_hash + target locale)
+    should reuse the first translation instead of calling the provider
+    again. Catches the Gemini-temperature-0 inconsistency where 5 quiz
+    options with the same RU source rendered 4 times to "Do not move"
+    and once to "Don't move" — once dedupe is in, every duplicate option
+    gets the same EN text and the provider is called only for the first.
+    """
+    from app.services.translation.orchestrator import TranslationFieldSpec, translate_entity_fields
+
+    _ensure_teacher(db)
+    # Two sibling "entities" (we use quiz_option in spirit but any
+    # entity_type works for the dedupe primitive — the rule is
+    # source_hash + target_locale, not entity_type).
+    eid_a = str(uuid.uuid4())
+    eid_b = str(uuid.uuid4())
+    shared_text = "Не двигай одну фигуру много раз"  # noqa: RUF001
+
+    provider = _RecordingProvider()
+    spec_a = [TranslationFieldSpec(field="option_text", text=shared_text, content_kind="quiz_option")]
+    spec_b = [TranslationFieldSpec(field="option_text", text=shared_text, content_kind="quiz_option")]
+
+    report_a = translate_entity_fields(
+        db,
+        entity_type="quiz_option",
+        entity_id=eid_a,
+        source_locale="ru",
+        fields=spec_a,
+        provider=provider,
+    )
+    report_b = translate_entity_fields(
+        db,
+        entity_type="quiz_option",
+        entity_id=eid_b,
+        source_locale="ru",
+        fields=spec_b,
+        provider=provider,
+    )
+    assert report_a.translated == 1
+    assert report_b.translated == 1
+    # The second call must NOT have invoked the provider — it found a
+    # twin row with the same source_hash and reused its text.
+    assert len(provider.calls) == 1
+    row_a = (
+        db.query(ContentVersion)
+        .filter_by(entity_type="quiz_option", entity_id=eid_a, field="option_text", locale="en", superseded_by=None)
+        .one()
+    )
+    row_b = (
+        db.query(ContentVersion)
+        .filter_by(entity_type="quiz_option", entity_id=eid_b, field="option_text", locale="en", superseded_by=None)
+        .one()
+    )
+    assert row_a.text == row_b.text, "identical RU source must produce identical EN text"
+    assert row_b.origin == "mt"
+    assert row_b.status == "ok"
+
+
 def test_translate_course_metadata_retranslates_when_source_changes(db: Session):
     course = _make_course(db)
     provider = _RecordingProvider()


### PR DESCRIPTION
## Summary

Gemini at `temperature=0` is not strictly deterministic — observed on prod course **Тайтл**:

```
5 quiz options with identical RU source "Не двигай одну фигуру много раз"
→ 4×  "Do not move one piece many times"
→ 1×  "Don't move one piece many times"
```

Semantically equivalent but jarring in a "perfect bilingual UX" promise.

This PR adds a single indexed lookup in `_translate_one_field`: before calling `provider.translate`, search for any other active+ok content_versions row with the same `(target_locale, source_hash)`. If one exists, reuse its text. Same-entity rows are excluded so the in-place `existing` short-circuit stays authoritative.

### Effects

- Every duplicate option now gets **identical** translated text — no more 4/1 split.
- Only the first of N identical sources costs a Gemini call.

### Caveats

A teacher who later edits one duplicate independently is unaffected — that row's source_hash changes, so it'll re-translate on its own. The dedupe is purely a write-time optimisation, not a runtime link.

## Test plan

- [x] `pytest -q` → 904 passed (+1 new dedupe test)
- [x] `mypy` clean
- [x] `ruff check` clean
- [ ] After merge: re-trigger `/api/v1/courses/{id}/translate` on a course with duplicate quiz-option sources; verify all duplicates land identical EN text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)