### PR TITLE
fix(bilingual): V1 phase 5ae — announcement delete sweeps recipient notifications

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -15,6 +15,7 @@ from app.core.sanitize import sanitize_string
 from app.models.announcement import Announcement
 from app.models.course import Course
 from app.models.enrollment import Enrollment
+from app.models.notification import Notification
 from app.models.user import User, UserRole
 from app.schemas.announcement import (
     AnnouncementCreate,
@@ -467,5 +468,26 @@ def delete_announcement(
     # nothing for Postgres to cascade. Drop the rows explicitly so a
     # hard-delete doesn't leave orphan cv text behind.
     delete_entity_cv_rows(db, entity_type="announcement", entity_id=announcement.id)
+    # Phase 5ae: every enrolled student got a ``new_announcement``
+    # notification via ``create_notifications_bulk`` (see
+    # ``create_announcement``) — those rows reference this announcement
+    # only through ``meta->>'announcement_id'``, which Postgres has no
+    # way to follow on its own. Without this sweep the notification
+    # card stays in every recipient's panel showing stale text long
+    # after the announcement is gone. ``Notification.link`` was set to
+    # ``/courses/{course_id}`` in the fan-out, so we narrow the candidate
+    # set by type + link in SQL and then Python-filter on the
+    # ``meta`` dict — sidesteps the dialect-specific ``->>`` /
+    # ``json_extract`` split while keeping the candidate count bounded
+    # by the enrollment size of one course.
+    target_id = str(announcement.id)
+    candidates = (
+        db.query(Notification)
+        .filter(Notification.type == "new_announcement", Notification.link == f"/courses/{announcement.course_id}")
+        .all()
+    )
+    stale_ids = [n.id for n in candidates if isinstance(n.meta, dict) and n.meta.get("announcement_id") == target_id]
+    if stale_ids:
+        db.query(Notification).filter(Notification.id.in_(stale_ids)).delete(synchronize_session=False)
     db.delete(announcement)
     db.commit()

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -1756,6 +1756,35 @@ class TestDeleteAnnouncement:
         )
         assert cv_after == 0
 
+    def test_delete_sweeps_associated_notifications(self, client: TestClient, db: Session, student):
+        """Phase 5ae regression: hard-delete must drop the
+        ``new_announcement`` notifications fanned out to enrolled
+        students. The notification's only link to the announcement is
+        ``meta->>'announcement_id'`` (no FK), so without an explicit
+        sweep the rows stay forever showing stale text."""
+        course = _create_course_via_api(client)
+        _seed_enrollment(db, user_id=STUDENT_ID, course_id=course["id"])
+
+        resp = client.post(
+            ANNOUNCEMENT_PREFIX,
+            json=_announcement_payload(course_id=course["id"]),
+        )
+        ann_id = resp.json()["id"]
+        notif_before = (
+            db.query(Notification)
+            .filter(Notification.type == "new_announcement", Notification.user_id == STUDENT_ID)
+            .count()
+        )
+        assert notif_before == 1
+
+        client.delete(f"{ANNOUNCEMENT_PREFIX}/{ann_id}")
+        notif_after = (
+            db.query(Notification)
+            .filter(Notification.type == "new_announcement", Notification.user_id == STUDENT_ID)
+            .count()
+        )
+        assert notif_after == 0
+
     def test_student_cannot_delete(self, student_client: TestClient, db: Session):
         from ._cv_helpers import make_announcement_with_text
 


### PR DESCRIPTION
## Summary

**Caught in prod** after deleting four test announcements: the `new_announcement` notifications fanned out to the enrolled student stayed in the notifications table forever. Each row referenced the deleted announcement only through `meta->>"announcement_id"` (no FK back), so the entity-table CASCADE missed them.

This PR sweeps the matching notification rows inside the `delete_announcement` handler:

- Narrows the candidate set in SQL by `type=new_announcement` AND `link=/courses/{course_id}` — bounded by the enrollment size of one course, no full-table scan.
- Python-filters on `meta["announcement_id"]`. Avoids the dialect split between Postgres `->>` and SQLite `json_extract` that the equivalent SQL predicate would require.
- Bulk DELETE-by-id of the survivors.

## Out of scope

Cert / assignment-graded notifications follow the same orphan pattern but their delete paths donʼt fire from a user-facing route today, so theyʼd need a different cleanup hook. Filed as follow-up.

## Test plan

- [x] `pytest -q` → 909 passed (+1 regression test)
- [x] `mypy` clean
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)