### PR TITLE
fix(votd): remap Hebrew→Septuagint Psalm numbering for NRT

### DIFF
--- a/backend/app/services/verse_of_the_day.py
+++ b/backend/app/services/verse_of_the_day.py
@@ -338,6 +338,46 @@ class VerseNotInBible(Exception):
     numbering doesn't match our catalog's (NRT in particular)."""
 
 
+# Hebrew Psalm chapter → Septuagint chapter for the simple-offset
+# range. Outside this range the mapping is non-injective (chapters
+# 9-10, 114-116, 147 either combine or split), so we refuse those
+# rather than serve a different verse. Catalog references in the
+# "complex" range raise ``VerseNotInBible`` for Septuagint-numbered
+# bibles, which triggers the walk-forward to the next clean entry.
+_SEPTUAGINT_PSALM_OFFSET_RANGE = (11, 113, 117, 146)
+_SEPTUAGINT_LOCALES = frozenset({"ru"})
+
+
+def _remap_ref_for_locale(ref: str, locale: LocaleCode) -> str | None:
+    """Translate a catalog (Hebrew-numbered) reference into the
+    upstream-bible's numbering for the given locale.
+
+    Returns ``None`` when the reference falls in a chapter where
+    Hebrew↔Septuagint psalm splits/combines (Hebrew 9, 10, 114, 115,
+    116, 147) — the caller treats that as "not in this bible" and
+    advances. Everything else maps cleanly: 1-8 and 148-150 are
+    identical across both numbering systems; 11-113 and 117-146 take
+    a -1 offset for Septuagint-numbered bibles like NRT.
+    """
+    if locale not in _SEPTUAGINT_LOCALES:
+        return ref
+    if not ref.startswith("PSA."):
+        return ref
+    try:
+        _, chapter_str, verse_str = ref.split(".", 2)
+        chapter = int(chapter_str)
+    except (ValueError, IndexError):
+        return ref
+    low_a, high_a, low_b, high_b = _SEPTUAGINT_PSALM_OFFSET_RANGE
+    if 1 <= chapter <= 8 or 148 <= chapter <= 150:
+        return ref
+    if low_a <= chapter <= high_a or low_b <= chapter <= high_b:
+        return f"PSA.{chapter - 1}.{verse_str}"
+    # Complex chapters (Hebrew 9, 10, 114, 115, 116, 147) where the
+    # split/combine boundary makes a clean per-verse remap impossible.
+    return None
+
+
 @dataclass(frozen=True)
 class VerseOfTheDay:
     reference: str
@@ -459,18 +499,27 @@ def get_verse_of_the_day(locale: LocaleCode, *, today: dt.date | None = None) ->
         return cached
 
     # Septuagint/Masoretic Psalm numbering differs between Russian
-    # NRT and our canonical-English catalog: e.g. PSA.27.14 (catalog)
-    # has no NRT counterpart because NRT uses Hebrew numbering. Walk
-    # forward through the catalog when the chosen ref is genuinely
-    # absent from the bible; the deterministic offset means every
-    # client lands on the same fallback verse for the same UTC day.
+    # NRT and our canonical-English (Hebrew-numbered) catalog. For the
+    # simple-offset range we remap chapter X → X-1 so the content
+    # matches what BSB returns for the same catalog reference;
+    # complex split/combine boundaries (Hebrew 9-10, 114-116, 147)
+    # raise ``VerseNotInBible`` so the walk advances to a clean entry.
+    # The walk also fires on genuine 404s (verse missing from the
+    # bible entirely). The deterministic offset means every client
+    # lands on the same fallback for the same UTC day.
     last_not_in_bible: VerseNotInBible | None = None
     localized_ref: str | None = None
     text: str | None = None
     for offset in range(_FALLBACK_WALK_CAP):
-        ref = _pick_reference_offset(today, offset)
+        catalog_ref = _pick_reference_offset(today, offset)
+        upstream_ref = _remap_ref_for_locale(catalog_ref, locale)
+        if upstream_ref is None:
+            last_not_in_bible = VerseNotInBible(
+                f"{catalog_ref} falls in the complex Septuagint/Masoretic boundary for locale {locale!r}"
+            )
+            continue
         try:
-            localized_ref, text = _fetch_passage(api_key, bible_id, ref)
+            localized_ref, text = _fetch_passage(api_key, bible_id, upstream_ref)
             break
         except VerseNotInBible as exc:
             last_not_in_bible = exc
@@ -484,7 +533,9 @@ def get_verse_of_the_day(locale: LocaleCode, *, today: dt.date | None = None) ->
         # Catalog exhausted — every ref in the walk was missing. Logging
         # the last seen 404 helps spot catalog rot if it ever happens.
         logger.warning("VOTD walk cap exceeded for locale %s: %s", locale, last_not_in_bible)
-        raise VerseOfTheDayUnavailable(f"No reference in catalog available in bible {bible_id}; last attempted: {ref}")
+        raise VerseOfTheDayUnavailable(
+            f"No reference in catalog available in bible {bible_id}; last error: {last_not_in_bible}"
+        )
 
     verse = VerseOfTheDay(
         reference=localized_ref,

--- a/backend/tests/test_verse_of_the_day.py
+++ b/backend/tests/test_verse_of_the_day.py
@@ -157,7 +157,10 @@ def test_walks_forward_on_verse_not_in_bible(monkeypatch):
         return f"{ref} ru-ref", "RU body"
 
     monkeypatch.setattr(svc, "_fetch_passage", _selective)
-    verse = svc.get_verse_of_the_day("ru", today=today)
+    # Use EN locale so the catalog ref reaches ``_fetch_passage`` without
+    # the Psalms Septuagint remap; the locale-specific remap behaviour
+    # is covered by dedicated tests below.
+    verse = svc.get_verse_of_the_day("en", today=today)
     assert verse.reference == f"{fallback} ru-ref"
     assert seen == [primary, fallback]
 
@@ -177,8 +180,8 @@ def test_walks_forward_then_caches_the_fallback(monkeypatch):
         return "fallback-ref", "fallback body"
 
     monkeypatch.setattr(svc, "_fetch_passage", _selective)
-    svc.get_verse_of_the_day("ru", today=today)
-    svc.get_verse_of_the_day("ru", today=today)
+    svc.get_verse_of_the_day("en", today=today)
+    svc.get_verse_of_the_day("en", today=today)
     # First call: 2 fetches (primary 404 → fallback ok). Second call:
     # 0 fetches (cache hit). Total: 2.
     assert calls["n"] == 2
@@ -195,7 +198,9 @@ def test_gives_up_after_walk_cap(monkeypatch):
 
     monkeypatch.setattr(svc, "_fetch_passage", _always_missing)
     with pytest.raises(svc.VerseOfTheDayUnavailable):
-        svc.get_verse_of_the_day("ru", today=dt.date(2026, 5, 31))
+        # EN locale to avoid the Psalms Septuagint remap shadowing
+        # this cap-exhaustion path; the RU remap has its own tests.
+        svc.get_verse_of_the_day("en", today=dt.date(2026, 5, 31))
 
 
 def test_walk_does_not_consume_transient_errors(monkeypatch):
@@ -213,3 +218,83 @@ def test_walk_does_not_consume_transient_errors(monkeypatch):
     monkeypatch.setattr(svc, "_fetch_passage", _transient)
     with pytest.raises(svc.VerseOfTheDayUnavailable):
         svc.get_verse_of_the_day("en", today=dt.date(2026, 5, 31))
+
+
+def test_remap_psalm_for_ru_simple_offset_range() -> None:
+    """For the simple offset range (Hebrew 11-113, 117-146), NRT
+    references should be one chapter lower than the catalog."""
+    assert svc._remap_ref_for_locale("PSA.23.1", "ru") == "PSA.22.1"
+    assert svc._remap_ref_for_locale("PSA.28.7", "ru") == "PSA.27.7"
+    assert svc._remap_ref_for_locale("PSA.119.105", "ru") == "PSA.118.105"
+    assert svc._remap_ref_for_locale("PSA.121.1", "ru") == "PSA.120.1"
+
+
+def test_remap_psalm_for_ru_identical_range() -> None:
+    """Hebrew Psalms 1-8 and 148-150 match Septuagint numbering."""
+    assert svc._remap_ref_for_locale("PSA.1.1", "ru") == "PSA.1.1"
+    assert svc._remap_ref_for_locale("PSA.4.8", "ru") == "PSA.4.8"
+    assert svc._remap_ref_for_locale("PSA.148.1", "ru") == "PSA.148.1"
+
+
+def test_remap_psalm_for_ru_complex_boundary_refuses() -> None:
+    """Hebrew Psalms 9, 10, 114, 115, 116, 147 split/combine across
+    the boundary — remap returns None so the walk advances."""
+    for ch in (9, 10, 114, 115, 116, 147):
+        assert svc._remap_ref_for_locale(f"PSA.{ch}.1", "ru") is None
+
+
+def test_remap_non_psalm_or_non_ru_is_identity() -> None:
+    """Only the RU (NRT) locale + Psalms book needs remapping."""
+    assert svc._remap_ref_for_locale("JHN.3.16", "ru") == "JHN.3.16"
+    assert svc._remap_ref_for_locale("PSA.23.1", "en") == "PSA.23.1"
+
+
+def test_walk_skips_complex_psalm_chapters_for_ru(monkeypatch) -> None:
+    """When today's catalog ref falls on a complex psalm boundary
+    for RU, the walk must advance to the next catalog entry rather
+    than serving wrong content."""
+    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    today = dt.date(2026, 5, 31)
+    # Find an offset where the catalog hits a complex chapter; fall
+    # back to monkey-stubbing the picker so the test is deterministic.
+    seen_refs: list[str] = []
+
+    def _picker(d: dt.date, offset: int) -> str:
+        # offset 0 returns a complex psalm; offset 1 returns a clean one.
+        return ["PSA.9.1", "JHN.3.16"][offset]
+
+    def _stub_fetch(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
+        seen_refs.append(ref)
+        return "От Иоанна 3:16", "Ведь Бог так полюбил мир..."
+
+    monkeypatch.setattr(svc, "_pick_reference_offset", _picker)
+    monkeypatch.setattr(svc, "_fetch_passage", _stub_fetch)
+    verse = svc.get_verse_of_the_day("ru", today=today)
+    assert verse.reference == "От Иоанна 3:16"
+    # The complex PSA.9.1 was skipped without even hitting the API.
+    assert seen_refs == ["JHN.3.16"]
+
+
+def test_psalm_for_ru_uses_remapped_chapter(monkeypatch) -> None:
+    """For an RU Psalm in the simple-offset range, the route must
+    call the upstream API with chapter-1 so the returned content
+    matches the catalog's intent (the Hebrew-numbered verse)."""
+    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    today = dt.date(2026, 6, 1)
+    requested: list[str] = []
+
+    def _picker(d: dt.date, offset: int) -> str:
+        # offset 0 is the day's verse; only one offset needed.
+        return "PSA.28.7" if offset == 0 else "JHN.1.1"
+
+    def _stub_fetch(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
+        requested.append(ref)
+        return "Псалтирь 27:7", "Господь — моя сила и щит"
+
+    monkeypatch.setattr(svc, "_pick_reference_offset", _picker)
+    monkeypatch.setattr(svc, "_fetch_passage", _stub_fetch)
+    verse = svc.get_verse_of_the_day("ru", today=today)
+    assert "сила и щит" in verse.text
+    # Pinned: the upstream request used the SEPTUAGINT reference,
+    # not the Hebrew one the catalog stores.
+    assert requested == ["PSA.27.7"]


### PR DESCRIPTION
## Summary

While verifying prod after merging the dependabot PRs I caught a content-mismatch bug. EN returns BSB "Psalm 28:7" — "The Lord is my strength and my shield" — while RU returns NRT "Псалтирь 28:7" — "Голос Господа как молния разит". Same reference, different verses; users on the two locales were seeing different verses **every day a psalm landed in the rotation**.

## Root cause

NRT uses Septuagint chapter numbering for Psalms 9-147; our catalog uses Hebrew/Masoretic numbering (matching BSB / KJV). PR #619 fixed the 404 case (NRT genuinely lacks Hebrew Psalm 27:14 → walk forward) but missed the 200 case where NRT returns _different content_ under the _same chapter number_.

## The fix

Per-locale ref remap before the upstream call:

| Hebrew chapters | NRT remap |
|---|---|
| 1-8, 148-150 | identity (numbering matches) |
| 11-113, 117-146 | -1 offset |
| 9, 10, 114, 115, 116, 147 | refuse (split/combined boundary) — walk advances |

The remap fires inside the existing walk-forward loop. Today's `PSA.28.7` for RU now queries upstream `PSA.27.7` so the user sees "Господь — моя сила и щит", which is what BSB shows in EN.

## Test plan

- [x] **6 new tests**: simple offset, identity range, complex-boundary refusal, non-psalm/non-ru identity, walk integration (complex skip), happy-path remap upstream call
- [x] **1073 backend tests pass**
- [x] `ruff` + `mypy` clean

The 3 pre-existing walk-forward tests now use the EN locale to exercise the cap+caching paths without the locale-specific remap shadowing them; the RU remap has dedicated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)