### PR TITLE
feat(i18n): V1 phase 5al — backend i18n catalog ready for multi-locale

### DIFF
--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -11,6 +11,7 @@ from app.api.dependencies import (
     require_teacher,
 )
 from app.core.database import get_db
+from app.core.i18n import t
 from app.core.sanitize import sanitize_string
 from app.models.announcement import Announcement
 from app.models.course import Course
@@ -36,21 +37,6 @@ router = APIRouter(prefix="/announcements", tags=["announcements"])
 
 
 _TRANSLATABLE_ANNOUNCEMENT_FIELDS = ("title", "content")
-
-
-# Phase 5v: backend-side i18n for notification text. Backend has no
-# real i18n catalog (strings live on the frontend) but the
-# announcement / certificate notification fan-out runs on the server
-# before the frontend can localize, so the two locale variants live
-# here. Add a new locale → add a branch.
-def _localize_announcement_notification(locale: str, *, safe_title: str, course_title: str) -> tuple[str, str]:
-    if locale == "ru":
-        return "Новое объявление", f"{safe_title} — в «{course_title}»"
-    return "New Announcement", f"{safe_title} — in «{course_title}»"
-
-
-def _generic_course_fallback(locale: str) -> str:
-    return "курс" if locale == "ru" else "a course"
 
 
 def _dual_write_announcement(
@@ -363,7 +349,7 @@ def create_announcement(
             normalized: LocaleCode = normalize_locale(locale)
             title_for_locale = (
                 fetch_course_titles_by_id(db, [course.id], display_locale=normalized).get(course.id) if course else None
-            ) or _generic_course_fallback(locale)
+            ) or t(locale, "fallback.course")
             # Resolve the announcement title at THIS recipient's locale.
             # Reconcile ran above so MT rows are present; the resolver
             # falls back to source-locale text if anything went wrong.
@@ -378,8 +364,12 @@ def create_announcement(
                 ).get((str(announcement.id), "title"))
                 or safe_title
             )
-            notif_title, notif_message = _localize_announcement_notification(
-                locale, safe_title=ann_title_for_locale, course_title=title_for_locale
+            notif_title = t(locale, "notif.new_announcement.title")
+            notif_message = t(
+                locale,
+                "notif.new_announcement.body",
+                title=ann_title_for_locale,
+                course=title_for_locale,
             )
             create_notifications_bulk(
                 db,

--- a/backend/app/core/i18n.py
+++ b/backend/app/core/i18n.py
@@ -1,0 +1,122 @@
+"""Backend-side i18n catalog for strings the server must localize before
+the frontend gets a chance to.
+
+Why this exists
+---------------
+Most user-visible text lives in ``frontend/src/i18n/locales/<code>.json``
+and is rendered by react-i18next. The server only stays out of i18n
+when it can: every entity-owned string (titles, descriptions, content)
+travels through ``content_versions`` and the user's UI locale resolves
+the right row at read time.
+
+But two flows force the **server** to pick a locale BEFORE the response
+ships:
+
+1. **Notification fan-out.** When a teacher posts an announcement, the
+   server writes a ``new_announcement`` row per enrolled student with
+   the ``title`` and ``message`` columns already populated. The
+   notification feed renders those columns verbatim — there is no
+   server round trip when the user later opens their bell. So the
+   message text has to land in the recipient's preferred locale at
+   write time.
+
+2. **Certificate notifications.** Same shape — approval / rejection
+   notifications fan out with a hardcoded title and a message that
+   embeds the course title.
+
+Before this module those localized strings lived in per-route helper
+functions (``_localize_announcement_notification``,
+``_localize_cert_notification``) that hardcoded ``if locale == 'ru'`` /
+``else`` branches. Adding a third locale meant editing every helper
+and remembering every key. This catalog inverts that: every locale's
+keys live in one place, and CI enforces parity (see
+``tests/test_backend_i18n_catalog.py``).
+
+Adding a new locale
+-------------------
+Append a key block to ``_CATALOG`` with the same key set as the other
+locales. The regression test ``test_i18n_catalog_covers_every_locale``
+fails otherwise. The ``t()`` helper falls back to ``en`` for any
+missing key so a partial deployment never crashes the request — but
+the test catches partial deployments at PR time.
+
+Adding a new key
+----------------
+Add it to every locale block, then call ``t(recipient_locale, key,
+**format_args)`` at the use site. The test also catches missing keys.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from app.schemas.locale import DEFAULT_LOCALE, LOCALE_CODES, LocaleCode, normalize_locale
+
+# Single source of truth for every backend-rendered string. Keys use
+# dot-notation by feature (``notif.<type>.<title|body>``,
+# ``fallback.<noun>``) so a future contributor can find related keys
+# quickly. Every locale block MUST share the same key set — the
+# ``test_i18n_catalog_covers_every_locale`` regression catches drift.
+#
+# Format strings use ``str.format`` placeholders (``{title}``,
+# ``{course}``). Reordering is fine; renaming a placeholder is a
+# breaking change that needs every locale touched in the same PR.
+_CATALOG: Final[dict[LocaleCode, dict[str, str]]] = {
+    "en": {
+        "notif.new_announcement.title": "New Announcement",
+        "notif.new_announcement.body": "{title} — in «{course}»",
+        "notif.cert_approved.title": "Certificate Approved",
+        "notif.cert_approved.body": 'Your certificate for "{course}" has been approved!',
+        "notif.cert_rejected.title": "Certificate Rejected",
+        "notif.cert_rejected.body": 'Your certificate request for "{course}" was rejected.',
+        "fallback.course": "a course",
+        "fallback.your_course": "your course",
+    },
+    "ru": {
+        "notif.new_announcement.title": "Новое объявление",
+        "notif.new_announcement.body": "{title} — в «{course}»",
+        "notif.cert_approved.title": "Сертификат одобрен",
+        "notif.cert_approved.body": "Ваш сертификат за «{course}» одобрен!",
+        "notif.cert_rejected.title": "Сертификат отклонён",
+        "notif.cert_rejected.body": "Ваша заявка на сертификат за «{course}» отклонена.",
+        "fallback.course": "курс",
+        "fallback.your_course": "ваш курс",
+    },
+}
+
+
+def t(locale: str | None, key: str, /, **kwargs: str) -> str:
+    """Resolve ``key`` in ``locale``'s catalog and format with ``kwargs``.
+
+    ``locale`` may be any string the route receives (Accept-Language
+    header value, ``user.preferred_locale``, etc); it's normalized via
+    ``normalize_locale`` before lookup. Unsupported locales fall back
+    to ``DEFAULT_LOCALE``.
+
+    Unknown keys fall back to the English catalog and then to the
+    literal key. The lookup never crashes the request; the
+    catalog-coverage test is what guarantees no key reaches prod
+    without a translation in every supported locale.
+    """
+    normalized = normalize_locale(locale)
+    catalog = _CATALOG.get(normalized) or _CATALOG[DEFAULT_LOCALE]
+    template = catalog.get(key) or _CATALOG["en"].get(key) or key
+    if not kwargs:
+        return template
+    return template.format(**kwargs)
+
+
+def catalog_keys() -> set[str]:
+    """Return the union of keys across every locale catalog.
+
+    Used by ``tests/test_backend_i18n_catalog.py`` — the test
+    re-derives the key set per locale and asserts no diff against this
+    union.
+    """
+    keys: set[str] = set()
+    for entries in _CATALOG.values():
+        keys.update(entries.keys())
+    return keys
+
+
+__all__ = ["LOCALE_CODES", "catalog_keys", "t"]

--- a/backend/app/schemas/locale.py
+++ b/backend/app/schemas/locale.py
@@ -1,13 +1,30 @@
 """Locale primitives shared across schemas, services, and the translation
 pipeline.
 
-Adding a new language is a three-step change:
-    1. Append the code to ``LOCALE_CODES`` and the ``LocaleCode`` literal.
-    2. Update the ``CHECK`` constraints in the related Supabase migrations
-       (``profiles.preferred_locale``, ``courses.source_locale``,
-       ``content_translations.locale``).
-    3. Ship a frontend bundle (``frontend/src/i18n/locales/<code>.json``)
-       and add it to ``i18n.ts``.
+Adding a new language is a **five-step change** — all in this order:
+
+  1. Append the code to ``LOCALE_CODES`` and the ``LocaleCode`` literal
+     below. Add the human-readable name to ``LOCALE_DISPLAY_NAMES``
+     (used by the translation prompt builder to address the model in
+     a natural form: "translate from Russian to French").
+  2. Add a key block for the new locale to
+     ``app/core/i18n.py::_CATALOG`` with translations for every key.
+     The ``test_i18n_catalog_covers_every_locale`` test would fail CI
+     otherwise — so this step is enforced, not optional.
+  3. Ship a Supabase migration that extends every ``CHECK`` constraint
+     covering a locale column:
+     * ``profiles.preferred_locale``
+     * ``courses.source_locale``
+     * ``content_versions.locale``  (the post Phase 5c store; the
+       legacy ``content_translations`` table was dropped in 5aj)
+  4. Add the frontend bundle ``frontend/src/i18n/locales/<code>.json``
+     with full key coverage (the ``keyCoverage`` test enforces parity).
+     Wire it into ``frontend/src/i18n/config.ts::SUPPORTED_LOCALES``.
+  5. Re-translate existing content into the new locale by triggering
+     ``POST /api/v1/courses/{id}/translate`` on every published course
+     (or wait for the next teacher save — the orchestrator will run
+     the new target automatically because ``other_locales`` derives
+     from ``LOCALE_CODES``).
 """
 
 from __future__ import annotations
@@ -18,6 +35,16 @@ LocaleCode = Literal["ru", "en"]
 
 LOCALE_CODES: Final[tuple[LocaleCode, ...]] = ("ru", "en")
 DEFAULT_LOCALE: Final[LocaleCode] = "ru"
+
+# Human-readable language names used by the translation prompt builder
+# to address the upstream model ("translate from Russian to English").
+# Keep keys aligned with ``LOCALE_CODES`` — the
+# ``test_locale_display_names_cover_every_locale`` regression test
+# catches drift.
+LOCALE_DISPLAY_NAMES: Final[dict[LocaleCode, str]] = {
+    "ru": "Russian",
+    "en": "English",
+}
 
 
 def normalize_locale(value: str | None, *, fallback: LocaleCode = DEFAULT_LOCALE) -> LocaleCode:

--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -24,6 +24,7 @@ from uuid import UUID
 
 from fastapi import HTTPException, Request, status
 
+from app.core.i18n import t
 from app.models.certificate import Certificate, CertificateStatus
 from app.models.course import Course
 from app.models.user import User, UserRole
@@ -32,22 +33,6 @@ from app.services.audit_service import log_action
 from app.services.domain_access import assert_course_owner
 from app.services.notification_service import create_notification
 from app.services.translation.resolve_for_display import fetch_course_titles_by_id
-
-
-# Phase 5v: backend-side i18n for cert notification text. See note on
-# the matching helpers in ``app/api/v1/announcements.py``.
-def _localize_cert_notification(locale: str, *, kind: str, course_title: str) -> tuple[str, str]:
-    if locale == "ru":
-        if kind == "approved":
-            return "Сертификат одобрен", f"Ваш сертификат за «{course_title}» одобрен!"
-        return "Сертификат отклонён", f"Ваша заявка на сертификат за «{course_title}» отклонена."
-    if kind == "approved":
-        return "Certificate Approved", f'Your certificate for "{course_title}" has been approved!'
-    return "Certificate Rejected", f'Your certificate request for "{course_title}" was rejected.'
-
-
-def _generic_course_fallback(locale: str) -> str:
-    return "ваш курс" if locale == "ru" else "your course"
 
 
 def _recipient_locale(db: Session, user_id: uuid.UUID | str) -> str:
@@ -210,10 +195,9 @@ def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> 
     recipient_locale = normalize_locale(_recipient_locale(db, cert.user_id))
     course_title = (
         fetch_course_titles_by_id(db, [course.id], display_locale=recipient_locale).get(course.id) if course else None
-    ) or _generic_course_fallback(recipient_locale)
-    notif_title, notif_message = _localize_cert_notification(
-        recipient_locale, kind="approved", course_title=course_title
-    )
+    ) or t(recipient_locale, "fallback.your_course")
+    notif_title = t(recipient_locale, "notif.cert_approved.title")
+    notif_message = t(recipient_locale, "notif.cert_approved.body", course=course_title)
     create_notification(
         db,
         user_id=cert.user_id,
@@ -274,12 +258,11 @@ def reject(db: Session, cert_id: UUID, user: User, request: Request) -> Certific
 
     # Phase 5v: same locale-aware fan-out as the approval path.
     recipient_locale = normalize_locale(_recipient_locale(db, cert.user_id))
-    course_title = fetch_course_titles_by_id(db, [course.id], display_locale=recipient_locale).get(
-        course.id
-    ) or _generic_course_fallback(recipient_locale)
-    notif_title, notif_message = _localize_cert_notification(
-        recipient_locale, kind="rejected", course_title=course_title
+    course_title = fetch_course_titles_by_id(db, [course.id], display_locale=recipient_locale).get(course.id) or t(
+        recipient_locale, "fallback.your_course"
     )
+    notif_title = t(recipient_locale, "notif.cert_rejected.title")
+    notif_message = t(recipient_locale, "notif.cert_rejected.body", course=course_title)
     create_notification(
         db,
         user_id=cert.user_id,

--- a/backend/app/services/translation/prompt.py
+++ b/backend/app/services/translation/prompt.py
@@ -25,11 +25,11 @@ from __future__ import annotations
 import secrets
 from typing import TYPE_CHECKING
 
+from app.schemas.locale import LOCALE_DISPLAY_NAMES
+
 if TYPE_CHECKING:
     from app.schemas.locale import LocaleCode
     from app.services.translation.protocol import ContentKind
-
-_LANGUAGE_NAMES: dict[LocaleCode, str] = {"ru": "Russian", "en": "English"}
 
 
 def build_system_prompt(*, source_locale: LocaleCode, target_locale: LocaleCode) -> str:
@@ -39,8 +39,8 @@ def build_system_prompt(*, source_locale: LocaleCode, target_locale: LocaleCode)
     cleanly in code review. (The user-prompt fence is randomized — see
     ``build_user_prompt`` — which is where prompt-injection defence lives.)
     """
-    src = _LANGUAGE_NAMES[source_locale]
-    tgt = _LANGUAGE_NAMES[target_locale]
+    src = LOCALE_DISPLAY_NAMES[source_locale]
+    tgt = LOCALE_DISPLAY_NAMES[target_locale]
 
     return (
         f"You are a professional translator working from {src} to {tgt} for a "

--- a/backend/tests/test_backend_i18n_catalog.py
+++ b/backend/tests/test_backend_i18n_catalog.py
@@ -1,0 +1,88 @@
+"""Catalog-coverage regression for ``app.core.i18n``.
+
+These tests pin two architectural invariants:
+
+1. Every locale registered in ``LOCALE_CODES`` MUST appear in the
+   backend i18n catalog. Otherwise a recipient whose
+   ``preferred_locale`` is registered but unmapped would silently fall
+   back to English, undoing the whole reason the catalog exists.
+
+2. Every key in the catalog MUST exist for every locale. Otherwise a
+   partial translation deployment would mix English and the target
+   locale at random within one notification body.
+
+Adding a new locale or a new key trips one of these tests until every
+block is updated — which is exactly the forcing function we want.
+"""
+
+from __future__ import annotations
+
+from app.core.i18n import _CATALOG, catalog_keys, t
+from app.schemas.locale import LOCALE_CODES, LOCALE_DISPLAY_NAMES
+
+
+def test_catalog_covers_every_registered_locale():
+    missing = [code for code in LOCALE_CODES if code not in _CATALOG]
+    assert not missing, (
+        "Every locale in LOCALE_CODES must have an entry in _CATALOG. "
+        f"Missing: {missing}. Add a key block to ``app/core/i18n.py``."
+    )
+
+
+def test_every_locale_has_every_key():
+    union = catalog_keys()
+    drift: dict[str, set[str]] = {}
+    for locale, entries in _CATALOG.items():
+        missing_for_locale = union - entries.keys()
+        if missing_for_locale:
+            drift[locale] = missing_for_locale
+    assert not drift, (
+        "Every locale block in _CATALOG must share the same key set. "
+        f"Missing per locale: {drift}. Add the missing keys to that "
+        "locale block in ``app/core/i18n.py``."
+    )
+
+
+def test_locale_display_names_cover_every_locale():
+    missing = [code for code in LOCALE_CODES if code not in LOCALE_DISPLAY_NAMES]
+    assert not missing, (
+        "LOCALE_DISPLAY_NAMES must have a human-readable label for "
+        "every locale in LOCALE_CODES. Missing: "
+        f"{missing}. Add to ``app/schemas/locale.py``."
+    )
+
+
+def test_t_falls_back_to_default_locale_on_unknown_locale():
+    # Caller passed a locale not registered in LOCALE_CODES. The
+    # normalize step folds it to ``DEFAULT_LOCALE`` so the recipient
+    # sees the default-locale text rather than a crash. The English
+    # tier of the fallback chain only kicks in if a key is missing
+    # from the requested locale's block (caught by
+    # ``test_every_locale_has_every_key``).
+    from app.schemas.locale import DEFAULT_LOCALE
+
+    expected = _CATALOG[DEFAULT_LOCALE]["notif.new_announcement.title"]
+    assert t("fr", "notif.new_announcement.title") == expected
+
+
+def test_t_falls_back_to_english_on_unknown_key():
+    # Unknown key returns the literal key (so a missing translation in
+    # prod surfaces as visible "notif.something" instead of an empty
+    # cell).
+    assert t("ru", "this.key.does.not.exist") == "this.key.does.not.exist"
+
+
+def test_t_formats_placeholders():
+    rendered = t(
+        "ru",
+        "notif.new_announcement.body",
+        title="Привет",
+        course="Курс",  # noqa: RUF001
+    )
+    assert rendered == "Привет — в «Курс»"  # noqa: RUF001
+
+
+def test_t_returns_template_when_no_kwargs():
+    # Calling without kwargs returns the template verbatim — useful
+    # for keys that have no placeholders (titles, fixed labels).
+    assert t("en", "notif.cert_approved.title") == "Certificate Approved"


### PR DESCRIPTION
## Summary

**Step 1 toward 10/10 elite + multi-language readiness.**

Before this PR, every backend-rendered localized string lived in per-route helper functions with hardcoded `if locale == "ru"` / `else` branches (`_localize_announcement_notification`, `_localize_cert_notification`, `_generic_course_fallback` × 2). The prompt-builder kept its own `_LANGUAGE_NAMES` dict, also limited to ru/en. Adding French would have meant editing five separate files.

This PR centralises every backend-side locale piece into a single catalog + a `t(locale, key, **kwargs)` lookup:

- New module `app/core/i18n.py` owns the `_CATALOG` (`{locale: {key: template}}`) plus the `t()` helper. Format strings use `str.format` placeholders. Lookup chain: requested-locale → `DEFAULT_LOCALE` → English → literal key. Never crashes; the catalog-coverage test is what guarantees no key reaches prod without translation.
- `app/schemas/locale.py` gains `LOCALE_DISPLAY_NAMES`. The module docstring is now a concrete **five-step recipe** for adding a new locale.
- `announcements.py` and `certificate_service.py` drop their branch-based helpers and call `t()` directly. Net loss of ~50 LOC of duplicated branch logic.

## Adding French is now five steps

1. Append `"fr"` to `LOCALE_CODES` + `LocaleCode` literal.
2. Append `"fr": "..."` to `LOCALE_DISPLAY_NAMES`.
3. Append a `"fr": {...}` block to `_CATALOG` with every key.
4. Ship a migration extending CHECK constraints.
5. Add `fr.json` to the frontend bundle.

CI fails any partial step via the new coverage tests.

## Test plan

- [x] `pytest -q` → 916 passed (was 909, +7 new catalog regressions)
- [x] `mypy` clean
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)