### PR TITLE
docs(governance): add GOVERNANCE.md — codebase vs hosted instance + trademark notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ makes a real difference.
 
 ## Table of contents
 
+- [What contributing gives you (and what it doesn't)](#what-contributing-gives-you-and-what-it-doesnt)
 - [Quick start](#quick-start)
 - [Project structure](#project-structure)
 - [Development workflow](#development-workflow)
@@ -15,6 +16,31 @@ makes a real difference.
 - [Finding work to do](#finding-work-to-do)
 - [Style guides](#style-guides)
 - [Getting help](#getting-help)
+
+## What contributing gives you (and what it doesn't)
+
+Equip is two things at once:
+
+1. **The open-source codebase** (`github.com/ArVaViT/equip`, MIT) — anyone
+   can read, fork, self-host, or contribute.
+2. **The hosted instance at [equipbible.com](https://equipbible.com)** —
+   operated by the Equip team. Same code, separately managed brand,
+   moderation, and teacher roster.
+
+Contributing lands your work in (1). It does **not** automatically grant
+you teaching privileges on equipbible.com, admin access to the hosted
+instance, paid roles, or the right to publish courses under the Equip
+brand.
+
+Teaching on equipbible.com requires a separate application covering
+doctrinal alignment and educational background — see
+[`GOVERNANCE.md`](GOVERNANCE.md). Contributors are welcome to apply
+through that channel; writing code is not a shortcut around it.
+
+**If you want full autonomy** — your own teachers, your own doctrinal
+standard, your own brand — that is exactly what the open-source license
+is for. Self-host your own instance and run it under your own name (see
+[`GOVERNANCE.md`](GOVERNANCE.md) for trademark notes).
 
 ## Quick start
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,98 @@
+# Equip Governance
+
+Equip is two distinct things that share a name:
+
+1. **The open-source codebase** at `github.com/ArVaViT/equip` (MIT).
+2. **The hosted instance at [equipbible.com](https://equipbible.com)**,
+   operated by the Equip team.
+
+This document explains how each is governed and how they relate. The
+goal is that nobody — contributor, student, teacher, or fork
+maintainer — invests time under the wrong assumption.
+
+## The codebase
+
+### Decision-making
+
+Equip currently follows a **BDFL** model: Vadym Arnaut (`@ArVaViT`) is
+project lead and has final say on direction, architecture, and merges.
+Day-to-day reviews may be delegated to maintainers as the project grows.
+
+### Becoming a maintainer
+
+There is no formal application. Sustained, high-quality contribution
+across different areas, plus constructive engagement in reviews, earns
+an invitation. Becoming a code maintainer is **independent** of any role
+on the hosted instance.
+
+### Contributor License
+
+By submitting a PR, you license your contribution under the project's
+[MIT License](LICENSE). No separate CLA is required at this time.
+
+## The hosted instance (equipbible.com)
+
+### Who operates it
+
+equipbible.com is operated by the Equip team, currently led by Vadym
+Arnaut. It is a single hosted brand instance, not a federation.
+Decisions about moderation, doctrinal scope, pricing, and hosted-feature
+priorities rest with the Equip team.
+
+### Students
+
+Open registration. Anyone can sign up and enroll in published courses,
+subject to the site's terms of service.
+
+### Teachers
+
+Teaching on equipbible.com requires a separate application that covers:
+
+- **Doctrinal alignment** with the Equip statement of faith.
+  *(TODO: publish the statement of faith at a stable URL and link it
+  here.)*
+- **Educational and ministry background** appropriate for the courses
+  being proposed.
+- Agreement to the teacher conduct guidelines.
+
+Only approved teachers may publish courses on equipbible.com. Code
+contributors are welcome to apply through the same channel —
+contributing code is neither a prerequisite nor a shortcut.
+
+### Suspension
+
+The Equip team may suspend teachers, courses, or accounts that violate
+the doctrinal statement, conduct guidelines, or terms of service.
+Questions go to `supportequip@gmail.com`.
+
+## Forks and self-hosting
+
+The MIT license gives you full freedom to:
+
+- Run your own instance for your own school, denomination, or community
+- Approve your own teachers under your own standards
+- Modify the code for your needs
+
+This is encouraged for groups whose teaching standards, doctrinal scope,
+or governance differ from equipbible.com.
+
+## Trademark
+
+The name **"Equip"**, the `equipbible.com` brand, and associated logos
+are trademarks of the Equip project. The MIT license covers the **code**;
+it does **not** grant the right to use the Equip name or brand to
+identify your own instance.
+
+Concretely:
+
+- ✅ "Powered by Equip (open source)" — fine.
+- ✅ "Based on the Equip LMS" — fine.
+- ❌ Running your fork as "Equip" or in a way that implies you are the
+  official equipbible.com — not allowed.
+
+Brand questions: `supportequip@gmail.com`.
+
+## Contact
+
+- Code questions: GitHub Discussions or Issues
+- Hosted instance / brand: `supportequip@gmail.com`


### PR DESCRIPTION
## Summary

Adds **`GOVERNANCE.md`** at the repo root and a matching section in `CONTRIBUTING.md`. Equip is two things sharing one name — the open-source codebase (MIT) and the hosted equipbible.com brand — and that split was not written down anywhere.

Without this:
- contributors reasonably assume code contributions grant teaching rights on equipbible.com
- forks can run as “Equip” without realizing MIT does not cover trademarks
- doctrinal disagreements have no clear off-ramp (fork-and-self-host)

## What's in GOVERNANCE.md

- **Codebase** — BDFL model under `@ArVaViT`; no CLA (contributions licensed under MIT); maintainership earned through sustained contribution, **independent** of hosted-instance role.
- **Hosted instance (equipbible.com)** — single curated brand, not a federation. Teaching requires a separate application covering doctrinal alignment + educational background.
- **Forks and self-hosting** — explicitly encouraged for groups with different doctrinal scope. “This is what the MIT license is for.”
- **Trademark** — “Equip” / `equipbible.com` are trademarks. MIT covers the code, not the name. Concrete ✅/❌ examples included (✅ “Powered by Equip” / ❌ running your fork as “Equip”).

## CONTRIBUTING.md change

New section **“What contributing gives you (and what it doesn’t)”** + matching TOC entry. Links to `GOVERNANCE.md` so first-time contributors see the boundary before they sink a weekend into a PR.

## Known TODO (intentionally left in)

GOVERNANCE.md has `*(TODO: publish the statement of faith at a stable URL and link it here.)*` — the placeholder ships as-is; the URL lands when the statement is written.

## Test plan

- [x] Docs-only change — no runtime impact, no migrations, no schema work
- [x] Markdown links from CONTRIBUTING.md → GOVERNANCE.md resolve once both files land together in the same commit
- [x] No CI configuration changes; relying on existing markdown checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
