### PR TITLE
feat(daily-challenge): Sprint 2 — service layer + 3 student endpoints

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -11,6 +11,7 @@ from app.api.v1 import (
     certificates,
     cohorts,
     courses,
+    daily_challenge,
     grades,
     health,
     internal_translation_worker,
@@ -47,3 +48,4 @@ api_router.include_router(calendar_mod.event_router)
 api_router.include_router(verse_of_the_day.router)
 api_router.include_router(admin_translations.router)
 api_router.include_router(internal_translation_worker.router)
+api_router.include_router(daily_challenge.router)

--- a/backend/app/api/v1/daily_challenge.py
+++ b/backend/app/api/v1/daily_challenge.py
@@ -1,0 +1,227 @@
+"""Daily Challenge API routes.
+
+Sprint 2 ships three student-facing endpoints. Authoring + scheduling
+admin routes land in Sprint 3 with the editorial pipeline.
+
+Authentication: all routes require an authenticated user. There's no
+role gate — every authenticated user, including students, can read
+today's question, submit an attempt, and check their streak.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header, Response, status
+from sqlalchemy.orm import Session  # noqa: TC002 — FastAPI Depends runtime use
+
+from app.api.dependencies import get_current_user
+from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
+from app.models.daily_challenge import DailyChallengeAttempt
+from app.models.user import User  # noqa: TC001 — FastAPI Depends runtime use
+from app.schemas.daily_challenge import (
+    DailyChallengeAttemptCreate,
+    DailyChallengeAttemptResponse,
+    DailyChallengeAttemptSummary,
+    DailyChallengeOptionStudentView,
+    DailyChallengeStreakResponse,
+    DailyChallengeTodayResponse,
+)
+from app.schemas.locale import normalize_locale
+from app.services.daily_challenge import (
+    InvalidOptionError,
+    NoScheduleError,
+    fetch_question_text_bundle,
+    get_today_question,
+    get_user_streak,
+    submit_today_attempt,
+)
+from app.services.daily_challenge.schedule import utc_today
+
+router = APIRouter(prefix="/daily-challenge", tags=["daily-challenge"])
+
+
+@router.get(
+    "/today",
+    response_model=DailyChallengeTodayResponse,
+    summary="Today's question + the user's existing attempt (if any)",
+    responses={
+        200: {"description": "Today's question. ``user_attempt`` populated when the user already submitted."},
+        404: {"description": "No question scheduled for today. Frontend should hide the daily card."},
+    },
+)
+def get_today(
+    response: Response,
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> DailyChallengeTodayResponse:
+    """Return today's question + the user's existing attempt (if any).
+
+    Answer key (``is_correct`` on options, the correct option id, the
+    explanation) is NOT included. Those reveal on the submit response.
+    """
+    response.headers["Vary"] = "Accept-Language"
+    today = utc_today()
+
+    schedule_q = get_today_question(db, on_date=today)
+    if schedule_q is None:
+        raise equip_error(
+            ErrorCode.DAILY_CHALLENGE_NOT_SCHEDULED,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="No Daily Challenge is scheduled for today",
+            context={"challenge_date": today.isoformat()},
+        )
+    schedule, question = schedule_q
+
+    display_locale = normalize_locale(accept_language)
+    bundle = fetch_question_text_bundle(
+        db,
+        question=question,
+        display_locale=display_locale,
+    )
+
+    options_view = [
+        DailyChallengeOptionStudentView(
+            id=o.id,
+            option_text=bundle.options.get(o.id, ""),
+            order_index=o.order_index,
+        )
+        for o in sorted(question.options, key=lambda o: o.order_index)
+    ]
+
+    existing = (
+        db.query(DailyChallengeAttempt)
+        .filter(
+            DailyChallengeAttempt.user_id == current_user.id,
+            DailyChallengeAttempt.challenge_date == today,
+            DailyChallengeAttempt.is_archive.is_(False),
+        )
+        .one_or_none()
+    )
+    user_attempt_view: DailyChallengeAttemptSummary | None = None
+    if existing is not None:
+        user_attempt_view = DailyChallengeAttemptSummary(
+            id=existing.id,
+            selected_option_id=existing.selected_option_id,
+            is_correct=existing.is_correct,
+            streak_after=existing.streak_after,
+            submitted_at=existing.submitted_at,
+        )
+
+    return DailyChallengeTodayResponse(
+        challenge_date=schedule.challenge_date,
+        question_id=question.id,
+        question_type=question.question_type,
+        question_text=bundle.question_text,
+        options=options_view,
+        bible_book=question.bible_book,
+        bible_chapter=question.bible_chapter,
+        bible_verse_from=question.bible_verse_from,
+        bible_verse_to=question.bible_verse_to,
+        already_attempted=existing is not None,
+        user_attempt=user_attempt_view,
+    )
+
+
+@router.post(
+    "/today/attempt",
+    response_model=DailyChallengeAttemptResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Submit today's attempt",
+    responses={
+        201: {
+            "description": "Attempt persisted. Returns the reveal payload (correct option + explanation + new streak)."
+        },
+        404: {"description": "No question scheduled for today."},
+        422: {"description": "``selected_option_id`` does not belong to today's question."},
+    },
+)
+def submit_attempt(
+    data: DailyChallengeAttemptCreate,
+    accept_language: str | None = Header(default=None, alias="Accept-Language"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> DailyChallengeAttemptResponse:
+    """Submit the user's answer for today's question.
+
+    Idempotent — a repeat submit with the same option returns the
+    existing attempt verbatim. The streak service is called once per
+    real attempt.
+
+    Race-safe — the partial unique constraint catches the two-tab
+    race; the service layer re-reads and returns the winning attempt.
+    """
+    try:
+        outcome = submit_today_attempt(
+            db,
+            user_id=current_user.id,
+            selected_option_id=data.selected_option_id,
+        )
+    except NoScheduleError:
+        today = utc_today()
+        raise equip_error(
+            ErrorCode.DAILY_CHALLENGE_NOT_SCHEDULED,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="No Daily Challenge is scheduled for today",
+            context={"challenge_date": today.isoformat()},
+        ) from None
+    except InvalidOptionError as exc:
+        raise equip_error(
+            ErrorCode.DAILY_CHALLENGE_INVALID_OPTION,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            message="The selected option does not belong to today's question",
+            context={
+                "selected_option_id": str(exc.selected_option_id),
+                "question_id": str(exc.question_id),
+            },
+        ) from None
+
+    # Fetch the explanation in the caller's display locale so the
+    # post-submit reveal renders the right text without a second
+    # round-trip.
+    display_locale = normalize_locale(accept_language)
+    bundle = fetch_question_text_bundle(
+        db,
+        question=outcome.question,
+        display_locale=display_locale,
+    )
+
+    return DailyChallengeAttemptResponse(
+        id=outcome.attempt.id,
+        challenge_date=outcome.attempt.challenge_date,
+        selected_option_id=outcome.attempt.selected_option_id,
+        correct_option_id=outcome.correct_option_id,
+        is_correct=outcome.attempt.is_correct,
+        explanation=bundle.explanation,
+        streak_after=outcome.streak_after,
+        submitted_at=outcome.attempt.submitted_at,
+    )
+
+
+@router.get(
+    "/streak",
+    response_model=DailyChallengeStreakResponse,
+    summary="Current user's streak",
+    responses={
+        200: {"description": "Zero counters returned for users who have never engaged."},
+    },
+)
+def get_streak(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> DailyChallengeStreakResponse:
+    """Return the caller's streak counters. Users with no engagement
+    history get zeros — the route does NOT 404 for the empty case so
+    the client doesn't have to special-case it."""
+    streak = get_user_streak(db, user_id=current_user.id)
+    if streak is None:
+        return DailyChallengeStreakResponse(
+            current_streak=0,
+            longest_streak=0,
+            last_engaged_date=None,
+        )
+    return DailyChallengeStreakResponse(
+        current_streak=streak.current_streak,
+        longest_streak=streak.longest_streak,
+        last_engaged_date=streak.last_engaged_date,
+    )

--- a/backend/app/api/v1/daily_challenge.py
+++ b/backend/app/api/v1/daily_challenge.py
@@ -10,6 +10,8 @@ today's question, submit an attempt, and check their streak.
 
 from __future__ import annotations
 
+from typing import cast
+
 from fastapi import APIRouter, Depends, Header, Response, status
 from sqlalchemy.orm import Session  # noqa: TC002 — FastAPI Depends runtime use
 
@@ -23,6 +25,7 @@ from app.schemas.daily_challenge import (
     DailyChallengeAttemptResponse,
     DailyChallengeAttemptSummary,
     DailyChallengeOptionStudentView,
+    DailyChallengeQuestionType,
     DailyChallengeStreakResponse,
     DailyChallengeTodayResponse,
 )
@@ -111,7 +114,10 @@ def get_today(
     return DailyChallengeTodayResponse(
         challenge_date=schedule.challenge_date,
         question_id=question.id,
-        question_type=question.question_type,
+        # ORM column is plain ``str`` (enum lives only in Python land);
+        # cast to satisfy the Pydantic Literal. CHECK constraint on the
+        # DB guarantees the runtime value is in the literal set.
+        question_type=cast("DailyChallengeQuestionType", question.question_type),
         question_text=bundle.question_text,
         options=options_view,
         bible_book=question.bible_book,
@@ -186,10 +192,16 @@ def submit_attempt(
         display_locale=display_locale,
     )
 
+    # ``selected_option_id`` is nullable on the ORM (ON DELETE SET NULL
+    # for archival safety), but a freshly-created attempt always has it
+    # set — we wrote it in this same transaction. Fall back to the
+    # caller's submitted id rather than risking a Pydantic None.
+    selected_id = outcome.attempt.selected_option_id or data.selected_option_id
+
     return DailyChallengeAttemptResponse(
         id=outcome.attempt.id,
         challenge_date=outcome.attempt.challenge_date,
-        selected_option_id=outcome.attempt.selected_option_id,
+        selected_option_id=selected_id,
         correct_option_id=outcome.correct_option_id,
         is_correct=outcome.attempt.is_correct,
         explanation=bundle.explanation,

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -101,6 +101,22 @@ class ErrorCode(enum.StrEnum):
     QUIZ_ATTEMPTS_EXHAUSTED = "quiz.attempts_exhausted"
     """Student has hit the per-quiz attempt cap."""
 
+    # ── Daily Challenge ─────────────────────────────────────────────────
+    DAILY_CHALLENGE_NOT_SCHEDULED = "daily_challenge.not_scheduled"
+    """No question is scheduled for the requested UTC date — usually
+    means today's question hasn't been published yet, or the editorial
+    team has gaps in the schedule. Frontend should hide the daily card
+    instead of showing an error toast."""
+
+    DAILY_CHALLENGE_ALREADY_ATTEMPTED = "daily_challenge.already_attempted"
+    """User already submitted a live attempt for the current UTC date.
+    Frontend re-renders the post-submit state from the returned
+    ``context.existing_attempt``."""
+
+    DAILY_CHALLENGE_INVALID_OPTION = "daily_challenge.invalid_option"
+    """The submitted ``selected_option_id`` does not belong to today's
+    question. Either a stale frontend cache or a tampered request."""
+
     # ── Validation ──────────────────────────────────────────────────────
     VALIDATION_FAILED = "validation.failed"
     """Request body / params failed semantic validation beyond the

--- a/backend/app/models/content_version.py
+++ b/backend/app/models/content_version.py
@@ -56,6 +56,8 @@ ContentVersionEntityType = Literal[
     "announcement",
     "course_event",
     "cohort",
+    "daily_challenge_question",
+    "daily_challenge_option",
 ]
 
 ContentVersionField = Literal[
@@ -65,6 +67,7 @@ ContentVersionField = Literal[
     "question_text",
     "option_text",
     "instructions",
+    "explanation",
 ]
 
 ContentVersionOrigin = Literal["human", "mt"]

--- a/backend/app/models/daily_challenge.py
+++ b/backend/app/models/daily_challenge.py
@@ -1,0 +1,295 @@
+"""ORM mapping for the Daily Challenge MVP.
+
+Five tables — see ``supabase/migrations/20260529210000_add_daily_challenge_
+foundation.sql`` for the canonical schema commentary. Mapped[] models
+mirror the SQL exactly; the SQLite test path materialises the schema
+via ``Base.metadata.create_all`` so partial indexes carry the
+``sqlite_where`` variant alongside ``postgresql_where``.
+
+Architecture decisions locked 2026-05-29 by Vadym after a 4-agent
+parallel review. Read ``memory:
+project-equip-daily-challenge-decisions.md`` before editing this file.
+
+Translatable text lives in ``content_versions`` — there are no
+``question_text`` / ``option_text`` / ``explanation`` columns on these
+tables. The new entity types ``daily_challenge_question`` and
+``daily_challenge_option`` are appended to ``ContentVersionEntityType``
+in ``content_version.py``; the new field ``explanation`` is added to
+``ContentVersionField`` in the same file.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import date, datetime  # noqa: TC003 — Mapped[] runtime resolution
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID as PgUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class DailyChallengeQuestionType(enum.StrEnum):
+    """The two auto-validatable question shapes supported by the MVP.
+
+    Locked by Vadym 2026-05-29: only types that can be graded by
+    ``selected_option_id`` comparison — no string-match fuzziness, no
+    teacher-graded essays on the daily surface. Adding a new type is
+    an append-only migration that extends the CHECK constraint AND
+    this enum AND the Pydantic ``Literal``; the registry-drift test
+    catches mismatches.
+    """
+
+    MULTIPLE_CHOICE = "multiple_choice"
+    TRUE_FALSE = "true_false"
+
+
+class DailyChallengeQuestionStatus(enum.StrEnum):
+    """Forward-only editorial pipeline.
+
+    Stages 2-5 correspond to Agent C's 5-stage review (scripture →
+    doctrine → bilingual → pilot). ``published`` is the terminal live
+    state. ``archived`` is the terminal end-of-life state for a
+    question that has rotated out of the pool.
+
+    The ``rejected`` boolean on the row is orthogonal: a question can
+    be rejected at any stage. Rejection does NOT roll the status back;
+    the row stays at whatever stage killed it, ``rejected=true``, and
+    is excluded from the publishable pool forever.
+    """
+
+    DRAFT = "draft"
+    SCRIPTURE_VALIDATED = "scripture_validated"
+    DOCTRINALLY_REVIEWED = "doctrinally_reviewed"
+    BILINGUALLY_REVIEWED = "bilingually_reviewed"
+    PILOT_PASSED = "pilot_passed"
+    PUBLISHED = "published"
+    ARCHIVED = "archived"
+
+
+class DailyChallengeQuestion(Base):
+    """Editorial bank entry. Translatable text lives in
+    ``content_versions`` — see module docstring."""
+
+    __tablename__ = "daily_challenge_questions"
+    __table_args__ = (
+        CheckConstraint(
+            "question_type IN ('multiple_choice', 'true_false')",
+            name="daily_challenge_questions_type_check",
+        ),
+        CheckConstraint(
+            "status IN ('draft', 'scripture_validated', 'doctrinally_reviewed', "
+            "'bilingually_reviewed', 'pilot_passed', 'published', 'archived')",
+            name="daily_challenge_questions_status_check",
+        ),
+        CheckConstraint("bible_chapter > 0", name="daily_challenge_questions_chapter_pos"),
+        CheckConstraint(
+            "bible_verse_from IS NULL OR bible_verse_from > 0",
+            name="daily_challenge_questions_verse_from_pos",
+        ),
+        CheckConstraint(
+            "bible_verse_to IS NULL OR (bible_verse_from IS NOT NULL AND bible_verse_to >= bible_verse_from)",
+            name="daily_challenge_questions_verse_range",
+        ),
+        Index(
+            "ix_dc_questions_status_created",
+            "status",
+            "created_at",
+            postgresql_where="rejected = FALSE AND status <> 'archived'",
+            sqlite_where=text("rejected = 0 AND status <> 'archived'"),
+        ),
+        Index(
+            "ix_dc_questions_publishable",
+            "published_at",
+            postgresql_where="status = 'published' AND rejected = FALSE",
+            sqlite_where=text("status = 'published' AND rejected = 0"),
+        ),
+        Index(
+            "ix_dc_questions_scripture",
+            "bible_book",
+            "bible_chapter",
+            "bible_verse_from",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    question_type: Mapped[str] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(Text, default="draft", server_default="draft")
+
+    # Rejection — orthogonal to status. See module docstring.
+    rejected: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    rejection_reason: Mapped[str | None] = mapped_column(Text)
+    rejected_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
+    )
+    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    # Publication breadcrumb — published_at being non-NULL + status =
+    # 'published' + rejected = FALSE is the schedule trigger's gate.
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    published_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
+    )
+
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
+    )
+
+    # Scripture anchor — every question must cite a verse range.
+    bible_book: Mapped[str] = mapped_column(Text)
+    bible_chapter: Mapped[int] = mapped_column(Integer)
+    bible_verse_from: Mapped[int | None] = mapped_column(Integer)
+    bible_verse_to: Mapped[int | None] = mapped_column(Integer)
+
+    # Editorial category — free-form text. Pydantic Literal gates at
+    # the API edge; categories can evolve without a migration.
+    category: Mapped[str | None] = mapped_column(Text)
+
+    # Source locale of the human-authored text (RU / EN / …). Same
+    # detection pattern as ``courses.source_locale``.
+    source_locale: Mapped[str | None] = mapped_column(Text)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    options: Mapped[list[DailyChallengeOption]] = relationship(
+        back_populates="question",
+        cascade="all, delete-orphan",
+        order_by="DailyChallengeOption.order_index",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<DailyChallengeQuestion id={self.id} type={self.question_type} "
+            f"status={self.status} rejected={self.rejected}>"
+        )
+
+
+class DailyChallengeOption(Base):
+    """One option on a question. ``option_text`` lives in
+    ``content_versions`` — see module docstring."""
+
+    __tablename__ = "daily_challenge_options"
+    __table_args__ = (
+        CheckConstraint("order_index BETWEEN 0 AND 5", name="daily_challenge_options_order_check"),
+        Index("ix_dc_options_question", "question_id", "order_index"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("daily_challenge_questions.id", ondelete="CASCADE"),
+    )
+    is_correct: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    order_index: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    question: Mapped[DailyChallengeQuestion] = relationship(back_populates="options")
+
+
+class DailyChallengeSchedule(Base):
+    """Maps a UTC date to the question scheduled for that date.
+
+    PK is ``challenge_date`` — at most one question per UTC day.
+    A Postgres trigger (``dc_schedule_assert_publishable``) enforces
+    that ``question_id`` references a row with ``status='published'``,
+    ``rejected=false``, and ``published_at IS NOT NULL``.
+    """
+
+    __tablename__ = "daily_challenge_schedule"
+    __table_args__ = (Index("ix_dc_schedule_question", "question_id"),)
+
+    challenge_date: Mapped[date] = mapped_column(Date, primary_key=True)
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("daily_challenge_questions.id", ondelete="RESTRICT"),
+    )
+    scheduled_by: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
+    )
+    scheduled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class DailyChallengeAttempt(Base):
+    """Per-user attempt. Live attempts move the streak; archive replays
+    don't (enforced by the ``is_archive`` flag + the partial unique
+    index + a CHECK constraint that archives have NULL ``streak_after``)."""
+
+    __tablename__ = "daily_challenge_attempts"
+    __table_args__ = (
+        CheckConstraint(
+            "NOT is_archive OR streak_after IS NULL",
+            name="dc_attempts_archive_null_streak",
+        ),
+        Index(
+            "uniq_dc_attempts_live_per_day",
+            "user_id",
+            "challenge_date",
+            unique=True,
+            postgresql_where="is_archive = FALSE",
+            sqlite_where=text("is_archive = 0"),
+        ),
+        Index("ix_dc_attempts_user_date", "user_id", "challenge_date"),
+        Index("ix_dc_attempts_question", "question_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="CASCADE"))
+    question_id: Mapped[uuid.UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("daily_challenge_questions.id", ondelete="CASCADE"),
+    )
+    challenge_date: Mapped[date] = mapped_column(Date)
+    is_archive: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    selected_option_id: Mapped[uuid.UUID | None] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("daily_challenge_options.id", ondelete="SET NULL"),
+    )
+    is_correct: Mapped[bool] = mapped_column(Boolean)
+    streak_after: Mapped[int | None] = mapped_column(Integer)
+    submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class DailyChallengeStreak(Base):
+    """Per-user streak counter. YouVersion-style semantics — any
+    submission counts. See module docstring for the math."""
+
+    __tablename__ = "daily_challenge_streaks"
+    __table_args__ = (
+        CheckConstraint("current_streak >= 0", name="dc_streaks_current_nonneg"),
+        CheckConstraint("longest_streak >= 0", name="dc_streaks_longest_nonneg"),
+        Index(
+            "ix_dc_streaks_last_engaged",
+            "last_engaged_date",
+            postgresql_where="current_streak >= 1",
+            sqlite_where=text("current_streak >= 1"),
+        ),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("profiles.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    current_streak: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    longest_streak: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    last_engaged_date: Mapped[date | None] = mapped_column(Date)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/schemas/daily_challenge.py
+++ b/backend/app/schemas/daily_challenge.py
@@ -1,0 +1,103 @@
+"""Pydantic schemas for the Daily Challenge surface.
+
+Three responses are public:
+
+* ``DailyChallengeTodayResponse`` — what the daily card renders before
+  the user submits. Answer key (``is_correct``, ``correct_option_id``,
+  ``explanation``) is NOT included; those land on the submit response.
+* ``DailyChallengeAttemptResponse`` — the post-submit reveal. Carries
+  the correct option id, explanation, and updated streak.
+* ``DailyChallengeStreakResponse`` — sidebar / profile chip data.
+
+Authoring schemas (``DailyChallengeQuestionCreate`` etc.) come in
+Sprint 3 with the editorial pipeline; not in this file yet.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime  # noqa: TC003 — Pydantic runtime resolution
+from typing import Literal
+from uuid import UUID  # noqa: TC003 — Pydantic runtime resolution
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Mirrors ``daily_challenge_questions.question_type`` CHECK.
+DailyChallengeQuestionType = Literal["multiple_choice", "true_false"]
+
+
+class DailyChallengeOptionStudentView(BaseModel):
+    """One option as it appears to the student BEFORE submitting.
+    No ``is_correct`` — the answer key is revealed only after submit.
+    Text is the locale-resolved string from ``content_versions``."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    option_text: str
+    order_index: int = Field(..., ge=0, le=5)
+
+
+class DailyChallengeAttemptSummary(BaseModel):
+    """The user's existing live attempt for today, embedded in the
+    today-response when present so the client renders the post-submit
+    state without a second round-trip."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    selected_option_id: UUID | None
+    is_correct: bool
+    streak_after: int | None
+    submitted_at: datetime
+
+
+class DailyChallengeTodayResponse(BaseModel):
+    """``GET /daily-challenge/today`` payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    challenge_date: date
+    question_id: UUID
+    question_type: DailyChallengeQuestionType
+    question_text: str
+    options: list[DailyChallengeOptionStudentView]
+    # Bible reference for "open this passage" link on the card.
+    bible_book: str
+    bible_chapter: int
+    bible_verse_from: int | None
+    bible_verse_to: int | None
+    # Set when the user already submitted today. Client renders the
+    # post-submit reveal state without calling the attempt endpoint.
+    already_attempted: bool
+    user_attempt: DailyChallengeAttemptSummary | None = None
+
+
+class DailyChallengeAttemptCreate(BaseModel):
+    """``POST /daily-challenge/today/attempt`` body."""
+
+    selected_option_id: UUID
+
+
+class DailyChallengeAttemptResponse(BaseModel):
+    """``POST /daily-challenge/today/attempt`` payload — the reveal."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    challenge_date: date
+    selected_option_id: UUID
+    correct_option_id: UUID
+    is_correct: bool
+    explanation: str | None
+    streak_after: int
+    submitted_at: datetime
+
+
+class DailyChallengeStreakResponse(BaseModel):
+    """``GET /daily-challenge/streak`` payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    current_streak: int = Field(..., ge=0)
+    longest_streak: int = Field(..., ge=0)
+    last_engaged_date: date | None

--- a/backend/app/services/daily_challenge/__init__.py
+++ b/backend/app/services/daily_challenge/__init__.py
@@ -1,0 +1,35 @@
+"""Daily Challenge service surface.
+
+Sprint 2 — service layer on top of the foundation schema (Phase 5c).
+Public entry points are re-exported here so route handlers import a
+single namespace.
+
+The Daily Challenge architecture is documented in
+``memory:project-equip-daily-challenge-decisions.md``. Read it before
+touching anything here.
+"""
+
+from app.services.daily_challenge.attempt import (
+    DailyChallengeAttemptOutcome,
+    InvalidOptionError,
+    NoScheduleError,
+    submit_today_attempt,
+)
+from app.services.daily_challenge.schedule import get_today_question
+from app.services.daily_challenge.streak import apply_streak_for_attempt, get_user_streak
+from app.services.daily_challenge.text import (
+    QuestionTextBundle,
+    fetch_question_text_bundle,
+)
+
+__all__ = [
+    "DailyChallengeAttemptOutcome",
+    "InvalidOptionError",
+    "NoScheduleError",
+    "QuestionTextBundle",
+    "apply_streak_for_attempt",
+    "fetch_question_text_bundle",
+    "get_today_question",
+    "get_user_streak",
+    "submit_today_attempt",
+]

--- a/backend/app/services/daily_challenge/attempt.py
+++ b/backend/app/services/daily_challenge/attempt.py
@@ -1,0 +1,182 @@
+"""Live attempt submission for the Daily Challenge.
+
+The hot service in Sprint 2. Three failure modes the route layer maps
+to typed error envelopes:
+
+* **No question scheduled for today** (``NoScheduleError``) — the
+  editorial team has a gap; the frontend hides the daily card.
+* **Selected option doesn't belong to today's question**
+  (``InvalidOptionError``) — stale frontend cache or a tampered
+  request.
+* **Already attempted** — handled silently. The partial-unique
+  ``(user_id, challenge_date) WHERE is_archive=FALSE`` makes the
+  second INSERT raise ``IntegrityError``; we catch it, re-read the
+  existing attempt, and return it verbatim. Idempotent on the same
+  request shape.
+
+The streak is updated inside the same transaction as the attempt
+INSERT, so a rollback rolls back both. The streak service holds
+``FOR UPDATE`` on the row.
+
+We materialise ``streak_after`` on the attempt row so the post-submit
+response doesn't need a second query and so observability ("what was
+the streak right after this attempt?") is one column away.
+"""
+
+from __future__ import annotations
+
+import uuid  # noqa: TC003 — used at runtime by dataclass annotations
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sqlalchemy.exc import IntegrityError
+
+from app.models.daily_challenge import (
+    DailyChallengeAttempt,
+    DailyChallengeOption,
+    DailyChallengeQuestion,
+    DailyChallengeSchedule,
+)
+from app.services.daily_challenge.schedule import get_today_question, utc_today
+from app.services.daily_challenge.streak import apply_streak_for_attempt
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class NoScheduleError(Exception):
+    """No question is scheduled for today."""
+
+
+class InvalidOptionError(Exception):
+    """The submitted option id doesn't belong to today's question."""
+
+    def __init__(self, *, selected_option_id: uuid.UUID, question_id: uuid.UUID) -> None:
+        super().__init__(f"option {selected_option_id} does not belong to question {question_id}")
+        self.selected_option_id = selected_option_id
+        self.question_id = question_id
+
+
+@dataclass(frozen=True, slots=True)
+class DailyChallengeAttemptOutcome:
+    """Service-level result. Route layer maps to ``AttemptResponse``."""
+
+    attempt: DailyChallengeAttempt
+    schedule: DailyChallengeSchedule
+    question: DailyChallengeQuestion
+    correct_option_id: uuid.UUID
+    streak_after: int
+    is_new_attempt: bool
+    """``True`` when this call created the attempt row; ``False`` when
+    the user had already submitted today and we returned the existing
+    row. The route uses this only for telemetry — the response shape
+    is the same either way (the client doesn't care)."""
+
+
+def _correct_option_for(question: DailyChallengeQuestion) -> DailyChallengeOption:
+    """Return the question's correct option. Application-level
+    invariant: exactly one. If anything else, raise — the schema let
+    a malformed question through and the service refuses to grade it
+    rather than silently picking the first correct match."""
+    correct = [o for o in question.options if o.is_correct]
+    if len(correct) != 1:
+        raise RuntimeError(
+            f"daily challenge question {question.id} has {len(correct)} correct "
+            "options; editorial pipeline failed to enforce the single-correct invariant"
+        )
+    return correct[0]
+
+
+def submit_today_attempt(
+    db: Session,
+    *,
+    user_id: uuid.UUID,
+    selected_option_id: uuid.UUID,
+) -> DailyChallengeAttemptOutcome:
+    """Submit an attempt at today's question.
+
+    Concurrency-safe — two simultaneous calls from the same user
+    resolve via the partial unique constraint; the loser re-reads
+    and returns the winner's attempt verbatim.
+
+    Idempotent — a repeat call with the same selected option after the
+    user already attempted today returns the existing attempt. The
+    streak service is not called a second time, so the streak counter
+    doesn't drift.
+
+    Raises ``NoScheduleError`` when no question is scheduled for today
+    and ``InvalidOptionError`` when ``selected_option_id`` belongs to
+    a different question.
+    """
+    today = utc_today()
+
+    schedule_q = get_today_question(db, on_date=today)
+    if schedule_q is None:
+        raise NoScheduleError(f"no question scheduled for UTC date {today.isoformat()}")
+    schedule, question = schedule_q
+
+    # Validate the option belongs to today's question. Done as one
+    # query instead of walking ``question.options`` so a malformed
+    # frontend payload is rejected before we touch the streak row.
+    selected = (
+        db.query(DailyChallengeOption)
+        .filter(
+            DailyChallengeOption.id == selected_option_id,
+            DailyChallengeOption.question_id == question.id,
+        )
+        .one_or_none()
+    )
+    if selected is None:
+        raise InvalidOptionError(selected_option_id=selected_option_id, question_id=question.id)
+
+    correct_option = _correct_option_for(question)
+    is_correct = selected.is_correct
+
+    # Try to insert the attempt. The partial unique blocks the
+    # two-tab race; on IntegrityError we re-read the existing row.
+    attempt = DailyChallengeAttempt(
+        user_id=user_id,
+        question_id=question.id,
+        challenge_date=today,
+        is_archive=False,
+        selected_option_id=selected.id,
+        is_correct=is_correct,
+    )
+    db.add(attempt)
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        existing = (
+            db.query(DailyChallengeAttempt)
+            .filter(
+                DailyChallengeAttempt.user_id == user_id,
+                DailyChallengeAttempt.challenge_date == today,
+                DailyChallengeAttempt.is_archive.is_(False),
+            )
+            .one()
+        )
+        # ``streak_after`` was set on the winning write; safe to return.
+        return DailyChallengeAttemptOutcome(
+            attempt=existing,
+            schedule=schedule,
+            question=question,
+            correct_option_id=correct_option.id,
+            streak_after=existing.streak_after or 0,
+            is_new_attempt=False,
+        )
+
+    new_streak = apply_streak_for_attempt(db, user_id=user_id, challenge_date=today)
+    attempt.streak_after = new_streak
+    db.flush()
+    db.commit()
+    db.refresh(attempt)
+
+    return DailyChallengeAttemptOutcome(
+        attempt=attempt,
+        schedule=schedule,
+        question=question,
+        correct_option_id=correct_option.id,
+        streak_after=new_streak,
+        is_new_attempt=True,
+    )

--- a/backend/app/services/daily_challenge/schedule.py
+++ b/backend/app/services/daily_challenge/schedule.py
@@ -1,0 +1,73 @@
+"""Schedule lookup for the Daily Challenge.
+
+Sprint 2 covers the read path — ``get_today_question`` is what every
+student-facing route uses to find "what's today's question?". The
+admin-side scheduling UI (set/replace a question for a given UTC date)
+lands in Sprint 3 alongside the editorial pipeline.
+
+Today's UTC date is the natural key — there's at most one row in
+``daily_challenge_schedule`` per ``challenge_date``. The schedule row
+points at a question whose status must be ``published`` and which
+isn't rejected; the Postgres trigger ``dc_schedule_assert_publishable``
+enforces that gate at write time, so this read path can trust the
+target question is valid.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import selectinload
+
+from app.models.daily_challenge import (
+    DailyChallengeQuestion,
+    DailyChallengeSchedule,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def utc_today() -> date:
+    """Single source of truth for "what's today?" — UTC-only, no
+    per-user timezone (deferred per the locked decisions)."""
+    return datetime.now(UTC).date()
+
+
+def get_today_question(
+    db: Session,
+    *,
+    on_date: date | None = None,
+) -> tuple[DailyChallengeSchedule, DailyChallengeQuestion] | None:
+    """Return today's (or another date's) scheduled question with
+    its options eager-loaded.
+
+    Returns ``None`` when no question is scheduled for the date —
+    the route layer maps that to a ``daily_challenge.not_scheduled``
+    error envelope.
+
+    ``on_date`` is exposed so the archive endpoint can reuse this
+    helper for any past date; default is UTC today.
+    """
+    target_date = on_date or utc_today()
+
+    schedule = (
+        db.query(DailyChallengeSchedule).filter(DailyChallengeSchedule.challenge_date == target_date).one_or_none()
+    )
+    if schedule is None:
+        return None
+
+    question = (
+        db.query(DailyChallengeQuestion)
+        .options(selectinload(DailyChallengeQuestion.options))
+        .filter(DailyChallengeQuestion.id == schedule.question_id)
+        .one_or_none()
+    )
+    if question is None:
+        # ON DELETE RESTRICT prevents this in prod, but we still
+        # guard against it instead of crashing — would only happen
+        # if someone bypassed the FK via raw SQL.
+        return None
+
+    return schedule, question

--- a/backend/app/services/daily_challenge/streak.py
+++ b/backend/app/services/daily_challenge/streak.py
@@ -1,0 +1,129 @@
+"""Streak accounting for the Daily Challenge.
+
+YouVersion-style semantics (Vadym, 2026-05-29): ANY submission counts
+as a day of engagement. The streak math doesn't care whether the user
+got it right — only whether they showed up.
+
+Algorithm
+---------
+
+On every live attempt submit:
+
+* Acquire a row lock on the user's streak row (``FOR UPDATE``). This
+  serialises concurrent submits from two browser tabs against each
+  other and against the daily cron.
+* If no row exists: insert one at ``current_streak=1``.
+* If the row's ``last_engaged_date`` already equals the attempt date:
+  no-op — same-day re-submits are idempotent.
+* If the row's ``last_engaged_date`` is the day before: increment
+  ``current_streak`` by 1.
+* Otherwise (gap of ≥ 2 days, OR ``last_engaged_date`` is NULL, OR
+  somehow ``last_engaged_date > attempt_date`` from clock skew):
+  reset to 1.
+* Track ``longest_streak`` as the max ever observed.
+
+No grace tokens, no XP — both intentionally deferred per the locked
+decisions. See ``memory:project-equip-daily-challenge-decisions.md``.
+
+Idempotency contract
+--------------------
+
+``apply_streak_for_attempt(db, user_id, challenge_date)`` is safe to
+call multiple times with the same arguments. The second call sees
+``last_engaged_date == challenge_date`` and returns the current
+streak verbatim. The route layer doesn't need a separate "did this
+attempt already write?" check.
+
+Race resolution
+---------------
+
+The attempt row carries a partial unique on
+``(user_id, challenge_date) WHERE is_archive = FALSE``. When two tabs
+submit at the same second the second INSERT fails with
+``IntegrityError``. The attempt service catches it, re-reads the
+existing attempt, and returns the recorded ``streak_after`` value
+WITHOUT calling this service a second time. That keeps the streak
+math monotonic.
+"""
+
+from __future__ import annotations
+
+import uuid  # noqa: TC003 — annotations evaluated by SQLAlchemy at runtime
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+
+from app.models.daily_challenge import DailyChallengeStreak
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def apply_streak_for_attempt(
+    db: Session,
+    *,
+    user_id: uuid.UUID,
+    challenge_date: date,
+) -> int:
+    """Increment / reset / no-op the user's streak based on the attempt
+    date. Returns the new ``current_streak`` value.
+
+    Must be called inside the same transaction as the attempt INSERT
+    so a rollback of the attempt also rolls back the streak update.
+    """
+    streak = (
+        db.query(DailyChallengeStreak).filter(DailyChallengeStreak.user_id == user_id).with_for_update().one_or_none()
+    )
+
+    if streak is None:
+        # First-ever attempt. Insert under the same transaction so the
+        # row lock acquired by FOR UPDATE on the (nonexistent) row is
+        # replaced by the lock implied by INSERT … the partial-unique
+        # on attempts is the second safety net for the create race.
+        streak = DailyChallengeStreak(
+            user_id=user_id,
+            current_streak=1,
+            longest_streak=1,
+            last_engaged_date=challenge_date,
+        )
+        db.add(streak)
+        db.flush()
+        return 1
+
+    last = streak.last_engaged_date
+
+    if last is None:
+        # Row exists (created by some other path?) but no prior
+        # engagement. Treat as first ever for the streak.
+        streak.current_streak = 1
+    elif last == challenge_date:
+        # Idempotent — same-day re-submit. No mutation.
+        return streak.current_streak
+    elif challenge_date == last + timedelta(days=1):
+        streak.current_streak += 1
+    elif challenge_date < last:
+        # Defensive: an attempt submitted with a challenge_date EARLIER
+        # than the recorded last engagement is logically impossible in
+        # a UTC-only world. If it ever happens (clock skew, manual
+        # backfill, test fixture) treat as a no-op rather than
+        # corrupting the counter downward.
+        return streak.current_streak
+    else:
+        # Gap of ≥ 2 days. Reset to 1 — today is the new start.
+        streak.current_streak = 1
+
+    if streak.current_streak > streak.longest_streak:
+        streak.longest_streak = streak.current_streak
+    streak.last_engaged_date = challenge_date
+    db.flush()
+    return streak.current_streak
+
+
+def get_user_streak(
+    db: Session,
+    *,
+    user_id: uuid.UUID,
+) -> DailyChallengeStreak | None:
+    """Return the user's streak row, or ``None`` if they've never
+    engaged. The endpoint layer turns ``None`` into a ``current=0``
+    response so the client doesn't have to handle the missing case."""
+    return db.query(DailyChallengeStreak).filter(DailyChallengeStreak.user_id == user_id).one_or_none()

--- a/backend/app/services/daily_challenge/text.py
+++ b/backend/app/services/daily_challenge/text.py
@@ -1,0 +1,97 @@
+"""Bilingual text resolution for Daily Challenge questions + options.
+
+Question text + option text + explanation all live in
+``content_versions``. The pattern mirrors what the quiz tree does in
+``app/services/translation/resolve_for_display.py`` — three calls to
+``fetch_cv_entity_texts_with_fallback`` (one per entity_type) so each
+gets its own ``fields=[...]`` list and the SQL is one tuple-IN per type.
+
+Tier order (managed by ``fetch_cv_entity_texts_with_fallback``):
+
+1. ``display_locale`` row.
+2. ``source_locale`` row.
+3. Any active+ok locale (earliest created — deterministic).
+
+For the editor's ``?source=1`` view we'd set
+``prefer_human=True`` so an MT row never masks a human-authored source.
+The Sprint 2 endpoints don't expose ``?source=1`` (editorial flows land
+in Sprint 3); this helper keeps the parameter for future use.
+"""
+
+from __future__ import annotations
+
+import uuid  # noqa: TC003 — used at runtime by dataclass annotations
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from app.schemas.locale import LocaleCode, normalize_locale
+from app.services.content_versions import fetch_cv_entity_texts_with_fallback
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from app.models.daily_challenge import DailyChallengeQuestion
+
+
+@dataclass(frozen=True, slots=True)
+class QuestionTextBundle:
+    """Resolved bilingual texts for one question + its options.
+
+    ``options`` maps the option's ``id`` to its locale-resolved text.
+    Missing ids resolve to ``None`` — the caller decides whether to
+    treat that as a render fallback or a hard error.
+    """
+
+    question_text: str
+    explanation: str | None
+    options: dict[uuid.UUID, str]
+
+
+def fetch_question_text_bundle(
+    db: Session,
+    *,
+    question: DailyChallengeQuestion,
+    display_locale: LocaleCode,
+    prefer_human: bool = False,
+) -> QuestionTextBundle:
+    """Resolve the bilingual texts for a fully-loaded question +
+    its options. The caller passes the ORM row with ``options``
+    already loaded (via ``selectinload`` in the schedule helper)."""
+    source_locale: LocaleCode = normalize_locale(question.source_locale)
+
+    question_texts = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="daily_challenge_question",
+        entity_ids=[str(question.id)],
+        fields=["question_text", "explanation"],
+        display_locale=display_locale,
+        source_locale=source_locale,
+        prefer_human=prefer_human,
+    )
+    question_text = question_texts.get((str(question.id), "question_text")) or ""
+    explanation = question_texts.get((str(question.id), "explanation"))
+
+    option_ids = [str(o.id) for o in question.options]
+    if option_ids:
+        option_texts = fetch_cv_entity_texts_with_fallback(
+            db,
+            entity_type="daily_challenge_option",
+            entity_ids=option_ids,
+            fields=["option_text"],
+            display_locale=display_locale,
+            source_locale=source_locale,
+            prefer_human=prefer_human,
+        )
+    else:
+        option_texts = {}
+
+    options_map: dict[uuid.UUID, str] = {}
+    for opt in question.options:
+        resolved = option_texts.get((str(opt.id), "option_text")) or ""
+        options_map[opt.id] = resolved
+
+    return QuestionTextBundle(
+        question_text=question_text,
+        explanation=explanation,
+        options=options_map,
+    )

--- a/backend/app/services/translation/protocol.py
+++ b/backend/app/services/translation/protocol.py
@@ -50,6 +50,8 @@ EntityType = Literal[
     "announcement",
     "course_event",
     "cohort",
+    "daily_challenge_question",
+    "daily_challenge_option",
 ]
 
 

--- a/backend/app/services/translation/registry.py
+++ b/backend/app/services/translation/registry.py
@@ -34,6 +34,7 @@ from app.models.chapter_block import ChapterBlock
 from app.models.cohort import Cohort
 from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent
+from app.models.daily_challenge import DailyChallengeOption, DailyChallengeQuestion
 from app.models.quiz import Quiz, QuizOption, QuizQuestion
 from app.schemas.locale import normalize_locale
 from app.services.language_detection import detect_locale
@@ -275,6 +276,37 @@ REGISTRY: dict[EntityType, EntityRegistration] = {
         resolve_course=_resolve_course_via_cohort_courses,
         build_context=lambda _co, c: f"Student cohort name in course «{c.title}»",
     ),
+    # Phase 5c — Daily Challenge platform surface. Questions are
+    # course-less by design (they're a platform-wide rotation, not
+    # course content). ``reconcile_entity`` skips orphans, so the
+    # standard "edit-triggers-translate" hook does NOT apply here —
+    # the Daily Challenge editorial pipeline invokes
+    # ``translate_entity_fields`` directly with ``source_locale``
+    # read off ``daily_challenge_questions.source_locale``.
+    #
+    # We still register so:
+    #   * the cv parity test passes (every entity_type referenced in
+    #     ``ContentVersionEntityType`` has a registry row),
+    #   * the ``ENTITY_MODEL`` table can route per-entity test
+    #     parametrization,
+    #   * ``resolve_for_display`` helpers that iterate the registry
+    #     for "what fields are translatable on entity X?" continue to
+    #     return correct answers for the daily challenge surfaces.
+    "daily_challenge_question": EntityRegistration(
+        entity_type="daily_challenge_question",
+        fields=(
+            FieldSpec("question_text", "quiz_question"),
+            FieldSpec("explanation", "plain"),
+        ),
+        resolve_course=lambda _db, _q: None,  # platform-wide; no course
+        build_context=lambda _q, _c: "Bible question for the Equip Daily Challenge.",
+    ),
+    "daily_challenge_option": EntityRegistration(
+        entity_type="daily_challenge_option",
+        fields=(FieldSpec("option_text", "quiz_option"),),
+        resolve_course=lambda _db, _o: None,  # platform-wide; no course
+        build_context=lambda _o, _c: "Answer option for an Equip Daily Challenge question.",
+    ),
 }
 
 
@@ -291,6 +323,8 @@ ENTITY_MODEL: dict[EntityType, type] = {
     "announcement": Announcement,
     "course_event": CourseEvent,
     "cohort": Cohort,
+    "daily_challenge_question": DailyChallengeQuestion,
+    "daily_challenge_option": DailyChallengeOption,
 }
 
 

--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -1314,6 +1314,47 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/daily-challenge/streak",
+    "params": [],
+    "responses": [
+      "200"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/daily-challenge/today",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ]
+    ],
+    "responses": [
+      "200",
+      "404",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/daily-challenge/today/attempt",
+    "params": [
+      [
+        "Accept-Language",
+        "header"
+      ]
+    ],
+    "responses": [
+      "201",
+      "404",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/grades/course/{course_id}",
     "params": [
       [

--- a/backend/tests/test_daily_challenge_foundation.py
+++ b/backend/tests/test_daily_challenge_foundation.py
@@ -1,0 +1,275 @@
+"""Foundation tests for the Daily Challenge MVP schema.
+
+Phase 5c — pins the load-bearing invariants of the schema before the
+service layer arrives. Three groups of tests:
+
+1. **Model defaults** — fresh rows carry the expected zero state so the
+   streak-init path in the service layer can rely on it.
+2. **Partial unique on attempts** — the partial index that resolves
+   the "two browser tabs" race for live attempts (but allows unlimited
+   archive replays).
+3. **Streak constraints** — the CHECK constraints that guarantee
+   non-negative counters survive the ORM round-trip.
+
+The Postgres-only invariants (the schedule-publishability trigger,
+the column-level REVOKE on ``options.is_correct``) are exercised by
+the schema-smoke-postgres CI job, not here — SQLite has no triggers
+or column-level grants.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session  # noqa: TC002 — used at runtime by fixture annotations
+
+from app.models.daily_challenge import (
+    DailyChallengeAttempt,
+    DailyChallengeOption,
+    DailyChallengeQuestion,
+    DailyChallengeQuestionStatus,
+    DailyChallengeQuestionType,
+    DailyChallengeSchedule,
+    DailyChallengeStreak,
+)
+from app.models.user import User, UserRole
+
+
+@pytest.fixture
+def author(db: Session) -> User:
+    """A teacher user that owns the questions we seed below."""
+    u = User(
+        id=uuid.uuid4(),
+        email=f"dc-author-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Daily Challenge Author",
+        role=UserRole.TEACHER.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+@pytest.fixture
+def student(db: Session) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email=f"dc-student-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Daily Challenge Student",
+        role=UserRole.STUDENT.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _make_question(
+    db: Session,
+    *,
+    author_id: uuid.UUID,
+    status: str = "draft",
+    rejected: bool = False,
+) -> DailyChallengeQuestion:
+    """Build a minimal valid question. Translatable text doesn't land
+    here — the Daily Challenge service layer writes to cv. For schema
+    tests we just need the structural row."""
+    q = DailyChallengeQuestion(
+        question_type=DailyChallengeQuestionType.MULTIPLE_CHOICE.value,
+        status=status,
+        rejected=rejected,
+        created_by=author_id,
+        bible_book="Romans",
+        bible_chapter=8,
+        bible_verse_from=1,
+        bible_verse_to=1,
+        category="passage_exegesis",
+        source_locale="en",
+    )
+    db.add(q)
+    db.flush()
+    for i in range(4):
+        db.add(
+            DailyChallengeOption(
+                question_id=q.id,
+                is_correct=(i == 0),
+                order_index=i,
+            )
+        )
+    db.commit()
+    db.refresh(q)
+    return q
+
+
+# ---------------------------------------------------------------------------
+# Model defaults
+# ---------------------------------------------------------------------------
+
+
+class TestQuestionDefaults:
+    def test_fresh_question_lands_in_draft_status(self, db: Session, author: User):
+        q = _make_question(db, author_id=author.id)
+        assert q.status == DailyChallengeQuestionStatus.DRAFT.value
+        assert q.rejected is False
+        assert q.published_at is None
+
+    def test_options_round_trip_with_order_and_correctness(self, db: Session, author: User):
+        q = _make_question(db, author_id=author.id)
+        opts = sorted(q.options, key=lambda o: o.order_index)
+        assert [o.order_index for o in opts] == [0, 1, 2, 3]
+        # Exactly one correct option — invariant the service layer
+        # asserts at commit time. Schema doesn't enforce it (would
+        # fight a multi-row INSERT that hasn't reached a coherent
+        # state yet) but the test asserts the helper produced it.
+        assert sum(1 for o in opts if o.is_correct) == 1
+        assert opts[0].is_correct is True
+
+
+class TestStreakDefaults:
+    def test_fresh_streak_starts_at_zero(self, db: Session, student: User):
+        s = DailyChallengeStreak(user_id=student.id)
+        db.add(s)
+        db.commit()
+        db.refresh(s)
+        assert s.current_streak == 0
+        assert s.longest_streak == 0
+        assert s.last_engaged_date is None
+
+
+# ---------------------------------------------------------------------------
+# Partial unique on attempts
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptUniqueness:
+    def test_two_live_attempts_same_user_same_date_violates(self, db: Session, author: User, student: User):
+        """The race-resolving partial unique. Same (user, date)
+        cannot have two live attempts. The second INSERT raises
+        ``IntegrityError`` — the route catches that and returns the
+        first attempt verbatim.
+        """
+        q = _make_question(db, author_id=author.id, status="published", rejected=False)
+        today = date(2026, 5, 29)
+        db.add(
+            DailyChallengeAttempt(
+                user_id=student.id,
+                question_id=q.id,
+                challenge_date=today,
+                is_archive=False,
+                is_correct=True,
+                streak_after=1,
+            )
+        )
+        db.commit()
+
+        # Second live attempt on the same date for the same user — should fail.
+        db.add(
+            DailyChallengeAttempt(
+                user_id=student.id,
+                question_id=q.id,
+                challenge_date=today,
+                is_archive=False,
+                is_correct=False,
+                streak_after=1,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_archive_replays_allowed_unbounded_for_same_user_same_date(self, db: Session, author: User, student: User):
+        """Archive attempts are excluded from the partial unique — a
+        student can replay yesterday's question as many times as they
+        want without violating any constraint. Streak math is decoupled
+        via the CHECK on ``streak_after`` (NULL for archives)."""
+        q = _make_question(db, author_id=author.id, status="published", rejected=False)
+        past_date = date(2026, 5, 20)
+        for _ in range(3):
+            db.add(
+                DailyChallengeAttempt(
+                    user_id=student.id,
+                    question_id=q.id,
+                    challenge_date=past_date,
+                    is_archive=True,
+                    is_correct=False,
+                    streak_after=None,
+                )
+            )
+        db.commit()
+        rows = db.query(DailyChallengeAttempt).filter_by(user_id=student.id, challenge_date=past_date).all()
+        assert len(rows) == 3
+
+    def test_one_live_attempt_plus_archive_replays_coexist(self, db: Session, author: User, student: User):
+        """The user submitted a live attempt today, then later replayed
+        an OLD question whose challenge_date happens to equal today
+        (a question previously scheduled for today is also available
+        in the archive — edge case but valid). The live attempt is
+        gated by the partial unique; the archive replay slips past."""
+        q1 = _make_question(db, author_id=author.id, status="published", rejected=False)
+        q2 = _make_question(db, author_id=author.id, status="published", rejected=False)
+        today = date(2026, 5, 29)
+        db.add(
+            DailyChallengeAttempt(
+                user_id=student.id,
+                question_id=q1.id,
+                challenge_date=today,
+                is_archive=False,
+                is_correct=True,
+                streak_after=5,
+            )
+        )
+        db.add(
+            DailyChallengeAttempt(
+                user_id=student.id,
+                question_id=q2.id,
+                challenge_date=today,
+                is_archive=True,
+                is_correct=True,
+                streak_after=None,
+            )
+        )
+        db.commit()
+        assert db.query(DailyChallengeAttempt).filter_by(user_id=student.id, challenge_date=today).count() == 2
+
+
+class TestStreakCheckConstraints:
+    def test_negative_current_streak_violates_check(self, db: Session, student: User):
+        s = DailyChallengeStreak(user_id=student.id, current_streak=-1)
+        db.add(s)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Schedule wiring
+# ---------------------------------------------------------------------------
+
+
+class TestSchedule:
+    def test_one_schedule_per_date(self, db: Session, author: User):
+        """``challenge_date`` is the PK on the schedule table — exactly
+        one question per UTC day. The second INSERT for the same date
+        raises an IntegrityError on the PK."""
+        q1 = _make_question(db, author_id=author.id, status="published", rejected=False)
+        q2 = _make_question(db, author_id=author.id, status="published", rejected=False)
+        today = date(2026, 5, 29)
+        db.add(
+            DailyChallengeSchedule(
+                challenge_date=today,
+                question_id=q1.id,
+                scheduled_by=author.id,
+            )
+        )
+        db.commit()
+        db.add(
+            DailyChallengeSchedule(
+                challenge_date=today,
+                question_id=q2.id,
+                scheduled_by=author.id,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()

--- a/backend/tests/test_daily_challenge_service.py
+++ b/backend/tests/test_daily_challenge_service.py
@@ -1,0 +1,371 @@
+"""Sprint 2 service-layer + endpoint tests for the Daily Challenge.
+
+Three groups:
+
+1. **Streak math** — the YouVersion-style increment / reset / no-op
+   rules. Pure unit tests on ``apply_streak_for_attempt`` so the rules
+   are pinned independently of the route layer.
+2. **Attempt race resolution** — the partial-unique-driven "two tabs"
+   race; the second call to ``submit_today_attempt`` must return the
+   first attempt's record verbatim without double-incrementing the
+   streak.
+3. **Endpoints** — happy path + error paths for ``GET /today``,
+   ``POST /today/attempt``, ``GET /streak`` using FastAPI's TestClient.
+
+Question + option text is seeded via ``record_human_version`` calls
+into ``content_versions`` to mirror how the Sprint 3 editorial
+pipeline will land them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.models.daily_challenge import (
+    DailyChallengeAttempt,
+    DailyChallengeOption,
+    DailyChallengeQuestion,
+    DailyChallengeSchedule,
+    DailyChallengeStreak,
+)
+from app.models.user import User, UserRole
+from app.services.content_versions.write import record_human_version
+from app.services.daily_challenge import (
+    InvalidOptionError,
+    NoScheduleError,
+    apply_streak_for_attempt,
+    submit_today_attempt,
+)
+from app.services.daily_challenge.schedule import utc_today
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def author(db: Session) -> User:
+    u = User(
+        id=uuid.uuid4(),
+        email=f"dc-author-{uuid.uuid4().hex[:8]}@example.com",
+        full_name="Test Author",
+        role=UserRole.TEACHER.value,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _seed_question_with_options(
+    db: Session,
+    *,
+    author_id: uuid.UUID,
+    status: str = "published",
+    source_locale: str = "en",
+) -> DailyChallengeQuestion:
+    """Build a fully-stocked published question + 4 options. Translatable
+    text lands in content_versions via record_human_version, matching
+    what the Sprint 3 editorial pipeline will do.
+    """
+    q = DailyChallengeQuestion(
+        question_type="multiple_choice",
+        status=status,
+        published_at=datetime.now(UTC) if status == "published" else None,
+        published_by=author_id if status == "published" else None,
+        created_by=author_id,
+        bible_book="Romans",
+        bible_chapter=8,
+        bible_verse_from=1,
+        bible_verse_to=1,
+        category="passage_exegesis",
+        source_locale=source_locale,
+    )
+    db.add(q)
+    db.flush()
+
+    record_human_version(
+        db,
+        entity_type="daily_challenge_question",
+        entity_id=str(q.id),
+        field="question_text",
+        locale=source_locale,
+        text="In Romans 8:1, who is free from condemnation?",
+        authored_by=author_id,
+    )
+    record_human_version(
+        db,
+        entity_type="daily_challenge_question",
+        entity_id=str(q.id),
+        field="explanation",
+        locale=source_locale,
+        text="Romans 8:1 — no condemnation for those in Christ Jesus.",
+        authored_by=author_id,
+    )
+
+    option_texts = [
+        ("Those in Christ Jesus", True),
+        ("Those who keep the law", False),
+        ("Those who are baptized", False),
+        ("Those born of God", False),
+    ]
+    for idx, (text, is_correct) in enumerate(option_texts):
+        opt = DailyChallengeOption(
+            question_id=q.id,
+            is_correct=is_correct,
+            order_index=idx,
+        )
+        db.add(opt)
+        db.flush()
+        record_human_version(
+            db,
+            entity_type="daily_challenge_option",
+            entity_id=str(opt.id),
+            field="option_text",
+            locale=source_locale,
+            text=text,
+            authored_by=author_id,
+        )
+
+    db.commit()
+    db.refresh(q)
+    return q
+
+
+def _schedule_for_today(db: Session, question: DailyChallengeQuestion, scheduled_by: uuid.UUID) -> None:
+    db.add(
+        DailyChallengeSchedule(
+            challenge_date=utc_today(),
+            question_id=question.id,
+            scheduled_by=scheduled_by,
+        )
+    )
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Streak math
+# ---------------------------------------------------------------------------
+
+
+class TestStreakMath:
+    """Pin the YouVersion-style streak rules. ANY attempt counts; the
+    streak math doesn't care about correctness."""
+
+    def test_first_ever_attempt_creates_row_at_one(self, db: Session, student):
+        new = apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 29))
+        assert new == 1
+        row = db.query(DailyChallengeStreak).filter_by(user_id=student.id).one()
+        assert row.current_streak == 1
+        assert row.longest_streak == 1
+        assert row.last_engaged_date == date(2026, 5, 29)
+
+    def test_same_day_resubmit_is_idempotent(self, db: Session, student):
+        d = date(2026, 5, 29)
+        apply_streak_for_attempt(db, user_id=student.id, challenge_date=d)
+        repeat = apply_streak_for_attempt(db, user_id=student.id, challenge_date=d)
+        assert repeat == 1
+        row = db.query(DailyChallengeStreak).filter_by(user_id=student.id).one()
+        assert row.current_streak == 1
+
+    def test_consecutive_day_increments(self, db: Session, student):
+        apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 28))
+        new = apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 29))
+        assert new == 2
+        row = db.query(DailyChallengeStreak).filter_by(user_id=student.id).one()
+        assert row.longest_streak == 2
+
+    def test_one_day_gap_resets_to_one(self, db: Session, student):
+        apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 28))
+        # Skip 2026-05-29 entirely; come back 2026-05-30. That's a gap
+        # of one missed day → reset (YouVersion strict; no grace
+        # tokens per the locked decisions).
+        new = apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 30))
+        assert new == 1
+        row = db.query(DailyChallengeStreak).filter_by(user_id=student.id).one()
+        # Longest is held even after the reset.
+        assert row.longest_streak == 1
+        assert row.current_streak == 1
+
+    def test_longer_gap_resets_to_one(self, db: Session, student):
+        apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 1))
+        new = apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 29))
+        assert new == 1
+
+    def test_longest_streak_tracks_max_across_resets(self, db: Session, student):
+        for delta in range(5):
+            apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 1) + timedelta(days=delta))
+        # Reset
+        apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 20))
+        row = db.query(DailyChallengeStreak).filter_by(user_id=student.id).one()
+        assert row.current_streak == 1
+        assert row.longest_streak == 5
+
+    def test_backward_date_is_noop(self, db: Session, student):
+        """Clock skew / test fixture / manual backfill submits a date
+        earlier than last_engaged. Defensive: no-op rather than
+        decrementing the counter."""
+        apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 29))
+        result = apply_streak_for_attempt(db, user_id=student.id, challenge_date=date(2026, 5, 28))
+        assert result == 1
+        row = db.query(DailyChallengeStreak).filter_by(user_id=student.id).one()
+        assert row.current_streak == 1
+        assert row.last_engaged_date == date(2026, 5, 29)
+
+
+# ---------------------------------------------------------------------------
+# Attempt service — race + invalid option + idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitTodayAttempt:
+    def test_no_schedule_raises(self, db: Session, author: User, student: User):
+        # Question exists but no schedule row for today.
+        q = _seed_question_with_options(db, author_id=author.id)
+        opt_id = q.options[0].id
+        with pytest.raises(NoScheduleError):
+            submit_today_attempt(db, user_id=student.id, selected_option_id=opt_id)
+
+    def test_invalid_option_raises(self, db: Session, author: User, student: User):
+        q = _seed_question_with_options(db, author_id=author.id)
+        _schedule_for_today(db, q, author.id)
+        with pytest.raises(InvalidOptionError):
+            submit_today_attempt(
+                db,
+                user_id=student.id,
+                selected_option_id=uuid.uuid4(),  # nonexistent
+            )
+
+    def test_correct_answer_records_streak_one(self, db: Session, author: User, student: User):
+        q = _seed_question_with_options(db, author_id=author.id)
+        _schedule_for_today(db, q, author.id)
+        correct = next(o for o in q.options if o.is_correct)
+        outcome = submit_today_attempt(db, user_id=student.id, selected_option_id=correct.id)
+        assert outcome.attempt.is_correct is True
+        assert outcome.streak_after == 1
+        assert outcome.is_new_attempt is True
+
+    def test_wrong_answer_still_records_streak_one_youversion_style(self, db: Session, author: User, student: User):
+        """Vadym's locked decision: any attempt counts for the streak.
+        Wrong answers still move the streak."""
+        q = _seed_question_with_options(db, author_id=author.id)
+        _schedule_for_today(db, q, author.id)
+        wrong = next(o for o in q.options if not o.is_correct)
+        outcome = submit_today_attempt(db, user_id=student.id, selected_option_id=wrong.id)
+        assert outcome.attempt.is_correct is False
+        assert outcome.streak_after == 1
+
+    def test_double_submit_returns_first_attempt_without_double_streak(self, db: Session, author: User, student: User):
+        """The "two browser tabs" race. The second call to
+        submit_today_attempt must return the first attempt verbatim
+        and NOT call the streak service a second time."""
+        q = _seed_question_with_options(db, author_id=author.id)
+        _schedule_for_today(db, q, author.id)
+        correct = next(o for o in q.options if o.is_correct)
+
+        first = submit_today_attempt(db, user_id=student.id, selected_option_id=correct.id)
+        # Second submission, same user, same day — simulates the
+        # second-tab race. Service should return the existing attempt
+        # and not double-count the streak.
+        second = submit_today_attempt(db, user_id=student.id, selected_option_id=correct.id)
+
+        assert second.attempt.id == first.attempt.id
+        assert second.is_new_attempt is False
+        assert second.streak_after == 1
+
+        attempts = db.query(DailyChallengeAttempt).filter_by(user_id=student.id, challenge_date=utc_today()).all()
+        assert len(attempts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestDailyChallengeEndpoints:
+    def test_today_returns_404_when_nothing_scheduled(self, db: Session, student_client: TestClient):
+        resp = student_client.get("/api/v1/daily-challenge/today")
+        assert resp.status_code == 404
+        detail = resp.json()["detail"]
+        assert detail["code"] == "daily_challenge.not_scheduled"
+
+    def test_today_returns_question_without_answer_key(
+        self,
+        db: Session,
+        author: User,
+        student_client: TestClient,
+    ):
+        q = _seed_question_with_options(db, author_id=author.id)
+        _schedule_for_today(db, q, author.id)
+        resp = student_client.get(
+            "/api/v1/daily-challenge/today",
+            headers={"Accept-Language": "en"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["question_text"].startswith("In Romans 8:1")
+        # Answer key is NOT in the response — only resolved option_text +
+        # id + order_index.
+        for opt in body["options"]:
+            assert "is_correct" not in opt
+            assert "option_text" in opt
+        assert body["already_attempted"] is False
+        assert body["user_attempt"] is None
+
+    def test_post_attempt_reveals_explanation_and_correct_id(
+        self,
+        db: Session,
+        author: User,
+        student_client: TestClient,
+    ):
+        q = _seed_question_with_options(db, author_id=author.id)
+        _schedule_for_today(db, q, author.id)
+        correct = next(o for o in q.options if o.is_correct)
+        resp = student_client.post(
+            "/api/v1/daily-challenge/today/attempt",
+            json={"selected_option_id": str(correct.id)},
+            headers={"Accept-Language": "en"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["is_correct"] is True
+        assert body["correct_option_id"] == str(correct.id)
+        assert body["streak_after"] == 1
+        assert body["explanation"]
+
+    def test_post_attempt_invalid_option_is_422(
+        self,
+        db: Session,
+        author: User,
+        student_client: TestClient,
+    ):
+        q = _seed_question_with_options(db, author_id=author.id)
+        _schedule_for_today(db, q, author.id)
+        resp = student_client.post(
+            "/api/v1/daily-challenge/today/attempt",
+            json={"selected_option_id": str(uuid.uuid4())},
+            headers={"Accept-Language": "en"},
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert detail["code"] == "daily_challenge.invalid_option"
+
+    def test_streak_endpoint_returns_zero_for_fresh_user(
+        self,
+        db: Session,
+        student_client: TestClient,
+    ):
+        resp = student_client.get("/api/v1/daily-challenge/streak")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["current_streak"] == 0
+        assert body["longest_streak"] == 0
+        assert body["last_engaged_date"] is None

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -59,6 +59,9 @@ def test_enum_values_are_stable_strings():
         "translation.worker_unconfigured",
         "quiz.not_open",
         "quiz.attempts_exhausted",
+        "daily_challenge.not_scheduled",
+        "daily_challenge.already_attempted",
+        "daily_challenge.invalid_option",
         "validation.failed",
     }
     assert {member.value for member in ErrorCode} == expected

--- a/backend/tests/test_translation_registry.py
+++ b/backend/tests/test_translation_registry.py
@@ -82,6 +82,11 @@ def test_registry_field_names_exist_on_models():
         "quiz_option",
         "course",
         "module",
+        # Phase 5c: daily challenge questions + options are bilingual
+        # surfaces by design and have no source text columns. Their
+        # text lives only in content_versions.
+        "daily_challenge_question",
+        "daily_challenge_option",
     }
     for entity_type, reg in REGISTRY.items():
         if entity_type in cv_only_entities:

--- a/frontend/src/lib/errorCode.ts
+++ b/frontend/src/lib/errorCode.ts
@@ -47,6 +47,10 @@ export type ErrorCode =
   // quiz / assignment
   | "quiz.not_open"
   | "quiz.attempts_exhausted"
+  // daily challenge
+  | "daily_challenge.not_scheduled"
+  | "daily_challenge.already_attempted"
+  | "daily_challenge.invalid_option"
   // validation
   | "validation.failed"
 

--- a/supabase/migrations/20260529210000_add_daily_challenge_foundation.sql
+++ b/supabase/migrations/20260529210000_add_daily_challenge_foundation.sql
@@ -1,0 +1,437 @@
+-- =====================================================================
+-- Phase 5c — Daily Challenge MVP foundation.
+--
+-- Five tables. Platform-wide (one question per UTC date for everyone).
+-- Question types: multiple_choice + true_false ONLY (auto-validatable by
+-- option_id; no string-match fuzziness). Pre-built bank — editorial team
+-- creates questions; daily rotation picks from the approved pool.
+-- =====================================================================
+--
+-- Architecture decisions locked 2026-05-29 by Vadym after a 4-agent
+-- parallel design review (memory:
+-- project-equip-daily-challenge-decisions.md). Highlights load-bearing
+-- to read before changing this schema:
+--
+--   1. Platform-wide, NOT school-scoped. challenge_date is the natural
+--      key on the schedule table — exactly one question per UTC date.
+--   2. Streak = YouVersion-style. ANY submission (correct or wrong)
+--      counts as a streak day. No grace tokens in MVP — if streak
+--      semantics ever tighten, that's an additive migration.
+--   3. No XP table in MVP. Vadym wants XP later; deliberately deferred
+--      until the design is locked. Add via append-only migration.
+--   4. 5-stage editorial pipeline before a question publishes:
+--        draft -> scripture_validated -> doctrinally_reviewed
+--              -> bilingually_reviewed -> pilot_passed -> published.
+--      Rejection is orthogonal to stage progression — captured by
+--      ``rejected`` boolean + ``rejection_reason`` text columns. A
+--      rejected question stays at whatever stage killed it but is
+--      excluded from publishing forever.
+--   5. Translatable text lives in ``content_versions`` via new entity
+--      types ``daily_challenge_question`` + ``daily_challenge_option``.
+--      No text columns on the tables below. Source-locale detection +
+--      dual-write follow the existing pattern used by courses, quizzes,
+--      announcements.
+--   6. Canonical answer-key text is KJV (1769) + Synodal (1876). The
+--      correct option must be defensible from BOTH translations. That
+--      rule is enforced in the editorial pipeline (Stage 2 =
+--      scripture_validated), not by the DB.
+--   7. Archive = full calendar of past questions; users can replay
+--      historical questions. Archive attempts carry zero streak impact
+--      via the ``is_archive`` flag + the partial unique index that only
+--      enforces uniqueness on live attempts.
+--
+-- This migration ships the FOUNDATION (tables, RLS, indexes,
+-- constraints). The 6-round AI question-generation flow + its audit
+-- trail table land in a follow-up migration in Sprint 3. Service layer
+-- + API endpoints land in Sprint 2.
+
+-- ---------------------------------------------------------------------
+-- 1. daily_challenge_questions
+-- ---------------------------------------------------------------------
+-- The editorial bank. Translatable fields (question_text, explanation)
+-- live in content_versions — entity_type='daily_challenge_question'.
+-- The ``status`` column drives the editorial workflow; the ``rejected``
+-- flag is the orthogonal kill-switch.
+
+CREATE TABLE daily_challenge_questions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Auto-validatable types only. Adding new types is an enum bump
+    -- via append-only migration; the CHECK constraint catches drift
+    -- against the Pydantic ``Literal`` at the API edge.
+    question_type   TEXT NOT NULL
+                    CHECK (question_type IN ('multiple_choice', 'true_false')),
+
+    -- Forward progression through the editorial pipeline. Status
+    -- NEVER moves backward; a rejected question stays at its current
+    -- stage but with ``rejected=true``. Only ``status='published'
+    -- AND rejected=false`` is eligible to be scheduled.
+    status          TEXT NOT NULL DEFAULT 'draft'
+                    CHECK (status IN (
+                        'draft',
+                        'scripture_validated',
+                        'doctrinally_reviewed',
+                        'bilingually_reviewed',
+                        'pilot_passed',
+                        'published',
+                        'archived'
+                    )),
+
+    -- Orthogonal to ``status``. When ``rejected=true``, the question is
+    -- terminally out of the rotation regardless of stage. The reason
+    -- is free-text rather than an enum so the editor can capture a
+    -- 1-2 line note ("answer ambiguous in NIV", "doctrinal lean toward
+    -- dispensationalism") without us pre-enumerating every shape.
+    rejected         BOOLEAN NOT NULL DEFAULT FALSE,
+    rejection_reason TEXT,
+    rejected_by      UUID REFERENCES profiles(id) ON DELETE SET NULL,
+    rejected_at      TIMESTAMPTZ,
+
+    -- Lifecycle audit: who promoted to each terminal-ish stage?
+    -- ``published_at`` doubles as the second gate that scheduling
+    -- enforces. ``approved_*`` is the moment the editor flipped the
+    -- bilingually_reviewed → pilot_passed → published terminal sequence;
+    -- the schedule trigger needs to see published_at set.
+    published_at    TIMESTAMPTZ,
+    published_by    UUID REFERENCES profiles(id) ON DELETE SET NULL,
+
+    -- Author / provenance. ``created_by`` may be NULL when an AI-only
+    -- draft hasn't been claimed by a human yet (Sprint 3).
+    created_by      UUID REFERENCES profiles(id) ON DELETE SET NULL,
+
+    -- Scripture anchor — every question must cite a verse range. Used
+    -- by Stage 2 (scripture_validated) to verify the cited passage
+    -- exists and supports the answer. The bible book set is fixed
+    -- across history — a 64-char text column covers UTF-8 names in
+    -- both EN ('Romans') and RU ('Послание к Римлянам'). Verse numbers
+    -- nullable so a question can reference a whole chapter
+    -- ('Romans 8') if it really must.
+    bible_book       TEXT NOT NULL,
+    bible_chapter    INT NOT NULL CHECK (bible_chapter > 0),
+    bible_verse_from INT CHECK (bible_verse_from IS NULL OR bible_verse_from > 0),
+    bible_verse_to   INT CHECK (bible_verse_to IS NULL
+                                OR (bible_verse_from IS NOT NULL
+                                    AND bible_verse_to >= bible_verse_from)),
+
+    -- Editorial category. Drives the launch-mix composition (see Agent
+    -- C's brief — ~40% narrative, ~35% exegesis, ~15% cross-reference,
+    -- ~10% historical-cultural). No CHECK constraint because we want
+    -- categories to evolve without a migration; Pydantic Literal at
+    -- the API edge is the gate.
+    category         TEXT,
+
+    -- Source locale of the human-authored text. Detected by the
+    -- write helper via ``detect_locale`` on question text +
+    -- explanation, same pattern as ``courses.source_locale``.
+    source_locale    TEXT,
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- "Show me drafts / scripture-validated / ... / published" editorial
+-- queue. Partial keeps the working set hot — archived + rejected
+-- rows are the cold tail.
+CREATE INDEX ix_dc_questions_status_created
+    ON daily_challenge_questions (status, created_at DESC)
+    WHERE rejected = FALSE AND status <> 'archived';
+
+-- Schedulable pool: only published, not rejected, not archived. Drives
+-- the editorial "pick a question for date X" UI and the schedule
+-- trigger.
+CREATE INDEX ix_dc_questions_publishable
+    ON daily_challenge_questions (published_at)
+    WHERE status = 'published' AND rejected = FALSE;
+
+-- Reverse-lookup from a scripture reference. Used by the editorial
+-- "have we already written a question on this passage?" duplicate
+-- check.
+CREATE INDEX ix_dc_questions_scripture
+    ON daily_challenge_questions (bible_book, bible_chapter, bible_verse_from);
+
+-- ---------------------------------------------------------------------
+-- 2. daily_challenge_options
+-- ---------------------------------------------------------------------
+-- One row per option. ``option_text`` lives in ``content_versions``
+-- (entity_type='daily_challenge_option', field='option_text'). For
+-- true_false questions: exactly 2 options, ``order_index`` 0 = True /
+-- 1 = False. For multiple_choice: 3-6 options typically; ``order_index``
+-- determines render order. Application-level invariant: exactly one
+-- option per question has ``is_correct=true``. Not a DB trigger because
+-- it would fight transactional INSERTs that build the question +
+-- options in one batch; the service layer enforces it at commit time.
+
+CREATE TABLE daily_challenge_options (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    question_id   UUID NOT NULL REFERENCES daily_challenge_questions(id)
+                    ON DELETE CASCADE,
+    is_correct    BOOLEAN NOT NULL DEFAULT FALSE,
+    -- Bounded so a malformed import can't blow up the render. Six
+    -- options is more than any Bible MCQ should ever need; tighter at
+    -- the Pydantic edge.
+    order_index   INT NOT NULL DEFAULT 0
+                    CHECK (order_index BETWEEN 0 AND 5),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ix_dc_options_question
+    ON daily_challenge_options (question_id, order_index);
+
+-- ---------------------------------------------------------------------
+-- 3. daily_challenge_schedule
+-- ---------------------------------------------------------------------
+-- One row per UTC date. PK is the date itself — at most one question
+-- live per day. The schedule trigger enforces the "only
+-- published+non-rejected questions can be scheduled" gate; ON DELETE
+-- RESTRICT on the FK to questions ensures a scheduled question can't
+-- vanish under the day it's scheduled for.
+
+CREATE TABLE daily_challenge_schedule (
+    challenge_date  DATE PRIMARY KEY,
+    question_id     UUID NOT NULL REFERENCES daily_challenge_questions(id)
+                    ON DELETE RESTRICT,
+    scheduled_by    UUID REFERENCES profiles(id) ON DELETE SET NULL,
+    scheduled_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Reverse lookup: "show me every date this question has been on".
+-- Editorial uses this to surface re-use (we may eventually allow a
+-- question to be re-aired after a long cooldown).
+CREATE INDEX ix_dc_schedule_question
+    ON daily_challenge_schedule (question_id);
+
+-- Trigger-enforced "only published, not rejected, not archived
+-- questions can be scheduled". Done via a trigger because Postgres
+-- CHECK constraints cannot reference another table's columns.
+CREATE OR REPLACE FUNCTION dc_schedule_assert_publishable()
+RETURNS trigger AS $$
+DECLARE
+    q_status TEXT;
+    q_rejected BOOLEAN;
+    q_pub TIMESTAMPTZ;
+BEGIN
+    SELECT status, rejected, published_at
+      INTO q_status, q_rejected, q_pub
+      FROM daily_challenge_questions
+     WHERE id = NEW.question_id;
+
+    IF q_status IS DISTINCT FROM 'published' THEN
+        RAISE EXCEPTION 'daily_challenge_schedule.question_id % is not at status=published (current: %)',
+            NEW.question_id, q_status
+            USING ERRCODE = 'check_violation';
+    END IF;
+    IF q_rejected THEN
+        RAISE EXCEPTION 'daily_challenge_schedule.question_id % is rejected; cannot schedule', NEW.question_id
+            USING ERRCODE = 'check_violation';
+    END IF;
+    IF q_pub IS NULL THEN
+        RAISE EXCEPTION 'daily_challenge_schedule.question_id % has NULL published_at', NEW.question_id
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER dc_schedule_publishable_guard
+    BEFORE INSERT OR UPDATE OF question_id ON daily_challenge_schedule
+    FOR EACH ROW EXECUTE FUNCTION dc_schedule_assert_publishable();
+
+-- ---------------------------------------------------------------------
+-- 4. daily_challenge_attempts
+-- ---------------------------------------------------------------------
+-- Per-user attempt. Live attempts (is_archive=false) impact the
+-- streak; archive replays (is_archive=true) never do — that's the
+-- "you can revisit yesterday's question without resetting your
+-- streak math" guarantee.
+
+CREATE TABLE daily_challenge_attempts (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id              UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    question_id          UUID NOT NULL REFERENCES daily_challenge_questions(id)
+                            ON DELETE CASCADE,
+    -- For live attempts: equals daily_challenge_schedule.challenge_date
+    -- (the UTC date the question was the daily question). For archive
+    -- attempts: the historical date the user is replaying. Stored, not
+    -- derived, so the partial unique index can include it cheaply.
+    challenge_date       DATE NOT NULL,
+    is_archive           BOOLEAN NOT NULL DEFAULT FALSE,
+    selected_option_id   UUID REFERENCES daily_challenge_options(id) ON DELETE SET NULL,
+    is_correct           BOOLEAN NOT NULL,
+    -- Materialised post-attempt for observability — "what was the
+    -- streak right after this submit?" The streak service writes this
+    -- under the same FOR UPDATE lock as the streak row update.
+    -- NULL on archive attempts (enforced by CHECK below).
+    streak_after         INT,
+    submitted_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Archive attempts never touch the streak.
+    CHECK (NOT is_archive OR streak_after IS NULL)
+);
+
+-- The race-resolving partial unique. At most ONE live attempt per
+-- (user_id, challenge_date) — the second INSERT raises IntegrityError
+-- and the route returns the existing attempt. Archive replays are
+-- allowed unlimited times so the partial WHERE excludes them.
+CREATE UNIQUE INDEX uniq_dc_attempts_live_per_day
+    ON daily_challenge_attempts (user_id, challenge_date)
+    WHERE is_archive = FALSE;
+
+-- Profile / history view.
+CREATE INDEX ix_dc_attempts_user_date
+    ON daily_challenge_attempts (user_id, challenge_date DESC);
+
+-- "How hard was this question?" editorial difficulty heatmap.
+CREATE INDEX ix_dc_attempts_question
+    ON daily_challenge_attempts (question_id);
+
+-- ---------------------------------------------------------------------
+-- 5. daily_challenge_streaks
+-- ---------------------------------------------------------------------
+-- Per-user counter. One row per user — created lazily on first
+-- attempt via ON CONFLICT DO UPDATE in the streak service.
+--
+-- YouVersion-style semantics (Vadym 2026-05-29):
+--   * Any submission (right or wrong) counts as engagement.
+--   * On submit: if last_engaged_date < challenge_date, increment
+--     current_streak by 1 (idempotent via uniqueness check).
+--   * If last_engaged_date < challenge_date - 1 (i.e. missed at least
+--     one full day in between), current_streak resets to 1 (today's
+--     attempt is itself the start of a new streak).
+--   * No grace tokens in MVP — strictness is acceptable because the
+--     bar for "engagement" is just attempting (not getting it right).
+--   * longest_streak tracks all-time so the user has a permanent
+--     accomplishment even after a reset.
+--   * No XP. Vadym wants XP added later via an additive migration
+--     once the rules are designed; intentionally absent here.
+
+CREATE TABLE daily_challenge_streaks (
+    user_id                  UUID PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+    current_streak           INT NOT NULL DEFAULT 0
+                                CHECK (current_streak >= 0),
+    longest_streak           INT NOT NULL DEFAULT 0
+                                CHECK (longest_streak >= 0),
+    last_engaged_date        DATE,
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Cohort-style "everyone with active recent streaks" query. Used by
+-- the at-risk notification job: "find users with current_streak >= 3
+-- who haven't engaged today." Partial keeps the index tight.
+CREATE INDEX ix_dc_streaks_last_engaged
+    ON daily_challenge_streaks (last_engaged_date)
+    WHERE current_streak >= 1;
+
+-- =====================================================================
+-- Row-Level Security
+-- =====================================================================
+--
+-- service_role bypasses RLS automatically — backend writes flow
+-- through it. The policies below cover the PostgREST surface that an
+-- authenticated user JWT can hit directly.
+
+ALTER TABLE daily_challenge_questions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_options   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_schedule  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_attempts  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_streaks   ENABLE ROW LEVEL SECURITY;
+
+-- Questions: students see archive (past dates' published questions) +
+-- today's question (but the backend slices off ``options.is_correct``
+-- and the answer-key fields before responding). Editorial role (teacher
+-- + admin) sees everything including drafts. The "today's question"
+-- read is routed through the backend service_role for the answer-key
+-- redaction; the direct PostgREST read is for the archive surface.
+
+CREATE POLICY dc_questions_select_archive ON daily_challenge_questions
+    FOR SELECT TO authenticated
+    USING (
+        status = 'published'
+        AND rejected = FALSE
+        AND EXISTS (
+            SELECT 1 FROM daily_challenge_schedule s
+             WHERE s.question_id = daily_challenge_questions.id
+               AND s.challenge_date <= (now() AT TIME ZONE 'UTC')::date
+        )
+    );
+
+CREATE POLICY dc_questions_select_editorial ON daily_challenge_questions
+    FOR SELECT TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM profiles p
+             WHERE p.id = (SELECT auth.uid())
+               AND p.role IN ('teacher', 'admin')
+        )
+    );
+
+-- Options: piggy-back on the parent question's visibility.
+CREATE POLICY dc_options_select_via_question ON daily_challenge_options
+    FOR SELECT TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM daily_challenge_questions q
+             WHERE q.id = daily_challenge_options.question_id
+               AND (
+                    (q.status = 'published' AND q.rejected = FALSE
+                     AND EXISTS (
+                         SELECT 1 FROM daily_challenge_schedule s
+                          WHERE s.question_id = q.id
+                            AND s.challenge_date <= (now() AT TIME ZONE 'UTC')::date
+                     ))
+                    OR EXISTS (
+                         SELECT 1 FROM profiles p
+                          WHERE p.id = (SELECT auth.uid())
+                            AND p.role IN ('teacher', 'admin')
+                     )
+               )
+        )
+    );
+
+-- Schedule: students see past + today (today's question_id is needed
+-- to JOIN on options for rendering). The backend redacts the answer
+-- key in the API response.
+CREATE POLICY dc_schedule_select_visible ON daily_challenge_schedule
+    FOR SELECT TO authenticated
+    USING (
+        challenge_date <= (now() AT TIME ZONE 'UTC')::date
+        OR EXISTS (
+            SELECT 1 FROM profiles p
+             WHERE p.id = (SELECT auth.uid())
+               AND p.role IN ('teacher', 'admin')
+        )
+    );
+
+-- Attempts + streaks: each user sees only their own row.
+CREATE POLICY dc_attempts_select_own ON daily_challenge_attempts
+    FOR SELECT TO authenticated
+    USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY dc_streaks_select_own ON daily_challenge_streaks
+    FOR SELECT TO authenticated
+    USING (user_id = (SELECT auth.uid()));
+
+-- All writes go through the backend (service_role). Belt-and-suspenders
+-- REVOKE mirrors the 20260515184512_rls_tighten_write_policies.sql
+-- pattern.
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_questions FROM authenticated, anon;
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_options   FROM authenticated, anon;
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_schedule  FROM authenticated, anon;
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_attempts  FROM authenticated, anon;
+REVOKE INSERT, UPDATE, DELETE ON daily_challenge_streaks   FROM authenticated, anon;
+
+-- Column-level defence on the answer key. Even if a student knows
+-- today's question_id and bypasses the API to query options directly
+-- via PostgREST, the ``is_correct`` column is hidden from them. The
+-- backend, running under service_role, still sees the column.
+-- Without this, an RLS SELECT policy that lets authenticated users
+-- read options (necessary for archive rendering) would leak the
+-- answer key.
+--
+-- Editorial role (teacher + admin) needs ``is_correct`` to manage the
+-- question. Granting back to authenticated WHERE role IN
+-- ('teacher','admin') is not expressible via column-level GRANT — RLS
+-- already controls which rows they see, but column-level grants are
+-- per-role, not per-policy. The right pattern: keep ``is_correct``
+-- revoked from ``authenticated`` entirely, and have the editorial UI
+-- read through a backend route (which uses service_role).
+REVOKE SELECT (is_correct) ON daily_challenge_options FROM authenticated, anon;


### PR DESCRIPTION
Phase 5c Sprint 2 — student-facing endpoints + service layer. **Stacked on PR #610; merge that first.**

Until #610 merges this PR shows both the foundation commit and the Sprint 2 commits; once #610 lands the diff naturally shrinks to just Sprint 2.

### Services
- `streak.py` — `apply_streak_for_attempt` with FOR UPDATE + YouVersion math (same-day idempotent, consecutive +1, gap reset, backward-date no-op)
- `attempt.py` — `submit_today_attempt` resolves the two-tab race via partial-unique IntegrityError catch; idempotent
- `schedule.py` — `get_today_question` + `utc_today()`
- `text.py` — bilingual resolver

### Endpoints
- `GET /daily-challenge/today` (answer key stripped, embeds existing attempt)
- `POST /daily-challenge/today/attempt` (reveal: correct_option_id + explanation + streak)
- `GET /daily-challenge/streak` (zeros for fresh user)

### New error codes
`daily_challenge.not_scheduled` / `already_attempted` / `invalid_option` — mirrored to frontend.

### Tests
17 new (997 total): streak math (7), submit + race (5), endpoints (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)