### PR TITLE
feat(errors): V1 phase 5ay — typed error envelope foundation

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -1,0 +1,145 @@
+"""Typed error envelope for HTTPExceptions.
+
+Why this exists
+---------------
+
+Before this module every route raised
+``HTTPException(detail="Course 'xyz' not found")`` — a free-form
+human string. The frontend's only way to react differently to
+"course missing" vs "you don't have permission" was substring-matching
+on the message text, which:
+
+* breaks when someone reworded the message
+* breaks when the locale changes (Russian-speaking teacher,
+  English-speaking admin)
+* fights every accessibility / i18n best practice that says
+  machine-readable codes belong in metadata, not in copy
+
+This module introduces a small contract: each domain failure has a
+short stable code (``ErrorCode`` enum), a human message that the
+frontend toasts as-is, and an optional ``context`` dict for the
+machine-readable bits (the ``course_id`` that wasn't found, the
+``min_attempts`` left, etc.). The frontend has a typed switch on
+the code; the toast still renders the message string.
+
+Backwards-compatible by construction
+------------------------------------
+
+``equip_error`` returns an ``HTTPException`` whose ``detail`` field is
+the structured envelope (a dict). FastAPI serialises that to JSON
+verbatim, so the response body becomes::
+
+    {"detail": {"code": "course_not_found", "message": "...", "context": {...}}}
+
+instead of the old::
+
+    {"detail": "..."}
+
+Old routes that still raise ``HTTPException(detail="...")`` continue
+to work — the frontend's ``getErrorDetail`` extractor falls back to
+the string detail when no code is present. Migration is route-by-route
+in follow-up PRs.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any
+
+from fastapi import HTTPException
+
+
+class ErrorCode(enum.StrEnum):
+    """Stable machine-readable identifiers for every domain failure.
+
+    Codes are ``snake_case``, scoped by feature (``auth.*``,
+    ``course.*``, etc.). Adding a new code is a one-line append here
+    + one client switch arm; removing one is a public-API break.
+
+    Each member is documented inline so a frontend author can pick the
+    right one without reading the route source.
+    """
+
+    # ── Auth / permissions ──────────────────────────────────────────────
+    AUTH_REQUIRED = "auth.required"
+    """No valid session; the user must sign in."""
+
+    AUTH_FORBIDDEN = "auth.forbidden"
+    """Caller is authenticated but lacks the required role / ownership."""
+
+    # ── Generic resource lookups ────────────────────────────────────────
+    RESOURCE_NOT_FOUND = "resource.not_found"
+    """A specific entity was not located. ``context.resource_type`` +
+    ``context.resource_id`` carry the specifics; route docstrings
+    document what shape they take."""
+
+    # ── Course lifecycle ────────────────────────────────────────────────
+    COURSE_NOT_PUBLISHED = "course.not_published"
+    """Action requires a published course; current state is draft or
+    soft-deleted."""
+
+    COURSE_ALREADY_ENROLLED = "course.already_enrolled"
+    """Student tried to enrol in a course they're already in."""
+
+    COURSE_ENROLMENT_CLOSED = "course.enrolment_closed"
+    """Enrolment window is not currently open."""
+
+    # ── Translation pipeline ────────────────────────────────────────────
+    TRANSLATION_DISABLED = "translation.disabled"
+    """Translation provider is not configured on this deployment."""
+
+    TRANSLATION_WORKER_UNAUTHORIZED = "translation.worker_unauthorized"
+    """Worker secret missing or wrong."""
+
+    TRANSLATION_WORKER_UNCONFIGURED = "translation.worker_unconfigured"
+    """``TRANSLATION_WORKER_SECRET`` env var unset on this deployment."""
+
+    # ── Quiz / assignment lifecycle ─────────────────────────────────────
+    QUIZ_NOT_OPEN = "quiz.not_open"
+    """Quiz is not currently accepting submissions."""
+
+    QUIZ_ATTEMPTS_EXHAUSTED = "quiz.attempts_exhausted"
+    """Student has hit the per-quiz attempt cap."""
+
+    # ── Validation ──────────────────────────────────────────────────────
+    VALIDATION_FAILED = "validation.failed"
+    """Request body / params failed semantic validation beyond the
+    Pydantic schema layer."""
+
+
+def equip_error(
+    code: ErrorCode,
+    *,
+    status_code: int,
+    message: str,
+    context: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> HTTPException:
+    """Build an ``HTTPException`` with the typed-envelope ``detail``.
+
+    Usage::
+
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=404,
+            message=f"Course '{course_id}' not found",
+            context={"resource_type": "course", "resource_id": course_id},
+        )
+
+    The frontend extracts ``code`` for type-safe branching and renders
+    ``message`` for the toast. ``context`` is the machine-readable
+    payload for code that needs to render specifics (e.g. show the
+    remaining attempt count).
+    """
+    return HTTPException(
+        status_code=status_code,
+        detail={
+            "code": code.value,
+            "message": message,
+            "context": context or {},
+        },
+        headers=headers,
+    )
+
+
+__all__ = ["ErrorCode", "equip_error"]

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -1,0 +1,78 @@
+"""Regression tests for the typed error envelope.
+
+These pin three invariants future contributors must not break:
+
+1. ``equip_error`` produces an ``HTTPException`` whose ``detail`` is
+   a dict with the documented shape (``code``, ``message``,
+   ``context``).
+2. The code-enum string values stay stable. A renamed enum entry is a
+   breaking change for every client that switch-matches on the code;
+   this test catches that at PR time.
+3. ``context`` defaults to an empty dict, never ``None`` — the
+   frontend can always read ``context.<field>`` without a null check.
+"""
+
+from __future__ import annotations
+
+from app.core.errors import ErrorCode, equip_error
+
+
+def test_equip_error_returns_structured_detail():
+    exc = equip_error(
+        ErrorCode.RESOURCE_NOT_FOUND,
+        status_code=404,
+        message="Course 'x' not found",
+        context={"resource_type": "course", "resource_id": "x"},
+    )
+    assert exc.status_code == 404
+    assert exc.detail == {
+        "code": "resource.not_found",
+        "message": "Course 'x' not found",
+        "context": {"resource_type": "course", "resource_id": "x"},
+    }
+
+
+def test_context_defaults_to_empty_dict_not_none():
+    exc = equip_error(
+        ErrorCode.AUTH_REQUIRED,
+        status_code=401,
+        message="Sign in to continue",
+    )
+    # The frontend extracts ``context`` and reads fields off it; a
+    # ``None`` here would force every caller into a null check.
+    assert exc.detail["context"] == {}
+
+
+def test_enum_values_are_stable_strings():
+    """Renaming a member breaks every consumer that switch-matches on
+    the value. Pin the current set so a rename surfaces in code
+    review."""
+    expected = {
+        "auth.required",
+        "auth.forbidden",
+        "resource.not_found",
+        "course.not_published",
+        "course.already_enrolled",
+        "course.enrolment_closed",
+        "translation.disabled",
+        "translation.worker_unauthorized",
+        "translation.worker_unconfigured",
+        "quiz.not_open",
+        "quiz.attempts_exhausted",
+        "validation.failed",
+    }
+    assert {member.value for member in ErrorCode} == expected
+
+
+def test_equip_error_headers_passthrough():
+    """``headers=`` lands on the raised HTTPException unchanged so a
+    consumer that needs ``WWW-Authenticate`` / ``Retry-After`` can
+    still set them alongside the code."""
+    exc = equip_error(
+        ErrorCode.QUIZ_ATTEMPTS_EXHAUSTED,
+        status_code=429,
+        message="Try again later",
+        context={"retry_after_seconds": 60},
+        headers={"Retry-After": "60"},
+    )
+    assert exc.headers == {"Retry-After": "60"}

--- a/frontend/src/lib/__tests__/errorCode.test.ts
+++ b/frontend/src/lib/__tests__/errorCode.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Pin the contract between `getErrorCode` / `getErrorContext` and the
+ * backend's typed error envelope (Phase 5ay). These tests are the
+ * canonical examples of how a route handler should react to a typed
+ * code; the existing string-detail fallback path is also pinned so
+ * routes that haven't migrated yet keep working.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { getErrorCode, getErrorContext } from "../errorCode"
+
+function fakeAxiosError(body: unknown, status = 400): unknown {
+  // Shape mirrors what `axios.isAxiosError` accepts. The
+  // `isAxiosError` flag is the marker the runtime check uses.
+  return {
+    isAxiosError: true,
+    response: { status, data: body },
+  }
+}
+
+describe("getErrorCode", () => {
+  it("returns the code when the backend used equip_error", () => {
+    const err = fakeAxiosError({
+      detail: {
+        code: "course.already_enrolled",
+        message: "You're already enrolled in this course",
+        context: { course_id: "abc" },
+      },
+    })
+    expect(getErrorCode(err)).toBe("course.already_enrolled")
+  })
+
+  it("returns null for the legacy string-detail shape", () => {
+    const err = fakeAxiosError({ detail: "Course 'abc' not found" })
+    expect(getErrorCode(err)).toBeNull()
+  })
+
+  it("returns null when the response has no body", () => {
+    const err = fakeAxiosError(undefined)
+    expect(getErrorCode(err)).toBeNull()
+  })
+
+  it("returns null when the error is not an axios error at all", () => {
+    expect(getErrorCode(new Error("boom"))).toBeNull()
+    expect(getErrorCode("plain string")).toBeNull()
+    expect(getErrorCode(null)).toBeNull()
+  })
+})
+
+describe("getErrorContext", () => {
+  it("returns the context dict when present", () => {
+    const err = fakeAxiosError({
+      detail: {
+        code: "quiz.attempts_exhausted",
+        message: "Out of attempts",
+        context: { remaining: 0, cap: 3 },
+      },
+    })
+    expect(getErrorContext(err)).toEqual({ remaining: 0, cap: 3 })
+  })
+
+  it("returns an empty object when context is missing", () => {
+    const err = fakeAxiosError({
+      detail: { code: "auth.required", message: "Sign in" },
+    })
+    expect(getErrorContext(err)).toEqual({})
+  })
+
+  it("returns an empty object for the legacy string detail", () => {
+    const err = fakeAxiosError({ detail: "Course not found" })
+    expect(getErrorContext(err)).toEqual({})
+  })
+})

--- a/frontend/src/lib/errorCode.ts
+++ b/frontend/src/lib/errorCode.ts
@@ -1,0 +1,91 @@
+/**
+ * Typed error-code envelope on top of `getErrorDetail`.
+ *
+ * The backend started emitting structured errors in Phase 5ay:
+ *
+ *   { detail: { code: "course.not_published", message: "...", context: {...} } }
+ *
+ * instead of the legacy `{ detail: "..." }` (a plain string). This
+ * module gives the frontend a typed switch:
+ *
+ *   const code = getErrorCode(err)
+ *   switch (code) {
+ *     case "course.already_enrolled": ...
+ *   }
+ *
+ * Routes that haven't migrated yet still return the string-detail
+ * shape; `getErrorCode` returns `null` for those so the caller falls
+ * back to `getErrorDetail` for the toast text. No flag day required.
+ */
+
+import { isAxiosError } from "axios"
+
+/**
+ * Stable machine-readable identifiers mirror
+ * `backend/app/core/errors.py::ErrorCode`. Sorted by feature scope.
+ *
+ * To add a code:
+ *   1. Append the value to `ErrorCode` in the backend.
+ *   2. Append the same string to this union.
+ *   3. The exhaustiveness check on `switch (code)` calls catches
+ *      every consumer that needs to handle it.
+ */
+export type ErrorCode =
+  // auth / permissions
+  | "auth.required"
+  | "auth.forbidden"
+  // generic resource lookups
+  | "resource.not_found"
+  // course lifecycle
+  | "course.not_published"
+  | "course.already_enrolled"
+  | "course.enrolment_closed"
+  // translation pipeline
+  | "translation.disabled"
+  | "translation.worker_unauthorized"
+  | "translation.worker_unconfigured"
+  // quiz / assignment
+  | "quiz.not_open"
+  | "quiz.attempts_exhausted"
+  // validation
+  | "validation.failed"
+
+interface StructuredErrorDetail {
+  code: ErrorCode
+  message: string
+  context?: Record<string, unknown>
+}
+
+function isStructuredErrorDetail(value: unknown): value is StructuredErrorDetail {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "code" in value &&
+    typeof (value as { code: unknown }).code === "string" &&
+    "message" in value &&
+    typeof (value as { message: unknown }).message === "string"
+  )
+}
+
+/**
+ * Return the structured error code from an Axios error response, or
+ * `null` when the backend returned a legacy string detail (or the
+ * error isn't an Axios error at all). Never throws.
+ */
+export function getErrorCode(err: unknown): ErrorCode | null {
+  if (!isAxiosError(err)) return null
+  const detail: unknown = err.response?.data?.detail
+  return isStructuredErrorDetail(detail) ? detail.code : null
+}
+
+/**
+ * Return the `context` dict from a structured error, or an empty
+ * object when the error is legacy / unstructured. Useful for codes
+ * that include machine-readable parameters (e.g. retries left,
+ * conflicting resource id).
+ */
+export function getErrorContext(err: unknown): Record<string, unknown> {
+  if (!isAxiosError(err)) return {}
+  const detail: unknown = err.response?.data?.detail
+  return isStructuredErrorDetail(detail) ? detail.context ?? {} : {}
+}

--- a/frontend/src/lib/errorDetail.ts
+++ b/frontend/src/lib/errorDetail.ts
@@ -26,6 +26,17 @@ export function getErrorDetail(err: unknown, fallback = "An error occurred"): st
   if (isAxiosError(err)) {
     const detail: unknown = err.response?.data?.detail
     if (typeof detail === "string") return detail
+    // Phase 5ay: structured envelope ``{code, message, context}``.
+    // Render ``message`` for the toast; ``getErrorCode`` extracts
+    // the typed code for switch logic separately.
+    if (
+      detail &&
+      typeof detail === "object" &&
+      "message" in detail &&
+      typeof (detail as { message: unknown }).message === "string"
+    ) {
+      return (detail as { message: string }).message
+    }
     if (detail) {
       const pretty = safeStringify(detail)
       if (pretty) return pretty


### PR DESCRIPTION
## Summary

Architecture review #5 flagged the error envelope as the biggest remaining "this is what a top-tier eng team would have done differently" gap. Today every route raises `HTTPException(detail="Course xyz not found")` — free-form human text. Frontend can only react to "course missing" vs "permission denied" by substring-matching the message, which breaks on rephrase, breaks on locale change (RU teacher / EN admin), and is the opposite of every i18n + a11y best practice.

This PR ships the **foundation**. Individual route migrations are 5az+ incremental work.

## Backend

- `app/core/errors.py` — `ErrorCode` StrEnum with 12 initial codes scoped by feature (`auth.*`, `course.*`, `translation.*`, `quiz.*`, `resource.*`, `validation.*`) and the `equip_error` helper.
- `equip_error` returns an `HTTPException` whose `detail` is `{code, message, context}`. FastAPI serializes verbatim.
- `context` defaults to `{}` (never `None`) so the frontend can read `context.<field>` without a null check.
- `headers=` still flows through for `WWW-Authenticate` / `Retry-After`.

## Frontend

- `src/lib/errorCode.ts` — typed `ErrorCode` union mirroring the backend enum + `getErrorCode(err)` / `getErrorContext(err)` helpers.
- `getErrorCode` returns `null` for the legacy string-detail shape so routes that havenʼt migrated yet keep working. **No flag day, no big-bang migration.**
- `src/lib/errorDetail.ts` learns to extract `detail.message` from the new envelope so toasts render the human string.

## Test plan

| Layer | Count | Coverage |
|---|---|---|
| Backend | 4 | shape, default context, enum value stability, headers passthrough |
| Frontend | 7 | code extraction, legacy fallback, non-axios → null, context with + without |

`pytest -q` → 955 passed. `npm run test:run -- src/lib` → 116 passed. `mypy` + `ruff` + `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)