### PR TITLE
feat(contract): V1 phase 5at — pin OpenAPI route surface in CI

### DIFF
--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -1,0 +1,2024 @@
+[
+  {
+    "method": "GET",
+    "path": "/",
+    "params": [],
+    "responses": [
+      "200"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/analytics/course/{course_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "403",
+      "404",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/announcements",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "query"
+      ],
+      [
+        "global_only",
+        "query"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ],
+      [
+        "source",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/announcements",
+    "params": [],
+    "responses": [
+      "201",
+      "403",
+      "404",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/announcements/{announcement_id}",
+    "params": [
+      [
+        "announcement_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/announcements/{announcement_id}",
+    "params": [
+      [
+        "announcement_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/assignments",
+    "params": [],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/assignments/chapter/{chapter_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "chapter_id",
+        "path"
+      ],
+      [
+        "source",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/assignments/submissions/{submission_id}/grade",
+    "params": [
+      [
+        "submission_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/assignments/{assignment_id}",
+    "params": [
+      [
+        "assignment_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/assignments/{assignment_id}",
+    "params": [
+      [
+        "assignment_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/assignments/{assignment_id}/my-submissions",
+    "params": [
+      [
+        "assignment_id",
+        "path"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/assignments/{assignment_id}/submissions",
+    "params": [
+      [
+        "assignment_id",
+        "path"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/assignments/{assignment_id}/submit",
+    "params": [
+      [
+        "assignment_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "403",
+      "404",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/audit",
+    "params": [
+      [
+        "action",
+        "query"
+      ],
+      [
+        "date_from",
+        "query"
+      ],
+      [
+        "date_to",
+        "query"
+      ],
+      [
+        "page",
+        "query"
+      ],
+      [
+        "page_size",
+        "query"
+      ],
+      [
+        "resource_type",
+        "query"
+      ],
+      [
+        "user_id",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "400",
+      "403",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/auth/me",
+    "params": [],
+    "responses": [
+      "200",
+      "401"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/blocks/chapter/{chapter_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "chapter_id",
+        "path"
+      ],
+      [
+        "source",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/blocks/chapter/{chapter_id}",
+    "params": [
+      [
+        "chapter_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "403",
+      "404",
+      "409",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/blocks/chapter/{chapter_id}/reorder",
+    "params": [
+      [
+        "chapter_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/blocks/{block_id}",
+    "params": [
+      [
+        "block_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/blocks/{block_id}",
+    "params": [
+      [
+        "block_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "403",
+      "404",
+      "409",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/calendar/events",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/certificates/admin/pending",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/certificates/course/{course_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/certificates/course/{course_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/certificates/my",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/certificates/pending",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/certificates/verify/{certificate_number}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "certificate_number",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/certificates/{cert_id}/admin-approve",
+    "params": [
+      [
+        "cert_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "400",
+      "403",
+      "404",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/certificates/{cert_id}/reject",
+    "params": [
+      [
+        "cert_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "400",
+      "403",
+      "404",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/certificates/{cert_id}/teacher-approve",
+    "params": [
+      [
+        "cert_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "400",
+      "403",
+      "404",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/cohorts",
+    "params": [
+      [
+        "status",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/cohorts",
+    "params": [],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/cohorts/course/{course_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/cohorts/{cohort_id}",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/cohorts/{cohort_id}",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PATCH",
+    "path": "/api/v1/cohorts/{cohort_id}",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/cohorts/{cohort_id}/complete",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/cohorts/{cohort_id}/courses",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/cohorts/{cohort_id}/courses",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/cohorts/{cohort_id}/courses/{course_id}",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ],
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/cohorts/{cohort_id}/students",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/cohorts/{cohort_id}/students",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/cohorts/{cohort_id}/students/{user_id}",
+    "params": [
+      [
+        "cohort_id",
+        "path"
+      ],
+      [
+        "user_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "search",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/courses",
+    "params": [],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses/_diag/translation-status",
+    "params": [],
+    "responses": [
+      "200"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses/my",
+    "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses/my/trash",
+    "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/courses/{course_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses/{course_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "source",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/courses/{course_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/courses/{course_id}/clone",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/courses/{course_id}/enroll",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses/{course_id}/enrollment-status",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses/{course_id}/events",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "source",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/courses/{course_id}/events",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/courses/{course_id}/events/{event_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "event_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/courses/{course_id}/events/{event_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "event_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/courses/{course_id}/modules",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/courses/{course_id}/modules/{module_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "module_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses/{course_id}/modules/{module_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "module_id",
+        "path"
+      ],
+      [
+        "source",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/courses/{course_id}/modules/{module_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "module_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/courses/{course_id}/modules/{module_id}/chapters",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "module_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/courses/{course_id}/modules/{module_id}/chapters/{chapter_id}",
+    "params": [
+      [
+        "chapter_id",
+        "path"
+      ],
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "module_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/courses/{course_id}/modules/{module_id}/chapters/{chapter_id}",
+    "params": [
+      [
+        "chapter_id",
+        "path"
+      ],
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "module_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/courses/{course_id}/permanent",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/courses/{course_id}/readiness",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/courses/{course_id}/restore",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/courses/{course_id}/translate",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/grades/course/{course_id}",
+    "params": [
+      [
+        "cohort_id",
+        "query"
+      ],
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/grades/course/{course_id}/config",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/grades/course/{course_id}/config",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/grades/course/{course_id}/export-csv",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/grades/course/{course_id}/student/{student_id}",
+    "params": [
+      [
+        "cohort_id",
+        "query"
+      ],
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "student_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/grades/course/{course_id}/student/{student_id}",
+    "params": [
+      [
+        "cohort_id",
+        "query"
+      ],
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "student_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/grades/course/{course_id}/student/{student_id}/calculated",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "student_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/grades/course/{course_id}/summary",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/grades/my",
+    "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/grades/my/{course_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/health/db",
+    "params": [],
+    "responses": [
+      "200"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/notifications",
+    "params": [
+      [
+        "page",
+        "query"
+      ],
+      [
+        "page_size",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/notifications/read-all",
+    "params": [],
+    "responses": [
+      "200"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/notifications/unread-count",
+    "params": [],
+    "responses": [
+      "200"
+    ],
+    "body": false
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/notifications/{notification_id}",
+    "params": [
+      [
+        "notification_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PATCH",
+    "path": "/api/v1/notifications/{notification_id}/read",
+    "params": [
+      [
+        "notification_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/prerequisites/course/{course_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/prerequisites/course/{course_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/progress/chapter/{chapter_id}/student/{student_id}/complete",
+    "params": [
+      [
+        "chapter_id",
+        "path"
+      ],
+      [
+        "student_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/progress/chapter/{chapter_id}/student/{student_id}/incomplete",
+    "params": [
+      [
+        "chapter_id",
+        "path"
+      ],
+      [
+        "student_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/progress/course/{course_id}/my-progress",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/progress/course/{course_id}/students",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/quizzes",
+    "params": [],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "PATCH",
+    "path": "/api/v1/quizzes/answers/{answer_id}",
+    "params": [
+      [
+        "answer_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/quizzes/chapter/{chapter_id}",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "chapter_id",
+        "path"
+      ],
+      [
+        "source",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/quizzes/{quiz_id}",
+    "params": [
+      [
+        "quiz_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/quizzes/{quiz_id}",
+    "params": [
+      [
+        "quiz_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/quizzes/{quiz_id}",
+    "params": [
+      [
+        "quiz_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/quizzes/{quiz_id}/attempts",
+    "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "quiz_id",
+        "path"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/quizzes/{quiz_id}/extra-attempts",
+    "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "quiz_id",
+        "path"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/quizzes/{quiz_id}/extra-attempts",
+    "params": [
+      [
+        "quiz_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/quizzes/{quiz_id}/my-attempts",
+    "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "quiz_id",
+        "path"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/quizzes/{quiz_id}/pending-answers",
+    "params": [
+      [
+        "include_graded",
+        "query"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "quiz_id",
+        "path"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/quizzes/{quiz_id}/submit",
+    "params": [
+      [
+        "quiz_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "403",
+      "404",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/reviews/course/{course_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/reviews/course/{course_id}",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/reviews/{review_id}",
+    "params": [
+      [
+        "review_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/users/admin/users",
+    "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/users/admin/users/bulk-role",
+    "params": [],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/users/admin/users/{user_id}",
+    "params": [
+      [
+        "user_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/users/admin/users/{user_id}/role",
+    "params": [
+      [
+        "role",
+        "query"
+      ],
+      [
+        "user_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/users/me/courses",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ],
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "PATCH",
+    "path": "/api/v1/users/me/preferences",
+    "params": [],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/verse-of-the-day",
+    "params": [
+      [
+        "locale",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/health",
+    "params": [],
+    "responses": [
+      "200"
+    ],
+    "body": false
+  }
+]

--- a/backend/tests/test_openapi_contract.py
+++ b/backend/tests/test_openapi_contract.py
@@ -1,0 +1,110 @@
+"""Pin the public API surface.
+
+The snapshot at ``tests/contracts/openapi_routes.json`` captures, per
+route:
+
+* HTTP method + path
+* parameter names + locations (``query`` / ``path`` / ``header``)
+* response status codes
+* whether the route accepts a request body
+
+Any silent change to those — a renamed path, a dropped query param, a
+status code that flipped from 200 to 204 — fails this test and shows up
+in code review with the exact route line that drifted.
+
+How to intentionally update the snapshot
+-----------------------------------------
+
+Run ``UPDATE_OPENAPI_CONTRACT=1 pytest
+tests/test_openapi_contract.py`` (or invoke the inline regen below
+manually) and commit the new ``openapi_routes.json``. A diff in the
+snapshot file IS the API change log entry that the PR description
+should explain.
+
+Why this layer of contract instead of the full ``app.openapi()`` JSON
+---------------------------------------------------------------------
+
+The full spec is 135 KB and changes whenever a Pydantic field gets a
+new ``description``. That's noise. The slim shape here is the part
+that matters for a frontend or external consumer — what routes exist
+and what shape they require — without the prose drift that would
+nag every PR.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from app.main import app
+
+_SNAPSHOT = Path(__file__).parent / "contracts" / "openapi_routes.json"
+
+
+def _build_contract() -> list[dict]:
+    spec = app.openapi()
+    contract: list[dict] = []
+    for path in sorted(spec["paths"]):
+        methods = spec["paths"][path]
+        for method in sorted(methods):
+            route = methods[method]
+            params = sorted([[p.get("name"), p.get("in")] for p in route.get("parameters", [])])
+            responses = sorted(route.get("responses", {}).keys())
+            body = bool(route.get("requestBody"))
+            contract.append(
+                {
+                    "method": method.upper(),
+                    "path": path,
+                    "params": params,
+                    "responses": responses,
+                    "body": body,
+                }
+            )
+    return contract
+
+
+def test_openapi_routes_match_snapshot():
+    """If this fails, run ``UPDATE_OPENAPI_CONTRACT=1 pytest
+    tests/test_openapi_contract.py`` and commit the diff."""
+    current = _build_contract()
+
+    if os.environ.get("UPDATE_OPENAPI_CONTRACT") == "1":
+        _SNAPSHOT.write_text(
+            json.dumps(current, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        return
+
+    assert _SNAPSHOT.exists(), (
+        "OpenAPI contract snapshot is missing. Run "
+        "``UPDATE_OPENAPI_CONTRACT=1 pytest tests/test_openapi_contract.py`` "
+        "to bootstrap it."
+    )
+    stored = json.loads(_SNAPSHOT.read_text(encoding="utf-8"))
+
+    current_by_key = {(r["method"], r["path"]): r for r in current}
+    stored_by_key = {(r["method"], r["path"]): r for r in stored}
+
+    added = sorted(current_by_key.keys() - stored_by_key.keys())
+    removed = sorted(stored_by_key.keys() - current_by_key.keys())
+    diffs: list[str] = []
+    for key in sorted(current_by_key.keys() & stored_by_key.keys()):
+        if current_by_key[key] != stored_by_key[key]:
+            diffs.append(f"{key[0]} {key[1]}: stored={stored_by_key[key]!r} current={current_by_key[key]!r}")
+
+    if added or removed or diffs:
+        msg_lines = ["OpenAPI contract drift detected:"]
+        if added:
+            msg_lines.append(f"  ADDED routes: {added}")
+        if removed:
+            msg_lines.append(f"  REMOVED routes: {removed}")
+        if diffs:
+            msg_lines.append("  CHANGED routes:")
+            msg_lines.extend(f"    {d}" for d in diffs)
+        msg_lines.append(
+            "  If this is intentional, run "
+            "``UPDATE_OPENAPI_CONTRACT=1 pytest tests/test_openapi_contract.py`` "
+            "and commit the snapshot diff."
+        )
+        raise AssertionError("\n".join(msg_lines))


### PR DESCRIPTION
## Summary

Architecture review #6 flagged this as the cleanest "how would a top-tier eng team have built this" gap: there was no test that catches a backend refactor silently breaking the frontend's API expectations. A renamed query param, a dropped status code, or a path that shifted from `/courses/{id}` to `/course/{id}` would slip through CI and surface only on prod as a 404.

This PR adds a snapshot of the OpenAPI route surface:

- `tests/contracts/openapi_routes.json` captures per route: method, path, parameter names + locations, response status codes, request-body presence. 115 routes, ~18 KB.
- `tests/test_openapi_contract.py` rebuilds the contract from `app.openapi()` and diffs against the snapshot. Drift fails CI with a structured report listing ADDED / REMOVED / CHANGED routes.

The snapshot deliberately uses a **slim** shape, not the full 135 KB spec. Pydantic description churn or a renamed fieldʼs docstring should not fail this test; a renamed query param should. The distinction matches what an external API consumer actually depends on.

Updating the snapshot is one command:

```
UPDATE_OPENAPI_CONTRACT=1 pytest tests/test_openapi_contract.py
```

The diff in `openapi_routes.json` IS the API change-log entry that the PR description should explain.

## Test plan

- [x] `pytest -q` → 924 passed (+1 new contract test)
- [x] `mypy` clean
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)