### PR TITLE
refactor(errors): migrate users, grades, reviews, prerequisites to equip_error envelope

### DIFF
--- a/backend/app/api/v1/grades.py
+++ b/backend/app/api/v1/grades.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_teacher, verify_course_owner
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.course import Course
 from app.models.enrollment import Enrollment
 from app.models.student_grade import StudentGrade
@@ -44,7 +45,12 @@ def get_grading_config(
 ):
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Course not found",
+            context={"resource_type": "course", "resource_id": course_id},
+        )
 
     is_owner = str(course.created_by) == str(current_user.id)
     is_admin = current_user.role == UserRole.ADMIN.value
@@ -53,7 +59,12 @@ def get_grading_config(
         is not None
     )
     if not (is_owner or is_admin or is_enrolled):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
+            status_code=status.HTTP_403_FORBIDDEN,
+            message="Access denied",
+            context={"resource_type": "grading_config", "course_id": course_id},
+        )
 
     return GradingConfigResponse.model_validate(course)
 
@@ -90,14 +101,21 @@ def get_calculated_grade(
         db.query(Enrollment).filter(Enrollment.user_id == str(student_id), Enrollment.course_id == course_id).first()
     )
     if not enrolled:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Student not enrolled in this course",
+            message="Student not enrolled in this course",
+            context={"resource_type": "enrollment", "student_id": str(student_id), "course_id": course_id},
         )
 
     user = db.query(User).filter(User.id == str(student_id)).first()
     if not user:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Student not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Student not found",
+            context={"resource_type": "user", "resource_id": str(student_id)},
+        )
 
     breakdown = calculate_student_grade_for_course(db, course, student_id)
 
@@ -139,9 +157,11 @@ def get_grade_summary(
         raise
     except SQLAlchemyError as exc:
         logger.exception("Grade summary DB error for course %s", course_id)
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Grade calculation failed",
+            message="Grade calculation failed",
+            context={"resource_type": "grade_summary", "course_id": course_id},
         ) from exc
 
 
@@ -255,9 +275,11 @@ def get_my_grade_for_course(
         .first()
     )
     if not grade:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"No grade found for course '{course_id}'",
+            message=f"No grade found for course '{course_id}'",
+            context={"resource_type": "grade", "course_id": course_id},
         )
     return grade
 
@@ -295,9 +317,11 @@ def get_student_grade(
         query = query.filter(StudentGrade.cohort_id == cohort_id)
     grade = query.first()
     if not grade:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"No grade found for student '{student_id}' in course '{course_id}'",
+            message=f"No grade found for student '{student_id}' in course '{course_id}'",
+            context={"resource_type": "grade", "student_id": student_id, "course_id": course_id},
         )
     return grade
 
@@ -315,7 +339,12 @@ def upsert_student_grade(
 
     enrolled = db.query(Enrollment).filter(Enrollment.user_id == student_id, Enrollment.course_id == course_id).first()
     if not enrolled:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Student is not enrolled in this course")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Student is not enrolled in this course",
+            context={"resource_type": "enrollment", "student_id": student_id, "course_id": course_id},
+        )
 
     query = db.query(StudentGrade).filter(
         StudentGrade.student_id == student_id,
@@ -369,9 +398,11 @@ def upsert_student_grade(
             # IntegrityError without a matching row means a different
             # constraint fired (FK violation, etc). Surface a clean 409
             # instead of leaking via the generic SQLAlchemy 503 handler.
-            raise HTTPException(
+            raise equip_error(
+                ErrorCode.VALIDATION_FAILED,
                 status_code=status.HTTP_409_CONFLICT,
-                detail="Grade could not be saved due to a conflict; please retry.",
+                message="Grade could not be saved due to a conflict; please retry.",
+                context={"resource_type": "grade", "student_id": student_id, "course_id": course_id},
             ) from None
         if data.grade is not None:
             existing.grade = data.grade

--- a/backend/app/api/v1/prerequisites.py
+++ b/backend/app/api/v1/prerequisites.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from fastapi import APIRouter, Depends, Header, Response, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_teacher, verify_course_owner
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.course import Course, CourseStatus
 from app.models.prerequisite import CoursePrerequisite
 from app.models.user import User, UserRole
@@ -56,13 +57,23 @@ def get_prerequisites(
     # treated as not found so deleted prerequisites don't leak either.
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Course not found",
+            context={"resource_type": "course", "resource_id": course_id},
+        )
 
     is_admin = current_user.role == UserRole.ADMIN.value
     is_owner = str(course.created_by) == str(current_user.id)
     is_published = getattr(course, "status", None) == CourseStatus.PUBLISHED
     if not (is_admin or is_owner or is_published):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Course not found",
+            context={"resource_type": "course", "resource_id": course_id},
+        )
 
     prereqs = db.query(CoursePrerequisite).filter(CoursePrerequisite.course_id == course_id).all()
     prereq_ids = [p.prerequisite_course_id for p in prereqs]
@@ -99,9 +110,11 @@ def set_prerequisites(
     # Prevent self-cycle (A -> A) up front -- the multi-node check below
     # would catch this too, but the targeted error message is friendlier.
     if course_id in prereq_ids:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="A course cannot be its own prerequisite",
+            message="A course cannot be its own prerequisite",
+            context={"resource_type": "prerequisite", "course_id": course_id},
         )
 
     if prereq_ids:
@@ -111,9 +124,11 @@ def set_prerequisites(
         existing_ids = {str(c.id) for c in existing_courses}
         for pid in prereq_ids:
             if pid not in existing_ids:
-                raise HTTPException(
+                raise equip_error(
+                    ErrorCode.RESOURCE_NOT_FOUND,
                     status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Prerequisite course '{pid}' not found",
+                    message=f"Prerequisite course '{pid}' not found",
+                    context={"resource_type": "course", "resource_id": pid, "depending_on": course_id},
                 )
 
         # Multi-node cycle detection. Without this a teacher can wire
@@ -144,12 +159,18 @@ def set_prerequisites(
                     continue
                 visited.add(node)
                 if node == course_id:
-                    raise HTTPException(
+                    raise equip_error(
+                        ErrorCode.VALIDATION_FAILED,
                         status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=(
+                        message=(
                             f"Adding '{pid}' as a prerequisite would create a "
                             "circular dependency with the course's existing prerequisite chain."
                         ),
+                        context={
+                            "resource_type": "prerequisite",
+                            "course_id": course_id,
+                            "prerequisite_course_id": pid,
+                        },
                     )
                 stack.extend(requires.get(node, set()) - visited)
 

--- a/backend/app/api/v1/reviews.py
+++ b/backend/app/api/v1/reviews.py
@@ -1,11 +1,12 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, Query, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.certificate import Certificate
 from app.models.course import Course, CourseStatus
 from app.models.review import CourseReview
@@ -24,7 +25,12 @@ def list_course_reviews(
 ):
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course or course.status != CourseStatus.PUBLISHED:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Course not found",
+            context={"resource_type": "course", "resource_id": course_id},
+        )
     return (
         db.query(CourseReview)
         .filter(CourseReview.course_id == course_id)
@@ -53,9 +59,11 @@ def create_or_update_review(
         .first()
     )
     if not cert:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You must complete the course and receive a certificate before reviewing",
+            message="You must complete the course and receive a certificate before reviewing",
+            context={"resource_type": "review", "course_id": course_id},
         )
 
     existing = (
@@ -98,9 +106,11 @@ def create_or_update_review(
         # Concurrent delete between the duplicate insert and this read, or a
         # different constraint fired. Return a clean 409 instead of leaking the
         # raw IntegrityError to the generic DB handler (which would report 503).
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_409_CONFLICT,
-            detail="Review could not be saved due to a conflict; please retry.",
+            message="Review could not be saved due to a conflict; please retry.",
+            context={"resource_type": "review", "course_id": course_id},
         ) from None
     db.refresh(review)
     response.status_code = status.HTTP_201_CREATED
@@ -115,8 +125,18 @@ def delete_review(
 ):
     review = db.query(CourseReview).filter(CourseReview.id == review_id).first()
     if not review:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Review not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Review not found",
+            context={"resource_type": "review", "resource_id": str(review_id)},
+        )
     if review.user_id != current_user.id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only delete your own reviews")
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
+            status_code=status.HTTP_403_FORBIDDEN,
+            message="You can only delete your own reviews",
+            context={"resource_type": "review", "resource_id": str(review_id)},
+        )
     db.delete(review)
     db.commit()

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -2,12 +2,13 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Header, Query, Request, Response, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_admin
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.assignment import AssignmentSubmission
 from app.models.audit_log import AuditLog
 from app.models.certificate import Certificate
@@ -46,7 +47,12 @@ def _parse_user_uuid(user_id: str) -> UUID:
     try:
         return UUID(user_id)
     except ValueError:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found") from None
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="User not found",
+            context={"resource_type": "user", "resource_id": user_id},
+        ) from None
 
 
 @router.get("/me/courses", response_model=list[EnrollmentSummaryResponse])
@@ -218,9 +224,19 @@ def bulk_update_user_roles(
     db: Session = Depends(get_db),
 ) -> dict:
     if body.role not in VALID_ROLES:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid role")
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message="Invalid role",
+            context={"resource_type": "user", "role": body.role, "valid_roles": list(VALID_ROLES)},
+        )
     if len(body.user_ids) > 100:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Maximum 100 users per batch")
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message="Maximum 100 users per batch",
+            context={"resource_type": "user", "submitted": len(body.user_ids), "max": 100},
+        )
 
     valid_uuids: list[UUID] = []
     for uid_str in body.user_ids:
@@ -230,7 +246,12 @@ def bulk_update_user_roles(
             continue
 
     if not valid_uuids:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "No valid user IDs provided")
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message="No valid user IDs provided",
+            context={"resource_type": "user"},
+        )
 
     # Admins must not demote themselves; silently skip their own id.
     safe_uuids = [u for u in valid_uuids if u != admin.id]
@@ -262,13 +283,28 @@ def update_user_role(
     db: Session = Depends(get_db),
 ) -> dict:
     if role not in VALID_ROLES:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid role")
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message="Invalid role",
+            context={"resource_type": "user", "role": role, "valid_roles": list(VALID_ROLES)},
+        )
     uid = _parse_user_uuid(user_id)
     if uid == admin.id:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Cannot change your own role")
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message="Cannot change your own role",
+            context={"resource_type": "user", "user_id": str(uid)},
+        )
     user = db.query(User).filter(User.id == uid).first()
     if not user:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="User not found",
+            context={"resource_type": "user", "resource_id": str(uid)},
+        )
     old_role = user.role
     user.role = role
     db.commit()
@@ -296,11 +332,21 @@ def admin_delete_user(
     """
     uid = _parse_user_uuid(user_id)
     if uid == admin.id:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Admins cannot delete their own account")
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message="Admins cannot delete their own account",
+            context={"resource_type": "user", "user_id": str(uid)},
+        )
 
     target = db.query(User).filter(User.id == uid).first()
     if not target:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="User not found",
+            context={"resource_type": "user", "resource_id": str(uid)},
+        )
 
     log_action(
         db,
@@ -318,9 +364,11 @@ def admin_delete_user(
     except Exception as exc:
         db.rollback()
         logger.exception("Admin-initiated deletion failed for user %s", uid)
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="User deletion failed. Please try again or contact support.",
+            message="User deletion failed. Please try again or contact support.",
+            context={"resource_type": "user", "user_id": str(uid)},
         ) from exc
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/test_admin_bulk_trash_and_csv.py
+++ b/backend/tests/test_admin_bulk_trash_and_csv.py
@@ -179,7 +179,7 @@ class TestBulkUpdateRoles:
             json={"user_ids": ids, "role": "student"},
         )
         assert resp.status_code == 400
-        assert "Maximum 100" in resp.json()["detail"]
+        assert "Maximum 100" in resp.json()["detail"]["message"]
 
     def test_invalid_uuids_are_ignored(self, admin_client: TestClient, db: Session):
         other = _make_other_student(db)

--- a/backend/tests/test_users_reviews_misc.py
+++ b/backend/tests/test_users_reviews_misc.py
@@ -470,7 +470,7 @@ class TestSetPrerequisites:
             json={"prerequisite_course_ids": ["course-a"]},
         )
         assert resp.status_code == 400
-        assert "circular" in resp.json()["detail"].lower()
+        assert "circular" in resp.json()["detail"]["message"].lower()
 
     def test_three_node_cycle_rejected(self, client: TestClient, db: Session):
         # A -> B -> C already exists; C -> A would close a 3-node cycle.


### PR DESCRIPTION
## Summary
Phase 5bf: 29 raise sites in users/grades/reviews/prerequisites migrated to typed `equip_error` envelope.

**Per-file:**
- `users.py` (10): UUID parse 404, bulk-role 400s (invalid role / batch >100 / no valid ids), per-user role 400s (invalid role / self-demote), user 404 × 2, admin-self-delete 400, deletion 500
- `grades.py` (9): course 404, access 403, student-not-enrolled 404 × 2, student 404, calc 500 with `course_id`, my-grade 404, student-grade 404, upsert 409 race
- `reviews.py` (5): course 404, no-cert 403, race 409, review 404, owner 403
- `prerequisites.py` (5): course 404 × 2, self-loop 400, missing prereq 404, cycle-detection 400

**Note**: reviews.py edits also fix a latent bug — I had referenced `data.course_id` in two error context dicts, but `ReviewCreate` doesn't carry it (it's a path param). Bound to the path `course_id` variable instead. Caught by running the test suite end-to-end before pushing.

**Test updates** (legacy string-shape assertions caught by the new envelope):
- `test_admin_bulk_trash_and_csv.py`: 1 `detail` direct comparison → `detail["message"]`
- `test_users_reviews_misc.py`: 1 `detail.lower()` → `detail["message"].lower()`

## Test plan
- [x] 961 backend tests pass locally
- [x] ruff check + ruff format clean
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)