### PR TITLE
fix(navbar): V1 phase 5ah — drop tooltip + inline panel in mobile sheet

### DIFF
--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -77,55 +77,66 @@ export default function NotificationBell({
   const isSheet = panelVariant === "sheet"
   const isNavRow = triggerVariant === "navRow"
 
+  const triggerButton = (
+    <Button
+      ref={buttonRef}
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "relative shadow-none ring-offset-background focus-visible:ring-1",
+        isNavRow
+          ? "flex h-auto min-h-10 w-full flex-row items-center justify-between rounded-md px-3 py-2 text-left text-sm font-normal hover:bg-muted"
+          : "p-0",
+        !isNavRow && isSheet && "h-10 min-h-10 w-10 min-w-10",
+        !isNavRow && !isSheet && "h-7 w-7",
+        isNavRow && open && "bg-muted/80",
+      )}
+      onClick={() => setOpen((prev) => !prev)}
+      aria-label={isNavRow ? undefined : t("notifications.menuAriaLabel")}
+      aria-expanded={open}
+      aria-haspopup="true"
+    >
+      {isNavRow ? (
+        <>
+          <span className="text-sm font-medium text-foreground">{t("notifications.title")}</span>
+          <span className="flex min-w-[1.25rem] items-center justify-end">
+            {unreadCount > 0 ? (
+              <span className="rounded-full bg-destructive px-2 py-0.5 text-xs font-semibold tabular-nums text-destructive-foreground">
+                {unreadCount > 99 ? "99+" : unreadCount}
+              </span>
+            ) : null}
+          </span>
+        </>
+      ) : (
+        <>
+          <Bell className="h-3.5 w-3.5" strokeWidth={1.75} />
+          {unreadCount > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 flex min-h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-xs font-bold leading-none text-destructive-foreground">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          )}
+        </>
+      )}
+    </Button>
+  )
+
   return (
     <div className={cn("relative", isSheet && "w-full")}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            ref={buttonRef}
-            variant="ghost"
-            size="sm"
-            className={cn(
-              "relative shadow-none ring-offset-background focus-visible:ring-1",
-              isNavRow
-                ? "flex h-auto min-h-10 w-full flex-row items-center justify-between rounded-md px-3 py-2 text-left text-sm font-normal hover:bg-muted"
-                : "p-0",
-              !isNavRow && isSheet && "h-10 min-h-10 w-10 min-w-10",
-              !isNavRow && !isSheet && "h-7 w-7",
-              isNavRow && open && "bg-muted/80",
-            )}
-            onClick={() => setOpen((prev) => !prev)}
-            aria-label={isNavRow ? undefined : t("notifications.menuAriaLabel")}
-            aria-expanded={open}
-            aria-haspopup="true"
-          >
-            {isNavRow ? (
-              <>
-                <span className="text-sm font-medium text-foreground">{t("notifications.title")}</span>
-                <span className="flex min-w-[1.25rem] items-center justify-end">
-                  {unreadCount > 0 ? (
-                    <span className="rounded-full bg-destructive px-2 py-0.5 text-xs font-semibold tabular-nums text-destructive-foreground">
-                      {unreadCount > 99 ? "99+" : unreadCount}
-                    </span>
-                  ) : null}
-                </span>
-              </>
-            ) : (
-              <>
-                <Bell className="h-3.5 w-3.5" strokeWidth={1.75} />
-                {unreadCount > 0 && (
-                  <span className="absolute -right-0.5 -top-0.5 flex min-h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-xs font-bold leading-none text-destructive-foreground">
-                    {unreadCount > 99 ? "99+" : unreadCount}
-                  </span>
-                )}
-              </>
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <p>{t("header.notifications")}</p>
-        </TooltipContent>
-      </Tooltip>
+      {/* The icon variant needs a tooltip because the bell is the only
+          affordance; the navRow variant already renders a full
+          "Уведомления" / "Notifications" label, so a tooltip on top of
+          that just stacks a duplicate "Notifications" overlay on tap
+          inside the mobile sheet. Skip the wrapper entirely there. */}
+      {isNavRow ? (
+        triggerButton
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>{triggerButton}</TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p>{t("header.notifications")}</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
 
       {open && (
         <NotificationPanel

--- a/frontend/src/components/layout/notifications/NotificationPanel.tsx
+++ b/frontend/src/components/layout/notifications/NotificationPanel.tsx
@@ -54,15 +54,21 @@ export const NotificationPanel = forwardRef<HTMLDivElement, Props>(
         role="region"
         aria-label={t("notifications.panelAriaLabel")}
         className={cn(
-          "absolute top-full z-50 mt-2 overflow-hidden rounded-lg border border-border shadow-lg",
-          // Glass effect on the desktop popover only: when the notification
-          // dropdown floats over a busy course/admin page, the frosted layer
-          // separates it from the content underneath without using a hard
-          // shadow alone. Stays solid on the mobile sheet variant — the
-          // sheet already has its own backdrop, doubling up reads as noise.
+          "mt-2 overflow-hidden rounded-lg border border-border shadow-lg",
+          // Sheet variant: live in the flex flow so it pushes the
+          // "Profile" link below it instead of floating over the next
+          // nav row as a phantom overlay (the original
+          // ``absolute top-full`` covered every menu item under the
+          // bell in the mobile sheet — what Vadym called the overlay
+          // "помимо основного пункта"). Solid background here is fine
+          // because the mobile sheet already has its own backdrop.
+          //
+          // Popover variant: still anchored absolutely over the page
+          // content. The frosted layer separates the dropdown from the
+          // busy course/admin pages it floats over.
           isSheet
-            ? "left-0 right-0 z-[60] w-full max-w-none bg-background"
-            : "right-0 w-80 sm:w-96 bg-background/85 backdrop-blur-md supports-[backdrop-filter]:bg-background/75",
+            ? "w-full bg-background"
+            : "absolute right-0 top-full z-50 w-80 bg-background/85 backdrop-blur-md sm:w-96 supports-[backdrop-filter]:bg-background/75",
         )}
       >
         <div className="flex items-center justify-between border-b border-border px-4 py-3">


### PR DESCRIPTION
## Summary

**User-reported bug:** opening Notifications inside the mobile header sheet shows "некий overlay помимо основного пункта уведомления". Two distinct issues in the sheet variant (`triggerVariant="navRow"`, `panelVariant="sheet"`):

### 1. Duplicate tooltip overlay on tap

The trigger button is always wrapped in `<Tooltip>` with TooltipContent showing "Notifications". The navRow trigger already shows a visible "Уведомления" / "Notifications" label, so on tap the floating tooltip stacks a duplicate copy beside the row.

**Fix:** skip the `Tooltip` wrapper when `isNavRow`. The visible label is the only affordance needed.

### 2. Panel floats over the next nav row

The dropdown was `absolute top-full z-50` regardless of variant. In the popover variant thatʼs correct (floats over page content). In the sheet variant the bell trigger lives inside a vertical flex column with "Profile and settings" below it, so the absolute panel covers that link instead of pushing it down.

**Fix:** sheet variant drops `absolute / top-full / z-50` and stays in the static flex flow with `mt-2`. The Profile link slides below the expanded panel as expected.

Popover variant unchanged; the `bg-background/85 backdrop-blur-md` frosted layer still floats over busy course/admin pages.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run -- src/components/layout` → 13 passed
- [ ] Manual: open the mobile header sheet, tap Notifications — the panel expands inline (no floating overlay), the "Profile and settings" link slides below it, no duplicate "Notifications" tooltip appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)