### PR TITLE
feat(bilingual): V1 phase 5u — frontend ?source=1 for announcement + event editors

### DIFF
--- a/frontend/src/pages/Teacher/editor/useAnnouncementsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useAnnouncementsSection.ts
@@ -37,7 +37,7 @@ export function useAnnouncementsSection(
     if (!courseId) return
     let cancelled = false
     coursesService
-      .getAnnouncements(courseId)
+      .getAnnouncementsForEdit(courseId)
       .then((a) => {
         if (!cancelled) setAnnouncements(a)
       })

--- a/frontend/src/pages/Teacher/editor/useEventsSection.ts
+++ b/frontend/src/pages/Teacher/editor/useEventsSection.ts
@@ -39,7 +39,7 @@ export function useEventsSection(
     if (!courseId) return
     let cancelled = false
     coursesService
-      .getCourseEvents(courseId)
+      .getCourseEventsForEdit(courseId)
       .then((e) => {
         if (!cancelled) setEvents(e)
       })

--- a/frontend/src/services/announcements.ts
+++ b/frontend/src/services/announcements.ts
@@ -12,6 +12,26 @@ export const announcementsService = {
     })
   },
 
+  /**
+   * Teacher-only fetch that returns source-language announcement text
+   * regardless of the UI's Accept-Language. Required for the announcement
+   * editor so a teacher viewing their RU course in EN UI types into the
+   * original RU text, not the machine-translated EN overlay (which would
+   * silently overwrite the source on save).
+   *
+   * Backend requires a course_id filter for ?source=1 (course-scoped
+   * authorization gate), so this method takes courseId positionally.
+   * Bypasses the shared `announcements:course:{id}` cache for the same
+   * reason as `getCourseForEdit` — student and teacher views must not
+   * cross-contaminate.
+   */
+  async getAnnouncementsForEdit(courseId: string): Promise<Announcement[]> {
+    const response = await api.get<Announcement[]>("/announcements", {
+      params: { course_id: courseId, source: 1 },
+    })
+    return response.data
+  },
+
   // Banner-only feed. ``getAnnouncements()`` returns every row visible
   // to the user (enrolled + owned + site-wide), so the banner used to
   // pull dozens of course-scoped rows just to ``find`` the site-wide

--- a/frontend/src/services/calendar.ts
+++ b/frontend/src/services/calendar.ts
@@ -18,6 +18,24 @@ export const calendarService = {
     })
   },
 
+  /**
+   * Teacher-only fetch returning source-language event titles +
+   * descriptions, used by the calendar event editor. Mirrors the
+   * `?source=1` pattern from `getCourseForEdit` /
+   * `getAnnouncementsForEdit`: bypass the locale overlay so the
+   * teacher edits their own typed text, not the MT version.
+   *
+   * Bypasses the `calendar:course-events:{id}` cache to keep the
+   * student-facing localized payload separate from the teacher-only
+   * source payload.
+   */
+  async getCourseEventsForEdit(courseId: string): Promise<CourseEvent[]> {
+    const response = await api.get<CourseEvent[]>(`/courses/${courseId}/events`, {
+      params: { source: 1 },
+    })
+    return response.data
+  },
+
   async createCourseEvent(
     courseId: string,
     data: {


### PR DESCRIPTION
## Summary

Phase 5q shipped the \`?source=1\` query flag on \`GET /api/v1/announcements\` and \`GET /courses/{id}/events\` but the frontend teacher editor never asked for it. Result: a teacher editing a Russian announcement from an English UI would see the MT-rendered English text in the textarea and the save would overwrite the source via dual_write_entity_content locale-detection on the new English text.

This PR adds two service methods and wires them into the editor hooks:

- \`announcementsService.getAnnouncementsForEdit(courseId)\` → \`GET /announcements?course_id={id}&source=1\`
- \`calendarService.getCourseEventsForEdit(courseId)\` → \`GET /courses/{id}/events?source=1\`
- \`useAnnouncementsSection\` and \`useEventsSection\` swap their list fetches over to the new methods.

Mirrors the existing pattern from \`getCourseForEdit\` / \`getChapterBlocksForEdit\` / \`getChapterQuizForEdit\` / \`getChapterAssignmentsForEdit\`. Bypasses the shared list cache to keep student-localised reads separate from teacher source-reads.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run -- src/services\` — 15 passed
- [ ] Manual: as a teacher with EN UI, open an announcement on a RU-source course; verify the textarea shows the RU text, not the EN MT overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)