### PR TITLE
fix(votd): walk forward when a verse isn't in the target bible

### DIFF
--- a/backend/app/services/verse_of_the_day.py
+++ b/backend/app/services/verse_of_the_day.py
@@ -331,6 +331,13 @@ class VerseOfTheDayUnavailable(Exception):
     """
 
 
+class VerseNotInBible(Exception):
+    """Distinct from ``VerseOfTheDayUnavailable``: the upstream Bible
+    simply doesn't carry this reference. Used to drive the
+    Septuagint/Masoretic fallback walk for locales whose Psalm
+    numbering doesn't match our catalog's (NRT in particular)."""
+
+
 @dataclass(frozen=True)
 class VerseOfTheDay:
     reference: str
@@ -365,6 +372,22 @@ def _pick_reference(date: dt.date) -> str:
     return _VERSES[date.toordinal() % len(_VERSES)]
 
 
+# Cap on how far we walk forward when a verse is missing in the target
+# bible. Eight is plenty: a contiguous run of eight missing references
+# across the curated catalog would mean something far worse than a
+# Septuagint/Masoretic mismatch (more like the bible itself is dead),
+# and at that point silent-hide is the right behaviour anyway.
+_FALLBACK_WALK_CAP = 8
+
+
+def _pick_reference_offset(date: dt.date, offset: int) -> str:
+    """Pick the ``offset``-th-after-today reference. Wraps via modulo
+    so the walk-forward fallback can't run off the end of the
+    catalog. Together with ``_FALLBACK_WALK_CAP`` this makes the
+    fallback bounded and deterministic for a given (date, locale)."""
+    return _VERSES[(date.toordinal() + offset) % len(_VERSES)]
+
+
 def _strip_html(html: str) -> str:
     """YouVersion ``content`` may include a single ``<p>`` wrapper and
     occasional ``<span>`` markers. We render scripture as plain prose in
@@ -383,10 +406,19 @@ def _fetch_passage(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
     """Return ``(localized_reference, plain_text)`` from YouVersion.
 
     Wrapped here so tests can monkeypatch this single function.
+
+    Raises ``VerseNotInBible`` when YouVersion returns 404 — the bible
+    is fine, the reference just doesn't exist in this translation
+    (typically a Psalm versification difference). Callers can walk
+    forward in the catalog to find the next valid ref. Any other
+    non-200 status raises ``VerseOfTheDayUnavailable`` (treated as a
+    transient outage, not a content gap).
     """
     url = f"{YOUVERSION_API_BASE}/bibles/{bible_id}/passages/{ref}"
     with httpx.Client(timeout=8.0) as client:
         response = client.get(url, headers={"X-YVP-App-Key": api_key})
+    if response.status_code == 404:
+        raise VerseNotInBible(f"YouVersion has no {ref} for bible {bible_id}")
     if response.status_code != 200:
         raise VerseOfTheDayUnavailable(f"YouVersion responded {response.status_code} for {ref} (bible {bible_id})")
     payload = response.json()
@@ -426,14 +458,33 @@ def get_verse_of_the_day(locale: LocaleCode, *, today: dt.date | None = None) ->
     if cached is not None:
         return cached
 
-    ref = _pick_reference(today)
-    try:
-        localized_ref, text = _fetch_passage(api_key, bible_id, ref)
-    except httpx.HTTPError as exc:
-        # Don't pollute logs with a stack trace on the happy path of
-        # "YouVersion blipped"; the route already maps this to 404.
-        logger.warning("YouVersion request failed: %s", exc)
-        raise VerseOfTheDayUnavailable("YouVersion request failed") from exc
+    # Septuagint/Masoretic Psalm numbering differs between Russian
+    # NRT and our canonical-English catalog: e.g. PSA.27.14 (catalog)
+    # has no NRT counterpart because NRT uses Hebrew numbering. Walk
+    # forward through the catalog when the chosen ref is genuinely
+    # absent from the bible; the deterministic offset means every
+    # client lands on the same fallback verse for the same UTC day.
+    last_not_in_bible: VerseNotInBible | None = None
+    localized_ref: str | None = None
+    text: str | None = None
+    for offset in range(_FALLBACK_WALK_CAP):
+        ref = _pick_reference_offset(today, offset)
+        try:
+            localized_ref, text = _fetch_passage(api_key, bible_id, ref)
+            break
+        except VerseNotInBible as exc:
+            last_not_in_bible = exc
+            continue
+        except httpx.HTTPError as exc:
+            # Don't pollute logs with a stack trace on the happy path of
+            # "YouVersion blipped"; the route already maps this to 404.
+            logger.warning("YouVersion request failed: %s", exc)
+            raise VerseOfTheDayUnavailable("YouVersion request failed") from exc
+    if localized_ref is None or text is None:
+        # Catalog exhausted — every ref in the walk was missing. Logging
+        # the last seen 404 helps spot catalog rot if it ever happens.
+        logger.warning("VOTD walk cap exceeded for locale %s: %s", locale, last_not_in_bible)
+        raise VerseOfTheDayUnavailable(f"No reference in catalog available in bible {bible_id}; last attempted: {ref}")
 
     verse = VerseOfTheDay(
         reference=localized_ref,

--- a/backend/tests/test_verse_of_the_day.py
+++ b/backend/tests/test_verse_of_the_day.py
@@ -137,3 +137,62 @@ def test_route_returns_404_when_apikey_missing(monkeypatch):
         resp = tc.get("/api/v1/verse-of-the-day?locale=en")
     assert resp.status_code == 404
     assert resp.json()["detail"]["message"] == "verse_of_the_day_unavailable"
+
+
+def test_walks_forward_on_verse_not_in_bible(monkeypatch):
+    """NRT lacks some Psalm verses due to Septuagint/Masoretic
+    numbering differences. The service must walk forward in the
+    catalog until a present reference is found, and the chosen
+    fallback must be deterministic for (date, locale)."""
+    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    today = dt.date(2026, 5, 31)
+    primary = svc._pick_reference(today)
+    fallback = svc._pick_reference_offset(today, 1)
+    seen: list[str] = []
+
+    def _selective(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
+        seen.append(ref)
+        if ref == primary:
+            raise svc.VerseNotInBible(f"no {ref} in {bible_id}")
+        return f"{ref} ru-ref", "RU body"
+
+    monkeypatch.setattr(svc, "_fetch_passage", _selective)
+    verse = svc.get_verse_of_the_day("ru", today=today)
+    assert verse.reference == f"{fallback} ru-ref"
+    assert seen == [primary, fallback]
+
+
+def test_walks_forward_then_caches_the_fallback(monkeypatch):
+    """A successful walk-forward fallback must cache so the second
+    call on the same UTC date does NOT walk again."""
+    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    today = dt.date(2026, 5, 31)
+    primary = svc._pick_reference(today)
+    calls = {"n": 0}
+
+    def _selective(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
+        calls["n"] += 1
+        if ref == primary:
+            raise svc.VerseNotInBible(f"no {ref} in {bible_id}")
+        return "fallback-ref", "fallback body"
+
+    monkeypatch.setattr(svc, "_fetch_passage", _selective)
+    svc.get_verse_of_the_day("ru", today=today)
+    svc.get_verse_of_the_day("ru", today=today)
+    # First call: 2 fetches (primary 404 → fallback ok). Second call:
+    # 0 fetches (cache hit). Total: 2.
+    assert calls["n"] == 2
+
+
+def test_gives_up_after_walk_cap(monkeypatch):
+    """If every reference in the walk window is absent, surface the
+    standard ``VerseOfTheDayUnavailable`` so the frontend hides the
+    card silently — never expose a partial / broken state."""
+    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+
+    def _always_missing(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
+        raise svc.VerseNotInBible(f"no {ref} in {bible_id}")
+
+    monkeypatch.setattr(svc, "_fetch_passage", _always_missing)
+    with pytest.raises(svc.VerseOfTheDayUnavailable):
+        svc.get_verse_of_the_day("ru", today=dt.date(2026, 5, 31))


### PR DESCRIPTION
## Summary

Today on prod: `GET /verse-of-the-day?locale=ru` returns 404 because NRT (YouVersion bible id 143) doesn't have `PSA.27.14`. Result: the dashboard verse card silently hides for every Russian user — has been hidden whenever the deterministic ref lands on one of the 8 Psalm refs out of 50 that NRT doesn't carry (versification difference — NRT uses Hebrew/Masoretic numbering vs the catalog's convention).

## The fix

A bounded walk-forward fallback inside `get_verse_of_the_day`:

1. New `VerseNotInBible` exception distinguishes "passage not in this translation" from "YouVersion blipped"
2. On `VerseNotInBible`, walk up to 8 catalog entries forward (deterministic per date+locale)
3. Successful result caches normally — at most one walk per locale per day per Python process

Tests added: walk-forward selection + walk-result caching + cap-exhaustion fallback to the standard "unavailable" path.

## Test plan

- [x] 14 VOTD unit tests pass (3 new for the walk-forward path)
- [x] **1026 backend tests pass**
- [x] `ruff`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)