### PR TITLE
fix(theme): V1 phase 5aq — fix invisible buttons in dark mode

### DIFF
--- a/frontend/src/components/quiz/QuizTaker.tsx
+++ b/frontend/src/components/quiz/QuizTaker.tsx
@@ -209,7 +209,7 @@ export default function QuizTaker({ chapterId, quizId, onSubmitted }: QuizTakerP
             className={
               !allAnswered || submitting || attemptsReached
                 ? "w-full"
-                : "w-full bg-cta-glow"
+                : "w-full cta-glow"
             }
           >
             {submitting ? (

--- a/frontend/src/components/ui/buttonVariants.ts
+++ b/frontend/src/components/ui/buttonVariants.ts
@@ -1,7 +1,13 @@
 import { cva } from "class-variance-authority"
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[color,box-shadow,transform] duration-150 ease-editorial focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  // Disabled state uses explicit muted tokens instead of ``opacity-50``.
+  // ``opacity-50`` on a dark-mode primary button (lavender at 50%
+  // luminance on top of a near-black surface) collapses contrast to
+  // sub-AA and effectively makes the button — and any spinner / icon
+  // inside — invisible. The token-based approach gives a deliberate
+  // disabled colour that the design system controls per theme.
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[color,box-shadow,transform] duration-150 ease-editorial focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted",
   {
     variants: {
       variant: {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -471,11 +471,11 @@
     }
   }
 
-  .bg-cta-glow {
+  .cta-glow {
     position: relative;
     isolation: isolate;
   }
-  .bg-cta-glow::after {
+  .cta-glow::after {
     content: "";
     position: absolute;
     inset: -1px;
@@ -490,12 +490,12 @@
     transition: opacity 0.28s cubic-bezier(0.22, 1, 0.36, 1);
     pointer-events: none;
   }
-  .bg-cta-glow:hover::after,
-  .bg-cta-glow:focus-visible::after {
+  .cta-glow:hover::after,
+  .cta-glow:focus-visible::after {
     opacity: 1;
   }
   @media (prefers-reduced-motion: reduce) {
-    .bg-cta-glow::after {
+    .cta-glow::after {
       transition: none;
     }
   }

--- a/frontend/src/pages/Auth/ForgotPassword.tsx
+++ b/frontend/src/pages/Auth/ForgotPassword.tsx
@@ -99,7 +99,7 @@ export default function ForgotPassword() {
             />
           </div>
 
-          <Button type="submit" size="lg" className="bg-cta-glow w-full font-medium" disabled={loading}>
+          <Button type="submit" size="lg" className="cta-glow w-full font-medium" disabled={loading}>
             {loading ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" strokeWidth={1.75} />

--- a/frontend/src/pages/Auth/Login.tsx
+++ b/frontend/src/pages/Auth/Login.tsx
@@ -146,7 +146,7 @@ export default function Login() {
             {errors.password && <p id="password-error" role="alert" className="text-xs text-destructive mt-1">{errors.password}</p>}
           </div>
 
-          <Button type="submit" size="lg" className="bg-cta-glow w-full font-medium rounded-md" disabled={loading}>
+          <Button type="submit" size="lg" className="cta-glow w-full font-medium rounded-md" disabled={loading}>
             {loading ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" strokeWidth={1.75} />

--- a/frontend/src/pages/Auth/ResetPassword.tsx
+++ b/frontend/src/pages/Auth/ResetPassword.tsx
@@ -154,7 +154,7 @@ export default function ResetPassword() {
             )}
           </div>
 
-          <Button type="submit" size="lg" className="bg-cta-glow w-full font-medium" disabled={loading}>
+          <Button type="submit" size="lg" className="cta-glow w-full font-medium" disabled={loading}>
             {loading ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" strokeWidth={1.75} />

--- a/frontend/src/pages/Auth/register/RegisterForm.tsx
+++ b/frontend/src/pages/Auth/register/RegisterForm.tsx
@@ -249,7 +249,7 @@ export function RegisterForm({
           <Button
             type="submit"
             size="lg"
-            className="bg-cta-glow w-full font-medium rounded-md"
+            className="cta-glow w-full font-medium rounded-md"
             disabled={loading}
           >
             {loading ? (

--- a/frontend/src/pages/Course/detail/NotEnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/NotEnrolledView.tsx
@@ -201,7 +201,7 @@ export function NotEnrolledView({
           // surfaced the prior conditional that hid Enroll from owners.
           <div className="flex flex-wrap items-center gap-3">
             <Link to={`/teacher/courses/${course.id}`}>
-              <Button size="lg" className="bg-cta-glow">
+              <Button size="lg" className="cta-glow">
                 {t("courseDetail.manageCourse")}
               </Button>
             </Link>
@@ -235,7 +235,7 @@ export function NotEnrolledView({
               onClick={handleEnrollClick}
               disabled={enrolling || !canEnroll}
               size="lg"
-              className={!canEnroll ? undefined : "bg-cta-glow"}
+              className={!canEnroll ? undefined : "cta-glow"}
             >
               <Users className="mr-2 h-4 w-4" strokeWidth={1.75} aria-hidden />
               {!canEnroll
@@ -254,7 +254,7 @@ export function NotEnrolledView({
           </div>
         ) : (
           <Link to="/login">
-            <Button size="lg" className="bg-cta-glow">
+            <Button size="lg" className="cta-glow">
               {t("courseDetail.signInToEnroll")}
             </Button>
           </Link>


### PR DESCRIPTION
## Summary

User-reported: «кнопки меняют цвета, и их становится не видно. Quiz submit пропадает, enroll иногда невидно.» Two root causes.

### Bug 1: Quiz submit becomes invisible when the form is filled

QuizTaker adds `className="... bg-cta-glow"` to apply a hover/focus glow. But `bg-cta-glow` is a custom class that starts with `bg-` — and the project pipes className through `cn() = twMerge(clsx(...))`. **tailwind-merge sees `bg-cta-glow` as a background-color utility and strips the variant's `bg-primary` token to avoid "two backgrounds".** The Button ends up with NO background colour — white `text-primary-foreground` on a transparent body that takes the page background. On the light theme that's white-on-white = invisible.

**Fix:** rename `bg-cta-glow` → `cta-glow` (no `bg-` prefix). tailwind-merge ignores it; the variant's `bg-primary` survives; the glow `::after` pseudo still renders. Touched every callsite: QuizTaker, Login, Register, ForgotPassword, ResetPassword, NotEnrolledView, and the CSS rule in `index.css`.

### Bug 2: Disabled state goes invisible in dark mode

The base button variant set `disabled:opacity-50`. Lavender `--primary` at 50% luminance on a near-black surface collapses contrast below WCAG AA, and the spinner / icon inside inherit the same opacity.

**Fix:** replace `disabled:opacity-50` with explicit semantic tokens: `disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted`. The design system now controls the disabled colour per theme; foreground stays readable; spinners stop inheriting an opacity-stacked muted-foreground.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run -- src/components` → 84 passed
- [ ] Manual: open the dark theme, fill out a quiz — the Submit Quiz button stays visible. Open the enrolled page logged-out — the Enroll button stays visible. Toggle a form submit button into loading state — the spinner stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)