### PR TITLE
feat(queue): V1 phase 5ax — publish path enqueues instead of sync translate

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -103,6 +103,17 @@ class Settings(BaseSettings):
         default=None,
         description="Shared secret the cron driver presents to drain the translation queue",
     )
+    # Feature flag that swaps the publish path from sync orchestrator
+    # calls (one Gemini call per cv field, up to 100+ for a chapter-
+    # heavy course, all inside the teacher's request) to a queue
+    # enqueue (one DB insert). The cron driver from Phase 5aw drains
+    # the queue out-of-band. Off by default so a deploy without the
+    # cron configured stays on the legacy sync path; flip ON after
+    # confirming the worker is running.
+    TRANSLATION_QUEUE_ENABLED: bool = Field(
+        default=False,
+        description="Use the queue-based publish path instead of sync orchestrator calls",
+    )
 
     @model_validator(mode="after")
     def load_alternative_env_vars(self):

--- a/backend/app/services/translation/pipeline_hooks.py
+++ b/backend/app/services/translation/pipeline_hooks.py
@@ -24,10 +24,12 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import SQLAlchemyError
 
+from app.core.config import settings
 from app.models.course import Course, CourseStatus
 from app.services.course_service import get_course
 from app.services.translation.course_pipeline import translate_course_content
 from app.services.translation.protocol import TranslationError
+from app.services.translation.queue import enqueue_course_translation
 from app.services.translation.registry import REGISTRY, reconcile_entity
 from app.services.translation.service import is_translation_enabled
 
@@ -86,6 +88,18 @@ def _log_pipeline_failure(
 def run_course_translation_pipeline_if_published(db: Session, course_id: str) -> None:
     """Re-run the full course tree pipeline when a published course mutates.
 
+    Two delivery modes, selected by ``settings.TRANSLATION_QUEUE_ENABLED``:
+
+    * **Queue mode** (Phase 5ax+, the production path going forward):
+      enqueue ONE row in ``translation_jobs`` and return. The cron-
+      driven worker from Phase 5aw drains the queue out-of-band, so a
+      100-block course publish takes one INSERT instead of 100
+      synchronous Gemini round-trips.
+    * **Sync mode** (legacy): call ``translate_course_content``
+      directly inside the teacher's request. Kept behind the feature
+      flag so a deploy without the worker cron configured stays on the
+      working old path.
+
     No-ops when the course is a draft, Gemini is disabled, or the load
     fails. Errors never propagate — teachers must never lose a save
     because MT lagged. The session is rolled back on SQLAlchemy errors
@@ -101,6 +115,30 @@ def run_course_translation_pipeline_if_published(db: Session, course_id: str) ->
     course_status = db.query(Course.status).filter(Course.id == course_id, Course.deleted_at.is_(None)).scalar()
     if course_status != CourseStatus.PUBLISHED:
         return
+
+    if settings.TRANSLATION_QUEUE_ENABLED:
+        # Queue-mode publish path. ``enqueue_course_translation`` is
+        # idempotent on pending jobs so a teacher mashing Save doesn't
+        # multiply the work the worker has to do.
+        try:
+            enqueue_course_translation(db, course_id)
+        except SQLAlchemyError as exc:
+            _safe_rollback(db)
+            _log_pipeline_failure(
+                scope="course-pipeline-enqueue",
+                entity_type="course",
+                entity_id=course_id,
+                exc=exc,
+            )
+        except Exception as exc:
+            _log_pipeline_failure(
+                scope="course-pipeline-enqueue",
+                entity_type="course",
+                entity_id=course_id,
+                exc=exc,
+            )
+        return
+
     course = get_course(db, course_id)
     if not course:
         return

--- a/backend/tests/test_translation_pipeline_hooks.py
+++ b/backend/tests/test_translation_pipeline_hooks.py
@@ -3,6 +3,11 @@
 The hooks have one job: never propagate an error to the caller and
 never leave the SQLAlchemy session in a broken state, no matter what
 the orchestrator or provider does.
+
+Phase 5ax adds a second delivery mode behind
+``settings.TRANSLATION_QUEUE_ENABLED``: instead of calling
+``translate_course_content`` synchronously, the publish hook
+enqueues a job for the cron-driven worker. Both modes are tested.
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ from sqlalchemy.orm import Session  # noqa: TC002 — pytest needs runtime types
 
 from app.models.announcement import Announcement
 from app.models.course import Course
+from app.models.translation_job import TranslationJob, TranslationJobStatus
 from app.services.translation.pipeline_hooks import (
     reconcile_entity_if_course_published,
     run_course_translation_pipeline_if_published,
@@ -175,3 +181,91 @@ def test_course_pipeline_skips_draft(db: Session, teacher):
     ):
         run_course_translation_pipeline_if_published(db, course.id)
     translate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase 5ax: queue-mode publish path
+# ---------------------------------------------------------------------------
+
+
+def test_queue_mode_enqueues_job_instead_of_calling_orchestrator(db: Session, teacher, monkeypatch):
+    """When TRANSLATION_QUEUE_ENABLED=True the hook MUST NOT call the
+    sync orchestrator. It enqueues one job and returns; the worker
+    cron drains it out-of-band."""
+    monkeypatch.setattr(
+        "app.services.translation.pipeline_hooks.settings.TRANSLATION_QUEUE_ENABLED",
+        True,
+        raising=False,
+    )
+    course = _seed_published_course(db, teacher.id)
+    with (
+        patch("app.services.translation.pipeline_hooks.translate_course_content") as orchestrator,
+        patch("app.services.translation.pipeline_hooks.is_translation_enabled", return_value=True),
+    ):
+        run_course_translation_pipeline_if_published(db, course.id)
+    orchestrator.assert_not_called()
+
+    queued = db.query(TranslationJob).filter_by(course_id=course.id).all()
+    assert len(queued) == 1
+    assert queued[0].status == TranslationJobStatus.QUEUED
+
+
+def test_queue_mode_is_idempotent_on_repeated_saves(db: Session, teacher, monkeypatch):
+    """A teacher mashing Save five times in a row must enqueue exactly
+    one pending job — the enqueue helper short-circuits on existing
+    queued/processing rows."""
+    monkeypatch.setattr(
+        "app.services.translation.pipeline_hooks.settings.TRANSLATION_QUEUE_ENABLED",
+        True,
+        raising=False,
+    )
+    course = _seed_published_course(db, teacher.id)
+    with patch("app.services.translation.pipeline_hooks.is_translation_enabled", return_value=True):
+        for _ in range(5):
+            run_course_translation_pipeline_if_published(db, course.id)
+
+    queued = db.query(TranslationJob).filter_by(course_id=course.id).all()
+    assert len(queued) == 1
+
+
+def test_queue_mode_no_op_on_draft_course(db: Session, teacher, monkeypatch):
+    """Draft course publish-hook fires during course building — must
+    not enqueue (no work to do) and must not blow up."""
+    monkeypatch.setattr(
+        "app.services.translation.pipeline_hooks.settings.TRANSLATION_QUEUE_ENABLED",
+        True,
+        raising=False,
+    )
+    course = Course(
+        id=f"hook-draft-{uuid.uuid4().hex[:8]}",
+        status="draft",
+        source_locale="ru",
+        created_by=teacher.id,
+    )
+    db.add(course)
+    db.commit()
+    with patch("app.services.translation.pipeline_hooks.is_translation_enabled", return_value=True):
+        run_course_translation_pipeline_if_published(db, course.id)
+    queued = db.query(TranslationJob).filter_by(course_id=course.id).count()
+    assert queued == 0
+
+
+def test_sync_mode_still_works_when_flag_is_off(db: Session, teacher, monkeypatch):
+    """The legacy sync path is the deploy-time default until the cron
+    worker is verified running. Make sure flipping the flag off keeps
+    the orchestrator wired."""
+    monkeypatch.setattr(
+        "app.services.translation.pipeline_hooks.settings.TRANSLATION_QUEUE_ENABLED",
+        False,
+        raising=False,
+    )
+    course = _seed_published_course(db, teacher.id)
+    with (
+        patch("app.services.translation.pipeline_hooks.translate_course_content") as orchestrator,
+        patch("app.services.translation.pipeline_hooks.is_translation_enabled", return_value=True),
+    ):
+        run_course_translation_pipeline_if_published(db, course.id)
+    orchestrator.assert_called_once()
+
+    queued = db.query(TranslationJob).filter_by(course_id=course.id).count()
+    assert queued == 0


### PR DESCRIPTION
## Summary

**Final step of the queue migration.** Stacks on #590 (5av foundation) + #591 (5aw worker endpoint). The publish hook now has two delivery modes selected by `settings.TRANSLATION_QUEUE_ENABLED`:

| Mode | Behaviour |
|---|---|
| **Queue** (new, default OFF) | Enqueue ONE `translation_jobs` row and return. Worker drains out-of-band. A 100-block publish drops from 100 sync Gemini round-trips inside the teacher POST to one INSERT. |
| **Sync** (legacy, deploy-time default) | Unchanged from Phase 5an — call `translate_course_content` directly inside the request. Stays the path until the worker cron is verified running. |

## Operator rollout

1. **Deploy this PR.** Sync mode stays on; nothing changes for users.
2. **Configure the cron driver** (Vercel Cron / Supabase Edge Function / external) to POST `/api/v1/internal/translation-worker` every minute with the shared secret from 5aw.
3. **Verify worker** by enqueuing a test job manually and watching the row flip to `done` after one tick.
4. **Flip `TRANSLATION_QUEUE_ENABLED=true`** in env. Publish path switches with no redeploy.
5. **If anything breaks**, flip OFF — sync mode resumes instantly.

## Scope

Per-entity hooks (`reconcile_entity_if_course_published`) stay **sync** on purpose. They run on per-block / per-announcement writes that already cost only 1-2 Gemini calls each, so the publish-button cost problem doesnʼt apply.

## Test plan

4 new regressions on top of the existing 7 hook tests:

- queue mode enqueues a job and does NOT call the orchestrator
- queue mode is idempotent on repeated saves (one row, not five)
- queue mode no-ops on draft courses
- sync mode keeps working when the flag is off

`pytest -q` → 955 passed (was 951). `mypy` + `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)