### PR TITLE
test(bilingual): remove dead runtime-attr writes + record real cv source change

### DIFF
--- a/backend/tests/test_courses.py
+++ b/backend/tests/test_courses.py
@@ -582,10 +582,18 @@ class TestCatalogLocalizedMetadata:
         anon_client: TestClient,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """``content_translations`` for the active UI locale should win over
-        course rows when both exist, so a Russian CT row is shown for RU UI
-        even if the course row is still in English and ``source_locale`` is ru
-        (legacy / mixed authoring)."""
+        """``content_versions`` for the active UI locale should win over the
+        source-locale row when both exist, so a Russian RU row is shown for
+        RU UI even when the source row carries English text (legacy / mixed
+        authoring).
+
+        Phase 5g: ``courses.title|description`` columns are gone. The
+        "source" here is the EN cv row laid down by ``_create_course``;
+        the overlay is the RU MT row added below. The previous
+        ``row.title = ...`` runtime-attribute writes were dead under
+        the new architecture (no column to persist to) and have been
+        removed so the test only mutates state that actually exists.
+        """
         monkeypatch.setattr(
             "app.api.v1.courses.crud.translate_course_content",
             lambda *args, **kwargs: OrchestratorReport(),
@@ -599,10 +607,6 @@ class TestCatalogLocalizedMetadata:
         client.put(f"{PREFIX}/{cid}", json={"status": "published"})
         from app.services.content_versions.write import record_mt_version
 
-        row = db.get(Course, cid)
-        assert row is not None
-        row.title = "EN title in DB not matching RU"
-        row.description = "EN desc in DB"
         record_mt_version(
             db,
             entity_type="course",

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -290,7 +290,24 @@ def test_translate_course_metadata_retranslates_when_source_changes(db: Session)
 
     translate_course_metadata(db, course, provider=provider)
 
-    course.title = "Acts of the Apostles — Revised"
+    # Phase 5g: ``courses.title`` column is gone. The orchestrator reads
+    # the source text from ``course.title`` (a runtime attribute) but
+    # the source-of-truth for "did the human edit?" lives in cv. Record
+    # a new human version FIRST so the change persists, then sync the
+    # runtime attribute so the orchestrator picks the new text up on its
+    # next pass. Previously this test only mutated the runtime attr,
+    # which silently masked any future regression that started reading
+    # the source from cv directly.
+    new_title = "Acts of the Apostles — Revised"
+    record_human_version(
+        db,
+        entity_type="course",
+        entity_id=course.id,
+        field="title",
+        locale=course.source_locale,
+        text=new_title,
+    )
+    course.title = new_title
     db.commit()
 
     report = translate_course_metadata(db, course, provider=provider)


### PR DESCRIPTION
## Summary
Phase 5bk closes 2 of the 3 P1 test tech-debt findings from the 5bh audit. The third (`test_users_reviews_misc.py` runtime-attr hydration in `_seed_course`) is a documented backwards-compat pattern that mirrors `populate_spine_texts` and is fine as-is — removing it would break ~30 tests that rely on the hydrated runtime attr without calling `populate_spine_texts` themselves.

### Fixes
1. **`tests/test_courses.py`** — `test_ru_ct_row_preferred_over_course_columns_when_source_locale_mismatch`. The `row.title = ...` / `row.description = ...` writes were dead under Phase 5g (no columns to persist to). They evaporate on `db.refresh` and never reach the DB. The test passed because `_create_course` already laid down the EN cv row via the API and the RU MT row was added below — but the misleading mutation made the test look like it was setting up a conflict at the column level. Removed; updated docstring.
2. **`tests/test_translation_orchestrator.py`** — `test_translate_course_metadata_retranslates_when_source_changes`. Single `course.title = ...` mutated only the runtime attribute. Currently the orchestrator reads from `course.title` so the test passed, but the cv source row was never updated — any future refactor that reads the orchestrator's source text from cv directly would silently break this test without it failing. Added `record_human_version` for the source-locale cv row first, then synced the runtime attr.

## Test plan
- [x] 969 backend tests pass locally
- [x] ruff check + ruff format clean
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)