### PR TITLE
feat(datadog): teacher-load + course-engagement dashboard specs

### DIFF
--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -1,0 +1,64 @@
+# Datadog dashboards
+
+This directory holds the JSON specs for Datadog dashboards Equip
+keeps in source control. Each spec corresponds to one dashboard
+that's importable via the Datadog UI:
+
+| Spec | Purpose |
+|---|---|
+| `teacher-load-dashboard.json` | Per-teacher grading-queue depth, response time, active courses, enrollment counts. |
+| `course-engagement-dashboard.json` | Per-course DAU, completion rate, time-to-first-drop-off, top drop-off chapters, locale split, average rating. |
+
+## Why JSON, not Terraform
+
+Equip's Datadog footprint is small enough that hand-importing two
+dashboards via the UI is faster than standing up a Terraform
+provider. When the dashboard count grows past ~5 or starts changing
+weekly, it's worth converting these to
+`datadog_dashboard_json` resources and managing through TF.
+
+## Importing a dashboard
+
+1. Datadog UI → `Dashboards` → `New Dashboard`.
+2. Click the `Configure` (gear) icon → `Import dashboard JSON`.
+3. Paste the file's contents.
+4. Set sharing: `Teamwide` for the Equip team.
+
+After import, the dashboard exists by ID. If you tweak it in the
+UI, export the updated JSON and paste it back into the file in
+this directory in the SAME PR — keeping source-of-truth out of
+sync with prod is the fastest way for dashboards to silently rot.
+
+## Required metrics
+
+Both dashboards reference custom metrics with the `equip.*` namespace.
+They're emitted by:
+
+* **`equip.grading.*`** — `app/api/v1/grades.py` and the manual-
+  grading flow in `app/api/v1/quizzes/grading.py` push a Datadog
+  StatsD metric every time a pending item enters or leaves the queue.
+* **`equip.questions.*`** — the course Q&A surface (when it lands)
+  will emit these; for now the panels render "no data" gracefully.
+* **`equip.activity.*`** — the request-logging middleware in
+  `app/main.py` tags every request with `course_id` and `locale`
+  when available; the DAU metric is derived from unique
+  `user_id` per day.
+* **`equip.completion.*`** — `app/services/student_progress_service.py`
+  updates a per-course/per-chapter completion rate on each
+  `mark_chapter_complete` call.
+* **`equip.engagement.first_dropoff.*`** — `dropoff_count` is the
+  count of enrollments where activity stopped without completion;
+  computed by a scheduled Datadog query.
+
+The teacher-load dashboard's grading queue tile + the course-
+engagement DAU tile are both live as of this PR; the others need
+the metric emission to be wired in subsequent PRs. The dashboards
+ship now so we can see the no-data tiles + know which metrics are
+still TODO.
+
+## See also
+
+- `docs/OBSERVABILITY.md` — Datadog setup, log forwarder config,
+  monitor inventory.
+- `Memory/datadog-equip.md` — current monitor IDs (in the private
+  ops repo).

--- a/docs/datadog/course-engagement-dashboard.json
+++ b/docs/datadog/course-engagement-dashboard.json
@@ -1,0 +1,182 @@
+{
+  "title": "Equip — Course Engagement",
+  "description": "Per-course health: DAU, completion rate, time-to-first-drop-off, locale split.\n\nUseful when:\n* Deciding which courses are pilot-ready vs. need more material.\n* Spotting the chapter where students consistently abandon.\n* Showing a school director the impact data after a cohort wraps.\n\nFilter by `course_id:<id>` to scope. The default view aggregates across all courses for a quick \"is anything obviously off\" scan.\n\nDeploy: Datadog UI -> Dashboards -> New Dashboard -> Import JSON.",
+  "layout_type": "ordered",
+  "reflow_type": "auto",
+  "template_variables": [
+    {
+      "name": "course_id",
+      "prefix": "course_id",
+      "default": "*"
+    },
+    {
+      "name": "env",
+      "prefix": "env",
+      "available_values": ["prod", "preview"],
+      "default": "prod"
+    }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "note",
+        "content": "## How to read this\n\n- **DAU** (daily active users) — students who hit any course-scoped route today.\n- **Completion rate** — `completed_chapters / total_chapters` per enrollment, averaged across the course.\n- **Time-to-first-drop-off** — median time from first chapter open to last activity, for students who never completed.\n- **Locale split** — RU vs EN traffic; if one drops to 0, the i18n pipeline may have broken.",
+        "background_color": "blue",
+        "font_size": "14",
+        "text_align": "left"
+      }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "title": "Active usage",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "DAU (today)",
+              "requests": [
+                {
+                  "q": "sum:equip.activity.daily_active_users{env:$env.value,course_id:$course_id.value}",
+                  "aggregator": "last"
+                }
+              ],
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "DAU over time",
+              "requests": [
+                {
+                  "q": "sum:equip.activity.daily_active_users{env:$env.value,course_id:$course_id.value} by {course_id}",
+                  "display_type": "area"
+                }
+              ],
+              "yaxis": { "min": "0", "include_zero": true }
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Active enrollments (7d)",
+              "requests": [
+                {
+                  "q": "sum:equip.enrollments.active_7d{env:$env.value,course_id:$course_id.value}",
+                  "aggregator": "last"
+                }
+              ],
+              "precision": 0
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "title": "Completion + drop-off",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Completion rate (avg %)",
+              "requests": [
+                {
+                  "q": "avg:equip.completion.course_avg_pct{env:$env.value,course_id:$course_id.value}",
+                  "aggregator": "avg",
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 70, "palette": "white_on_green" },
+                    { "comparator": ">", "value": 40, "palette": "white_on_yellow" },
+                    { "comparator": "<=", "value": 40, "palette": "white_on_red" }
+                  ]
+                }
+              ],
+              "custom_unit": "%",
+              "precision": 1
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Per-chapter completion (heatmap)",
+              "requests": [
+                {
+                  "q": "avg:equip.completion.chapter_avg_pct{env:$env.value,course_id:$course_id.value} by {chapter_id}",
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100", "include_zero": true }
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Median time to first drop-off",
+              "requests": [
+                {
+                  "q": "avg:equip.engagement.first_dropoff.p50{env:$env.value,course_id:$course_id.value}",
+                  "aggregator": "avg"
+                }
+              ],
+              "custom_unit": "s"
+            }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "Drop-off chapters (top 10)",
+              "requests": [
+                {
+                  "q": "top(sum:equip.engagement.dropoff_count{env:$env.value,course_id:$course_id.value} by {chapter_id}.rollup(last_7d), 10, 'sum', 'desc')"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "title": "Quality signals",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Average rating (out of 5)",
+              "requests": [
+                {
+                  "q": "avg:equip.reviews.rating_avg{env:$env.value,course_id:$course_id.value}",
+                  "aggregator": "avg",
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 4, "palette": "white_on_green" },
+                    { "comparator": ">", "value": 3, "palette": "white_on_yellow" },
+                    { "comparator": "<=", "value": 3, "palette": "white_on_red" }
+                  ]
+                }
+              ],
+              "precision": 2
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Locale split (RU vs EN)",
+              "requests": [
+                {
+                  "q": "sum:equip.activity.requests_total{env:$env.value,course_id:$course_id.value} by {locale}",
+                  "display_type": "area"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/datadog/teacher-load-dashboard.json
+++ b/docs/datadog/teacher-load-dashboard.json
@@ -1,0 +1,169 @@
+{
+  "title": "Equip — Teacher Load",
+  "description": "Per-teacher activity + grading-backlog dashboard.\n\nGoals:\n* Spot a teacher whose grading queue is growing (pending_grade events without matching graded events).\n* Spot a teacher whose response time on student questions has crept up.\n* Compare cohort sizes so a teacher with a 200-student backlog isn't asked to take more on.\n\nFilter the entire dashboard by `teacher_id:<uuid>` to scope to one teacher.\n\nDeploy: import this JSON via Datadog UI -> Dashboards -> New Dashboard -> Import JSON. After import, set the dashboard share with the Equip team.",
+  "layout_type": "ordered",
+  "reflow_type": "auto",
+  "template_variables": [
+    {
+      "name": "teacher_id",
+      "prefix": "teacher_id",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "env",
+      "prefix": "env",
+      "available_values": ["prod", "preview"],
+      "default": "prod"
+    }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "note",
+        "content": "## How to read this dashboard\n\n- **Pending grading items**: should hover near 0 between sprints. Sustained > 20 for one teacher → outreach.\n- **Median time to grade**: > 72h sustained → outreach.\n- **Active courses**: courses with at least one enrolled student in the last 7 days.\n- **Student message response time**: how long the teacher took to reply after a student posted to the course Q&A.",
+        "background_color": "blue",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "title": "Grading queue",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Pending grading items (now)",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "q": "sum:equip.grading.pending{env:$env.value,teacher_id:$teacher_id.value}",
+                  "aggregator": "last",
+                  "conditional_formats": [
+                    { "comparator": "<", "value": 5, "palette": "white_on_green" },
+                    { "comparator": "<", "value": 20, "palette": "white_on_yellow" },
+                    { "comparator": ">=", "value": 20, "palette": "white_on_red" }
+                  ]
+                }
+              ],
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Grading queue depth over time",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "requests": [
+                {
+                  "q": "max:equip.grading.pending{env:$env.value,teacher_id:$teacher_id.value} by {teacher_id}",
+                  "display_type": "line",
+                  "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "label": "items", "scale": "linear", "min": "0", "include_zero": true }
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Median time to grade (last 7d)",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "q": "avg:equip.grading.time_to_grade.p50{env:$env.value,teacher_id:$teacher_id.value}",
+                  "aggregator": "avg",
+                  "conditional_formats": [
+                    { "comparator": "<", "value": 86400, "palette": "white_on_green" },
+                    { "comparator": "<", "value": 259200, "palette": "white_on_yellow" },
+                    { "comparator": ">=", "value": 259200, "palette": "white_on_red" }
+                  ]
+                }
+              ],
+              "custom_unit": "s",
+              "precision": 0
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "title": "Student questions",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Open student questions",
+              "requests": [
+                {
+                  "q": "sum:equip.questions.open{env:$env.value,teacher_id:$teacher_id.value}",
+                  "aggregator": "last"
+                }
+              ],
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Median response time (last 7d)",
+              "requests": [
+                {
+                  "q": "avg:equip.questions.response_time.p50{env:$env.value,teacher_id:$teacher_id.value}",
+                  "aggregator": "avg"
+                }
+              ],
+              "custom_unit": "s"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "title": "Courses + cohorts",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Active courses (≥1 enrolled in last 7d)",
+              "requests": [
+                {
+                  "q": "max:equip.courses.active_7d{env:$env.value,teacher_id:$teacher_id.value}",
+                  "aggregator": "last"
+                }
+              ],
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "Enrollments per course",
+              "requests": [
+                {
+                  "q": "top(sum:equip.enrollments.count{env:$env.value,teacher_id:$teacher_id.value} by {course_id}.rollup(last_1h), 10, 'sum', 'desc')"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Item **7 of 8**. Adds source-controlled Datadog dashboard JSON specs for two teacher-facing analytics surfaces.

## What's added

* `docs/datadog/teacher-load-dashboard.json` — per-teacher grading-queue depth, median time-to-grade (last 7d), open student questions, response time, active courses, enrollments-per-course top-list. Template variables: `teacher_id` (default \*), `env` (prod/preview). **Conditional formats:** grading queue <5 green / <20 yellow / ≥20 red so a single glance surfaces overload.
* `docs/datadog/course-engagement-dashboard.json` — per-course DAU, completion rate (green >70% / yellow >40% / red ≤40%), per-chapter completion line, median time-to-first-drop-off, top 10 drop-off chapters, average rating, locale split (RU vs EN).
* `docs/datadog/README.md` — import instructions (Datadog UI → Dashboards → Import JSON), why JSON not Terraform (only 2 dashboards; revisit when count grows), and the metric-source inventory (which app file emits each `equip.*` metric and which still need wiring).

## Status

The teacher-load grading queue tile + the course-engagement DAU tile are live as of this PR; the others render 'no data' gracefully until the metric emission is wired in subsequent PRs.

## Deploy

Datadog UI → Dashboards → New Dashboard → Import JSON → paste contents → save → set sharing to Teamwide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)