### PR TITLE
fix(bilingual): hydrate course.title before audit logs + locale-aware analytics

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query, Response
+from fastapi import APIRouter, Depends, Header, Query, Response
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -6,6 +6,7 @@ from app.api.dependencies import require_teacher, verify_course_owner
 from app.core.database import get_db
 from app.models.enrollment import Enrollment
 from app.models.user import User
+from app.schemas.locale import normalize_locale
 from app.services.translation.resolve_for_display import populate_spine_texts
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
@@ -25,6 +26,7 @@ def get_course_analytics(
     response: Response,
     skip: int = Query(0, ge=0),
     limit: int = Query(500, ge=1, le=2000),
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ):
@@ -39,7 +41,11 @@ def get_course_analytics(
     """
     course = verify_course_owner(db, course_id, teacher)
     # Phase 5g: courses.title moved to cv — hydrate before serialising.
-    populate_spine_texts(db, [course])
+    # Phase 5bi: respect Accept-Language so a Russian teacher viewing an
+    # EN-source course sees the localized title (matching the editor
+    # overlay) instead of always the source. Tier order:
+    # display_locale → source_locale → any-locale.
+    populate_spine_texts(db, [course], display_locale=normalize_locale(accept_language))
     # Course title is locale-resolved via populate_spine_texts; downstream
     # caches must not conflate the EN and RU variants of the same payload.
     response.headers["Vary"] = "Accept-Language"

--- a/backend/app/api/v1/courses/crud.py
+++ b/backend/app/api/v1/courses/crud.py
@@ -126,6 +126,11 @@ def remove_course(
             context={"resource_type": "course", "resource_id": course_id},
         )
     assert_course_owner(course, teacher, allow_admin=False)
+    # Phase 5bi: ``course.title`` is a runtime attribute hydrated by
+    # ``populate_spine_texts``. ``get_course`` does NOT hydrate, so the
+    # log_action below would stamp ``None`` into the audit row without
+    # this call. The cost is one indexed cv lookup per delete.
+    populate_spine_texts(db, [course])
     log_action(db, teacher.id, "delete", "course", course_id, details={"title": course.title}, request=request)
     delete_course(db, course)
 
@@ -220,6 +225,8 @@ def permanently_remove_course(
             message="Course must be soft-deleted before permanent deletion",
             context={"resource_type": "course", "course_id": course_id},
         )
+    # Phase 5bi: hydrate before logging, same reason as ``remove_course``.
+    populate_spine_texts(db, [course])
     log_action(
         db,
         teacher.id,

--- a/backend/app/services/course_service/_courses.py
+++ b/backend/app/services/course_service/_courses.py
@@ -10,7 +10,11 @@ from sqlalchemy import select
 
 from app.models.certificate import Certificate
 from app.models.course import Chapter, Course, Module
-from app.services.content_versions import delete_entity_cv_rows, dual_write_entity_content
+from app.services.content_versions import (
+    delete_entity_cv_rows,
+    dual_write_entity_content,
+    fetch_cv_entity_texts_with_fallback,
+)
 from app.services.language_detection import detect_locale
 from app.services.translation.resolve_for_display import populate_spine_texts
 
@@ -199,11 +203,27 @@ def permanently_delete_course(db: Session, course: Course) -> None:
     # ``ON DELETE SET NULL`` nulls ``course_id`` and the title becomes
     # unrecoverable. Mirrors the trigger's `WHERE archived_course_title
     # IS NULL` clause so re-deletes don't overwrite an earlier snapshot.
+    #
+    # Phase 5bi: read the title from content_versions instead of the
+    # ``course.title`` runtime attribute. Callers that didn't go through
+    # ``populate_spine_texts`` (admin permanent-delete from a list view)
+    # otherwise stamp ``None`` and the certificate loses its title for
+    # good once the FK nulls.
+    cv_texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="course",
+        entity_ids=[course.id],
+        fields=["title"],
+        display_locale=course.source_locale or "en",
+        source_locale=course.source_locale or "en",
+        prefer_human=True,
+    )
+    archived_title = cv_texts.get((course.id, "title")) or ""
     db.query(Certificate).filter(
         Certificate.course_id == course.id,
         Certificate.archived_course_title.is_(None),
     ).update(
-        {Certificate.archived_course_title: course.title},
+        {Certificate.archived_course_title: archived_title},
         synchronize_session=False,
     )
     # Phase 5ad: content_versions has no FK back to entity tables

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -137,12 +137,21 @@ def build_localized_course_summaries(
 def populate_spine_texts(
     db: Session,
     courses: list[Course],
+    *,
+    display_locale: LocaleCode | None = None,
 ) -> None:
     """Phase 5g: ``courses.title|description`` and ``modules.title|description``
     columns dropped. Hydrate each course (and every loaded module/chapter
     title via the module list) with runtime attributes pulled from cv,
     so downstream serialization that reads ``course.title`` / ``module.title``
     keeps working unchanged.
+
+    By default the hydration uses each course's declared ``source_locale``
+    as the display_locale — that's the right choice for write paths (audit
+    logs, archive snapshots, clone) and for editor surfaces that want
+    source text. Pass ``display_locale`` explicitly when the caller wants
+    a locale overlay (e.g. ``Accept-Language`` on a student or
+    teacher-analytics read).
 
     Each entity's source_locale fallback is applied per-entity (a course
     declared ``source_locale='ru'`` falls back to its RU row when the
@@ -166,7 +175,7 @@ def populate_spine_texts(
                 entity_type="course",
                 entity_ids=ids,
                 fields=["title", "description"],
-                display_locale=src_locale,
+                display_locale=display_locale or src_locale,
                 source_locale=src_locale,
             )
         )
@@ -204,7 +213,7 @@ def populate_spine_texts(
             entity_type="module",
             entity_ids=[str(m.id) for m in mods],
             fields=["title", "description"],
-            display_locale=src_locale,
+            display_locale=display_locale or src_locale,
             source_locale=src_locale,
         )
         for m in mods:

--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -50,6 +50,10 @@
     "path": "/api/v1/analytics/course/{course_id}",
     "params": [
       [
+        "Accept-Language",
+        "header"
+      ],
+      [
         "course_id",
         "path"
       ],


### PR DESCRIPTION
## Summary
Phase 5bi closes **3 P0 bilingual gaps** found in the 5bh audit (4 parallel Explore agents).

### Bugs fixed
1. **`courses/crud.py` log_action stamps None** — `remove_course` + `permanently_remove_course` read `course.title` for audit details without `populate_spine_texts` first → audit row has `None` (or AttributeError). Fixed by hydrating before the log call.
2. **`Certificate.archived_course_title` lost on permanent delete** — `permanently_delete_course` stamps `course.title` onto certs to survive the FK null. Without caller hydration the archive ends up empty. Replaced with a direct `fetch_cv_entity_texts_with_fallback` call so the service is self-sufficient.
3. **`/analytics/course/{course_id}` ignores Accept-Language** — endpoint declares `Vary: Accept-Language` but calls `populate_spine_texts(db, [course])` without display_locale. Russian teacher always saw source-locale title. Added optional `display_locale` kwarg (default=None preserves source-locale for all 12 existing callers) and wired Accept-Language through.

### OpenAPI snapshot
Regenerated to include the new Accept-Language header parameter.

## Test plan
- [x] 969 backend tests pass locally
- [x] ruff check + ruff format clean
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)