### PR TITLE
feat(daily-challenge): foundation schema — 5 tables + RLS + ORM + tests

### DIFF
--- a/backend/app/models/content_version.py
+++ b/backend/app/models/content_version.py
@@ -56,6 +56,8 @@ ContentVersionEntityType = Literal[
     "announcement",
     "course_event",
     "cohort",
+    "daily_challenge_question",
+    "daily_challenge_option",
 ]
 
 ContentVersionField = Literal[
@@ -65,6 +67,7 @@ ContentVersionField = Literal[
     "question_text",
     "option_text",
     "instructions",
+    "explanation",
 ]
 
 ContentVersionOrigin = Literal["human", "mt"]

--- a/backend/app/models/daily_challenge.py
+++ b/backend/app/models/daily_challenge.py
@@ -1,0 +1,295 @@
+"""ORM mapping for the Daily Challenge MVP.
+
+Five tables — see ``supabase/migrations/20260529210000_add_daily_challenge_
+foundation.sql`` for the canonical schema commentary. Mapped[] models
+mirror the SQL exactly; the SQLite test path materialises the schema
+via ``Base.metadata.create_all`` so partial indexes carry the
+``sqlite_where`` variant alongside ``postgresql_where``.
+
+Architecture decisions locked 2026-05-29 by Vadym after a 4-agent
+parallel review. Read ``memory:
+project-equip-daily-challenge-decisions.md`` before editing this file.
+
+Translatable text lives in ``content_versions`` — there are no
+``question_text`` / ``option_text`` / ``explanation`` columns on these
+tables. The new entity types ``daily_challenge_question`` and
+``daily_challenge_option`` are appended to ``ContentVersionEntityType``
+in ``content_version.py``; the new field ``explanation`` is added to
+``ContentVersionField`` in the same file.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import date, datetime  # noqa: TC003 — Mapped[] runtime resolution
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID as PgUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class DailyChallengeQuestionType(enum.StrEnum):
+    """The two auto-validatable question shapes supported by the MVP.
+
+    Locked by Vadym 2026-05-29: only types that can be graded by
+    ``selected_option_id`` comparison — no string-match fuzziness, no
+    teacher-graded essays on the daily surface. Adding a new type is
+    an append-only migration that extends the CHECK constraint AND
+    this enum AND the Pydantic ``Literal``; the registry-drift test
+    catches mismatches.
+    """
+
+    MULTIPLE_CHOICE = "multiple_choice"
+    TRUE_FALSE = "true_false"
+
+
+class DailyChallengeQuestionStatus(enum.StrEnum):
+    """Forward-only editorial pipeline.
+
+    Stages 2-5 correspond to Agent C's 5-stage review (scripture →
+    doctrine → bilingual → pilot). ``published`` is the terminal live
+    state. ``archived`` is the terminal end-of-life state for a
+    question that has rotated out of the pool.
+
+    The ``rejected`` boolean on the row is orthogonal: a question can
+    be rejected at any stage. Rejection does NOT roll the status back;
+    the row stays at whatever stage killed it, ``rejected=true``, and
+    is excluded from the publishable pool forever.
+    """
+
+    DRAFT = "draft"
+    SCRIPTURE_VALIDATED = "scripture_validated"
+    DOCTRINALLY_REVIEWED = "doctrinally_reviewed"
+    BILINGUALLY_REVIEWED = "bilingually_reviewed"
+    PILOT_PASSED = "pilot_passed"
+    PUBLISHED = "published"
+    ARCHIVED = "archived"
+
+
+class DailyChallengeQuestion(Base):
+    """Editorial bank entry. Translatable text lives in
+    ``content_versions`` — see module docstring."""
+
+    __tablename__ = "daily_challenge_questions"
+    __table_args__ = (
+        CheckConstraint(
+            "question_type IN ('multiple_choice', 'true_false')",
+            name="daily_challenge_questions_type_check",
+        ),
+        CheckConstraint(
+            "status IN ('draft', 'scripture_validated', 'doctrinally_reviewed', "
+            "'bilingually_reviewed', 'pilot_passed', 'published', 'archived')",
+            name="daily_challenge_questions_status_check",
+        ),
+        CheckConstraint("bible_chapter > 0", name="daily_challenge_questions_chapter_pos"),
+        CheckConstraint(
+            "bible_verse_from IS NULL OR bible_verse_from > 0",
+            name="daily_challenge_questions_verse_from_pos",
+        ),
+        CheckConstraint(
+            "bible_verse_to IS NULL OR (bible_verse_from IS NOT NULL AND bible_verse_to >= bible_verse_from)",
+            name="daily_challenge_questions_verse_range",
+        ),
+        Index(
+            "ix_dc_questions_status_created",
+            "status",
+            "created_at",
+            postgresql_where="rejected = FALSE AND status <> 'archived'",
+            sqlite_where=text("rejected = 0 AND status <> 'archived'"),
+        ),
+        Index(
+            "ix_dc_questions_publishable",
+            "published_at",
+            postgresql_where="status = 'published' AND rejected = FALSE",
+            sqlite_where=text("status = 'published' AND rejected = 0"),
+        ),
+        Index(
+            "ix_dc_questions_scripture",
+            "bible_book",
+            "bible_chapter",
+            "bible_verse_from",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    question_type: Mapped[str] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(Text, default="draft", server_default="draft")
+
+    # Rejection — orthogonal to status. See module docstring.
+    rejected: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    rejection_reason: Mapped[str | None] = mapped_column(Text)
+    rejected_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
+    )
+    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    # Publication breadcrumb — published_at being non-NULL + status =
+    # 'published' + rejected = FALSE is the schedule trigger's gate.
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    published_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
+    )
+
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
+    )
+
+    # Scripture anchor — every question must cite a verse range.
+    bible_book: Mapped[str] = mapped_column(Text)
+    bible_chapter: Mapped[int] = mapped_column(Integer)
+    bible_verse_from: Mapped[int | None] = mapped_column(Integer)
+    bible_verse_to: Mapped[int | None] = mapped_column(Integer)
+
+    # Editorial category — free-form text. Pydantic Literal gates at
+    # the API edge; categories can evolve without a migration.
+    category: Mapped[str | None] = mapped_column(Text)
+
+    # Source locale of the human-authored text (RU / EN / …). Same
+    # detection pattern as ``courses.source_locale``.
+    source_locale: Mapped[str | None] = mapped_column(Text)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    options: Mapped[list[DailyChallengeOption]] = relationship(
+        back_populates="question",
+        cascade="all, delete-orphan",
+        order_by="DailyChallengeOption.order_index",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<DailyChallengeQuestion id={self.id} type={self.question_type} "
+            f"status={self.status} rejected={self.rejected}>"
+        )
+
+
+class DailyChallengeOption(Base):
+    """One option on a question. ``option_text`` lives in
+    ``content_versions`` — see module docstring."""
+
+    __tablename__ = "daily_challenge_options"
+    __table_args__ = (
+        CheckConstraint("order_index BETWEEN 0 AND 5", name="daily_challenge_options_order_check"),
+        Index("ix_dc_options_question", "question_id", "order_index"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("daily_challenge_questions.id", ondelete="CASCADE"),
+    )
+    is_correct: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    order_index: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    question: Mapped[DailyChallengeQuestion] = relationship(back_populates="options")
+
+
+class DailyChallengeSchedule(Base):
+    """Maps a UTC date to the question scheduled for that date.
+
+    PK is ``challenge_date`` — at most one question per UTC day.
+    A Postgres trigger (``dc_schedule_assert_publishable``) enforces
+    that ``question_id`` references a row with ``status='published'``,
+    ``rejected=false``, and ``published_at IS NOT NULL``.
+    """
+
+    __tablename__ = "daily_challenge_schedule"
+    __table_args__ = (Index("ix_dc_schedule_question", "question_id"),)
+
+    challenge_date: Mapped[date] = mapped_column(Date, primary_key=True)
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("daily_challenge_questions.id", ondelete="RESTRICT"),
+    )
+    scheduled_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
+    )
+    scheduled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class DailyChallengeAttempt(Base):
+    """Per-user attempt. Live attempts move the streak; archive replays
+    don't (enforced by the ``is_archive`` flag + the partial unique
+    index + a CHECK constraint that archives have NULL ``streak_after``)."""
+
+    __tablename__ = "daily_challenge_attempts"
+    __table_args__ = (
+        CheckConstraint(
+            "NOT is_archive OR streak_after IS NULL",
+            name="dc_attempts_archive_null_streak",
+        ),
+        Index(
+            "uniq_dc_attempts_live_per_day",
+            "user_id",
+            "challenge_date",
+            unique=True,
+            postgresql_where="is_archive = FALSE",
+            sqlite_where=text("is_archive = 0"),
+        ),
+        Index("ix_dc_attempts_user_date", "user_id", "challenge_date"),
+        Index("ix_dc_attempts_question", "question_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="CASCADE"))
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("daily_challenge_questions.id", ondelete="CASCADE"),
+    )
+    challenge_date: Mapped[date] = mapped_column(Date)
+    is_archive: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    selected_option_id: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("daily_challenge_options.id", ondelete="SET NULL"),
+    )
+    is_correct: Mapped[bool] = mapped_column(Boolean)
+    streak_after: Mapped[int | None] = mapped_column(Integer)
+    submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class DailyChallengeStreak(Base):
+    """Per-user streak counter. YouVersion-style semantics — any
+    submission counts. See module docstring for the math."""
+
+    __tablename__ = "daily_challenge_streaks"
+    __table_args__ = (
+        CheckConstraint("current_streak >= 0", name="dc_streaks_current_nonneg"),
+        CheckConstraint("longest_streak >= 0", name="dc_streaks_longest_nonneg"),
+        Index(
+            "ix_dc_streaks_last_engaged",
+            "last_engaged_date",
+            postgresql_where="current_streak >= 1",
+            sqlite_where=text("current_streak >= 1"),
+        ),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("profiles.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    current_streak: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    longest_streak: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    last_engaged_date: Mapped[date | None] = mapped_column(Date)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/services/translation/protocol.py
+++ b/backend/app/services/translation/protocol.py
@@ -50,6 +50,8 @@ EntityType = Literal[
     "announcement",
     "course_event",
     "cohort",
+    "daily_challenge_question",
+    "daily_challenge_option",
 ]
 
 

--- a/backend/app/services/translation/registry.py
+++ b/backend/app/services/translation/registry.py
@@ -34,6 +34,7 @@ from app.models.chapter_block import ChapterBlock
 from app.models.cohort import Cohort
 from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent
+from app.models.daily_challenge import DailyChallengeOption, DailyChallengeQuestion
 from app.models.quiz import Quiz, QuizOption, QuizQuestion
 from app.schemas.locale import normalize_locale
 from app.services.language_detection import detect_locale
@@ -275,6 +276,37 @@ REGISTRY: dict[EntityType, EntityRegistration] = {
         resolve_course=_resolve_course_via_cohort_courses,
         build_context=lambda _co, c: f"Student cohort name in course «{c.title}»",
     ),
+    # Phase 5c — Daily Challenge platform surface. Questions are
+    # course-less by design (they're a platform-wide rotation, not
+    # course content). ``reconcile_entity`` skips orphans, so the
+    # standard "edit-triggers-translate" hook does NOT apply here —
+    # the Daily Challenge editorial pipeline invokes
+    # ``translate_entity_fields`` directly with ``source_locale``
+    # read off ``daily_challenge_questions.source_locale``.
+    #
+    # We still register so:
+    #   * the cv parity test passes (every entity_type referenced in
+    #     ``ContentVersionEntityType`` has a registry row),
+    #   * the ``ENTITY_MODEL`` table can route per-entity test
+    #     parametrization,
+    #   * ``resolve_for_display`` helpers that iterate the registry
+    #     for "what fields are translatable on entity X?" continue to
+    #     return correct answers for the daily challenge surfaces.
+    "daily_challenge_question": EntityRegistration(
+        entity_type="daily_challenge_question",
+        fields=(
+            FieldSpec("question_text", "quiz_question"),
+            FieldSpec("explanation", "plain"),
+        ),
+        resolve_course=lambda _db, _q: None,  # platform-wide; no course
+        build_context=lambda _q, _c: "Bible question for the Equip Daily Challenge.",
+    ),
+    "daily_challenge_option": EntityRegistration(
+        entity_type="daily_challenge_option",
+        fields=(FieldSpec("option_text", "quiz_option"),),
+        resolve_course=lambda _db, _o: None,  # platform-wide; no course
+        build_context=lambda _o, _c: "Answer option for an Equip Daily Challenge question.",
+    ),
 }
 
 
@@ -291,6 +323,8 @@ ENTITY_MODEL: dict[EntityType, type] = {
     "announcement": Announcement,
     "course_event": CourseEvent,
     "cohort": Cohort,
+    "daily_challenge_question": DailyChallengeQuestion,
+    "daily_challenge_option": DailyChallengeOption,
 }
 
 

--- a/backend/tests/test_daily_challenge_foundation.py
+++ b/backend/tests/test_daily_challenge_foundation.py
@@ -1,0 +1,275 @@
+"""Foundation tests for the Daily Challenge MVP schema.
+
+Phase 5c — pins the load-bearing invariants of the schema before the
+service layer arrives. Three groups of tests:
+
+1. **Model defaults** — fresh rows carry the expected zero state so the
+   streak-init path in the service layer can rely on it.
+2. **Partial unique on attempts** — the partial index that resolves
+   the "two browser tabs" race for live attempts (but allows unlimited
+   archive replays).
+3. **Streak constraints** — the CHECK constraints that guarantee
+   non-negative counters survive the ORM round-trip.
+
+The Postgres-only invariants (the schedule-publishability trigger,
+the column-level REVOKE on ``options.is_correct``) are exercised by
+the schema-smoke-postgres CI job, not here — SQLite has no triggers
+or column-level grants.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session  # noqa: TC002 — used at runtime by fixture annotations
+
+from app.models.daily_challenge import (
+    DailyChallengeAttempt,
+    DailyChallengeOption,
+    DailyChallengeQuestion,
+    DailyChallengeQuestionStatus,
+    DailyChallengeQuestionType,
+    DailyChallengeSchedule,
+    DailyChallengeStreak,
+)
+from app.models.user import User, UserRole
+
+
+@pytest.fixture
+def author(db: Session) -> User:
+    """A teacher user that owns the questions we seed below."""
+    u = User(
+        id=uuid.uuid4(),
+        email=f"dc-author-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Daily Challenge Author",
+        role=UserRole.TEACHER.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+@pytest.fixture
+def student(db: Session) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email=f"dc-student-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Daily Challenge Student",
+        role=UserRole.STUDENT.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _make_question(
+    db: Session,
+    *,
+    author_id: uuid.UUID,
+    status: str = "draft",
+    rejected: bool = False,
+) -> DailyChallengeQuestion:
+    """Build a minimal valid question. Translatable text doesn't land
+    here — the Daily Challenge service layer writes to cv. For schema
+    tests we just need the structural row."""
+    q = DailyChallengeQuestion(
+        question_type=DailyChallengeQuestionType.MULTIPLE_CHOICE.value,
+        status=status,
+        rejected=rejected,
+        created_by=author_id,
+        bible_book="Romans",
+        bible_chapter=8,
+        bible_verse_from=1,
+        bible_verse_to=1,
+        category="passage_exegesis",
+        source_locale="en",
+    )
+    db.add(q)
+    db.flush()
+    for i in range(4):
+        db.add(
+            DailyChallengeOption(
+                question_id=q.id,
+                is_correct=(i == 0),
+                order_index=i,
+            )
+        )
+    db.commit()
+    db.refresh(q)
+    return q
+
+
+# ---------------------------------------------------------------------------
+# Model defaults
+# ---------------------------------------------------------------------------
+
+
+class TestQuestionDefaults:
+    def test_fresh_question_lands_in_draft_status(self, db: Session, author: User):
+        q = _make_question(db, author_id=author.id)
+        assert q.status == DailyChallengeQuestionStatus.DRAFT.value
+        assert q.rejected is False
+        assert q.published_at is None
+
+    def test_options_round_trip_with_order_and_correctness(self, db: Session, author: User):
+        q = _make_question(db, author_id=author.id)
+        opts = sorted(q.options, key=lambda o: o.order_index)
+        assert [o.order_index for o in opts] == [0, 1, 2, 3]
+        # Exactly one correct option — invariant the service layer
+        # asserts at commit time. Schema doesn't enforce it (would
+        # fight a multi-row INSERT that hasn't reached a coherent
+        # state yet) but the test asserts the helper produced it.
+        assert sum(1 for o in opts if o.is_correct) == 1
+        assert opts[0].is_correct is True
+
+
+class TestStreakDefaults:
+    def test_fresh_streak_starts_at_zero(self, db: Session, student: User):
+        s = DailyChallengeStreak(user_id=student.id)
+        db.add(s)
+        db.commit()
+        db.refresh(s)
+        assert s.current_streak == 0
+        assert s.longest_streak == 0
+        assert s.last_engaged_date is None
+
+
+# ---------------------------------------------------------------------------
+# Partial unique on attempts
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptUniqueness:
+    def test_two_live_attempts_same_user_same_date_violates(self, db: Session, author: User, student: User):
+        """The race-resolving partial unique. Same (user, date)
+        cannot have two live attempts. The second INSERT raises
+        ``IntegrityError`` — the route catches that and returns the
+        first attempt verbatim.
+        """
+        q = _make_question(db, author_id=author.id, status="published", rejected=False)
+        today = date(2026, 5, 29)
+        db.add(
+            DailyChallengeAttempt(
+                user_id=student.id,
+                question_id=q.id,
+                challenge_date=today,
+                is_archive=False,
+                is_correct=True,
+                streak_after=1,
+            )
+        )
+        db.commit()
+
+        # Second live attempt on the same date for the same user — should fail.
+        db.add(
+            DailyChallengeAttempt(
+                user_id=student.id,
+                question_id=q.id,
+                challenge_date=today,
+                is_archive=False,
+                is_correct=False,
+                streak_after=1,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_archive_replays_allowed_unbounded_for_same_user_same_date(self, db: Session, author: User, student: User):
+        """Archive attempts are excluded from the partial unique — a
+        student can replay yesterday's question as many times as they
+        want without violating any constraint. Streak math is decoupled
+        via the CHECK on ``streak_after`` (NULL for archives)."""
+        q = _make_question(db, author_id=author.id, status="published", rejected=False)
+        past_date = date(2026, 5, 20)
+        for _ in range(3):
+            db.add(
+                DailyChallengeAttempt(
+                    user_id=student.id,
+                    question_id=q.id,
+                    challenge_date=past_date,
+                    is_archive=True,
+                    is_correct=False,
+                    streak_after=None,
+                )
+            )
+        db.commit()
+        rows = db.query(DailyChallengeAttempt).filter_by(user_id=student.id, challenge_date=past_date).all()
+        assert len(rows) == 3
+
+    def test_one_live_attempt_plus_archive_replays_coexist(self, db: Session, author: User, student: User):
+        """The user submitted a live attempt today, then later replayed
+        an OLD question whose challenge_date happens to equal today
+        (a question previously scheduled for today is also available
+        in the archive — edge case but valid). The live attempt is
+        gated by the partial unique; the archive replay slips past."""
+        q1 = _make_question(db, author_id=author.id, status="published", rejected=False)
+        q2 = _make_question(db, author_id=author.id, status="published", rejected=False)
+        today = date(2026, 5, 29)
+        db.add(
+            DailyChallengeAttempt(
+                user_id=student.id,
+                question_id=q1.id,
+                challenge_date=today,
+                is_archive=False,
+                is_correct=True,
+                streak_after=5,
+            )
+        )
+        db.add(
+            DailyChallengeAttempt(
+                user_id=student.id,
+                question_id=q2.id,
+                challenge_date=today,
+                is_archive=True,
+                is_correct=True,
+                streak_after=None,
+            )
+        )
+        db.commit()
+        assert db.query(DailyChallengeAttempt).filter_by(user_id=student.id, challenge_date=today).count() == 2
+
+
+class TestStreakCheckConstraints:
+    def test_negative_current_streak_violates_check(self, db: Session, student: User):
+        s = DailyChallengeStreak(user_id=student.id, current_streak=-1)
+        db.add(s)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Schedule wiring
+# ---------------------------------------------------------------------------
+
+
+class TestSchedule:
+    def test_one_schedule_per_date(self, db: Session, author: User):
+        """``challenge_date`` is the PK on the schedule table — exactly
+        one question per UTC day. The second INSERT for the same date
+        raises an IntegrityError on the PK."""
+        q1 = _make_question(db, author_id=author.id, status="published", rejected=False)
+        q2 = _make_question(db, author_id=author.id, status="published", rejected=False)
+        today = date(2026, 5, 29)
+        db.add(
+            DailyChallengeSchedule(
+                challenge_date=today,
+                question_id=q1.id,
+                scheduled_by=author.id,
+            )
+        )
+        db.commit()
+        db.add(
+            DailyChallengeSchedule(
+                challenge_date=today,
+                question_id=q2.id,
+                scheduled_by=author.id,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()

--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -82,6 +82,11 @@ def test_registry_field_names_exist_on_models():
         "quiz_option",
         "course",
         "module",
+        # Phase 5c: daily challenge questions + options are bilingual
+        # surfaces by design and have no source text columns. Their
+        # text lives only in content_versions.
+        "daily_challenge_question",
+        "daily_challenge_option",
     }
     for entity_type, reg in REGISTRY.items():
         if entity_type in cv_only_entities:

--- a/supabase/migrations/20260529210000_add_daily_challenge_foundation.sql
+++ b/supabase/migrations/20260529210000_add_daily_challenge_foundation.sql
@@ -1,0 +1,437 @@
+-- =====================================================================
+-- Phase 5c — Daily Challenge MVP foundation.
+--
+-- Five tables. Platform-wide (one question per UTC date for everyone).
+-- Question types: multiple_choice + true_false ONLY (auto-validatable by
+-- option_id; no string-match fuzziness). Pre-built bank — editorial team
+-- creates questions; daily rotation picks from the approved pool.
+-- =====================================================================
+--
+-- Architecture decisions locked 2026-05-29 by Vadym after a 4-agent
+-- parallel design review (memory:
+-- project-equip-daily-challenge-decisions.md). Highlights load-bearing
+-- to read before changing this schema:
+--
+--   1. Platform-wide, NOT school-scoped. challenge_date is the natural
+--      key on the schedule table — exactly one question per UTC date.
+--   2. Streak = YouVersion-style. ANY submission (correct or wrong)
+--      counts as a streak day. No grace tokens in MVP — if streak
+--      semantics ever tighten, that's an additive migration.
+--   3. No XP table in MVP. Vadym wants XP later; deliberately deferred
+--      until the design is locked. Add via append-only migration.
+--   4. 5-stage editorial pipeline before a question publishes:
+--        draft -> scripture_validated -> doctrinally_reviewed
+--              -> bilingually_reviewed -> pilot_passed -> published.
+--      Rejection is orthogonal to stage progression — captured by
+--      ``rejected`` boolean + ``rejection_reason`` text columns. A
+--      rejected question stays at whatever stage killed it but is
+--      excluded from publishing forever.
+--   5. Translatable text lives in ``content_versions`` via new entity
+--      types ``daily_challenge_question`` + ``daily_challenge_option``.
+--      No text columns on the tables below. Source-locale detection +
+--      dual-write follow the existing pattern used by courses, quizzes,
+--      announcements.
+--   6. Canonical answer-key text is KJV (1769) + Synodal (1876). The
+--      correct option must be defensible from BOTH translations. That
+--      rule is enforced in the editorial pipeline (Stage 2 =
+--      scripture_validated), not by the DB.
+--   7. Archive = full calendar of past questions; users can replay
+--      historical questions. Archive attempts carry zero streak impact
+--      via the ``is_archive`` flag + the partial unique index that only
+--      enforces uniqueness on live attempts.
+--
+-- This migration ships the FOUNDATION (tables, RLS, indexes,
+-- constraints). The 6-round AI question-generation flow + its audit
+-- trail table land in a follow-up migration in Sprint 3. Service layer
+-- + API endpoints land in Sprint 2.
+
+-- ---------------------------------------------------------------------
+-- 1. daily_challenge_questions
+-- ---------------------------------------------------------------------
+-- The editorial bank. Translatable fields (question_text, explanation)
+-- live in content_versions — entity_type='daily_challenge_question'.
+-- The ``status`` column drives the editorial workflow; the ``rejected``
+-- flag is the orthogonal kill-switch.
+
+CREATE TABLE daily_challenge_questions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Auto-validatable types only. Adding new types is an enum bump
+    -- via append-only migration; the CHECK constraint catches drift
+    -- against the Pydantic ``Literal`` at the API edge.
+    question_type   TEXT NOT NULL
+                    CHECK (question_type IN ('multiple_choice', 'true_false')),
+
+    -- Forward progression through the editorial pipeline. Status
+    -- NEVER moves backward; a rejected question stays at its current
+    -- stage but with ``rejected=true``. Only ``status='published'
+    -- AND rejected=false`` is eligible to be scheduled.
+    status          TEXT NOT NULL DEFAULT 'draft'
+                    CHECK (status IN (
+                        'draft',
+                        'scripture_validated',
+                        'doctrinally_reviewed',
+                        'bilingually_reviewed',
+                        'pilot_passed',
+                        'published',
+                        'archived'
+                    )),
+
+    -- Orthogonal to ``status``. When ``rejected=true``, the question is
+    -- terminally out of the rotation regardless of stage. The reason
+    -- is free-text rather than an enum so the editor can capture a
+    -- 1-2 line note ("answer ambiguous in NIV", "doctrinal lean toward
+    -- dispensationalism") without us pre-enumerating every shape.
+    rejected         BOOLEAN NOT NULL DEFAULT FALSE,
+    rejection_reason TEXT,
+    rejected_by      UUID REFERENCES profiles(id) ON DELETE SET NULL,
+    rejected_at      TIMESTAMPTZ,
+
+    -- Lifecycle audit: who promoted to each terminal-ish stage?
+    -- ``published_at`` doubles as the second gate that scheduling
+    -- enforces. ``approved_*`` is the moment the editor flipped the
+    -- bilingually_reviewed → pilot_passed → published terminal sequence;
+    -- the schedule trigger needs to see published_at set.
+    published_at    TIMESTAMPTZ,
+    published_by    UUID REFERENCES profiles(id) ON DELETE SET NULL,
+
+    -- Author / provenance. ``created_by`` may be NULL when an AI-only
+    -- draft hasn't been claimed by a human yet (Sprint 3).
+    created_by      UUID REFERENCES profiles(id) ON DELETE SET NULL,
+
+    -- Scripture anchor — every question must cite a verse range. Used
+    -- by Stage 2 (scripture_validated) to verify the cited passage
+    -- exists and supports the answer. The bible book set is fixed
+    -- across history — a 64-char text column covers UTF-8 names in
+    -- both EN ('Romans') and RU ('Послание к Римлянам'). Verse numbers
+    -- nullable so a question can reference a whole chapter
+    -- ('Romans 8') if it really must.
+    bible_book       TEXT NOT NULL,
+    bible_chapter    INT NOT NULL CHECK (bible_chapter > 0),
+    bible_verse_from INT CHECK (bible_verse_from IS NULL OR bible_verse_from > 0),
+    bible_verse_to   INT CHECK (bible_verse_to IS NULL
+                                OR (bible_verse_from IS NOT NULL
+                                    AND bible_verse_to >= bible_verse_from)),
+
+    -- Editorial category. Drives the launch-mix composition (see Agent
+    -- C's brief — ~40% narrative, ~35% exegesis, ~15% cross-reference,
+    -- ~10% historical-cultural). No CHECK constraint because we want
+    -- categories to evolve without a migration; Pydantic Literal at
+    -- the API edge is the gate.
+    category         TEXT,
+
+    -- Source locale of the human-authored text. Detected by the
+    -- write helper via ``detect_locale`` on question text +
+    -- explanation, same pattern as ``courses.source_locale``.
+    source_locale    TEXT,
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- "Show me drafts / scripture-validated / ... / published" editorial
+-- queue. Partial keeps the working set hot — archived + rejected
+-- rows are the cold tail.
+CREATE INDEX ix_dc_questions_status_created
+    ON daily_challenge_questions (status, created_at DESC)
+    WHERE rejected = FALSE AND status <> 'archived';
+
+-- Schedulable pool: only published, not rejected, not archived. Drives
+-- the editorial "pick a question for date X" UI and the schedule
+-- trigger.
+CREATE INDEX ix_dc_questions_publishable
+    ON daily_challenge_questions (published_at)
+    WHERE status = 'published' AND rejected = FALSE;
+
+-- Reverse-lookup from a scripture reference. Used by the editorial
+-- "have we already written a question on this passage?" duplicate
+-- check.
+CREATE INDEX ix_dc_questions_scripture
+    ON daily_challenge_questions (bible_book, bible_chapter, bible_verse_from);
+
+-- ---------------------------------------------------------------------
+-- 2. daily_challenge_options
+-- ---------------------------------------------------------------------
+-- One row per option. ``option_text`` lives in ``content_versions``
+-- (entity_type='daily_challenge_option', field='option_text'). For
+-- true_false questions: exactly 2 options, ``order_index`` 0 = True /
+-- 1 = False. For multiple_choice: 3-6 options typically; ``order_index``
+-- determines render order. Application-level invariant: exactly one
+-- option per question has ``is_correct=true``. Not a DB trigger because
+-- it would fight transactional INSERTs that build the question +
+-- options in one batch; the service layer enforces it at commit time.
+
+CREATE TABLE daily_challenge_options (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    question_id   UUID NOT NULL REFERENCES daily_challenge_questions(id)
+                    ON DELETE CASCADE,
+    is_correct    BOOLEAN NOT NULL DEFAULT FALSE,
+    -- Bounded so a malformed import can't blow up the render. Six
+    -- options is more than any Bible MCQ should ever need; tighter at
+    -- the Pydantic edge.
+    order_index   INT NOT NULL DEFAULT 0
+                    CHECK (order_index BETWEEN 0 AND 5),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ix_dc_options_question
+    ON daily_challenge_options (question_id, order_index);
+
+-- ---------------------------------------------------------------------
+-- 3. daily_challenge_schedule
+-- ---------------------------------------------------------------------
+-- One row per UTC date. PK is the date itself — at most one question
+-- live per day. The schedule trigger enforces the "only
+-- published+non-rejected questions can be scheduled" gate; ON DELETE
+-- RESTRICT on the FK to questions ensures a scheduled question can't
+-- vanish under the day it's scheduled for.
+
+CREATE TABLE daily_challenge_schedule (
+    challenge_date  DATE PRIMARY KEY,
+    question_id     UUID NOT NULL REFERENCES daily_challenge_questions(id)
+                    ON DELETE RESTRICT,
+    scheduled_by    UUID REFERENCES profiles(id) ON DELETE SET NULL,
+    scheduled_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Reverse lookup: "show me every date this question has been on".
+-- Editorial uses this to surface re-use (we may eventually allow a
+-- question to be re-aired after a long cooldown).
+CREATE INDEX ix_dc_schedule_question
+    ON daily_challenge_schedule (question_id);
+
+-- Trigger-enforced "only published, not rejected, not archived
+-- questions can be scheduled". Done via a trigger because Postgres
+-- CHECK constraints cannot reference another table's columns.
+CREATE OR REPLACE FUNCTION dc_schedule_assert_publishable()
+RETURNS trigger AS $$
+DECLARE
+    q_status TEXT;
+    q_rejected BOOLEAN;
+    q_pub TIMESTAMPTZ;
+BEGIN
+    SELECT status, rejected, published_at
+      INTO q_status, q_rejected, q_pub
+      FROM daily_challenge_questions
+     WHERE id = NEW.question_id;
+
+    IF q_status IS DISTINCT FROM 'published' THEN
+        RAISE EXCEPTION 'daily_challenge_schedule.question_id % is not at status=published (current: %)',
+            NEW.question_id, q_status
+            USING ERRCODE = 'check_violation';
+    END IF;
+    IF q_rejected THEN
+        RAISE EXCEPTION 'daily_challenge_schedule.question_id % is rejected; cannot schedule', NEW.question_id
+            USING ERRCODE = 'check_violation';
+    END IF;
+    IF q_pub IS NULL THEN
+        RAISE EXCEPTION 'daily_challenge_schedule.question_id % has NULL published_at', NEW.question_id
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER dc_schedule_publishable_guard
+    BEFORE INSERT OR UPDATE OF question_id ON daily_challenge_schedule
+    FOR EACH ROW EXECUTE FUNCTION dc_schedule_assert_publishable();
+
+-- ---------------------------------------------------------------------
+-- 4. daily_challenge_attempts
+-- ---------------------------------------------------------------------
+-- Per-user attempt. Live attempts (is_archive=false) impact the
+-- streak; archive replays (is_archive=true) never do — that's the
+-- "you can revisit yesterday's question without resetting your
+-- streak math" guarantee.
+
+CREATE TABLE daily_challenge_attempts (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id              UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    question_id          UUID NOT NULL REFERENCES daily_challenge_questions(id)
+                            ON DELETE CASCADE,
+    -- For live attempts: equals daily_challenge_schedule.challenge_date
+    -- (the UTC date the question was the daily question). For archive
+    -- attempts: the historical date the user is replaying. Stored, not
+    -- derived, so the partial unique index can include it cheaply.
+    challenge_date       DATE NOT NULL,
+    is_archive           BOOLEAN NOT NULL DEFAULT FALSE,
+    selected_option_id   UUID REFERENCES daily_challenge_options(id) ON DELETE SET NULL,
+    is_correct           BOOLEAN NOT NULL,
+    -- Materialised post-attempt for observability — "what was the
+    -- streak right after this submit?" The streak service writes this
+    -- under the same FOR UPDATE lock as the streak row update.
+    -- NULL on archive attempts (enforced by CHECK below).
+    streak_after         INT,
+    submitted_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Archive attempts never touch the streak.
+    CHECK (NOT is_archive OR streak_after IS NULL)
+);
+
+-- The race-resolving partial unique. At most ONE live attempt per
+-- (user_id, challenge_date) — the second INSERT raises IntegrityError
+-- and the route returns the existing attempt. Archive replays are
+-- allowed unlimited times so the partial WHERE excludes them.
+CREATE UNIQUE INDEX uniq_dc_attempts_live_per_day
+    ON daily_challenge_attempts (user_id, challenge_date)
+    WHERE is_archive = FALSE;
+
+-- Profile / history view.
+CREATE INDEX ix_dc_attempts_user_date
+    ON daily_challenge_attempts (user_id, challenge_date DESC);
+
+-- "How hard was this question?" editorial difficulty heatmap.
+CREATE INDEX ix_dc_attempts_question
+    ON daily_challenge_attempts (question_id);
+
+-- ---------------------------------------------------------------------
+-- 5. daily_challenge_streaks
+-- ---------------------------------------------------------------------
+-- Per-user counter. One row per user — created lazily on first
+-- attempt via ON CONFLICT DO UPDATE in the streak service.
+--
+-- YouVersion-style semantics (Vadym 2026-05-29):
+--   * Any submission (right or wrong) counts as engagement.
+--   * On submit: if last_engaged_date < challenge_date, increment
+--     current_streak by 1 (idempotent via uniqueness check).
+--   * If last_engaged_date < challenge_date - 1 (i.e. missed at least
+--     one full day in between), current_streak resets to 1 (today's
+--     attempt is itself the start of a new streak).
+--   * No grace tokens in MVP — strictness is acceptable because the
+--     bar for "engagement" is just attempting (not getting it right).
+--   * longest_streak tracks all-time so the user has a permanent
+--     accomplishment even after a reset.
+--   * No XP. Vadym wants XP added later via an additive migration
+--     once the rules are designed; intentionally absent here.
+
+CREATE TABLE daily_challenge_streaks (
+    user_id                  UUID PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+    current_streak           INT NOT NULL DEFAULT 0
+                                CHECK (current_streak >= 0),
+    longest_streak           INT NOT NULL DEFAULT 0
+                                CHECK (longest_streak >= 0),
+    last_engaged_date        DATE,
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Cohort-style "everyone with active recent streaks" query. Used by
+-- the at-risk notification job: "find users with current_streak >= 3
+-- who haven't engaged today." Partial keeps the index tight.
+CREATE INDEX ix_dc_streaks_last_engaged
+    ON daily_challenge_streaks (last_engaged_date)
+    WHERE current_streak >= 1;
+
+-- =====================================================================
+-- Row-Level Security
+-- =====================================================================
+--
+-- service_role bypasses RLS automatically — backend writes flow
+-- through it. The policies below cover the PostgREST surface that an
+-- authenticated user JWT can hit directly.
+
+ALTER TABLE daily_challenge_questions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_options   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_schedule  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_attempts  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_streaks   ENABLE ROW LEVEL SECURITY;
+
+-- Questions: students see archive (past dates' published questions) +
+-- today's question (but the backend slices off ``options.is_correct``
+-- and the answer-key fields before responding). Editorial role (teacher
+-- + admin) sees everything including drafts. The "today's question"
+-- read is routed through the backend service_role for the answer-key
+-- redaction; the direct PostgREST read is for the archive surface.
+
+CREATE POLICY dc_questions_select_archive ON daily_challenge_questions
+    FOR SELECT TO authenticated
+    USING (
+        status = 'published'
+        AND rejected = FALSE
+        AND EXISTS (
+            SELECT 1 FROM daily_challenge_schedule s
+             WHERE s.question_id = daily_challenge_questions.id
+               AND s.challenge_date <= (now() AT TIME ZONE 'UTC')::date
+        )
+    );
+
+CREATE POLICY dc_questions_select_editorial ON daily_challenge_questions
+    FOR SELECT TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM profiles p
+             WHERE p.id = (SELECT auth.uid())
+               AND p.role IN ('teacher', 'admin')
+        )
+    );
+
+-- Options: piggy-back on the parent question's visibility.
+CREATE POLICY dc_options_select_via_question ON daily_challenge_options
+    FOR SELECT TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM daily_challenge_questions q
+             WHERE q.id = daily_challenge_options.question_id
+               AND (
+                    (q.status = 'published' AND q.rejected = FALSE
+                     AND EXISTS (
+                         SELECT 1 FROM daily_challenge_schedule s
+                          WHERE s.question_id = q.id
+                            AND s.challenge_date <= (now() AT TIME ZONE 'UTC')::date
+                     ))
+                    OR EXISTS (
+                         SELECT 1 FROM profiles p
+                          WHERE p.id = (SELECT auth.uid())
+                            AND p.role IN ('teacher', 'admin')
+                     )
+               )
+        )
+    );
+
+-- Schedule: students see past + today (today's question_id is needed
+-- to JOIN on options for rendering). The backend redacts the answer
+-- key in the API response.
+CREATE POLICY dc_schedule_select_visible ON daily_challenge_schedule
+    FOR SELECT TO authenticated
+    USING (
+        challenge_date <= (now() AT TIME ZONE 'UTC')::date
+        OR EXISTS (
+            SELECT 1 FROM profiles p
+             WHERE p.id = (SELECT auth.uid())
+               AND p.role IN ('teacher', 'admin')
+        )
+    );
+
+-- Attempts + streaks: each user sees only their own row.
+CREATE POLICY dc_attempts_select_own ON daily_challenge_attempts
+    FOR SELECT TO authenticated
+    USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY dc_streaks_select_own ON daily_challenge_streaks
+    FOR SELECT TO authenticated
+    USING (user_id = (SELECT auth.uid()));
+
+-- All writes go through the backend (service_role). Belt-and-suspenders
+-- REVOKE mirrors the 20260515184512_rls_tighten_write_policies.sql
+-- pattern.
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_questions FROM authenticated, anon;
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_options   FROM authenticated, anon;
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_schedule  FROM authenticated, anon;
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_attempts  FROM authenticated, anon;
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_streaks   FROM authenticated, anon;
+
+-- Column-level defence on the answer key. Even if a student knows
+-- today's question_id and bypasses the API to query options directly
+-- via PostgREST, the ``is_correct`` column is hidden from them. The
+-- backend, running under service_role, still sees the column.
+-- Without this, an RLS SELECT policy that lets authenticated users
+-- read options (necessary for archive rendering) would leak the
+-- answer key.
+--
+-- Editorial role (teacher + admin) needs ``is_correct`` to manage the
+-- question. Granting back to authenticated WHERE role IN
+-- ('teacher','admin') is not expressible via column-level GRANT — RLS
+-- already controls which rows they see, but column-level grants are
+-- per-role, not per-policy. The right pattern: keep ``is_correct``
+-- revoked from ``authenticated`` entirely, and have the editorial UI
+-- read through a backend route (which uses service_role).
+REVOKE SELECT (is_correct) ON daily_challenge_options FROM authenticated, anon;


### PR DESCRIPTION
## Summary
Phase 5c — Daily Challenge MVP foundation. Schema-only PR; the service layer + API endpoints + AI question-generation flow come in subsequent PRs (Sprint 2 + Sprint 3).

Architecture decisions locked 2026-05-29 by Vadym after a 4-agent parallel design review (memory: `project-equip-daily-challenge-decisions.md`).

### Five tables
- `daily_challenge_questions` — editorial bank with 5-stage pipeline (`draft → scripture_validated → doctrinally_reviewed → bilingually_reviewed → pilot_passed → published`) + orthogonal `rejected` boolean. Translatable text in `content_versions`.
- `daily_challenge_options` — MC/TF options. `option_text` in `content_versions`.
- `daily_challenge_schedule` — PK is `challenge_date` (one question per UTC date). Postgres trigger `dc_schedule_assert_publishable` enforces "only published + non-rejected questions can be scheduled."
- `daily_challenge_attempts` — live vs archive via `is_archive` flag. Partial unique `(user_id, challenge_date) WHERE is_archive=FALSE` resolves the two-tab race.
- `daily_challenge_streaks` — per-user counter. YouVersion-style: any submission counts. No grace tokens, no XP (intentionally deferred).

### Translation registry
- `ContentVersionEntityType` Literal gains `daily_challenge_question` + `daily_challenge_option`
- `ContentVersionField` Literal gains `explanation`
- `EntityType` (protocol.py) mirrors
- REGISTRY + ENTITY_MODEL entries with `resolve_course → None` (platform-wide, no course parent)

### RLS coverage
- Students: archived published questions + own attempts + own streak
- Editorial (teacher/admin): everything
- Backend service_role: redacts answer key on today's question
- Column-level REVOKE on `is_correct` — even direct PostgREST cannot leak the answer key

### Tests
- 8 new tests in `test_daily_challenge_foundation.py` pinning partial-unique race, archive replays, schedule PK uniqueness, ORM defaults
- 980 backend tests pass total (972 baseline + 8 new)
- `test_registry_field_names_exist_on_models` updated to exempt new cv-only entity types

### Migration applied to prod
Via Supabase MCP. Verified via `pg_class` query — all 5 tables show `relrowsecurity=true`.

## Test plan
- [x] 980 backend tests pass locally
- [x] ruff check + format clean
- [x] Migration applied to prod
- [ ] CI green (including schema-smoke-postgres which exercises the trigger + column-level grants)
- [ ] Auto-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)