### PR TITLE
refactor(errors): migrate quizzes domain to equip_error envelope

### DIFF
--- a/backend/app/api/v1/quizzes/attempts.py
+++ b/backend/app/api/v1/quizzes/attempts.py
@@ -3,7 +3,7 @@
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import Depends, HTTPException, Query, status
+from fastapi import Depends, Query, status
 from sqlalchemy.orm import Session, selectinload
 
 from app.api.dependencies import (
@@ -13,6 +13,7 @@ from app.api.dependencies import (
     verify_chapter_access,
 )
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.enrollment import Enrollment
 from app.models.quiz import Quiz, QuizAttempt, QuizQuestion
 from app.models.user import User
@@ -68,7 +69,12 @@ def submit_quiz(
     # legitimate submitters under load.
     pre_quiz = db.query(Quiz.chapter_id).filter(Quiz.id == quiz_id).first()
     if not pre_quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     course_id = resolve_chapter_course_id(db, pre_quiz.chapter_id)
     enrolled = (
         db.query(Enrollment)
@@ -79,9 +85,11 @@ def submit_quiz(
         .first()
     )
     if not enrolled:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You must be enrolled in this course to submit quizzes",
+            message="You must be enrolled in this course to submit quizzes",
+            context={"resource_type": "quiz", "quiz_id": str(quiz_id), "course_id": course_id},
         )
 
     quiz = (
@@ -94,7 +102,12 @@ def submit_quiz(
     if not quiz:
         # Lost-race fallback: someone deleted the quiz between the
         # pre-check and the lock. Same 404 the original flow returned.
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
 
     quiz_service.ensure_attempts_available(db, quiz, current_user.id)
 
@@ -156,7 +169,12 @@ def get_quiz_attempts(
 ):
     quiz = db.query(Quiz).filter(Quiz.id == quiz_id).first()
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     verify_quiz_owner(db, quiz, teacher.id)
     return (
         db.query(QuizAttempt)
@@ -179,7 +197,12 @@ def get_my_quiz_attempts(
 ):
     quiz = db.query(Quiz).filter(Quiz.id == quiz_id).first()
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     verify_chapter_access(db, quiz.chapter_id, current_user)
 
     return (

--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -6,7 +6,7 @@ Every route here attaches to the shared ``router`` in ``_router.py``.
 import uuid
 from uuid import UUID
 
-from fastapi import Depends, Header, HTTPException, Query, Response, status
+from fastapi import Depends, Header, Query, Response, status
 from sqlalchemy.orm import Session, selectinload
 
 from app.api.dependencies import (
@@ -16,6 +16,7 @@ from app.api.dependencies import (
     verify_chapter_owner,
 )
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.course import Chapter, Course, Module
 from app.models.quiz import Quiz, QuizExtraAttempt, QuizOption, QuizQuestion
 from app.models.user import User
@@ -91,9 +92,11 @@ def get_chapter_quiz(
     ctx = resolve_chapter_locale_context(db, chapter_id=chapter_id, current_user=current_user)
     if source:
         if not ctx.is_owner_or_admin:
-            raise HTTPException(
+            raise equip_error(
+                ErrorCode.AUTH_FORBIDDEN,
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Only the course owner or an admin can request source-language content",
+                message="Only the course owner or an admin can request source-language content",
+                context={"resource_type": "quiz", "chapter_id": chapter_id},
             )
         # Phase 5f: title / question_text / option_text columns dropped.
         # The student response is the same shape source==display surfaces,
@@ -135,7 +138,12 @@ def get_quiz_detail(
         .first()
     )
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     verify_quiz_owner(db, quiz, teacher.id)
     return build_quiz_response_from_cv(
         db, quiz, source_locale=normalize_locale(_course_source_locale_for_chapter(db, quiz.chapter_id))
@@ -222,7 +230,12 @@ def create_quiz(
         .first()
     )
     if reloaded is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id_val)},
+        )
     run_course_translation_pipeline_if_published(db, course_id)
     return build_quiz_response_from_cv(db, reloaded, source_locale=normalize_locale(fallback_locale))
 
@@ -236,7 +249,12 @@ def update_quiz(
 ):
     quiz = db.query(Quiz).filter(Quiz.id == quiz_id).first()
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     verify_quiz_owner(db, quiz, teacher.id)
 
     patch = data.model_dump(exclude_unset=True)
@@ -273,7 +291,12 @@ def update_quiz(
         .first()
     )
     if reloaded is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     reconcile_entity_if_course_published(db, "quiz", reloaded)
     return build_quiz_response_from_cv(db, reloaded, source_locale=normalize_locale(source_locale))
 
@@ -291,7 +314,12 @@ def delete_quiz(
         .first()
     )
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     verify_quiz_owner(db, quiz, teacher.id)
     # Phase 5ad: cv has no FK back; the quiz tree (quiz → questions →
     # options) is hard-deleted via cascade on the entity tables but

--- a/backend/app/api/v1/quizzes/extra.py
+++ b/backend/app/api/v1/quizzes/extra.py
@@ -2,12 +2,13 @@
 
 from uuid import UUID
 
-from fastapi import Depends, HTTPException, Query, status
+from fastapi import Depends, Query, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import require_teacher, resolve_chapter_course_id
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.enrollment import Enrollment
 from app.models.quiz import Quiz, QuizExtraAttempt
 from app.models.user import User
@@ -26,7 +27,12 @@ def grant_extra_attempts(
 ):
     quiz = db.query(Quiz).filter(Quiz.id == quiz_id).first()
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     verify_quiz_owner(db, quiz, teacher.id)
 
     course_id = resolve_chapter_course_id(db, quiz.chapter_id)
@@ -39,9 +45,11 @@ def grant_extra_attempts(
         .first()
     )
     if not enrolled:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Student is not enrolled in this course",
+            message="Student is not enrolled in this course",
+            context={"resource_type": "enrollment", "quiz_id": str(quiz_id), "course_id": course_id},
         )
 
     existing = (
@@ -80,9 +88,11 @@ def grant_extra_attempts(
             .first()
         )
         if existing is None:
-            raise HTTPException(
+            raise equip_error(
+                ErrorCode.VALIDATION_FAILED,
                 status_code=status.HTTP_409_CONFLICT,
-                detail="Could not grant extra attempts — please retry",
+                message="Could not grant extra attempts — please retry",
+                context={"resource_type": "quiz_extra_attempts", "quiz_id": str(quiz_id)},
             ) from None
         existing.extra_attempts = data.extra_attempts
         existing.granted_by = teacher.id
@@ -101,7 +111,12 @@ def list_extra_attempts(
 ):
     quiz = db.query(Quiz).filter(Quiz.id == quiz_id).first()
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     verify_quiz_owner(db, quiz, teacher.id)
 
     return (

--- a/backend/app/api/v1/quizzes/grading.py
+++ b/backend/app/api/v1/quizzes/grading.py
@@ -3,11 +3,12 @@
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import Depends, HTTPException, Query, status
+from fastapi import Depends, Query, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import require_teacher
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.quiz import Quiz, QuizAnswer, QuizAttempt, QuizQuestion
 from app.models.user import User
 from app.schemas.quiz import (
@@ -51,7 +52,12 @@ def list_pending_answers(
     """
     quiz = db.query(Quiz).filter(Quiz.id == quiz_id).first()
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(quiz_id)},
+        )
     verify_quiz_owner(db, quiz, teacher.id)
 
     query = (
@@ -136,15 +142,31 @@ def grade_answer(
     """
     answer = db.query(QuizAnswer).filter(QuizAnswer.id == answer_id).first()
     if not answer:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Answer not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Answer not found",
+            context={"resource_type": "quiz_answer", "resource_id": str(answer_id)},
+        )
 
     question = db.query(QuizQuestion).filter(QuizQuestion.id == answer.question_id).first()
     if not question:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Question not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Question not found",
+            context={"resource_type": "quiz_question", "resource_id": str(answer.question_id)},
+        )
     if question.question_type not in quiz_service.MANUAL_GRADED_QUESTION_TYPES:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Only open-ended answers (short_answer / essay) can be graded manually",
+            message="Only open-ended answers (short_answer / essay) can be graded manually",
+            context={
+                "resource_type": "quiz_answer",
+                "answer_id": str(answer_id),
+                "question_type": question.question_type,
+            },
         )
 
     # ``FOR UPDATE`` on the attempt row so two teachers grading two
@@ -158,17 +180,34 @@ def grade_answer(
     # the recompute + write of ``attempt.score`` / ``attempt.passed``.
     attempt = db.query(QuizAttempt).filter(QuizAttempt.id == answer.attempt_id).with_for_update().first()
     if not attempt:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attempt not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Attempt not found",
+            context={"resource_type": "quiz_attempt", "resource_id": str(answer.attempt_id)},
+        )
 
     quiz = db.query(Quiz).filter(Quiz.id == attempt.quiz_id).first()
     if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quiz not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Quiz not found",
+            context={"resource_type": "quiz", "resource_id": str(attempt.quiz_id)},
+        )
     verify_quiz_owner(db, quiz, teacher.id)
 
     if data.points_earned > int(question.points):
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"points_earned ({data.points_earned}) exceeds question cap ({question.points})",
+            message=f"points_earned ({data.points_earned}) exceeds question cap ({question.points})",
+            context={
+                "resource_type": "quiz_answer",
+                "answer_id": str(answer_id),
+                "points_earned": data.points_earned,
+                "max_points": int(question.points),
+            },
         )
 
     answer.points_earned = data.points_earned

--- a/backend/tests/test_quizzes_and_blocks.py
+++ b/backend/tests/test_quizzes_and_blocks.py
@@ -1022,7 +1022,7 @@ def test_submit_quiz_not_enrolled(client: TestClient, db: Session):
         },
     )
     assert resp.status_code == 403
-    assert "enrolled" in resp.json()["detail"].lower()
+    assert "enrolled" in resp.json()["detail"]["message"].lower()
 
 
 def test_submit_quiz_not_found(student_client: TestClient, db: Session):
@@ -1585,7 +1585,7 @@ def test_grade_answer_rejects_points_above_cap(client: TestClient, student, db: 
         json={"points_earned": 99},
     )
     assert resp.status_code == 400
-    assert "exceeds" in resp.json()["detail"].lower()
+    assert "exceeds" in resp.json()["detail"]["message"].lower()
 
 
 def test_grade_answer_rejects_auto_graded_question(student_client: TestClient, db: Session):
@@ -1619,7 +1619,7 @@ def test_grade_answer_rejects_auto_graded_question(student_client: TestClient, d
         if original is not None:
             app.dependency_overrides[get_current_user] = original
     assert resp.status_code == 400
-    assert "open-ended" in resp.json()["detail"].lower()
+    assert "open-ended" in resp.json()["detail"]["message"].lower()
 
 
 def test_grade_answer_student_forbidden(student_client: TestClient, db: Session):


### PR DESCRIPTION
## Summary
Phase 5bd continues the typed-error-envelope rollout (5ay foundation → 5az courses/catalog → 5bc blocks/announcements/cohorts/assignments). 22 raise sites across the quizzes domain now carry typed `ErrorCode` + structured `context`.

**Per-file breakdown:**
- `quizzes/crud.py` (6): source-locale 403, 5x quiz-not-found 404s across get/create (post-reload)/update (pre + post-reload)/delete
- `quizzes/attempts.py` (5): 3x quiz-not-found 404s, 1x not-enrolled 403 with `quiz_id` + `course_id` context
- `quizzes/extra.py` (4): 2x quiz-not-found 404s, not-enrolled 404, IntegrityError 409
- `quizzes/grading.py` (7): quiz/answer/question/attempt 404s, manual-grade type 400 with `question_type`, points-over-cap 400 with `points_earned` + `max_points`

**Behavior unchanged.** Status codes preserved. Message wording preserved so existing localization keys keep working.

**Test updates:** three legacy `detail.lower()` assertions → `detail["message"].lower()`.

## Test plan
- [x] 961 backend tests pass locally
- [x] ruff check + ruff format clean
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)