### PR TITLE
refactor(cert): V1 phase 5ag — use CertificateStatus enum

### DIFF
--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_admin, require_teacher
 from app.core.database import get_db
-from app.models.certificate import Certificate
+from app.models.certificate import Certificate, CertificateStatus
 from app.models.course import Course
 from app.models.enrollment import Enrollment
 from app.models.user import User
@@ -76,11 +76,11 @@ def request_certificate(
         db.query(Certificate).filter(Certificate.user_id == current_user.id, Certificate.course_id == course_id).first()
     )
     if existing is not None:
-        if existing.status == "rejected":
+        if existing.status == CertificateStatus.REJECTED:
             # Reopen the request rather than silently returning the
             # rejected row (which previously made the "request" button a
             # no-op for any student who had been rejected once).
-            existing.status = "pending"
+            existing.status = CertificateStatus.PENDING
             existing.teacher_approved_at = None
             existing.teacher_approved_by = None
             existing.admin_approved_at = None
@@ -89,7 +89,7 @@ def request_certificate(
             db.refresh(existing)
         return existing
 
-    cert = Certificate(user_id=current_user.id, course_id=course_id, status="pending")
+    cert = Certificate(user_id=current_user.id, course_id=course_id, status=CertificateStatus.PENDING)
     db.add(cert)
     try:
         db.commit()
@@ -101,8 +101,8 @@ def request_certificate(
             .first()
         )
         if existing is not None:
-            if existing.status == "rejected":
-                existing.status = "pending"
+            if existing.status == CertificateStatus.REJECTED:
+                existing.status = CertificateStatus.PENDING
                 existing.teacher_approved_at = None
                 existing.teacher_approved_by = None
                 existing.admin_approved_at = None
@@ -222,7 +222,7 @@ def list_pending_certificates(
         .filter(
             Course.created_by == teacher.id,
             Course.deleted_at.is_(None),
-            Certificate.status == "pending",
+            Certificate.status == CertificateStatus.PENDING,
         )
         .order_by(Certificate.requested_at.asc())
         .offset(skip)
@@ -247,7 +247,7 @@ def list_admin_pending_certificates(
     """
     certs = (
         db.query(Certificate)
-        .filter(Certificate.status == "teacher_approved")
+        .filter(Certificate.status == CertificateStatus.TEACHER_APPROVED)
         .order_by(Certificate.teacher_approved_at.asc())
         .offset(skip)
         .limit(limit)

--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -24,7 +24,7 @@ from uuid import UUID
 
 from fastapi import HTTPException, Request, status
 
-from app.models.certificate import Certificate
+from app.models.certificate import Certificate, CertificateStatus
 from app.models.course import Course
 from app.models.user import User, UserRole
 from app.schemas.locale import normalize_locale
@@ -140,23 +140,23 @@ def _assert_not_self_approval(cert: Certificate, approver: User) -> None:
 
 
 def _status_error_message(cert: Certificate, allowed: tuple[str, ...]) -> str:
-    if allowed == ("pending",):
+    if allowed == (CertificateStatus.PENDING,):
         return f"Certificate is not pending (current status: {cert.status})"
-    if allowed == ("teacher_approved",):
+    if allowed == (CertificateStatus.TEACHER_APPROVED,):
         return f"Certificate must be teacher-approved first (current status: {cert.status})"
     return f"Certificate cannot transition from status: {cert.status}"
 
 
 def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request) -> Certificate:
     cert = _load_cert_or_404(db, cert_id, for_update=True)
-    _assert_status(cert, "pending")
+    _assert_status(cert, CertificateStatus.PENDING)
     _assert_not_self_approval(cert, teacher)
 
     ownership_detail = "You can only approve certificates for your own courses"
     course = _load_active_course_or_403(db, cert.course_id, ownership_detail=ownership_detail)
     assert_course_owner(course, teacher, allow_admin=False, detail=ownership_detail)
 
-    cert.status = "teacher_approved"
+    cert.status = CertificateStatus.TEACHER_APPROVED
     cert.teacher_approved_at = datetime.now(UTC)
     cert.teacher_approved_by = teacher.id
     db.commit()
@@ -176,7 +176,7 @@ def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request)
 
 def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> Certificate:
     cert = _load_cert_or_404(db, cert_id, for_update=True)
-    _assert_status(cert, "teacher_approved")
+    _assert_status(cert, CertificateStatus.TEACHER_APPROVED)
     _assert_not_self_approval(cert, admin)
 
     # Two-eyes guard. An admin who is ALSO the course's teacher can land on
@@ -194,7 +194,7 @@ def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> 
             ),
         )
 
-    cert.status = "approved"
+    cert.status = CertificateStatus.APPROVED
     cert.certificate_number = generate_certificate_number()
     now = datetime.now(UTC)
     cert.admin_approved_at = now
@@ -241,7 +241,7 @@ def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> 
 
 def reject(db: Session, cert_id: UUID, user: User, request: Request) -> Certificate:
     cert = _load_cert_or_404(db, cert_id, for_update=True)
-    if cert.status in ("approved", "rejected"):
+    if cert.status in (CertificateStatus.APPROVED, CertificateStatus.REJECTED):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Certificate cannot be rejected (current status: {cert.status})",
@@ -256,7 +256,7 @@ def reject(db: Session, cert_id: UUID, user: User, request: Request) -> Certific
     # Without this gate, a course-owning teacher could teacher-approve a
     # cert, change their mind, and reject it after it reached the admin
     # queue -- effectively a one-person veto of their own prior approval.
-    if cert.status == "teacher_approved" and user.role != UserRole.ADMIN.value:
+    if cert.status == CertificateStatus.TEACHER_APPROVED and user.role != UserRole.ADMIN.value:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=("Only an administrator can reject a certificate that has already passed teacher approval."),
@@ -270,7 +270,7 @@ def reject(db: Session, cert_id: UUID, user: User, request: Request) -> Certific
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ownership_detail)
     assert_course_owner(course, user, detail=ownership_detail)
 
-    cert.status = "rejected"
+    cert.status = CertificateStatus.REJECTED
 
     # Phase 5v: same locale-aware fan-out as the approval path.
     recipient_locale = normalize_locale(_recipient_locale(db, cert.user_id))


### PR DESCRIPTION
## Summary

The `CertificateStatus` StrEnum already existed in `models/certificate.py` but every route + service still compared against bare string literals (`status == "pending"`, `status = "teacher_approved"`, …). A typo in any literal would silently mis-route the state machine with no static check to catch it.

Threads the enum through `api/v1/certificates.py` + `services/certificate_service.py`:

| Path | Transition |
|---|---|
| request-creation | PENDING / REJECTED |
| status-error-message helper | PENDING / TEACHER_APPROVED |
| `teacher_approve` | PENDING → TEACHER_APPROVED |
| `admin_approve` | TEACHER_APPROVED → APPROVED |
| `reject` | refuses APPROVED / REJECTED; TEACHER_APPROVED needs admin |
| `list_pending` / `list_admin_pending` | filter predicates |

The remaining bare-string literals in `certificate_service.py` are the `kind` parameter on `_localize_cert_notification` ("approved" / "rejected") — that is notification-flavour vocabulary, not the cert-state enum, so it deliberately stays as a literal.

Mirrors the pattern `cohorts.py` already uses with `CohortStatus`.

## Test plan

- [x] `pytest -q` → 909 passed
- [x] `mypy` clean
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)