### PR TITLE
feat(admin): V1 phase 5au — failed_permanent recovery endpoints

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.v1 import (
+    admin_translations,
     analytics,
     announcements,
     assignments,
@@ -43,3 +44,4 @@ api_router.include_router(audit.router)
 api_router.include_router(calendar_mod.router)
 api_router.include_router(calendar_mod.event_router)
 api_router.include_router(verse_of_the_day.router)
+api_router.include_router(admin_translations.router)

--- a/backend/app/api/v1/admin_translations.py
+++ b/backend/app/api/v1/admin_translations.py
@@ -1,0 +1,176 @@
+"""Admin tooling for the translation pipeline.
+
+The orchestrator is fire-and-forget per spec: when Gemini fails a row
+hits ``status='failed'`` and increments ``attempts``. After
+``CONTENT_VERSION_MAX_ATTEMPTS`` (5) it promotes to
+``failed_permanent`` — a terminal state where the auto-pipeline
+refuses further retries. That's correct for the common case (a true
+permanent failure: safety filter, oversize input) but trap-shaped for
+the operator: a transient outage that ran out the budget leaves rows
+stuck until someone touches the DB directly.
+
+This module exposes the admin-only escape hatch: reset a list of cv
+rows from ``failed_permanent`` back to ``failed`` and ``attempts=0``,
+so the next reconcile pass picks them up.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID  # noqa: TC003 — used by Pydantic schema at runtime
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session  # noqa: TC002 — used by FastAPI Depends at runtime
+
+from app.api.dependencies import require_admin
+from app.core.database import get_db
+from app.models.content_version import ContentVersion
+from app.services.audit_service import log_action
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+router = APIRouter(prefix="/admin/translations", tags=["admin-translations"])
+
+
+class ResetByIdsRequest(BaseModel):
+    """Reset a specific set of cv rows by primary key.
+
+    Use this when the operator already knows which rows are stuck
+    (e.g., from a Datadog alert that named the offending ids).
+    """
+
+    ids: list[UUID] = Field(..., min_length=1, max_length=500)
+
+
+class ResetByEntityRequest(BaseModel):
+    """Reset every failed row matching one ``(entity_type, entity_id,
+    field, locale)`` selector — useful when the operator wants to
+    unstick a whole entity without listing each row.
+    """
+
+    entity_type: str = Field(..., max_length=64)
+    entity_id: str = Field(..., max_length=64)
+    field: str = Field(..., max_length=64)
+    locale: str = Field(..., max_length=10)
+
+
+class ResetResponse(BaseModel):
+    reset: int
+
+
+@router.post(
+    "/reset-by-ids",
+    response_model=ResetResponse,
+    summary="Reset failed_permanent cv rows by primary key",
+    responses={
+        200: {"description": "Rows reset; ``reset`` counts those actually touched."},
+        404: {"description": "None of the supplied ids matched a failed_permanent row."},
+    },
+)
+def reset_by_ids(
+    payload: ResetByIdsRequest,
+    request: Request,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> ResetResponse:
+    """Flip the listed rows from ``failed_permanent`` to ``failed`` and
+    zero their ``attempts`` so the next orchestrator pass retries them.
+
+    Rows in any other status are ignored — the endpoint is idempotent
+    and refuses to silently mutate ``ok`` rows. Audit-logged.
+    """
+    try:
+        affected = (
+            db.query(ContentVersion)
+            .filter(
+                ContentVersion.id.in_(payload.ids),
+                ContentVersion.status == "failed_permanent",
+            )
+            .update(
+                {
+                    ContentVersion.status: "failed",
+                    ContentVersion.attempts: 0,
+                },
+                synchronize_session=False,
+            )
+        )
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise
+    if affected == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No failed_permanent rows matched the supplied ids.",
+        )
+    log_action(
+        db,
+        admin.id,
+        "reset_failed_permanent",
+        "content_version",
+        ",".join(str(i) for i in payload.ids[:10]),
+        details={"count": affected, "total_requested": len(payload.ids)},
+        request=request,
+    )
+    return ResetResponse(reset=affected)
+
+
+@router.post(
+    "/reset-by-entity",
+    response_model=ResetResponse,
+    summary="Reset failed_permanent cv rows matching one (entity, field, locale)",
+    responses={
+        200: {"description": "Rows reset; ``reset`` counts those actually touched."},
+        404: {"description": "No failed_permanent row matched the selector."},
+    },
+)
+def reset_by_entity(
+    payload: ResetByEntityRequest,
+    request: Request,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> ResetResponse:
+    """Flip every ``failed_permanent`` row matching the selector back
+    to ``failed`` with ``attempts=0``. Audit-logged.
+    """
+    try:
+        affected = (
+            db.query(ContentVersion)
+            .filter(
+                ContentVersion.entity_type == payload.entity_type,
+                ContentVersion.entity_id == payload.entity_id,
+                ContentVersion.field == payload.field,
+                ContentVersion.locale == payload.locale,
+                ContentVersion.status == "failed_permanent",
+            )
+            .update(
+                {
+                    ContentVersion.status: "failed",
+                    ContentVersion.attempts: 0,
+                },
+                synchronize_session=False,
+            )
+        )
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise
+    if affected == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No failed_permanent row matched the selector.",
+        )
+    log_action(
+        db,
+        admin.id,
+        "reset_failed_permanent",
+        "content_version",
+        f"{payload.entity_type}:{payload.entity_id}:{payload.field}:{payload.locale}",
+        details={"count": affected},
+        request=request,
+    )
+    return ResetResponse(reset=affected)

--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -9,6 +9,28 @@
     "body": false
   },
   {
+    "method": "POST",
+    "path": "/api/v1/admin/translations/reset-by-entity",
+    "params": [],
+    "responses": [
+      "200",
+      "404",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/translations/reset-by-ids",
+    "params": [],
+    "responses": [
+      "200",
+      "404",
+      "422"
+    ],
+    "body": true
+  },
+  {
     "method": "GET",
     "path": "/api/v1/analytics/course/{course_id}",
     "params": [

--- a/backend/tests/test_admin_translations.py
+++ b/backend/tests/test_admin_translations.py
@@ -1,0 +1,146 @@
+"""Tests for the admin failed_permanent reset endpoints.
+
+Both routes share the same shape — admin-only, audit-logged, idempotent
+on already-OK rows, 404 when no row matched the selector. The tests
+pin every important branch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from app.models.content_version import (
+    CONTENT_VERSION_MAX_ATTEMPTS,
+    ContentVersion,
+)
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+def _seed_failed_permanent(
+    db: Session,
+    *,
+    entity_id: str = "test-entity-1",
+    entity_type: str = "course",
+    field: str = "title",
+    locale: str = "en",
+) -> ContentVersion:
+    row = ContentVersion(
+        id=uuid.uuid4(),
+        entity_type=entity_type,
+        entity_id=entity_id,
+        field=field,
+        locale=locale,
+        text="",
+        origin="mt",
+        status="failed_permanent",
+        attempts=CONTENT_VERSION_MAX_ATTEMPTS,
+        source_locale="ru",
+        source_hash="x" * 64,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def test_reset_by_ids_flips_failed_permanent_to_failed(admin_client: TestClient, db: Session):
+    row = _seed_failed_permanent(db)
+    resp = admin_client.post(
+        "/api/v1/admin/translations/reset-by-ids",
+        json={"ids": [str(row.id)]},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"reset": 1}
+
+    db.refresh(row)
+    assert row.status == "failed"
+    assert row.attempts == 0
+
+
+def test_reset_by_ids_404_when_no_failed_permanent_match(admin_client: TestClient, db: Session):
+    """A row that's currently ``ok`` is silently skipped (the endpoint
+    only flips ``failed_permanent`` rows). When the result is zero
+    affected rows, the route returns 404 so the operator can spot the
+    misfire instead of seeing a 200 that did nothing."""
+    ok_row = ContentVersion(
+        id=uuid.uuid4(),
+        entity_type="course",
+        entity_id="x",
+        field="title",
+        locale="en",
+        text="alive",
+        origin="mt",
+        status="ok",
+        attempts=0,
+        source_locale="ru",
+        source_hash="y" * 64,
+    )
+    db.add(ok_row)
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/v1/admin/translations/reset-by-ids",
+        json={"ids": [str(ok_row.id)]},
+    )
+    assert resp.status_code == 404
+
+
+def test_reset_by_ids_requires_admin(client: TestClient, db: Session):
+    """The teacher-scoped client must be rejected."""
+    row = _seed_failed_permanent(db)
+    resp = client.post(
+        "/api/v1/admin/translations/reset-by-ids",
+        json={"ids": [str(row.id)]},
+    )
+    assert resp.status_code == 403
+
+
+def test_reset_by_entity_flips_matching_row(admin_client: TestClient, db: Session):
+    row = _seed_failed_permanent(
+        db,
+        entity_type="quiz_option",
+        entity_id="opt-1",
+        field="option_text",
+        locale="en",
+    )
+    resp = admin_client.post(
+        "/api/v1/admin/translations/reset-by-entity",
+        json={
+            "entity_type": "quiz_option",
+            "entity_id": "opt-1",
+            "field": "option_text",
+            "locale": "en",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"reset": 1}
+
+    db.refresh(row)
+    assert row.status == "failed"
+    assert row.attempts == 0
+
+
+def test_reset_by_entity_404_on_no_match(admin_client: TestClient):
+    resp = admin_client.post(
+        "/api/v1/admin/translations/reset-by-entity",
+        json={
+            "entity_type": "course",
+            "entity_id": "ghost",
+            "field": "title",
+            "locale": "en",
+        },
+    )
+    assert resp.status_code == 404
+
+
+def test_reset_by_ids_rejects_empty_id_list(admin_client: TestClient):
+    """``min_length=1`` on the Pydantic model surfaces as a 422."""
+    resp = admin_client.post(
+        "/api/v1/admin/translations/reset-by-ids",
+        json={"ids": []},
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

The orchestrator is fire-and-forget by design: when Gemini fails a cv row hits `status="failed"` + `attempts++`, and after `CONTENT_VERSION_MAX_ATTEMPTS` (5) it promotes to `failed_permanent` — terminal as far as the auto-pipeline is concerned. Thatʼs correct for genuinely permanent failures (safety filter, oversize input) but trap-shaped for the operator: a transient Gemini outage that ran out the budget leaves rows stuck until someone touches the DB directly.

This PR adds the admin-only escape hatch:

| Endpoint | Use case |
|---|---|
| `POST /api/v1/admin/translations/reset-by-ids` | Flip a specific list of cv row ids back to `failed` + `attempts=0`. Operator knows the ids (e.g. from a Datadog alert). |
| `POST /api/v1/admin/translations/reset-by-entity` | Flip every matching `failed_permanent` row for an `(entity_type, entity_id, field, locale)` selector. Operator wants to unstick a whole entity without enumerating rows. |

Both routes:

- require **admin** auth (403 to teachers, 401 to anonymous)
- are **idempotent** — they touch ONLY `failed_permanent` rows so a retry never silently mutates the `ok` row that is also active
- return **404** when no row matched so the operator spots a misfire instead of a no-op 200
- **audit-log** every reset with the row count + the calling admin

The next orchestrator pass picks the reset rows up via the normal `source_hash` short-circuit + retry-cap logic; no orchestrator change needed.

## Test plan

Six regression tests pin every branch (happy path, 404 on no-match, 403 for non-admin, 422 on empty id list, idempotency on already-ok rows). 930 tests pass overall.

The OpenAPI contract snapshot is updated to include the two new routes — diff in `tests/contracts/openapi_routes.json` is the intentional ADDED-routes entry the 5at test reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)