### PR TITLE
test(core): cover http.get_client_ip, course_cover_upload, sanitize edge paths

### DIFF
--- a/backend/tests/test_core_course_cover_upload.py
+++ b/backend/tests/test_core_course_cover_upload.py
@@ -1,0 +1,216 @@
+"""Unit tests for ``app.core.course_cover_upload``.
+
+The course-cover upload helper bridges the FastAPI route to Supabase
+Storage's REST API. It is server-only (uses the service-role key, which
+bypasses storage RLS) and must keep the object layout + public URL shape
+identical to what the frontend already generates via ``getPublicUrl``.
+
+Tests pin three things:
+
+1. ``public_img_path_for_course_cover`` returns the exact same URL shape
+   the frontend builds.
+2. ``upload_course_cover_bytes`` posts to the correct Storage REST
+   endpoint with the right headers (service-role bearer, ``x-upsert``,
+   content-type for the requested image extension).
+3. The error path raises ``RuntimeError`` for non-2xx responses so the
+   caller doesn't silently return a "valid" URL for a failed upload.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.core import course_cover_upload as ccu
+
+
+class TestPublicImgPath:
+    def test_default_extension_is_png(self) -> None:
+        assert ccu.public_img_path_for_course_cover("abc-123", "") == "/img/course-assets/abc-123/cover.png"
+
+    def test_lowercases_extension(self) -> None:
+        assert ccu.public_img_path_for_course_cover("abc-123", "JPG") == "/img/course-assets/abc-123/cover.jpg"
+
+    def test_strips_leading_dot(self) -> None:
+        assert ccu.public_img_path_for_course_cover("abc-123", ".webp") == "/img/course-assets/abc-123/cover.webp"
+
+    def test_unknown_extension_passes_through(self) -> None:
+        """Path builder is permissive — extension normalisation lives in
+        the upload function. This keeps the URL-shape helper a pure
+        string transform with no side-effects or surprises.
+        """
+        assert ccu.public_img_path_for_course_cover("abc-123", "tiff") == "/img/course-assets/abc-123/cover.tiff"
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeClient:
+    """Drop-in for ``httpx.Client`` used in the upload tests. Captures
+    the args the SUT passes so we can assert on URL / headers / body.
+    """
+
+    def __init__(self, *, response: _FakeResponse) -> None:
+        self._response = response
+        self.posted_url: str | None = None
+        self.posted_content: bytes | None = None
+        self.posted_headers: dict[str, str] | None = None
+
+    def __enter__(self) -> _FakeClient:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def post(self, url: str, *, content: bytes, headers: dict[str, str]) -> _FakeResponse:
+        self.posted_url = url
+        self.posted_content = content
+        self.posted_headers = headers
+        return self._response
+
+
+def _install_fake_client(monkeypatch: pytest.MonkeyPatch, response: _FakeResponse) -> _FakeClient:
+    fake = _FakeClient(response=response)
+
+    def factory(*_args: Any, **_kwargs: Any) -> _FakeClient:
+        return fake
+
+    monkeypatch.setattr(ccu.httpx, "Client", factory)
+    return fake
+
+
+class TestUploadCourseCoverBytes:
+    SUPABASE_URL = "https://proj.supabase.co"
+    SERVICE_KEY = "service-role-secret"
+    COURSE_ID = "course-xyz"
+    PAYLOAD = b"\x89PNG\r\n\x1a\nfake-bytes"
+
+    def test_success_returns_public_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _install_fake_client(monkeypatch, _FakeResponse(200))
+        result = ccu.upload_course_cover_bytes(
+            self.SUPABASE_URL,
+            self.SERVICE_KEY,
+            self.COURSE_ID,
+            self.PAYLOAD,
+        )
+        assert result == f"/img/course-assets/{self.COURSE_ID}/cover.png"
+        assert fake.posted_url == (f"{self.SUPABASE_URL}/storage/v1/object/course-assets/{self.COURSE_ID}/cover.png")
+        assert fake.posted_content == self.PAYLOAD
+
+    def test_sends_required_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _install_fake_client(monkeypatch, _FakeResponse(201))
+        ccu.upload_course_cover_bytes(
+            self.SUPABASE_URL,
+            self.SERVICE_KEY,
+            self.COURSE_ID,
+            self.PAYLOAD,
+        )
+        assert fake.posted_headers is not None
+        assert fake.posted_headers["Authorization"] == f"Bearer {self.SERVICE_KEY}"
+        # Supabase REST requires both ``Authorization`` and ``apikey`` for
+        # service-role calls — dropping ``apikey`` returns 401 silently.
+        assert fake.posted_headers["apikey"] == self.SERVICE_KEY
+        # ``x-upsert: true`` is what makes the second upload of a cover
+        # OVERWRITE the first instead of failing with "already exists".
+        assert fake.posted_headers["x-upsert"] == "true"
+
+    @pytest.mark.parametrize(
+        "ext, expected_content_type, expected_object_ext",
+        [
+            ("png", "image/png", "png"),
+            ("PNG", "image/png", "png"),
+            (".jpg", "image/jpeg", "jpg"),
+            ("jpeg", "image/jpeg", "jpeg"),
+            ("webp", "image/webp", "webp"),
+            ("gif", "image/gif", "gif"),
+        ],
+    )
+    def test_known_extensions_map_to_content_type(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        ext: str,
+        expected_content_type: str,
+        expected_object_ext: str,
+    ) -> None:
+        fake = _install_fake_client(monkeypatch, _FakeResponse(200))
+        result = ccu.upload_course_cover_bytes(
+            self.SUPABASE_URL,
+            self.SERVICE_KEY,
+            self.COURSE_ID,
+            self.PAYLOAD,
+            ext=ext,
+        )
+        assert fake.posted_headers is not None
+        assert fake.posted_headers["Content-Type"] == expected_content_type
+        assert fake.posted_url is not None
+        assert fake.posted_url.endswith(f"cover.{expected_object_ext}")
+        assert result.endswith(f"cover.{expected_object_ext}")
+
+    def test_unknown_extension_falls_back_to_png(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unsupported extension (e.g. ``"tiff"``) collapses to
+        ``png`` server-side so the on-disk object always has a content
+        type we know how to serve. The frontend only ever uploads from
+        the supported set, so this is purely defence-in-depth.
+        """
+        fake = _install_fake_client(monkeypatch, _FakeResponse(200))
+        result = ccu.upload_course_cover_bytes(
+            self.SUPABASE_URL,
+            self.SERVICE_KEY,
+            self.COURSE_ID,
+            self.PAYLOAD,
+            ext="tiff",
+        )
+        assert fake.posted_url is not None
+        assert fake.posted_url.endswith("cover.png")
+        assert result.endswith("cover.png")
+
+    def test_trailing_slash_on_supabase_url_is_normalised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _install_fake_client(monkeypatch, _FakeResponse(200))
+        ccu.upload_course_cover_bytes(
+            self.SUPABASE_URL + "/",
+            self.SERVICE_KEY,
+            self.COURSE_ID,
+            self.PAYLOAD,
+        )
+        assert fake.posted_url is not None
+        # No accidental double-slash between origin and ``/storage/v1/...``.
+        assert "//storage/v1/" not in fake.posted_url
+
+    def test_non_2xx_raises_runtime_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_client(monkeypatch, _FakeResponse(500, "Storage backend exploded"))
+        with pytest.raises(RuntimeError) as exc:
+            ccu.upload_course_cover_bytes(
+                self.SUPABASE_URL,
+                self.SERVICE_KEY,
+                self.COURSE_ID,
+                self.PAYLOAD,
+            )
+        # The error message must surface both the status code and the
+        # body prefix so the caller has something to log; without that
+        # an upload outage looks like a 500 with no signal.
+        assert "500" in str(exc.value)
+        assert "Storage backend exploded" in str(exc.value)
+
+    def test_404_also_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing bucket comes back as 404, not 5xx — also a failure."""
+        _install_fake_client(monkeypatch, _FakeResponse(404, "Bucket not found"))
+        with pytest.raises(RuntimeError):
+            ccu.upload_course_cover_bytes(
+                self.SUPABASE_URL,
+                self.SERVICE_KEY,
+                self.COURSE_ID,
+                self.PAYLOAD,
+            )
+
+
+def test_bucket_constant_matches_frontend_path() -> None:
+    """The bucket name is wired into the public URL shape; a rename
+    server-side without updating the frontend would break every existing
+    cover. Pin the constant so the rename is a deliberate two-step.
+    """
+    assert ccu.COURSE_ASSETS_BUCKET == "course-assets"
+    assert ccu.public_img_path_for_course_cover("X", "png").startswith(f"/img/{ccu.COURSE_ASSETS_BUCKET}/")

--- a/backend/tests/test_core_http.py
+++ b/backend/tests/test_core_http.py
@@ -1,0 +1,133 @@
+"""Unit tests for ``app.core.http.get_client_ip``.
+
+``get_client_ip`` is the single source of truth for the real client IP
+behind a reverse proxy. Rate limiting + audit logging both consume it,
+and the trust gate (``_TRUSTED_PROXY``) decides whether we believe the
+``X-Forwarded-For`` / ``X-Real-IP`` headers at all. Spoofing those
+headers in a bare deploy used to let any client farm fresh rate-limit
+buckets, so we pin the trust gate + fallback paths directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from starlette.requests import Request
+
+from app.core import http as core_http
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _make_request(
+    *,
+    headers: dict[str, str] | None = None,
+    client_host: str | None = "127.0.0.1",
+) -> Request:
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope: dict = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": raw_headers,
+        "client": (client_host, 12345) if client_host else None,
+    }
+    return Request(scope)
+
+
+class TestTrustedProxy:
+    """When a trusted reverse proxy is in front of us, X-Forwarded-For
+    is the authoritative source of the real client IP — left-most entry
+    of a comma-separated chain.
+    """
+
+    def test_xff_left_most_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(
+            headers={"x-forwarded-for": "203.0.113.5, 10.0.0.1, 10.0.0.2"},
+        )
+        assert core_http.get_client_ip(req) == "203.0.113.5"
+
+    def test_xff_single_ip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(headers={"x-forwarded-for": "203.0.113.5"})
+        assert core_http.get_client_ip(req) == "203.0.113.5"
+
+    def test_xff_trims_whitespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(
+            headers={"x-forwarded-for": "  203.0.113.5  , 10.0.0.1"},
+        )
+        assert core_http.get_client_ip(req) == "203.0.113.5"
+
+    def test_xff_empty_left_falls_back_to_xri(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An XFF that starts with a blank entry (``"" , 10.0.0.1, ...``)
+        is malformed; we shouldn't return the empty string. The
+        implementation skips the empty value and falls through to
+        ``X-Real-IP`` when present.
+        """
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(
+            headers={
+                "x-forwarded-for": ", 10.0.0.1",
+                "x-real-ip": "203.0.113.9",
+            },
+        )
+        assert core_http.get_client_ip(req) == "203.0.113.9"
+
+    def test_xri_when_no_xff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(headers={"x-real-ip": "203.0.113.7"})
+        assert core_http.get_client_ip(req) == "203.0.113.7"
+
+    def test_xri_whitespace_is_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(headers={"x-real-ip": "  203.0.113.7  "})
+        assert core_http.get_client_ip(req) == "203.0.113.7"
+
+
+class TestUntrustedProxy:
+    """Without a trusted proxy signal we MUST ignore X-Forwarded-For /
+    X-Real-IP — a client controlling the headers would otherwise spoof
+    a fresh rate-limit bucket per request.
+    """
+
+    def test_xff_ignored_when_untrusted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", False)
+        req = _make_request(
+            headers={"x-forwarded-for": "203.0.113.5"},
+            client_host="10.0.0.42",
+        )
+        assert core_http.get_client_ip(req) == "10.0.0.42"
+
+    def test_xri_ignored_when_untrusted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", False)
+        req = _make_request(
+            headers={"x-real-ip": "203.0.113.7"},
+            client_host="10.0.0.42",
+        )
+        assert core_http.get_client_ip(req) == "10.0.0.42"
+
+
+class TestFallback:
+    """Final fallback chain: ``request.client.host`` first, then the
+    caller-supplied ``fallback`` argument (``"unknown"`` for rate
+    limiter, ``None`` for audit logger).
+    """
+
+    def test_returns_client_host_when_no_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(client_host="198.51.100.10")
+        assert core_http.get_client_ip(req) == "198.51.100.10"
+
+    def test_returns_fallback_when_client_missing_and_no_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(client_host=None)
+        assert core_http.get_client_ip(req, fallback="unknown") == "unknown"
+
+    def test_returns_none_fallback_for_audit_logger(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Audit logger passes ``fallback=None`` so the DB column stays NULL."""
+        monkeypatch.setattr(core_http, "_TRUSTED_PROXY", True)
+        req = _make_request(client_host=None)
+        assert core_http.get_client_ip(req, fallback=None) is None

--- a/backend/tests/test_sanitize.py
+++ b/backend/tests/test_sanitize.py
@@ -9,7 +9,13 @@ diagnose. These unit tests pin the sanitizer's behaviour directly.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from app.core import sanitize as sanitize_mod
 from app.core.sanitize import sanitize_string
+
+if TYPE_CHECKING:
+    import pytest
 
 
 class TestBaseAllowlist:
@@ -212,3 +218,118 @@ class TestToggleCalloutAllowlist:
         )
         assert "ontoggle" not in cleaned
         assert "alert" not in cleaned
+
+
+class TestIframeAllowlist:
+    """Iframes are dangerous by default — only YouTube embeds get
+    through. Bleach treats ``iframe`` as a normal allowed tag (it
+    doesn't know which ``src`` values are safe), so the post-filter in
+    ``_strip_dangerous_iframes`` is what actually enforces the embed
+    policy. These tests pin both halves of the decision.
+    """
+
+    def test_youtube_embed_iframe_survives(self):
+        html = (
+            '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="560" height="315" allowfullscreen></iframe>'
+        )
+        cleaned = sanitize_string(html)
+        assert "<iframe" in cleaned
+        assert "youtube.com/embed/dQw4w9WgXcQ" in cleaned
+
+    def test_youtube_nocookie_embed_survives(self):
+        # The privacy-enhanced YouTube embed domain (``youtube-nocookie.com``)
+        # is the recommended embed form for cookie-conscious sites. The
+        # allowlist must accept it alongside the canonical domain.
+        html = '<iframe src="https://www.youtube-nocookie.com/embed/abcDEF12345"></iframe>'
+        cleaned = sanitize_string(html)
+        assert "<iframe" in cleaned
+        assert "youtube-nocookie.com/embed/" in cleaned
+
+    def test_non_youtube_iframe_is_stripped(self):
+        # The iframe wrapper is removed but the surrounding text stays
+        # intact — we strip the dangerous element, we don't blow up the
+        # whole block.
+        cleaned = sanitize_string('<p>before</p><iframe src="https://evil.example.com/track"></iframe><p>after</p>')
+        assert "<iframe" not in cleaned
+        assert "evil.example.com" not in cleaned
+        assert "<p>before</p>" in cleaned
+        assert "<p>after</p>" in cleaned
+
+    def test_iframe_with_no_src_is_stripped(self):
+        # An iframe without ``src`` cannot be a YouTube embed by
+        # construction — the post-filter treats "no src" as the
+        # untrusted case and strips it.
+        cleaned = sanitize_string("<iframe></iframe>")
+        assert "<iframe" not in cleaned
+
+    def test_iframe_with_single_quoted_src_handled(self):
+        # Bleach normalises attribute quoting, but a teacher pasting raw
+        # HTML can produce single-quoted attrs. The regex used by the
+        # post-filter accepts both quote styles.
+        cleaned = sanitize_string("<iframe src='https://www.youtube.com/embed/abc123'></iframe>")
+        # After bleach + post-filter the iframe should survive in some
+        # canonical form (quotes may be normalised).
+        assert "youtube.com/embed/abc123" in cleaned
+
+
+class TestEarlyReturns:
+    """Two zero-cost short-circuit paths in ``sanitize_string`` — both
+    skip the whole bleach + regex pipeline. Pin them so a future
+    refactor that drops the guard surfaces in CI rather than silently
+    starting to allocate per empty-string call.
+    """
+
+    def test_empty_string_returns_empty(self):
+        assert sanitize_string("") == ""
+
+    def test_none_passes_through_unchanged(self):
+        # ``sanitize_string`` is called on Pydantic-validated fields;
+        # an explicit ``None`` shouldn't crash on the ``not value``
+        # truthiness check — it returns the input as-is.
+        assert sanitize_string(None) is None  # type: ignore[arg-type]
+
+
+class TestRegexFallback:
+    """When ``bleach`` is not importable we fall back to a regex strip
+    of the worst offenders (scripts, event handlers, javascript: URLs).
+    This is the path that runs on bare deploys without the optional
+    sanitiser package; the production deploys all ship bleach, but the
+    fallback is the safety net.
+
+    The branch is gated on a module-level ``_HAS_BLEACH`` constant set
+    at import time, so we monkeypatch the flag directly rather than
+    trying to fight the optional dependency at runtime.
+    """
+
+    def test_regex_strips_script_tag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sanitize_mod, "_HAS_BLEACH", False)
+        cleaned = sanitize_string("<p>hi</p><script>alert(1)</script>")
+        assert "<script" not in cleaned
+        # The non-dangerous markup is left alone — regex fallback is a
+        # blacklist, not the bleach allowlist, so unrelated tags pass
+        # through. That's intentional: it's defence-in-depth on top of
+        # DOMPurify, not a primary sanitiser.
+        assert "<p>hi</p>" in cleaned
+
+    def test_regex_strips_event_handler_attr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sanitize_mod, "_HAS_BLEACH", False)
+        cleaned = sanitize_string('<a href="/x" onclick="evil()">x</a>')
+        assert "onclick" not in cleaned
+
+    def test_regex_strips_javascript_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sanitize_mod, "_HAS_BLEACH", False)
+        cleaned = sanitize_string('<a href="javascript:alert(1)">x</a>')
+        assert "javascript:" not in cleaned
+
+    def test_regex_strips_iframe_meta_link(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sanitize_mod, "_HAS_BLEACH", False)
+        cleaned = sanitize_string(
+            "<meta http-equiv='refresh' content='0'><link rel='stylesheet' href='evil.css'><style>body{}</style>"
+        )
+        assert "<meta" not in cleaned
+        assert "<link" not in cleaned
+        assert "<style" not in cleaned
+
+    def test_regex_path_strips_surrounding_whitespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sanitize_mod, "_HAS_BLEACH", False)
+        assert sanitize_string("   hello   ") == "hello"


### PR DESCRIPTION
## Summary

First PR in the **backend coverage → >95%** push. Baseline was **91% (1073 tests, 694 missing-line statements)**. This PR closes ~41 of those by pinning three previously-thin `app.core` modules at **100%**.

| Module | Was | Now |
|---|---:|---:|
| `app.core.http` | 47% | 100% |
| `app.core.course_cover_upload` | 0% | 100% |
| `app.core.sanitize` | 68% | 100% |

## What's pinned

* **`http.get_client_ip`** — the `_TRUSTED_PROXY` gate that protects rate limiting from spoofed `X-Forwarded-For` / `X-Real-IP` on bare deploys, plus the `request.client.host` fallback chain that audit logging relies on. Both trusted and untrusted-proxy paths covered; the empty-XFF-falls-back-to-XRI quirk is pinned explicitly.
* **`course_cover_upload`** — the public URL helper (no surprises in path shape), the happy-path POST to Supabase Storage (correct endpoint, `Authorization` + `apikey` + `x-upsert` headers, content type per extension), unknown-extension fallback to PNG, trailing-slash normalisation, and the non-2xx `RuntimeError` path. `httpx.Client` is replaced with a `_FakeClient` so the suite stays offline.
* **`sanitize`** — the iframe filter (YouTube + youtube-nocookie kept, everything else stripped, no-src stripped, single-quoted-src normalised), the empty-input short-circuit, and the regex-fallback branch (when `bleach` is not importable) covering script/event-handler/`javascript:`/meta/link/style strips.

## Test plan

- [x] `pytest tests/test_core_http.py tests/test_core_course_cover_upload.py tests/test_sanitize.py` — 62 passed
- [x] Full backend suite: **1113 passed** (was 1073)
- [x] `ruff check` + `ruff format --check` clean on new files
- [x] `mypy --config-file mypy.ini` clean on new files
- [x] No production-code changes
- [x] No new dependencies

## Coverage trajectory

This is **PR 1 of N** on the way to >95%. Next targets (from the same baseline): `core/security.py` (42%, 33 missing), `core/database.py` (71%, 19 missing), `api/dependencies.py` (72%, 24 missing), and the long tail of services at 80-90%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
