### PR TITLE
chore(bilingual): V1 phase 5aj — drop legacy content_translations table

### DIFF
--- a/supabase/migrations/20260529030000_drop_content_translations.sql
+++ b/supabase/migrations/20260529030000_drop_content_translations.sql
@@ -1,0 +1,32 @@
+-- Phase 5aj: drop the legacy `content_translations` table.
+--
+-- Architecture context:
+-- ---------------------
+-- The original Phase 1-4 design used `content_translations` as an
+-- overlay sitting next to entity tables that still owned the source
+-- text in their own `title` / `description` / `content` columns.
+--
+-- Phase 5e-g (May 2026) inverted that: every translatable field moved
+-- INTO `content_versions` and the entity-table source columns were
+-- dropped. `content_translations` was kept as a no-op shadow during
+-- Phase 5c so a rollback was cheap.
+--
+-- Verification before this drop:
+-- ------------------------------
+-- * No live Python module imports anything resembling
+--   `ContentTranslation` or queries the `content_translations` table.
+--   Only doc-comments in `app/models/content_version.py`,
+--   `app/services/content_versions/read.py`,
+--   `app/services/translation/orchestrator.py`, etc reference it as
+--   historical context. The model file `content_translation.py` no
+--   longer exists; the only artifacts were stale `__pycache__` entries.
+-- * Last successful write to the table in prod was 2026-05-23, which
+--   matches the cutoff when Phase 5c stopped writing.
+-- * 541 stale rows are present at the moment of this migration. They
+--   are not read by anything; the cv table is the only live store.
+--
+-- This drop is reversible only via Supabase point-in-time recovery
+-- since the rows themselves are gone. The schema can be re-created
+-- from `20260507000000_add_content_translations.sql` if needed.
+
+DROP TABLE IF EXISTS content_translations;


### PR DESCRIPTION
## Summary

`content_translations` was an overlay table from the Phase 1-4 design that sat alongside entity tables which still owned the source text. Phase 5e-g moved every translatable field INTO `content_versions` and dropped the entity-table source columns. The legacy table was kept as a Phase 5c shadow so a rollback was cheap; that window is now closed.

## Verification before drop

- No live Python module imports `ContentTranslation` or queries the table. Every reference left in code is a doc-comment recording history.
- The model file `content_translation.py` no longer exists; only stale `__pycache__` entries.
- Last successful prod write was 2026-05-23, matching the Phase 5c cutoff.
- 541 stale rows existed at drop time; none referenced by live code.

Migration applied directly to prod via Supabase MCP per the pre-release risk-window policy. File committed so a freshly cloned dev env reaches the same schema.

## Test plan

- [x] No code references the table (confirmed via grep across `app/`, `tests/`)
- [x] Prod table dropped, verified with `information_schema.tables`
- [x] Backend tests (909) green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)