### PR TITLE
feat(queue): V1 phase 5ba — activate translation queue via Vercel Cron

### DIFF
--- a/backend/app/api/v1/internal_translation_worker.py
+++ b/backend/app/api/v1/internal_translation_worker.py
@@ -66,10 +66,19 @@ class WorkerTickResponse(BaseModel):
 
 def _require_worker_secret(
     x_worker_secret: str | None = Header(default=None, alias="X-Worker-Secret"),
+    authorization: str | None = Header(default=None, alias="Authorization"),
 ) -> None:
     """Constant-time shared-secret check. Refuses every request when
     the env var is unset — opt-in by design so dev environments without
     the queue cron don't accidentally expose the endpoint.
+
+    Accepts two header shapes so a single env var serves both flows:
+
+    * ``X-Worker-Secret: <secret>`` — direct human / test access.
+    * ``Authorization: Bearer <secret>`` — what Vercel Cron Jobs send
+      automatically (Vercel signs each cron request with the
+      ``CRON_SECRET`` env var; we map ``TRANSLATION_WORKER_SECRET`` to
+      that value at deploy so the auth scheme matches).
     """
     expected = settings.TRANSLATION_WORKER_SECRET
     if expected is None or not expected.get_secret_value():
@@ -77,8 +86,13 @@ def _require_worker_secret(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Translation worker is not configured on this deployment.",
         )
+    expected_value = expected.get_secret_value()
+
     presented = x_worker_secret or ""
-    if not hmac.compare_digest(presented, expected.get_secret_value()):
+    if not presented and authorization and authorization.startswith("Bearer "):
+        presented = authorization.removeprefix("Bearer ").strip()
+
+    if not hmac.compare_digest(presented, expected_value):
         # 401 with a generic message so a probing attacker can't
         # distinguish 'wrong secret' from 'no secret header'.
         raise HTTPException(
@@ -165,6 +179,27 @@ def drain_one_job(
     _: None = Depends(_require_worker_secret),
 ) -> WorkerTickResponse:
     """Cron-callable. Claims one job and runs the orchestrator."""
+    return _run_one_tick(db)
+
+
+@router.get(
+    "/translation-worker",
+    response_model=WorkerTickResponse,
+    summary="Drain one translation job (GET alias for Vercel Cron)",
+    responses={
+        200: {"description": "Same payload as the POST variant."},
+        401: {"description": "Worker secret missing or wrong"},
+        503: {"description": "TRANSLATION_WORKER_SECRET is not configured on this deployment"},
+    },
+)
+def drain_one_job_get(
+    db: Session = Depends(get_db),
+    _: None = Depends(_require_worker_secret),
+) -> WorkerTickResponse:
+    """Vercel Cron Jobs send GET — same body as the POST handler. Kept
+    as a thin alias instead of changing the canonical method so test
+    drivers and admin tools that already use POST stay working.
+    """
     return _run_one_tick(db)
 
 

--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -1477,9 +1477,34 @@
     "body": false
   },
   {
+    "method": "GET",
+    "path": "/api/v1/internal/translation-worker",
+    "params": [
+      [
+        "Authorization",
+        "header"
+      ],
+      [
+        "X-Worker-Secret",
+        "header"
+      ]
+    ],
+    "responses": [
+      "200",
+      "401",
+      "422",
+      "503"
+    ],
+    "body": false
+  },
+  {
     "method": "POST",
     "path": "/api/v1/internal/translation-worker",
     "params": [
+      [
+        "Authorization",
+        "header"
+      ],
       [
         "X-Worker-Secret",
         "header"

--- a/backend/tests/test_translation_worker_endpoint.py
+++ b/backend/tests/test_translation_worker_endpoint.py
@@ -63,6 +63,30 @@ def _make_course(db: Session, teacher_id) -> Course:
     return course
 
 
+def test_accepts_authorization_bearer_header(client: TestClient, configured_worker):
+    """Vercel Cron sends ``Authorization: Bearer <secret>`` automatically.
+    The worker accepts that shape so the same env var serves both
+    direct human access (``X-Worker-Secret``) and the Vercel-managed
+    cron auth."""
+    resp = client.post(
+        _WORKER_PATH,
+        headers={"Authorization": f"Bearer {_GOOD_SECRET}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "idle"
+
+
+def test_get_alias_works_for_vercel_cron(client: TestClient, configured_worker):
+    """Vercel Cron sends GET — pin the alias so a refactor that drops
+    the GET method breaks CI instead of silently leaving the cron 405."""
+    resp = client.get(
+        _WORKER_PATH,
+        headers={"Authorization": f"Bearer {_GOOD_SECRET}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "idle"
+
+
 def test_503_when_worker_secret_is_unset(client: TestClient):
     """Default state: TRANSLATION_WORKER_SECRET is unset → endpoint
     refuses every call so a dev env that hasn't configured the queue

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -15,5 +15,11 @@
       "src": "/(.*)",
       "dest": "index.py"
     }
+  ],
+  "crons": [
+    {
+      "path": "/api/v1/internal/translation-worker",
+      "schedule": "*/1 * * * *"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Wires the queue from 5av-5ax to a Vercel Cron driver so the operator no longer has to think about how the queue drains.

## Code

- `internal_translation_worker.py` accepts `Authorization: Bearer <secret>` in addition to `X-Worker-Secret: <secret>`. Vercel Cron Jobs sign each request with the Bearer scheme automatically; the worker matches that out of the box without changing the direct-POST path that test scripts use.
- **GET alias** on the same path. Vercel Cron sends GET; keeping POST as the canonical method and adding GET as a thin alias is the lowest-risk wiring.
- `backend/vercel.json` gains a `crons` block: `*/1 * * * *` ticking the worker once per minute. One tick = one claim, by design — if the queue backs up the cron fires faster than the worker can drain it, and SKIP LOCKED keeps concurrent ticks safe.

## Operator activation (executed alongside this PR via Vercel API)

1. Mint a strong secret: `secrets.token_urlsafe(48)`.
2. Set `TRANSLATION_WORKER_SECRET` in Vercel production env.
3. Flip `TRANSLATION_QUEUE_ENABLED=true` in the same scope.
4. Deploy (this PR merge triggers prod build).
5. Watch `GET /api/v1/admin/translations/queue-status` for the first minute — `done_last_hour` should start incrementing as the cron fires.

## Test plan

Two new pins on the auth surface so a refactor doesnʼt silently break the cron driver:

- Authorization Bearer header accepted with the same secret
- GET method aliased to the POST handler

`pytest -q` → 961 passed. `mypy` + `ruff` clean. OpenAPI contract snapshot updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)