### PR TITLE
fix(i18n): localize 5 hardcoded English fallbacks in shared UI primitives

### DIFF
--- a/frontend/src/components/patterns/ErrorState.tsx
+++ b/frontend/src/components/patterns/ErrorState.tsx
@@ -1,11 +1,12 @@
 import type { ReactNode } from "react"
 import { AlertTriangle } from "lucide-react"
+import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 
 interface ErrorStateProps {
   /** Icon slot. Defaults to <AlertTriangle strokeWidth={1.75} />. */
   icon?: ReactNode
-  /** Short headline. Defaults to "Something went wrong". */
+  /** Short headline. Defaults to a localized "Something went wrong". */
   title?: string
   /** Optional longer explanation or retry hint. */
   description?: string
@@ -26,12 +27,14 @@ interface ErrorStateProps {
  */
 export function ErrorState({
   icon,
-  title = "Something went wrong",
+  title,
   description,
   action,
   secondaryAction,
   className,
 }: ErrorStateProps) {
+  const { t } = useTranslation()
+  const resolvedTitle = title ?? t("common.somethingWentWrong")
   return (
     <div
       role="alert"
@@ -44,7 +47,7 @@ export function ErrorState({
         {icon ?? <AlertTriangle strokeWidth={1.75} aria-hidden />}
       </span>
       <div className="space-y-1">
-        <h2 className="font-serif text-base font-semibold tracking-tight text-foreground">{title}</h2>
+        <h2 className="font-serif text-base font-semibold tracking-tight text-foreground">{resolvedTitle}</h2>
         {description && (
           <p className="max-w-md text-sm text-muted-foreground">{description}</p>
         )}

--- a/frontend/src/components/ui/PageSpinner.tsx
+++ b/frontend/src/components/ui/PageSpinner.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next"
+
 interface PageSpinnerProps {
   /** Variants:
    *  - `page`: route-level fallback, centered with generous vertical padding
@@ -7,8 +9,9 @@ interface PageSpinnerProps {
   variant?: "page" | "screen" | "section" | "inline"
   /** Optional helper label shown under the spinner (screen variant only).
    *  Also used as the accessible name announced to screen readers — when
-   *  `label` is omitted we still announce a generic "Loading" so AT users
-   *  know a fetch is in progress instead of meeting an empty region. */
+   *  `label` is omitted we still announce a localized generic "Loading"
+   *  so AT users know a fetch is in progress instead of meeting an empty
+   *  region. */
   label?: string
 }
 
@@ -21,7 +24,8 @@ interface PageSpinnerProps {
 // rotating ring itself is decorative — meaning lives in the label, which
 // is always available to AT (via `aria-label`) even when it's not shown.
 export default function PageSpinner({ variant = "page", label }: PageSpinnerProps) {
-  const accessibleLabel = label ?? "Loading"
+  const { t } = useTranslation()
+  const accessibleLabel = label ?? t("common.loadingAccessible")
 
   if (variant === "screen") {
     return (

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "./buttonVariants"
 
@@ -150,6 +151,7 @@ const PromptContext = React.createContext<(opts: PromptOptions) => Promise<strin
 )
 
 export function ConfirmProvider({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation()
   const [confirmState, setConfirmState] = React.useState<ConfirmState>({ open: false, title: "" })
   const [promptState, setPromptState] = React.useState<PromptState>({ open: false, title: "", value: "" })
 
@@ -216,13 +218,13 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel onClick={() => handleConfirmDone(false)}>
-                {confirmState.cancelLabel ?? "Cancel"}
+                {confirmState.cancelLabel ?? t("common.cancel")}
               </AlertDialogCancel>
               <AlertDialogAction
                 variant={confirmState.tone === "destructive" ? "destructive" : "default"}
                 onClick={() => handleConfirmDone(true)}
               >
-                {confirmState.confirmLabel ?? "Confirm"}
+                {confirmState.confirmLabel ?? t("common.confirm")}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
@@ -260,10 +262,10 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
               />
               <AlertDialogFooter className="mt-4">
                 <AlertDialogCancel type="button" onClick={() => handlePromptDone(null)}>
-                  {promptState.cancelLabel ?? "Cancel"}
+                  {promptState.cancelLabel ?? t("common.cancel")}
                 </AlertDialogCancel>
                 <AlertDialogAction type="submit">
-                  {promptState.confirmLabel ?? "OK"}
+                  {promptState.confirmLabel ?? t("common.ok")}
                 </AlertDialogAction>
               </AlertDialogFooter>
             </form>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2,9 +2,13 @@
   "common": {
     "appName": "Equip",
     "cancel": "Cancel",
+    "confirm": "Confirm",
+    "ok": "OK",
     "continue": "Continue",
     "tryAgain": "Try again",
     "loading": "Loading...",
+    "loadingAccessible": "Loading",
+    "somethingWentWrong": "Something went wrong",
     "view": "View",
     "signIn": "Sign In",
     "signOut": "Sign Out",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -2,9 +2,13 @@
   "common": {
     "appName": "Equip",
     "cancel": "Отмена",
+    "confirm": "Подтвердить",
+    "ok": "ОК",
     "continue": "Продолжить",
     "tryAgain": "Повторить",
     "loading": "Загрузка...",
+    "loadingAccessible": "Загрузка",
+    "somethingWentWrong": "Что-то пошло не так",
     "view": "Открыть",
     "signIn": "Войти",
     "signOut": "Выйти",


### PR DESCRIPTION
## Summary
Phase 5bj closes the **5 P0 hardcoded English strings** found in the 5bh frontend audit. All five lived in shared primitives that hundreds of callers use through fallback paths, so a Russian user hit English text on every confirm/error/loading interaction.

### Strings localized
- `alert-dialog.tsx` ConfirmProvider fallbacks: "Cancel" + "Confirm" → `t("common.cancel")` + `t("common.confirm")`
- `alert-dialog.tsx` PromptProvider fallbacks: "Cancel" + "OK" → `t("common.cancel")` + `t("common.ok")`
- `ErrorState.tsx` default title: "Something went wrong" → `t("common.somethingWentWrong")`. Callers that pass an explicit `title` still win — only the fallback localizes.
- `PageSpinner.tsx` default `aria-label`: "Loading" → `t("common.loadingAccessible")`. Kept separate from `common.loading` ("Loading...") because the visible-text ellipsis is fine on screen but garbled by screen readers.

### Locale bundles
- EN: added `common.confirm`, `common.ok`, `common.loadingAccessible`, `common.somethingWentWrong`
- RU: added the same with Russian translations ("Подтвердить", "ОК", "Загрузка", "Что-то пошло не так")
- `i18n:check` passes parity (1563 EN / 1621 RU keys — gap is existing plural variants, not regression)

## Test plan
- [x] 323 vitest tests pass locally
- [x] eslint + `tsc --noEmit` clean
- [x] i18n:check parity passes
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)