### PR TITLE
refactor(cv): V1 phase 5ar — ContentVersionStatus enum + stale-doc cleanup

### DIFF
--- a/backend/app/api/v1/blocks.py
+++ b/backend/app/api/v1/blocks.py
@@ -8,7 +8,7 @@ from app.api.dependencies import get_current_user, require_teacher, verify_chapt
 from app.core.database import get_db
 from app.core.sanitize import sanitize_string
 from app.models.chapter_block import ChapterBlock
-from app.models.content_version import ContentVersion
+from app.models.content_version import ContentVersion, ContentVersionStatus
 from app.models.course import Chapter, Course, Module
 from app.models.user import User
 from app.schemas.chapter_block import BlockCreate, BlockReorderItem, BlockResponse, BlockUpdate
@@ -40,7 +40,7 @@ def _block_to_response(db: Session, block: ChapterBlock) -> BlockResponse:
             ContentVersion.entity_id == str(block.id),
             ContentVersion.field == "content",
             ContentVersion.superseded_by.is_(None),
-            ContentVersion.status == "ok",
+            ContentVersion.status == ContentVersionStatus.OK,
         )
         .order_by(ContentVersion.created_at)
         .first()

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -170,7 +170,7 @@ def get_calendar_events(
         asg_rows_by_pair_locale: dict[tuple[str, str, str], str] = {}
         any_for_pair: dict[tuple[str, str], str] = {}
         if assignments:
-            from app.models.content_version import ContentVersion
+            from app.models.content_version import ContentVersion, ContentVersionStatus
 
             asg_ids = [str(a.id) for a in assignments]
             cv_rows = (
@@ -185,7 +185,7 @@ def get_calendar_events(
                     ContentVersion.entity_id.in_(asg_ids),
                     ContentVersion.field.in_(["title", "description"]),
                     ContentVersion.superseded_by.is_(None),
-                    ContentVersion.status == "ok",
+                    ContentVersion.status == ContentVersionStatus.OK,
                 )
                 .order_by(ContentVersion.entity_id, ContentVersion.field, ContentVersion.created_at)
                 .all()
@@ -231,7 +231,7 @@ def get_calendar_events(
     ce_rows_by_pair_locale: dict[tuple[str, str, str], str] = {}
     ce_any_for_pair: dict[tuple[str, str], str] = {}
     if course_events:
-        from app.models.content_version import ContentVersion
+        from app.models.content_version import ContentVersion, ContentVersionStatus
 
         ce_ids = [str(ce.id) for ce in course_events]
         cv_rows = (
@@ -246,7 +246,7 @@ def get_calendar_events(
                 ContentVersion.entity_id.in_(ce_ids),
                 ContentVersion.field.in_(["title", "description"]),
                 ContentVersion.superseded_by.is_(None),
-                ContentVersion.status == "ok",
+                ContentVersion.status == ContentVersionStatus.OK,
             )
             .order_by(ContentVersion.entity_id, ContentVersion.field, ContentVersion.created_at)
             .all()

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_optional_user, is_owner_or_admin, require_admin
 from app.core.database import get_db
 from app.models.cohort import Cohort, CohortCourse, CohortStatus
-from app.models.content_version import ContentVersion
+from app.models.content_version import ContentVersion, ContentVersionStatus
 from app.models.course import Course, CourseStatus
 from app.models.enrollment import Enrollment
 from app.models.user import User
@@ -91,7 +91,7 @@ def _fetch_cohort_names(db: Session, cohort_ids: list[UUID]) -> dict[str, str]:
             ContentVersion.entity_id.in_([str(cid) for cid in cohort_ids]),
             ContentVersion.field == "title",
             ContentVersion.superseded_by.is_(None),
-            ContentVersion.status == "ok",
+            ContentVersion.status == ContentVersionStatus.OK,
         )
         .order_by(ContentVersion.entity_id, ContentVersion.created_at)
         .all()

--- a/backend/app/api/v1/courses/catalog.py
+++ b/backend/app/api/v1/courses/catalog.py
@@ -180,7 +180,7 @@ def get_module_detail(
         # of overlay locale. Read the earliest active human-origin row
         # per field; fall back to the earliest of any origin so a content
         # row written by an importer still surfaces.
-        from app.models.content_version import ContentVersion
+        from app.models.content_version import ContentVersion, ContentVersionStatus
 
         cv_rows = (
             db.query(ContentVersion.field, ContentVersion.text, ContentVersion.origin)
@@ -189,7 +189,7 @@ def get_module_detail(
                 ContentVersion.entity_id == str(module.id),
                 ContentVersion.field.in_(["title", "description"]),
                 ContentVersion.superseded_by.is_(None),
-                ContentVersion.status == "ok",
+                ContentVersion.status == ContentVersionStatus.OK,
             )
             .order_by(ContentVersion.created_at)
             .all()

--- a/backend/app/models/content_version.py
+++ b/backend/app/models/content_version.py
@@ -1,28 +1,10 @@
 """ORM mapping for ``content_versions`` — the single multi-locale text store.
 
-Replaces the dual-table model (entity text columns = source +
-``content_translations`` = overlay). Every ``(entity, field, locale)``
-is a first-class row with its own provenance, status, and version
-chain.
-
-Phase rollout
--------------
-
-Phase 0 (this file): table + model + Pydantic mirror. Zero behaviour
-change — nothing reads or writes from it yet.
-
-Phase 1: dual-writes from every entity write path + the MT
-pipeline. Reads still go to entity columns + ``content_translations``.
-
-Phase 2: dual-reads. Resolve tries this table first, falls back to
-the legacy stores. Mismatches logged.
-
-Phase 3: backfill existing data into here.
-
-Phase 4: switch reads exclusive.
-
-Phase 5: drop entity text columns + drop ``content_translations`` +
-delete dead overlay code.
+Every ``(entity, field, locale)`` is a first-class row with its own
+provenance, status, and version chain. Replaces the original
+dual-table model (entity text columns = source + the now-dropped
+``content_translations`` overlay) since Phase 5e-g. The legacy table
+itself was dropped in Phase 5aj.
 
 Design rules pinned by the schema
 ---------------------------------
@@ -40,10 +22,13 @@ Design rules pinned by the schema
   (constraint would be too restrictive — operators can override).
 * ``source_version_id`` lets MT rows point at the EXACT version they
   were translated from. When a human row is superseded, every MT
-  derivative is precisely invalidatable — no more blunderbuss
-  ``purge_course_translations``.
+  derivative is precisely invalidatable.
+* ``status`` is a typed enum (``ContentVersionStatus``) — every
+  Python comparison goes through the enum so a typo silently breaks
+  the build instead of silently mis-routing the orchestrator.
 """
 
+import enum
 import uuid
 from datetime import datetime
 from typing import Literal
@@ -83,7 +68,22 @@ ContentVersionField = Literal[
 ]
 
 ContentVersionOrigin = Literal["human", "mt"]
-ContentVersionStatus = Literal["ok", "failed", "failed_permanent"]
+
+
+class ContentVersionStatus(enum.StrEnum):
+    """Lifecycle of a single ``content_versions`` row.
+
+    The string values match the ``content_versions_status_check`` CHECK
+    constraint (see ``__table_args__`` below). Every Python comparison
+    against ``ContentVersion.status`` goes through the enum so a typo
+    surfaces at the type-check pass instead of at runtime as a quiet
+    "no rows matched".
+    """
+
+    OK = "ok"
+    FAILED = "failed"
+    FAILED_PERMANENT = "failed_permanent"
+
 
 # How many MT attempts we tolerate before promoting to
 # ``failed_permanent``. Centralised here so admin tooling that

--- a/backend/app/services/content_versions/read.py
+++ b/backend/app/services/content_versions/read.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import tuple_
 
-from app.models.content_version import ContentVersion
+from app.models.content_version import ContentVersion, ContentVersionStatus
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -59,7 +59,7 @@ def fetch_cv_text_bulk(
             ).in_(uniq),
             ContentVersion.locale == display_locale,
             ContentVersion.superseded_by.is_(None),
-            ContentVersion.status == "ok",
+            ContentVersion.status == ContentVersionStatus.OK,
         )
         .all()
     )
@@ -112,7 +112,7 @@ def fetch_cv_entity_texts_with_fallback(
             ContentVersion.entity_id.in_(entity_ids),
             ContentVersion.field.in_(fields),
             ContentVersion.superseded_by.is_(None),
-            ContentVersion.status == "ok",
+            ContentVersion.status == ContentVersionStatus.OK,
         )
         .order_by(ContentVersion.entity_id, ContentVersion.field, ContentVersion.created_at)
         .all()

--- a/backend/app/services/content_versions/write.py
+++ b/backend/app/services/content_versions/write.py
@@ -30,13 +30,14 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from sqlalchemy import text as _text
 
 from app.models.content_version import (
     CONTENT_VERSION_MAX_ATTEMPTS,
     ContentVersion,
+    ContentVersionStatus,
 )
 
 if TYPE_CHECKING:
@@ -134,7 +135,7 @@ def record_human_version(
         locale=locale,
         text=text,
         origin="human",
-        status="ok",
+        status=ContentVersionStatus.OK,
         authored_by=authored_by,
     )
     db.add(new_row)
@@ -211,7 +212,7 @@ def record_mt_version(
         locale=locale,
         text=text,
         origin="mt",
-        status="ok",
+        status=ContentVersionStatus.OK,
         source_locale=source_locale,
         source_hash=source_hash,
         source_version_id=source_version_id,
@@ -265,8 +266,10 @@ def record_mt_failure(
         return existing
     if existing is not None and existing.origin == "mt":
         existing.attempts += 1
-        new_status: Literal["failed", "failed_permanent"] = (
-            "failed_permanent" if existing.attempts >= CONTENT_VERSION_MAX_ATTEMPTS else "failed"
+        new_status = (
+            ContentVersionStatus.FAILED_PERMANENT
+            if existing.attempts >= CONTENT_VERSION_MAX_ATTEMPTS
+            else ContentVersionStatus.FAILED
         )
         existing.status = new_status
         existing.source_locale = source_locale
@@ -287,7 +290,7 @@ def record_mt_failure(
         # out non-ok rows so this is never read by students.
         text="",
         origin="mt",
-        status="failed",
+        status=ContentVersionStatus.FAILED,
         attempts=1,
         source_locale=source_locale,
         source_hash=source_hash,

--- a/backend/app/services/course_readiness.py
+++ b/backend/app/services/course_readiness.py
@@ -275,7 +275,7 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
     all_block_ids = [str(b.id) for blocks in blocks_by_chapter.values() for b in blocks]
     blocks_with_cv_content: set[str] = set()
     if all_block_ids:
-        from app.models.content_version import ContentVersion
+        from app.models.content_version import ContentVersion, ContentVersionStatus
 
         # Filter out blank/whitespace text in Python — keeps the SQL
         # portable across SQLite (tests) and Postgres (prod). Pre-5e2
@@ -289,7 +289,7 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
                 ContentVersion.entity_id.in_(all_block_ids),
                 ContentVersion.field == "content",
                 ContentVersion.superseded_by.is_(None),
-                ContentVersion.status == "ok",
+                ContentVersion.status == ContentVersionStatus.OK,
             )
             .all()
             if text and text.strip()
@@ -318,7 +318,7 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
     # the per-chapter check can answer "has brief?" in O(1).
     assignments_with_cv_brief: set[str] = set()
     if assignments_by_chapter:
-        from app.models.content_version import ContentVersion
+        from app.models.content_version import ContentVersion, ContentVersionStatus
 
         assignment_ids = [str(a.id) for a in assignments_by_chapter.values()]
         assignments_with_cv_brief = {
@@ -329,7 +329,7 @@ def compute_readiness(db: Session, course: Course) -> ReadinessReport:
                 ContentVersion.entity_id.in_(assignment_ids),
                 ContentVersion.field == "description",
                 ContentVersion.superseded_by.is_(None),
-                ContentVersion.status == "ok",
+                ContentVersion.status == ContentVersionStatus.OK,
             )
             .all()
             if text and text.strip()

--- a/backend/app/services/course_service/_clone.py
+++ b/backend/app/services/course_service/_clone.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from app.models.assignment import Assignment
 from app.models.chapter_block import ChapterBlock
-from app.models.content_version import ContentVersion
+from app.models.content_version import ContentVersion, ContentVersionStatus
 from app.models.course import Chapter, Course, CourseStatus, Module
 from app.models.quiz import Quiz, QuizOption, QuizQuestion
 
@@ -57,7 +57,7 @@ def _clone_cv_rows(
             ContentVersion.entity_id.in_(list(id_map.keys())),
             ContentVersion.field.in_(fields),
             ContentVersion.superseded_by.is_(None),
-            ContentVersion.status == "ok",
+            ContentVersion.status == ContentVersionStatus.OK,
         )
         .all()
     )

--- a/backend/app/services/course_service/_queries.py
+++ b/backend/app/services/course_service/_queries.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload, selectinload
 
-from app.models.content_version import ContentVersion
+from app.models.content_version import ContentVersion, ContentVersionStatus
 from app.models.course import Chapter, Course, CourseStatus, Module
 from app.services.translation.resolve_for_display import populate_module_texts, populate_spine_texts
 
@@ -87,7 +87,7 @@ def get_courses(
                 ContentVersion.entity_type == "course",
                 ContentVersion.field.in_(["title", "description"]),
                 ContentVersion.superseded_by.is_(None),
-                ContentVersion.status == "ok",
+                ContentVersion.status == ContentVersionStatus.OK,
                 ContentVersion.text.ilike(term),
             )
             .distinct()

--- a/backend/app/services/translation/orchestrator.py
+++ b/backend/app/services/translation/orchestrator.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.models.content_version import ContentVersion
+from app.models.content_version import ContentVersion, ContentVersionStatus
 from app.schemas.locale import LOCALE_CODES, LocaleCode, normalize_locale
 from app.services.content_versions import record_mt_failure, record_mt_version
 from app.services.translation.hash import compute_source_hash
@@ -392,7 +392,7 @@ def _translate_one_field(
         .filter(
             ContentVersion.locale == target_locale,
             ContentVersion.source_hash == source_hash,
-            ContentVersion.status == "ok",
+            ContentVersion.status == ContentVersionStatus.OK,
             ContentVersion.superseded_by.is_(None),
             ~((ContentVersion.entity_type == entity_type) & (ContentVersion.entity_id == entity_id)),
         )

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Session  # noqa: TC002
 from app.models.announcement import Announcement  # noqa: TC001
 from app.models.assignment import Assignment  # noqa: TC001
 from app.models.chapter_block import ChapterBlock  # noqa: TC001
-from app.models.content_version import ContentVersion
+from app.models.content_version import ContentVersion, ContentVersionStatus
 from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent  # noqa: TC001
 from app.models.quiz import Quiz  # noqa: TC001
@@ -754,7 +754,7 @@ def localize_chapter_block_rows(
             ContentVersion.entity_id.in_(block_ids),
             ContentVersion.field == "content",
             ContentVersion.superseded_by.is_(None),
-            ContentVersion.status == "ok",
+            ContentVersion.status == ContentVersionStatus.OK,
         )
         .order_by(ContentVersion.entity_id, ContentVersion.created_at)
         .all()

--- a/backend/tests/test_content_version_status_enum.py
+++ b/backend/tests/test_content_version_status_enum.py
@@ -27,9 +27,7 @@ def test_enum_values_mirror_the_check_constraint():
     ]
     assert len(check_strs) == 1
     for value in expected:
-        assert f"'{value}'" in check_strs[0], (
-            f"CHECK constraint missing {value!r}; sync the enum and the constraint."
-        )
+        assert f"'{value}'" in check_strs[0], f"CHECK constraint missing {value!r}; sync the enum and the constraint."
 
 
 def test_enum_is_str_subclass():

--- a/backend/tests/test_content_version_status_enum.py
+++ b/backend/tests/test_content_version_status_enum.py
@@ -1,0 +1,42 @@
+"""Regression tests for ``ContentVersionStatus``.
+
+The enum mirrors the Postgres CHECK constraint on
+``content_versions.status``. Drift between the two is a class of bug
+that only surfaces at runtime as an IntegrityError on insert — these
+tests catch it at PR time.
+"""
+
+from __future__ import annotations
+
+from app.models.content_version import ContentVersion, ContentVersionStatus
+
+
+def test_enum_values_mirror_the_check_constraint():
+    """The CHECK constraint string in ``__table_args__`` enumerates
+    the allowed values. The Python enum must match exactly — adding a
+    new state in code without the migration to extend the CHECK would
+    silently fail INSERT in prod."""
+    expected = {"ok", "failed", "failed_permanent"}
+    assert {member.value for member in ContentVersionStatus} == expected
+
+    # And the CHECK constraint string itself uses the same set.
+    check_strs = [
+        str(constraint.sqltext)
+        for constraint in ContentVersion.__table_args__
+        if getattr(constraint, "name", None) == "content_versions_status_check"
+    ]
+    assert len(check_strs) == 1
+    for value in expected:
+        assert f"'{value}'" in check_strs[0], (
+            f"CHECK constraint missing {value!r}; sync the enum and the constraint."
+        )
+
+
+def test_enum_is_str_subclass():
+    """``StrEnum`` semantics — ``ContentVersionStatus.OK == 'ok'`` —
+    is what lets every legacy ``Status.X == 'ok'`` comparison keep
+    working without churn during the migration. Pin the contract."""
+    assert ContentVersionStatus.OK == "ok"
+    assert ContentVersionStatus.FAILED == "failed"
+    assert ContentVersionStatus.FAILED_PERMANENT == "failed_permanent"
+    assert isinstance(ContentVersionStatus.OK, str)


### PR DESCRIPTION
## Summary

The cv row's lifecycle (`"ok"` / `"failed"` / `"failed_permanent"`) was a bare-string vocabulary scattered across **12 files**. A typo anywhere (`"OK"` instead of `"ok"`, `"failed_perm"` instead of `"failed_permanent"`) silently mis-routed the orchestrator: queries matched nothing, supersession picked the wrong row, status promotion landed on a non-existent value that the CHECK constraint would reject at runtime.

## Change

- New `ContentVersionStatus` `StrEnum` in `models/content_version.py`. Three members mirror the Postgres CHECK constraint. StrEnum semantics keep `ContentVersionStatus.OK == "ok"`.
- Every `ContentVersion.status == "ok"` filter (10 callsites across routes + services) uses the enum. Same for `"failed"` / `"failed_permanent"`.
- Write helpers (`record_human_version`, `record_mt_version`, `record_mt_failure`) use the enum on insert + supersession.
- The stale `Literal["failed", "failed_permanent"]` annotation in `record_mt_failure` is replaced; the `Literal` import drops.
- Stale doc-comments referring to the dropped `content_translations` table (removed in 5aj) cleaned out of the model docstring.

## Regression tests

- `test_enum_values_mirror_the_check_constraint` — drift between the Python enum and the Postgres CHECK is caught at PR time, not at runtime as an IntegrityError on insert.
- `test_enum_is_str_subclass` — pins the StrEnum semantics so any future `enum.Enum` swap that breaks string comparison is loud.

## Test plan

- [x] `pytest -q` → 925 passed (was 923)
- [x] `mypy` clean
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)