### PR TITLE
refactor(errors): final equip_error envelope migrations — calendar, certs, progress, etc

### DIFF
--- a/backend/app/api/v1/audit.py
+++ b/backend/app/api/v1/audit.py
@@ -1,12 +1,13 @@
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import require_admin
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.audit_log import AuditLog
 from app.models.user import User
 
@@ -80,9 +81,11 @@ def list_audit_logs(
         try:
             parsed_user_id = UUID(user_id)
         except ValueError as exc:
-            raise HTTPException(
+            raise equip_error(
+                ErrorCode.VALIDATION_FAILED,
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="user_id must be a valid UUID",
+                message="user_id must be a valid UUID",
+                context={"resource_type": "audit_log", "field": "user_id", "value": user_id},
             ) from exc
         q = q.filter(AuditLog.user_id == parsed_user_id)
     if resource_type:

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -1,10 +1,11 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, Header, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_teacher, verify_course_owner
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.core.sanitize import sanitize_string
 from app.models.assignment import Assignment
 from app.models.course import Chapter, Course, Module
@@ -356,7 +357,12 @@ def list_course_events(
         .first()
     )
     if not course_row:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Course not found",
+            context={"resource_type": "course", "resource_id": course_id},
+        )
     is_owner = str(course_row.created_by) == str(current_user.id)
     is_admin = current_user.role == UserRole.ADMIN.value
     if not is_owner and not is_admin:
@@ -366,14 +372,18 @@ def list_course_events(
             .first()
         )
         if not enrolled:
-            raise HTTPException(
+            raise equip_error(
+                ErrorCode.AUTH_FORBIDDEN,
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="You must be enrolled in this course to view events",
+                message="You must be enrolled in this course to view events",
+                context={"resource_type": "course_event", "course_id": course_id},
             )
     if source and not (is_owner or is_admin):
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only the course owner or an admin can request source-language content",
+            message="Only the course owner or an admin can request source-language content",
+            context={"resource_type": "course_event", "course_id": course_id},
         )
     rows = db.query(CourseEvent).filter(CourseEvent.course_id == course_id).order_by(CourseEvent.event_date).all()
     # Locale wins. Every reader — students, owners, admins — gets the locale
@@ -412,7 +422,12 @@ def update_course_event(
         .first()
     )
     if not event:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Event not found",
+            context={"resource_type": "course_event", "resource_id": str(event_id), "course_id": course_id},
+        )
     # Phase 5e4: title + description live in cv. Pop them off the patch
     # before the setattr loop and route through dual_write.
     updates = data.model_dump(exclude_unset=True)
@@ -463,7 +478,12 @@ def delete_course_event(
         .first()
     )
     if not event:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Event not found",
+            context={"resource_type": "course_event", "resource_id": str(event_id), "course_id": course_id},
+        )
     # Phase 5ad: cv polymorphic — drop rows explicitly.
     delete_entity_cv_rows(db, entity_type="course_event", entity_id=event.id)
     db.delete(event)

--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -1,11 +1,12 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Header, Path, Query, Request, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_admin, require_teacher
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.certificate import Certificate, CertificateStatus
 from app.models.course import Course
 from app.models.enrollment import Enrollment
@@ -59,17 +60,29 @@ def request_certificate(
     # Soft-deleted courses must not accept new certificate requests.
     course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
     if not course:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Course not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Course not found",
+            context={"resource_type": "course", "resource_id": course_id},
+        )
 
     enrollment = (
         db.query(Enrollment).filter(Enrollment.user_id == current_user.id, Enrollment.course_id == course_id).first()
     )
     if not enrollment:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Not enrolled in this course")
-    if enrollment.progress < 100:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Course not completed. Current progress: {enrollment.progress}%",
+            message="Not enrolled in this course",
+            context={"resource_type": "certificate", "course_id": course_id},
+        )
+    if enrollment.progress < 100:
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message=f"Course not completed. Current progress: {enrollment.progress}%",
+            context={"resource_type": "certificate", "course_id": course_id, "progress": enrollment.progress},
         )
 
     existing = (
@@ -110,7 +123,12 @@ def request_certificate(
                 db.commit()
                 db.refresh(existing)
             return existing
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Certificate already requested") from exc
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_409_CONFLICT,
+            message="Certificate already requested",
+            context={"resource_type": "certificate", "course_id": course_id},
+        ) from exc
     db.refresh(cert)
     return cert
 
@@ -129,7 +147,12 @@ def get_course_certificate(
         db.query(Certificate).filter(Certificate.user_id == current_user.id, Certificate.course_id == course_id).first()
     )
     if not cert:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No certificate found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="No certificate found",
+            context={"resource_type": "certificate", "course_id": course_id},
+        )
     display_locale: LocaleCode = normalize_locale(accept_language)
     return _localize_cert_responses(db, [cert], display_locale=display_locale)[0]
 

--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -1,12 +1,13 @@
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import require_admin
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.user import User
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,9 @@ def check_database(
         return {"status": "ok", "database": "connected"}
     except SQLAlchemyError:
         logger.exception("Database health check failed")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database connection failed"
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            message="Database connection failed",
+            context={"resource_type": "health"},
         ) from None

--- a/backend/app/api/v1/internal_translation_worker.py
+++ b/backend/app/api/v1/internal_translation_worker.py
@@ -26,13 +26,14 @@ import logging
 import secrets
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, status
 from pydantic import BaseModel
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session  # noqa: TC002 — used by FastAPI Depends at runtime
 
 from app.core.config import settings
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.services.course_service import get_course
 from app.services.translation.course_pipeline import translate_course_content
 from app.services.translation.queue import (
@@ -82,9 +83,11 @@ def _require_worker_secret(
     """
     expected = settings.TRANSLATION_WORKER_SECRET
     if expected is None or not expected.get_secret_value():
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.TRANSLATION_WORKER_UNCONFIGURED,
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Translation worker is not configured on this deployment.",
+            message="Translation worker is not configured on this deployment.",
+            context={"resource_type": "translation_worker"},
         )
     expected_value = expected.get_secret_value()
 
@@ -95,9 +98,11 @@ def _require_worker_secret(
     if not hmac.compare_digest(presented, expected_value):
         # 401 with a generic message so a probing attacker can't
         # distinguish 'wrong secret' from 'no secret header'.
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.TRANSLATION_WORKER_UNAUTHORIZED,
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Worker authentication failed.",
+            message="Worker authentication failed.",
+            context={"resource_type": "translation_worker"},
         )
 
 

--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -1,11 +1,12 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.notification import Notification
 from app.models.user import User
 from app.schemas.notification import (
@@ -75,7 +76,12 @@ def mark_as_read(
         .first()
     )
     if not notification:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Notification not found",
+            context={"resource_type": "notification", "resource_id": str(notification_id)},
+        )
 
     notification.is_read = True
     db.commit()
@@ -108,7 +114,12 @@ def delete_notification(
         .first()
     )
     if not notification:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Notification not found",
+            context={"resource_type": "notification", "resource_id": str(notification_id)},
+        )
 
     db.delete(notification)
     db.commit()

--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -1,12 +1,13 @@
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user, require_teacher, verify_chapter_owner, verify_course_owner
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.chapter_progress import ChapterProgress
 from app.models.course import Chapter, Module
 from app.models.enrollment import Enrollment
@@ -27,9 +28,11 @@ def get_my_chapter_progress(
         db.query(Enrollment).filter(Enrollment.user_id == current_user.id, Enrollment.course_id == course_id).first()
     )
     if not enrolled:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not enrolled in this course",
+            message="Not enrolled in this course",
+            context={"resource_type": "progress", "course_id": course_id},
         )
 
     completed = (
@@ -69,9 +72,11 @@ def teacher_complete_chapter(
 
     enrolled = db.query(Enrollment).filter(Enrollment.user_id == student_id, Enrollment.course_id == course_id).first()
     if not enrolled:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Student is not enrolled in this course",
+            message="Student is not enrolled in this course",
+            context={"resource_type": "progress"},
         )
 
     progress = (
@@ -148,9 +153,11 @@ def teacher_uncomplete_chapter(
 
     enrolled = db.query(Enrollment).filter(Enrollment.user_id == student_id, Enrollment.course_id == course_id).first()
     if not enrolled:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Student is not enrolled in this course",
+            message="Student is not enrolled in this course",
+            context={"resource_type": "progress"},
         )
 
     progress = (
@@ -159,9 +166,11 @@ def teacher_uncomplete_chapter(
         .first()
     )
     if not progress or not progress.completed:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Chapter is not completed",
+            message="Chapter is not completed",
+            context={"resource_type": "chapter_progress"},
         )
     progress.completed = False
     progress.completed_at = None

--- a/backend/app/api/v1/verse_of_the_day.py
+++ b/backend/app/api/v1/verse_of_the_day.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Query, status
 
+from app.core.errors import ErrorCode, equip_error
 from app.schemas.locale import normalize_locale
 from app.schemas.verse_of_the_day import VerseOfTheDayResponse
 from app.services.verse_of_the_day import (
@@ -44,9 +45,11 @@ def read_verse_of_the_day(
         # the card. Logging stays at INFO since the route can legitimately
         # serve 404 in CI / preview deployments without the API key.
         logger.info("Verse of the day unavailable: %s", exc)
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="verse_of_the_day_unavailable",
+            message="verse_of_the_day_unavailable",
+            context={"resource_type": "verse_of_the_day"},
         ) from None
 
     return VerseOfTheDayResponse(

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -209,13 +209,13 @@ class TestRequestCertificate:
         _seed_course(db)
         r = student_client.post("/api/v1/certificates/course/course-1")
         assert r.status_code == 400
-        assert "Not enrolled" in r.json()["detail"]
+        assert "Not enrolled" in r.json()["detail"]["message"]
 
     def test_progress_incomplete(self, student_client: TestClient, db: Session):
         _seed_enrolled_course(db, progress=50)
         r = student_client.post("/api/v1/certificates/course/course-1")
         assert r.status_code == 400
-        assert "50%" in r.json()["detail"]
+        assert "50%" in r.json()["detail"]["message"]
 
     def test_course_not_found(self, student_client: TestClient, db: Session):
         r = student_client.post("/api/v1/certificates/course/nonexistent")

--- a/backend/tests/test_users_reviews_misc.py
+++ b/backend/tests/test_users_reviews_misc.py
@@ -681,7 +681,7 @@ class TestAuditLog:
         # a recoverable client error.
         resp = admin_client.get("/api/v1/audit?user_id=not-a-uuid")
         assert resp.status_code == 400
-        assert "uuid" in resp.json()["detail"].lower()
+        assert "uuid" in resp.json()["detail"]["message"].lower()
 
     def test_anon_rejected(self, anon_client: TestClient):
         resp = anon_client.get("/api/v1/audit")

--- a/backend/tests/test_verse_of_the_day.py
+++ b/backend/tests/test_verse_of_the_day.py
@@ -136,4 +136,4 @@ def test_route_returns_404_when_apikey_missing(monkeypatch):
     with TestClient(app) as tc:
         resp = tc.get("/api/v1/verse-of-the-day?locale=en")
     assert resp.status_code == 404
-    assert resp.json()["detail"] == "verse_of_the_day_unavailable"
+    assert resp.json()["detail"]["message"] == "verse_of_the_day_unavailable"


### PR DESCRIPTION
## Summary
Phase 5bg completes the typed-error-envelope rollout. **21 raise sites** migrated across the remaining route modules, bringing the total this session to **131 sites across 7 PRs** (5bc → 5bg + 5az).

**Per-file:**
- `calendar.py` (5): course 404, enrollment 403, source-locale 403, 2× event 404
- `certificates.py` (5): course 404, not-enrolled 400, progress-incomplete 400 carrying actual progress, already-requested 409, no-cert 404
- `progress.py` (4): not-enrolled 403 × 3, chapter-not-completed 400
- `notifications.py` (2): notification 404 × 2
- `audit.py` (1): user_id UUID 400 with bad value in context
- `internal_translation_worker.py` (2): unconfigured 503 → `TRANSLATION_WORKER_UNCONFIGURED`, 401 → `TRANSLATION_WORKER_UNAUTHORIZED`. Both codes from 5ay, so the operator dashboard can distinguish them.
- `verse_of_the_day.py` (1): unavailable 404
- `health.py` (1): DB-unreachable 503

After this PR the only remaining `raise HTTPException` sites in `app/api/v1/` live in `courses/catalog.py` and `admin_translations.py` — already covered by 5az (#594), excluded here to avoid 3-way merge.

**Test updates** (legacy string-shape assertions caught by the new envelope):
- `test_certificates_and_grades.py`: 2 `detail` direct comparisons → `detail["message"]`
- `test_users_reviews_misc.py`: 1 `detail.lower()` → `detail["message"].lower()`
- `test_verse_of_the_day.py`: 1 `detail` direct comparison → `detail["message"]`

## Test plan
- [x] 961 backend tests pass locally
- [x] ruff check + ruff format clean
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)