### PR TITLE
db(rls): enable RLS on translation_jobs (5bo)

### DIFF
--- a/supabase/migrations/20260529180000_translation_jobs_rls.sql
+++ b/supabase/migrations/20260529180000_translation_jobs_rls.sql
@@ -1,0 +1,43 @@
+-- Phase 5bo: enable RLS on translation_jobs.
+--
+-- Why
+-- ===
+-- The 5av queue migration (20260529150000_translation_jobs_table.sql)
+-- created the table without ALTER TABLE ... ENABLE ROW LEVEL SECURITY.
+-- Equip's standard is "RLS on by default, policies explicit" — every
+-- other newer user-visible table (notifications, course_events,
+-- audit_logs, content_versions, ...) follows this. Internal-only
+-- tables don't get a free pass because:
+--
+--   * The cron worker authenticates with the service_role key, which
+--     bypasses RLS — so locking down to service_role only costs
+--     nothing at runtime.
+--   * Any future Supabase Edge Function or anon-key client that
+--     accidentally inherits SELECT/INSERT/DELETE permission would
+--     otherwise see the full queue (course publish history is a
+--     low-value but real info disclosure).
+--   * The architectural invariant is more valuable than the table's
+--     current risk profile — keeping RLS-by-default consistent means
+--     a future contributor adding a similar internal table doesn't
+--     also forget.
+--
+-- The 5bn audit (auth + perf) flagged this gap. Fix is one ALTER + a
+-- single restrictive policy.
+
+ALTER TABLE public.translation_jobs ENABLE ROW LEVEL SECURITY;
+
+-- service_role bypasses RLS automatically, so we don't need a policy
+-- for the cron worker. The only policy we add is an explicit DENY for
+-- the authenticated and anon roles: an empty USING clause (no rows
+-- match) on a SELECT/INSERT/UPDATE/DELETE policy is the standard
+-- Postgres pattern for "RLS is on, no one matches" — equivalent to
+-- "no policy" but with the intent documented in source.
+--
+-- Admin observability still goes through ``GET /admin/translations/
+-- queue-status`` which runs server-side under service_role; admins do
+-- NOT need direct table access via the Supabase client.
+
+CREATE POLICY translation_jobs_no_client_access ON public.translation_jobs
+  FOR ALL TO authenticated, anon
+  USING (false)
+  WITH CHECK (false);


### PR DESCRIPTION
## Summary
Phase 5bo closes the one material finding from the frontend perf + DB hygiene audit pair: `translation_jobs` was created in 5av without `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`.

Equip's architectural standard is "RLS on by default, policies explicit" — every other newer user-visible table follows this. Internal-only tables don't get a free pass because:
- service_role bypasses RLS — locking down to authenticated/anon costs nothing at runtime
- Future Supabase Edge Function or anon-key client could otherwise inherit access to publish history (low-value but real info disclosure)
- The architectural invariant is more valuable than the table's current risk profile

New migration `20260529180000_translation_jobs_rls.sql` enables RLS + adds restrictive `USING(false) WITH CHECK(false)` policy denying ALL access to `authenticated` and `anon`. Cron worker continues to work transparently via service_role.

**Migration applied to prod via the Supabase MCP** (pre-release-risk window — no real users yet).

### NOT shipped (verified non-bugs)
- *Missing FK declarations on `StudentGrade` / `AssignmentSubmission` / `AuditLog`* — DB FKs target `auth.users(id)`, Supabase's managed schema not in SQLAlchemy's registry. Bare `mapped_column()` is the deliberate choice; adding `ForeignKey("profiles.id")` would diverge ORM from DB.
- *Frontend StudentRow memo / image dimensions* — all P2 defensive items, no measurable user-facing impact.

## Test plan
- [x] 972 backend tests pass locally
- [x] Migration applied to prod successfully (apply_migration returned {success: true})
- [ ] CI green
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)