### PR TITLE
fix(bilingual): V1 phase 5ab — hydrate course before build_context in reconcile

### DIFF
--- a/backend/app/services/translation/registry.py
+++ b/backend/app/services/translation/registry.py
@@ -379,6 +379,17 @@ def reconcile_entity(
     if not fields:
         return OrchestratorReport()
 
+    # Phase 5g: courses.title lives in cv. The fresh Course returned by
+    # ``resolve_course`` is not guaranteed to have its runtime title
+    # attribute attached — and every entity's ``build_context`` lambda
+    # below reads ``c.title``. Without the hydration here, the lambda
+    # raises AttributeError, the outer ``reconcile_entity_if_course_published``
+    # try/except swallows it, and the entity silently stays
+    # untranslated. Hydrate once so every lambda below is safe.
+    from app.services.translation.resolve_for_display import populate_spine_texts
+
+    populate_spine_texts(db, [course])
+
     context: str | None = None
     if reg.build_context is not None:
         context = reg.build_context(entity, course)

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -7,6 +7,7 @@ are made and how the resulting ``content_translations`` rows look.
 
 from __future__ import annotations
 
+import contextlib
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -224,6 +225,63 @@ def test_translate_entity_fields_reuses_existing_translation_for_identical_sourc
     assert row_a.text == row_b.text, "identical RU source must produce identical EN text"
     assert row_b.origin == "mt"
     assert row_b.status == "ok"
+
+
+def test_reconcile_entity_hydrates_course_before_build_context(db: Session):
+    """Phase 5g + 5x regression: every entity's ``build_context`` lambda in
+    ``REGISTRY`` reads ``c.title``. The fresh Course returned by the
+    per-entity ``resolve_course`` is NOT hydrated by default — so without
+    a pre-call to ``populate_spine_texts``, the lambda raises
+    AttributeError and the outer try/except in
+    ``reconcile_entity_if_course_published`` swallows the failure.
+
+    Reproduces the prod-observed bug where a freshly POSTed announcement
+    never got its EN translation row even though the orchestrator was
+    enabled, the source row existed, and Gemini was reachable.
+    """
+    from app.models.announcement import Announcement
+    from app.services.content_versions.write import record_human_version
+    from app.services.translation.registry import reconcile_entity
+
+    _ensure_teacher(db)
+    course = _make_course(db, status="published")
+    course_id = course.id
+    # Evict the hydrated Course from the identity map and clear any
+    # runtime title attr so the resolver inside reconcile re-issues a
+    # fresh query and gets an un-hydrated Course, matching prod where
+    # the announcement-create route queries Course without
+    # ``populate_spine_texts``.
+    with contextlib.suppress(AttributeError):
+        delattr(course, "title")
+    with contextlib.suppress(AttributeError):
+        delattr(course, "description")
+    db.expunge(course)
+    # Refetch so the test holds a reference but the inner resolver's
+    # query path is the production path.
+    course = db.get(Course, course_id)
+    assert course is not None
+    ann = Announcement(
+        id=uuid.uuid4(),
+        course_id=course.id,
+        created_by=TEACHER_ID,
+    )
+    db.add(ann)
+    db.flush()
+    record_human_version(
+        db, entity_type="announcement", entity_id=str(ann.id), field="title", locale="ru", text="Тестовое объявление"
+    )
+    record_human_version(
+        db, entity_type="announcement", entity_id=str(ann.id), field="content", locale="ru", text="Тестовое содержимое"
+    )
+    db.commit()
+
+    # Must NOT raise AttributeError on ``c.title`` inside build_context.
+    provider = _RecordingProvider()
+    report = reconcile_entity(db, "announcement", ann, provider=provider)
+    db.commit()
+    # Provider must have been called once per translatable field.
+    assert len(provider.calls) >= 1
+    assert report.translated >= 1
 
 
 def test_translate_course_metadata_retranslates_when_source_changes(db: Session):


### PR DESCRIPTION
## Summary

**Live prod bug** — verified by posting three test announcements: each landed with RU rows only even though the orchestrator was enabled, the source row was committed before reconcile, and a manual `POST /translate` translated them correctly on the same course.

**Root cause.** Every entity's `build_context` lambda in `REGISTRY` reads `c.title` (e.g. `lambda _a, c: f"Announcement in course «{c.title}»"`). The Course returned by the per-entity `resolve_course` is a fresh ORM query result with no runtime title attr (Phase 5g dropped the column; `populate_spine_texts` is what attaches it). On access, `c.title` raises AttributeError. The outer `reconcile_entity_if_course_published` try/except swallows it, the entity silently stays untranslated, and the 5x notification fan-out falls back to source-locale text.

**Why `translate_course_content` masks this.** Its outer `get_course` call hydrates the course, and SQLAlchemy's identity-map returns the same hydrated Python object on subsequent `resolve_course` queries within the same session. The single-entity write hooks (announcement create, block create, …) hit a cold session and the resolver returns a fresh, un-hydrated Course.

**Fix.** One-line `populate_spine_texts(db, [course])` inside `reconcile_entity` before `build_context` runs. Every lambda below now sees a hydrated course. No call-site changes needed.

## Regression test

`test_reconcile_entity_hydrates_course_before_build_context` reproduces the prod failure mode by evicting the Course from the identity-map and clearing its runtime title before calling `reconcile_entity`. Without the fix the test fails on the exact AttributeError seen in prod; with the fix it passes.

## Test plan

- [x] `pytest -q` → 907 passed (+1 regression)
- [x] `mypy` clean
- [x] `ruff check` clean
- [ ] After deploy: post a fresh announcement to course Тайтл, verify the EN cv row materialises **inside** the request and the notification body shows the EN translated title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)