### PR TITLE
feat(bilingual): V1 phase 5y — locale-scope frontend cache + Vary headers

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -22,6 +22,7 @@ router = APIRouter(prefix="/analytics", tags=["analytics"])
 )
 def get_course_analytics(
     course_id: str,
+    response: Response,
     skip: int = Query(0, ge=0),
     limit: int = Query(500, ge=1, le=2000),
     teacher: User = Depends(require_teacher),
@@ -39,6 +40,9 @@ def get_course_analytics(
     course = verify_course_owner(db, course_id, teacher)
     # Phase 5g: courses.title moved to cv — hydrate before serialising.
     populate_spine_texts(db, [course])
+    # Course title is locale-resolved via populate_spine_texts; downstream
+    # caches must not conflate the EN and RU variants of the same payload.
+    response.headers["Vary"] = "Accept-Language"
 
     # Aggregates in one round-trip instead of loading everything into Python.
     agg = (

--- a/backend/app/api/v1/grades.py
+++ b/backend/app/api/v1/grades.py
@@ -212,6 +212,10 @@ def export_grades_csv(
         media_type="text/csv; charset=utf-8",
         headers={
             "Content-Disposition": (f"attachment; filename=\"{ascii_filename}\"; filename*=UTF-8''{utf8_filename}"),
+            # Filename is derived from the locale-resolved course title, so
+            # an EN and RU caller see different downloads. Vary keeps the
+            # HTTP cache layers from conflating them.
+            "Vary": "Accept-Language",
         },
     )
 

--- a/frontend/src/lib/cache.ts
+++ b/frontend/src/lib/cache.ts
@@ -1,5 +1,23 @@
+import i18n from "@/i18n/config"
+
 const DEFAULT_TTL = 5 * 60 * 1000
 const MAX_ENTRIES = 200
+
+/**
+ * Translatable content read through the API depends on the current
+ * UI locale (Accept-Language). A cache key that's not scoped to the
+ * locale lets a user who switches RU → EN read the cached RU payload
+ * for up to the cache TTL (3 minutes for course details). Suffixing
+ * every key with the current locale keeps the two views in lockstep:
+ * switching the language naturally misses the cache and refetches.
+ *
+ * Lives here (not at each call site) so existing service code stays
+ * unchanged and so any future cache user inherits the same guarantee.
+ */
+function localeScoped(key: string): string {
+  const locale = i18n.language || "ru"
+  return `${key}::${locale}`
+}
 
 /**
  * Named TTLs used by service caches. Picking from this menu keeps the
@@ -46,25 +64,38 @@ function evictIfNeeded(): void {
 }
 
 export function cacheGet<T = unknown>(key: string): T | undefined {
-  const entry = store.get(key)
+  const scoped = localeScoped(key)
+  const entry = store.get(scoped)
   if (!entry) return undefined
   if (Date.now() > entry.expiresAt) {
-    store.delete(key)
+    store.delete(scoped)
     return undefined
   }
   return entry.value as T
 }
 
 export function cacheSet<T = unknown>(key: string, value: T, ttlMs: number = DEFAULT_TTL): void {
-  store.set(key, { value, expiresAt: Date.now() + ttlMs })
+  store.set(localeScoped(key), { value, expiresAt: Date.now() + ttlMs })
   evictIfNeeded()
 }
 
 export function cacheInvalidate(key: string): void {
-  store.delete(key)
+  // Invalidate the key across every locale variant — a write in one
+  // locale must clear the cached overlay in the other too. Cheap: the
+  // store is bounded at MAX_ENTRIES.
+  const tail = `::`
+  for (const stored of store.keys()) {
+    const sepIdx = stored.lastIndexOf(tail)
+    if (sepIdx > 0 && stored.slice(0, sepIdx) === key) {
+      store.delete(stored)
+    }
+  }
 }
 
 export function cacheInvalidatePrefix(prefix: string): void {
+  // Prefix invalidation must also span locale variants. Because we
+  // suffix with ``::<locale>``, a substring match against ``prefix``
+  // is still sound — the locale tail comes after the original key.
   for (const key of store.keys()) {
     if (key.startsWith(prefix)) store.delete(key)
   }


### PR DESCRIPTION
## Summary

Two related bugs surfaced by a cache-consistency audit.

### P0 — Frontend cache keys ignore the UI locale

Every \`cached(key, ttl, fn)\` call in \`services/*\` uses a locale-blind key (e.g. \`courses:detail:123\`). A user reading the EN payload caches it, then switches to RU and reads the SAME cached EN payload until TTL (3 min for course details).

Fix lives in \`lib/cache.ts\`: every \`cacheGet\` / \`cacheSet\` now suffixes the key with the current i18n locale (\`::<locale>\`). Existing call sites are unchanged — they inherit locale scoping for free. \`cacheInvalidate\` walks every locale variant; \`cacheInvalidatePrefix\` keeps existing prefix-match semantics (original key is the prefix, the \`::<locale>\` tail comes after, so \`startsWith\` is still sound).

### P1 — Backend endpoints missing \`Vary: Accept-Language\`

Two endpoints that resolve text via \`populate_spine_texts\` did not set the Vary header, so CDN/browser caches conflate the EN and RU variants:

- \`GET /api/v1/analytics/course/{id}\` — injects \`Response\`, sets header.
- \`GET /api/v1/grades/course/{id}/export.csv\` — adds to the \`StreamingResponse\` headers dict (the filename is locale-derived, so the file actually differs between locales).

## Test plan

- [x] \`pytest -q\` → 905 passed
- [x] \`mypy\` clean
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] \`npm run lint\` + \`tsc --noEmit\` + \`npm run test:run\` → 316 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)