### PR TITLE
feat(design): visual overhaul v2 Wave 2 — bridge layer

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,19 @@
 @tailwind utilities;
 
 /*
+ * Visual overhaul v2 — Wave 2 bridge. Defines the v2 semantic token
+ * names backed by the v1 HSL palette, so components can opt into the
+ * new vocabulary today and the rest of the migration is invisible.
+ * Imported AFTER the v1 ``@layer base`` block (below) so v1 vars
+ * are declared by the time the bridge resolves them.
+ *
+ * Until Wave 3 starts swapping component code, this import is a
+ * no-op at the rendered-pixel level — every bridge token resolves to
+ * the same v1 color. See ADR-0011.
+ */
+@import "./styles/tokens-bridge.css";
+
+/*
  * Theme: warm editorial paper (light) + zinc-depth dark (2025–2026 practice).
  * Brand = deep violet ink (light) / soft violet glow (dark) — not generic “tech blue”.
  * Accent = sage (heritage / calm). Mesh gradients + slow ambient motion on :before.

--- a/frontend/src/styles/__tests__/tokens-bridge.test.ts
+++ b/frontend/src/styles/__tests__/tokens-bridge.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Sentinel for the Wave 2 bridge layer.
+ *
+ * Pins:
+ * - Bridge file exists, parses, and is imported by index.css (Wave 2
+ *   IS wired, unlike Wave 1 which was preview-only).
+ * - Every token name from tokens-v2.css ALSO appears in the bridge
+ *   so any component using a v2 name has a backing value today.
+ * - Every bridge value is a ``var(--*)`` pass-through into the v1
+ *   palette (no direct hex / hsl / oklch — those belong in the
+ *   palette files, not the bridge).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_FILE = resolve(HERE, "..", "tokens-bridge.css");
+const V2_FILE = resolve(HERE, "..", "tokens-v2.css");
+const INDEX_FILE = resolve(HERE, "..", "..", "index.css");
+
+const REQUIRED_TOKENS = [
+  "--color-surface",
+  "--color-surface-elevated",
+  "--color-surface-sunken",
+  "--color-ink",
+  "--color-ink-muted",
+  "--color-ink-inverted",
+  "--color-accent",
+  "--color-accent-quiet",
+  "--color-accent-strong",
+  "--color-heritage",
+  "--color-heritage-quiet",
+  "--color-edge",
+  "--color-edge-strong",
+  "--color-success",
+  "--color-success-quiet",
+  "--color-warning",
+  "--color-warning-quiet",
+  "--color-danger",
+  "--color-danger-quiet",
+  "--color-info",
+  "--color-info-quiet",
+  "--color-focus-ring",
+];
+
+describe("tokens-bridge.css (ADR-0011 Wave 2)", () => {
+  it("file is present + readable", () => {
+    const content = readFileSync(BRIDGE_FILE, "utf-8");
+    expect(content.length).toBeGreaterThan(200);
+  });
+
+  it("is imported by index.css (Wave 2 IS wired)", () => {
+    const index = readFileSync(INDEX_FILE, "utf-8");
+    expect(index.includes("tokens-bridge")).toBe(true);
+  });
+
+  it("matches the canonical v2 token vocabulary", () => {
+    const bridge = readFileSync(BRIDGE_FILE, "utf-8");
+    const v2 = readFileSync(V2_FILE, "utf-8");
+    for (const token of REQUIRED_TOKENS) {
+      // Both files must declare every canonical token name.
+      expect(bridge.includes(token), `bridge missing ${token}`).toBe(true);
+      expect(v2.includes(token), `tokens-v2 missing ${token}`).toBe(true);
+    }
+  });
+
+  it("declares every token in both :root and .dark scopes", () => {
+    const bridge = readFileSync(BRIDGE_FILE, "utf-8");
+    const [light = "", dark = ""] = bridge.split(".dark");
+    for (const token of REQUIRED_TOKENS) {
+      expect(light.includes(token), `:root missing ${token}`).toBe(true);
+      expect(dark.includes(token), `.dark missing ${token}`).toBe(true);
+    }
+  });
+
+  it("uses only var(--*) pass-throughs (no hex / hsl / oklch literals)", () => {
+    const bridge = readFileSync(BRIDGE_FILE, "utf-8");
+    // Strip comments first so the ADR reference + explanation prose
+    // doesn't trigger the hex / hsl matchers.
+    const stripped = bridge.replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(stripped.match(/#[0-9a-fA-F]{3,8}/g) ?? []).toEqual([]);
+    expect(stripped.match(/hsl\s*\(/g) ?? []).toEqual([]);
+    expect(stripped.match(/oklch\s*\(/g) ?? []).toEqual([]);
+  });
+});

--- a/frontend/src/styles/tokens-bridge.css
+++ b/frontend/src/styles/tokens-bridge.css
@@ -1,0 +1,93 @@
+/*
+ * Visual overhaul v2 — Wave 2 bridge layer (ADR-0011).
+ *
+ * Defines the v2 semantic token NAMES (--color-surface, --color-ink,
+ * etc.) backed by the existing v1 HSL palette via ``hsl(var(--*))``
+ * pass-throughs. This way:
+ *
+ * 1. Component code can start using the new names immediately
+ *    (``bg-[hsl(var(--color-surface))]``), and the rendered result
+ *    matches the v1 palette today.
+ * 2. When Wave 9 swaps the backing palette over to the OKLCH values
+ *    in ``tokens-v2.css``, every consumer flips at once with no
+ *    component-level edit.
+ * 3. The OKLCH layer (``tokens-v2.css``) stays unused until then —
+ *    it's the future-state preview the design team iterates on
+ *    without touching production.
+ *
+ * Imported by ``index.css`` after the v1 token block so the v1 tokens
+ * are already declared by the time these references resolve.
+ *
+ * The names mirror ``tokens-v2.css`` exactly (the OKLCH future-state).
+ * Anything missing here is intentional — it means that token isn't
+ * usable yet and a component using it would fail visually, which is
+ * the signal a wave hasn't covered that surface.
+ */
+
+:root,
+.light {
+  /* Page surfaces — back into v1 ``--background`` / ``--card`` etc. */
+  --color-surface: var(--background);
+  --color-surface-elevated: var(--card);
+  --color-surface-sunken: var(--muted);
+
+  /* Ink — back into v1 ``--foreground`` / ``--muted-foreground``. */
+  --color-ink: var(--foreground);
+  --color-ink-muted: var(--muted-foreground);
+  --color-ink-inverted: var(--primary-foreground);
+
+  /* Accents. */
+  --color-accent: var(--primary);
+  --color-accent-quiet: var(--secondary);
+  --color-accent-strong: var(--ring);
+
+  --color-heritage: var(--accent);
+  --color-heritage-quiet: var(--sidebar-accent);
+
+  /* Edges. */
+  --color-edge: var(--border);
+  --color-edge-strong: var(--input);
+
+  /* Status semantics. */
+  --color-success: var(--success);
+  --color-success-quiet: var(--secondary);
+  --color-warning: var(--warning);
+  --color-warning-quiet: var(--secondary);
+  --color-danger: var(--destructive);
+  --color-danger-quiet: var(--secondary);
+  --color-info: var(--info);
+  --color-info-quiet: var(--secondary);
+
+  --color-focus-ring: var(--ring);
+}
+
+.dark {
+  --color-surface: var(--background);
+  --color-surface-elevated: var(--card);
+  --color-surface-sunken: var(--muted);
+
+  --color-ink: var(--foreground);
+  --color-ink-muted: var(--muted-foreground);
+  --color-ink-inverted: var(--primary-foreground);
+
+  --color-accent: var(--primary);
+  --color-accent-quiet: var(--secondary);
+  --color-accent-strong: var(--ring);
+
+  --color-heritage: var(--accent);
+  --color-heritage-quiet: var(--sidebar-accent);
+
+  --color-edge: var(--border);
+  --color-edge-strong: var(--input);
+
+  --color-success: var(--success);
+  --color-success-quiet: var(--secondary);
+  --color-warning: var(--warning);
+  --color-warning-quiet: var(--secondary);
+  --color-danger: var(--destructive);
+  --color-danger-quiet: var(--secondary);
+  --color-info: var(--info);
+  --color-info-quiet: var(--secondary);
+
+  --color-focus-ring: var(--ring);
+}


### PR DESCRIPTION
ADR-0011 **Wave 2 of 10**. Defines the v2 semantic token NAMES backed by the v1 HSL palette via `var(--*)` pass-throughs, and wires the bridge into `index.css`.

## What's added

* `frontend/src/styles/tokens-bridge.css` — every v2 token name from Wave 1's `tokens-v2.css` gets a backing value here that points at the existing v1 token. So a component using `bg-[hsl(var(--color-surface))]` renders the same color as `bg-[hsl(var(--background))]` **today**, but flips to the OKLCH palette in Wave 9 with no component-level edit.
* `frontend/src/index.css` — imports the bridge AFTER `@tailwind` so v1 tokens are declared before the bridge resolves them.
* `frontend/src/styles/__tests__/tokens-bridge.test.ts` — sentinel asserting:
  - Bridge file present
  - **Imported by index.css** (Wave 2 IS wired, unlike Wave 1)
  - Every v2 token name appears in bridge AND tokens-v2 (anti-divergence)
  - Every token declared in `:root` AND `.dark`
  - Bridge values are pass-through `var(--*)` references only (no hex / hsl / oklch literals — those belong in the palette files, not the bridge)

## Zero rendered-pixel impact

Every bridge token resolves to its v1 counterpart. Wave 3 will start swapping components to use the v2 names.

## Test plan

- [x] +5 sentinel tests
- [x] Full frontend suite (**340 total**) green
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)