### PR TITLE
perf: defensive cap on /calendar/events + pagination on /cohorts

### DIFF
--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -72,6 +72,14 @@ def get_calendar_events(
     response: Response,
     # 36 = UUID length; matches the bound on every Create schema id.
     course_id: str | None = Query(None, max_length=36),
+    # Phase 5bn: defensive cap. A student enrolled in 10+ courses with
+    # years of module deadlines + assignment deadlines + course events
+    # could otherwise fan out into the thousands; on Vercel serverless
+    # the 10s function budget is the floor. 1000 covers any realistic
+    # workload (calendar UI typically shows < 100 events at a time);
+    # 2000 is the absolute ceiling. Applied AFTER the in-Python
+    # event_date sort so the cap drops the oldest items first.
+    limit: int = Query(1000, ge=1, le=2000),
     accept_language: str | None = Header(default=None, alias="Accept-Language"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -284,7 +292,11 @@ def get_calendar_events(
         )
 
     events.sort(key=lambda e: e.event_date)
-    return events
+    # Phase 5bn: apply defensive cap AFTER sorting so the oldest events
+    # fall off the end first. Keeping the soonest ``limit`` events is the
+    # right shape for a calendar UI (upcoming deadlines matter more than
+    # ancient ones).
+    return events[-limit:]
 
 
 event_router = APIRouter(prefix="/courses", tags=["calendar"])

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -209,6 +209,12 @@ def list_cohorts(
     # legal cohort statuses before the query runs. Matches the constraint
     # already on ``CohortUpdate.status`` and the DB ``CHECK``.
     status_filter: Literal["upcoming", "active", "completed"] | None = Query(None, alias="status"),
+    # Phase 5bn: defensive pagination. An admin panel scrolling cohort
+    # history shouldn't pull the full table on every keystroke; cap and
+    # paginate. Defaults match the other admin list endpoints
+    # (audit, users, queue-status).
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> list[CohortResponse]:
@@ -217,7 +223,7 @@ def list_cohorts(
     q = db.query(Cohort)
     if status_filter:
         q = q.filter(Cohort.status == status_filter)
-    cohorts = q.order_by(Cohort.start_date.desc()).all()
+    cohorts = q.order_by(Cohort.start_date.desc()).offset(skip).limit(limit).all()
     return _serialize_many(db, cohorts)
 
 

--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -443,6 +443,10 @@
       [
         "course_id",
         "query"
+      ],
+      [
+        "limit",
+        "query"
       ]
     ],
     "responses": [
@@ -631,6 +635,14 @@
     "method": "GET",
     "path": "/api/v1/cohorts",
     "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ],
       [
         "status",
         "query"


### PR DESCRIPTION
## Summary
Phase 5bn ships the genuine defensive findings from auth + perf audits. Most flagged items were false positives; this PR keeps only real hardening.

### Real fixes
1. **GET `/calendar/events`** was completely unbounded — fans across module deadlines + chapter assignments + course events for every enrolled course. Added `limit: int = Query(1000, ge=1, le=2000)` with `events[-limit:]` after the ascending date sort so oldest items drop off first (upcoming-events shape for the calendar UI). Default 1000 covers any realistic workload; frontend unchanged.
2. **GET `/cohorts`** (admin) was unbounded. Added standard admin pagination (`skip` + `limit: int = Query(100, ge=1, le=500)`) matching audit/users/queue-status endpoints.

### NOT shipped (verified non-bugs)
- *Missing `Enrollment.user_id` index* — false positive. Composite UNIQUE `(user_id, course_id, cohort_id)` makes `user_id` the leading column of a B-tree; Postgres uses it for single-column filters.
- *Late ownership check in `grade_answer`* — `verify_quiz_owner` fires at line 198, BEFORE first mutation at line 213. Hypothetical concern, not an IDOR.
- *`content_versions` composite index* — already well-designed via `ix_content_versions_active_lookup`. Agent itself said no action needed.

OpenAPI snapshot regenerated to include the new query params.

## Test plan
- [x] 972 backend tests pass locally
- [x] ruff check + ruff format clean
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)