### PR TITLE
feat(daily-challenge): localize Bible book name in /today response

### DIFF
--- a/backend/app/api/v1/daily_challenge.py
+++ b/backend/app/api/v1/daily_challenge.py
@@ -30,6 +30,7 @@ from app.schemas.daily_challenge import (
     DailyChallengeTodayResponse,
 )
 from app.schemas.locale import normalize_locale
+from app.services.bible.books import display_book_name, find_book
 from app.services.daily_challenge import (
     InvalidOptionError,
     NoScheduleError,
@@ -111,6 +112,14 @@ def get_today(
             submitted_at=existing.submitted_at,
         )
 
+    # Localize the book name server-side so the client doesn't need
+    # to ship a 66-entry vocabulary. Fall back to the canonical English
+    # book name when the locale isn't bundled or the slug is unknown
+    # (defensive — the editorial pipeline only accepts canonical
+    # references, but a future ingest path might not).
+    slug = find_book(question.bible_book)
+    bible_book_label = (display_book_name(slug, display_locale) if slug is not None else None) or question.bible_book
+
     return DailyChallengeTodayResponse(
         challenge_date=schedule.challenge_date,
         question_id=question.id,
@@ -121,6 +130,7 @@ def get_today(
         question_text=bundle.question_text,
         options=options_view,
         bible_book=question.bible_book,
+        bible_book_label=bible_book_label,
         bible_chapter=question.bible_chapter,
         bible_verse_from=question.bible_verse_from,
         bible_verse_to=question.bible_verse_to,

--- a/backend/app/schemas/daily_challenge.py
+++ b/backend/app/schemas/daily_challenge.py
@@ -63,6 +63,11 @@ class DailyChallengeTodayResponse(BaseModel):
     options: list[DailyChallengeOptionStudentView]
     # Bible reference for "open this passage" link on the card.
     bible_book: str
+    # Localized short-form book label (e.g. "Ин." for ru, "John" for en)
+    # rendered straight into the card heading so the client doesn't have
+    # to ship the book vocabulary. Falls back to ``bible_book`` (the raw
+    # canonical English) when the locale isn't bundled.
+    bible_book_label: str
     bible_chapter: int
     bible_verse_from: int | None
     bible_verse_to: int | None

--- a/backend/tests/test_daily_challenge_service.py
+++ b/backend/tests/test_daily_challenge_service.py
@@ -319,6 +319,28 @@ class TestDailyChallengeEndpoints:
             assert "option_text" in opt
         assert body["already_attempted"] is False
         assert body["user_attempt"] is None
+        # Book label localized for EN locale (canonical English).
+        assert body["bible_book"] == "Romans"
+        assert body["bible_book_label"] == "Rom."
+
+    def test_today_book_label_localizes_to_russian_under_ru_locale(
+        self,
+        db: Session,
+        author: User,
+        student_client: TestClient,
+    ):
+        q = _seed_question_with_options(db, author_id=author.id)
+        _schedule_for_today(db, q, author.id)
+        resp = student_client.get(
+            "/api/v1/daily-challenge/today",
+            headers={"Accept-Language": "ru"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        # ``bible_book`` stays the canonical English (for analytics/joins);
+        # ``bible_book_label`` is the localized short-form.
+        assert body["bible_book"] == "Romans"
+        assert body["bible_book_label"] == "Рим."
 
     def test_post_attempt_reveals_explanation_and_correct_id(
         self,

--- a/frontend/src/components/dashboard/DailyChallengeCard.tsx
+++ b/frontend/src/components/dashboard/DailyChallengeCard.tsx
@@ -217,14 +217,11 @@ export function DailyChallengeCard() {
           ? `${data.bible_verse_from}-${data.bible_verse_to}`
           : `${data.bible_verse_from}`
         : ""
-    // Bilingual book-name rendering is a backend concern — the server
-    // already returns the book in the caller's Accept-Language locale
-    // for cv-backed fields. For now the API ships the canonical English
-    // slug; a follow-up will localise it server-side rather than
-    // duplicating the book table on the client.
+    // The backend returns ``bible_book_label`` already localized per the
+    // caller's ``Accept-Language`` (e.g. "Ин." for ru, "John" for en).
     return range
-      ? `${data.bible_book} ${data.bible_chapter}:${range}`
-      : `${data.bible_book} ${data.bible_chapter}`
+      ? `${data.bible_book_label} ${data.bible_chapter}:${range}`
+      : `${data.bible_book_label} ${data.bible_chapter}`
   }, [data])
 
   return (

--- a/frontend/src/components/dashboard/__tests__/DailyChallengeCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DailyChallengeCard.test.tsx
@@ -39,6 +39,7 @@ function todayPayload(overrides: Partial<Parameters<typeof Object.assign>[0]> = 
       { id: "o-4", option_text: "A new covenant", order_index: 3 },
     ],
     bible_book: "John",
+    bible_book_label: "John",
     bible_chapter: 3,
     bible_verse_from: 16,
     bible_verse_to: null,

--- a/frontend/src/services/dailyChallenge.ts
+++ b/frontend/src/services/dailyChallenge.ts
@@ -23,6 +23,8 @@ export interface DailyChallengeTodayResponse {
   question_text: string
   options: DailyChallengeOption[]
   bible_book: string
+  /** Localized short-form book label (e.g. "Ин." for ru, "John" for en). */
+  bible_book_label: string
   bible_chapter: number
   bible_verse_from: number | null
   bible_verse_to: number | null


### PR DESCRIPTION
## Summary

Closes a Sprint-4 follow-up: the `DailyChallengeCard` heading rendered the canonical English book name ("John 3:14") even in the Russian UI. Fix is server-side via the existing `app/services/bible/books.display_book_name` so the card stays free of a 66-entry book vocabulary.

## Changes

**Backend**
- `DailyChallengeTodayResponse` gains `bible_book_label` — short-form label localized via `Accept-Language`. Falls back to `bible_book` when the slug isn't recognised or the locale isn't bundled.
- `/daily-challenge/today` resolves `find_book(...)` → `display_book_name(slug, display_locale)`.
- Two new tests pin: en → `"Rom."`, ru → `"Рим."`. `bible_book` itself stays canonical English (preserved for analytics joins).

**Frontend**
- `dailyChallenge.ts` types the new field.
- `DailyChallengeCard` uses `data.bible_book_label` in `verseLabel`. The Sprint-4 "follow-up" comment is gone.

## Test plan
- [x] **1027 backend tests pass** (2 new), mypy + ruff clean
- [x] **324 frontend tests pass**, eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)