### PR TITLE
chore(empty-states): unify ModuleList + CertificatesPage on EmptyState pattern

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1586,6 +1586,7 @@
     "percentComplete": "{{percent}}% complete",
     "modulesHeading": "Modules",
     "noModulesAddedYet": "No modules added yet",
+    "noModulesAddedYetDescription": "The teacher hasn't published any modules for this course. Check back soon — they'll appear here as they're added.",
     "openModule": "Open",
     "moduleLocked": "Locked",
     "moduleLockHint": "Complete all assessments in the previous module to unlock.",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1243,6 +1243,7 @@
     "percentComplete": "{{percent}}% завершено",
     "modulesHeading": "Модули",
     "noModulesAddedYet": "Модули ещё не добавлены",
+    "noModulesAddedYetDescription": "Преподаватель пока не опубликовал ни одного модуля. Загляните позже — они появятся здесь.",
     "openModule": "Открыть",
     "moduleLocked": "Заблокировано",
     "moduleLockHint": "Завершите все задания предыдущего модуля, чтобы разблокировать.",

--- a/frontend/src/pages/Certificates/CertificatesPage.tsx
+++ b/frontend/src/pages/Certificates/CertificatesPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { ErrorState } from "@/components/patterns"
+import { EmptyState, ErrorState } from "@/components/patterns"
 import { coursesService } from "@/services/courses"
 import type { Certificate, Enrollment } from "@/types"
 import { Award, ArrowLeft, RefreshCw, ScrollText } from "lucide-react"
@@ -111,20 +111,16 @@ export default function CertificatesPage() {
           }
         />
       ) : certificates.length === 0 ? (
-        <Card className="border-dashed">
-          <CardContent className="flex flex-col items-center justify-center py-20 text-center">
-            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-              <ScrollText className="h-8 w-8 text-muted-foreground/50" strokeWidth={1.75} />
-            </div>
-            <h3 className="mb-1 text-lg font-medium">{t("certificates.emptyTitle")}</h3>
-            <p className="mb-6 max-w-sm text-sm text-muted-foreground">
-              {t("certificates.emptyDescription")}
-            </p>
+        <EmptyState
+          icon={<ScrollText strokeWidth={1.75} aria-hidden />}
+          title={t("certificates.emptyTitle")}
+          description={t("certificates.emptyDescription")}
+          action={
             <Link to="/courses">
               <Button size="sm">{t("certificates.browseCourses")}</Button>
             </Link>
-          </CardContent>
-        </Card>
+          }
+        />
       ) : (
         <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
           {certificates.map((cert) => {

--- a/frontend/src/pages/Course/detail/ModuleList.tsx
+++ b/frontend/src/pages/Course/detail/ModuleList.tsx
@@ -11,11 +11,11 @@ import {
 import { Button } from "@/components/ui/button"
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { EmptyState } from "@/components/patterns"
 import { StaggerChildren } from "@/components/motion"
 import { isGradableChapterType } from "@/lib/chapterTypes"
 import type { Module } from "@/types"
@@ -51,11 +51,11 @@ export function ModuleList({ courseId, modules, completedChapterIds }: Props) {
           ))}
         </StaggerChildren>
       ) : (
-        <Card className="border-dashed">
-          <CardContent className="py-8 text-center text-muted-foreground text-sm">
-            {t("courseDetail.noModulesAddedYet")}
-          </CardContent>
-        </Card>
+        <EmptyState
+          icon={<BookOpen strokeWidth={1.75} aria-hidden />}
+          title={t("courseDetail.noModulesAddedYet")}
+          description={t("courseDetail.noModulesAddedYetDescription")}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Replaces two custom Card-based empty states with the shared `EmptyState` pattern from `frontend/src/components/patterns/`. Both were already editorial in tone but ran their own DOM, drifting from the rest of the app.

- **ModuleList** (course detail): bordered-dashed `Card` → `EmptyState` (default variant) with `BookOpen` icon + new description aimed at the student waiting on a teacher.
- **CertificatesPage**: bespoke `Card` with a manually-styled centered icon ring → `EmptyState` (default variant) preserving the existing title + description + "Browse courses" CTA.

## Two P1 items dropped after closer read

- `VirtualAdminUsers`: parent `UsersCard.tsx:235` already short-circuits to `EmptyUsers` BEFORE mounting the react-window list. The audit's "virtual list renders empty div" worry never reaches the user.
- `PendingTeachers` / `PendingCerts` "disappear-when-empty" — a product UX decision (always-mount with zero state vs. omit), not a code fix. Left for Vadym to call.

## i18n

1 new key: `courseDetail.noModulesAddedYetDescription` in en + ru. Locale parity holds (`en.json: 1576`, `ru.json: 1634`).

## Test plan

- [x] `npm run lint` (eslint --max-warnings 0)
- [x] `npx tsc --noEmit` clean
- [x] `npm run i18n:check` — locale bundles in parity
- [x] **324 frontend tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)