### PR TITLE
chore(daily-challenge): post-audit follow-ups — pilot_reviews index + icon stroke

### DIFF
--- a/backend/app/models/daily_challenge.py
+++ b/backend/app/models/daily_challenge.py
@@ -378,6 +378,7 @@ class DailyChallengePilotReview(Base):
             name="dc_pilot_reviews_rating_check",
         ),
         Index("ix_dc_pilot_reviews_question", "question_id"),
+        Index("ix_dc_pilot_reviews_reviewer", "reviewer_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/frontend/src/components/dashboard/DailyChallengeCard.tsx
+++ b/frontend/src/components/dashboard/DailyChallengeCard.tsx
@@ -73,9 +73,9 @@ function OptionButton({ option, reveal, disabled, onClick }: OptionButtonProps) 
         )}
       >
         {showAsCorrect ? (
-          <Check className="h-3 w-3" strokeWidth={2} />
+          <Check className="h-3 w-3" strokeWidth={1.75} />
         ) : showAsWrong ? (
-          <X className="h-3 w-3" strokeWidth={2} />
+          <X className="h-3 w-3" strokeWidth={1.75} />
         ) : (
           String.fromCharCode(65 + option.order_index)
         )}

--- a/supabase/migrations/20260530010000_dc_pilot_reviews_reviewer_index.sql
+++ b/supabase/migrations/20260530010000_dc_pilot_reviews_reviewer_index.sql
@@ -1,0 +1,6 @@
+-- Adds an index on daily_challenge_pilot_reviews.reviewer_id so
+-- "rows reviewed by user X" queries don't sequential-scan as the
+-- pilot pool grows. Surfaced by the post-Sprint-6 architectural audit.
+
+CREATE INDEX IF NOT EXISTS ix_dc_pilot_reviews_reviewer
+    ON daily_challenge_pilot_reviews (reviewer_id);


### PR DESCRIPTION
## Summary

Closes the two NEEDS-FIX items from the 4-agent architectural audit after PRs #613-#615.

### 1. Index on `daily_challenge_pilot_reviews.reviewer_id`
Perf audit caught: FK existed but no index. "Rows reviewed by user X" queries would seq-scan as the pilot pool grew. Adds the index in both the SQLAlchemy `__table_args__` and a Supabase migration.

**Migration applied to prod via Supabase MCP** during this session.

### 2. Icon stroke weight on the Daily Challenge reveal badge
Frontend UX audit caught: `Check` + `X` icons inside the reveal-state circles used `strokeWidth={2}`, breaking the design-system rule of `strokeWidth={1.75}` across all icons.

## Other audit results (no action needed, FYI)

| Dimension | Verdict | Notes |
|---|---|---|
| Security | **PASS** | All 7 invariants verified — answer-key isolation, role gating, max_length, no SQLi, RLS, schedule trigger, no Gemini-key leakage |
| Bilingual | **PASS** | 4-way translation registry mirror intact; orchestrator dual-writes EN + RU cv rows; Bible book localization is a known follow-up |
| Perf + integrity | **PASS** (except this PR's fix) | FK indexes, FOR UPDATE on streak, IntegrityError race resolution, CASCADE semantics, schedule PK |
| Frontend UX | **PASS** (except this PR's fix) | Loading/empty/dark-mode/a11y all check out |

## Test plan

- [x] `ruff check`, `mypy` clean
- [x] **1023 backend tests pass**
- [x] `npm run lint`, `tsc --noEmit` clean
- [x] **4 DailyChallengeCard tests pass** after icon update
- [x] Migration `20260530010000_dc_pilot_reviews_reviewer_index.sql` applied to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)