### PR TITLE
feat(design): visual overhaul v2 Wave 3 — Card + Button to v2 vocabulary

### DIFF
--- a/frontend/src/components/ui/buttonVariants.ts
+++ b/frontend/src/components/ui/buttonVariants.ts
@@ -7,19 +7,26 @@ export const buttonVariants = cva(
   // sub-AA and effectively makes the button — and any spinner / icon
   // inside — invisible. The token-based approach gives a deliberate
   // disabled colour that the design system controls per theme.
+  //
+  // ADR-0011 Wave 3 — migrated to the v2 semantic palette via the
+  // tokens-bridge layer. Primary CTA → ``brand`` (the v2 name for
+  // the violet brand color; v1's ``accent`` is sage and stays
+  // available under that legacy name). Outline / ghost reach for the
+  // sage ``heritage`` palette. Disabled keeps ``muted`` (no v2
+  // equivalent yet — that's wave 4's form-primitives surface).
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[color,box-shadow,transform] duration-150 ease-editorial focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-brand text-brand-foreground hover:bg-brand/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-edge-strong bg-surface hover:bg-heritage hover:text-ink",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-brand-quiet text-ink hover:bg-brand-quiet/80",
+        ghost: "hover:bg-heritage hover:text-ink",
+        link: "text-brand underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -13,7 +13,12 @@ const Card = React.forwardRef<
       // — multiple call sites use `hover:border-primary/25..40`. Without this the
       // border jumps; with it, the hue settles over ~200ms, which reads as the
       // card "noticing" the cursor instead of toggling.
-      "rounded-md border border-border bg-card text-card-foreground shadow-none transition-[border-color,background-color] duration-200 ease-editorial",
+      //
+      // ADR-0011 Wave 3 — migrated from `border-border bg-card
+      // text-card-foreground` to the v2 semantic vocabulary (`border-edge
+      // bg-surface-elevated text-ink`). Identical pixels today via the
+      // tokens-bridge layer; flips to OKLCH in Wave 9 with no code change.
+      "rounded-md border border-edge bg-surface-elevated text-ink shadow-none transition-[border-color,background-color] duration-200 ease-editorial",
       className
     )}
     {...props}
@@ -54,7 +59,8 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    // Wave 3 — text-muted-foreground -> text-ink-muted (semantic v2).
+    className={cn("text-sm text-ink-muted", className)}
     {...props}
   />
 ))

--- a/frontend/src/styles/__tests__/wave3-card-button.test.ts
+++ b/frontend/src/styles/__tests__/wave3-card-button.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Sentinel for ADR-0011 Wave 3.
+ *
+ * Pins that Card and Button source files have been migrated to the
+ * v2 semantic vocabulary. The visual snapshot can stay identical
+ * because tokens-bridge.css resolves the v2 names to the same v1
+ * HSL values; this sentinel is the regression net for a refactor
+ * that accidentally reverts a class to the v1 name.
+ *
+ * NOT a visual diff — that's the human reviewer's job per the ADR's
+ * per-wave gate ("light + dark screenshots in PR body"). This is just
+ * the "did we actually do the swap" check.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CARD_FILE = resolve(HERE, "..", "..", "components", "ui", "card.tsx");
+const BUTTON_VARIANTS_FILE = resolve(
+  HERE,
+  "..",
+  "..",
+  "components",
+  "ui",
+  "buttonVariants.ts",
+);
+const TW_CONFIG = resolve(HERE, "..", "..", "..", "tailwind.config.js");
+
+describe("ADR-0011 Wave 3 — Card + Button migration", () => {
+  it("tailwind.config exposes the v2 palette (surface, ink, edge, brand, heritage)", () => {
+    const cfg = readFileSync(TW_CONFIG, "utf-8");
+    for (const name of ["surface", "ink", "edge", "brand", "heritage"]) {
+      expect(cfg.includes(name), `tailwind.config missing ${name}`).toBe(true);
+    }
+  });
+
+  it("Card uses v2 classes (bg-surface-elevated / border-edge / text-ink)", () => {
+    const raw = readFileSync(CARD_FILE, "utf-8");
+    // Strip comments before lock-out checks — the migration log
+    // mentions the v1 names in a comment we want to keep.
+    const code = raw.replace(/\/\/[^\n]*\n/g, "\n").replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(code.includes("bg-surface-elevated")).toBe(true);
+    expect(code.includes("border-edge")).toBe(true);
+    expect(code.includes("text-ink")).toBe(true);
+    expect(code.includes("text-ink-muted")).toBe(true);
+    // v1 names removed from the Card source (they would silently
+    // resolve to the same colors, so we lock them out by class name).
+    expect(code.includes("bg-card")).toBe(false);
+    expect(code.includes("text-card-foreground")).toBe(false);
+    expect(code.includes("border-border")).toBe(false);
+    expect(code.includes("text-muted-foreground")).toBe(false);
+  });
+
+  it("Button variants use v2 brand / heritage / edge / surface names", () => {
+    const raw = readFileSync(BUTTON_VARIANTS_FILE, "utf-8");
+    const code = raw.replace(/\/\/[^\n]*\n/g, "\n").replace(/\/\*[\s\S]*?\*\//g, "");
+    // Primary CTA = brand.
+    expect(code.includes("bg-brand text-brand-foreground")).toBe(true);
+    expect(code.includes("bg-brand-quiet")).toBe(true);
+    // Outline / ghost surface vocabulary.
+    expect(code.includes("bg-surface")).toBe(true);
+    expect(code.includes("border-edge-strong")).toBe(true);
+    expect(code.includes("hover:bg-heritage")).toBe(true);
+    // Link uses brand for the text color.
+    expect(code.includes("text-brand")).toBe(true);
+    // Old v1 names retired from the variants (disabled stays muted —
+    // that's wave 4's surface and intentionally still v1 here).
+    expect(code.includes("bg-primary ")).toBe(false);
+    expect(code.includes("text-primary-foreground")).toBe(false);
+    expect(code.includes("border-input")).toBe(false);
+    expect(code.includes("bg-background")).toBe(false);
+    expect(code.includes("hover:bg-accent ")).toBe(false);
+  });
+});

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -77,6 +77,40 @@ export default {
           4: "hsl(var(--chart-4))",
           5: "hsl(var(--chart-5))",
         },
+        // Visual overhaul v2 — Wave 3. Adds the v2 semantic palette
+        // alongside the v1 names so components can opt into the new
+        // vocabulary one-by-one. Resolved via tokens-bridge.css today
+        // (v1 HSL values); will flip to OKLCH in Wave 9 without
+        // touching component code.
+        //
+        // Naming note: v1 already owns ``accent`` (sage heritage) and
+        // ``primary`` (violet). v2's semantic accent (violet, the
+        // brand) lands as ``brand`` to avoid the collision. v2's
+        // heritage (sage) lands as ``heritage``. ADR-0011.
+        surface: {
+          DEFAULT: "hsl(var(--color-surface))",
+          elevated: "hsl(var(--color-surface-elevated))",
+          sunken: "hsl(var(--color-surface-sunken))",
+        },
+        ink: {
+          DEFAULT: "hsl(var(--color-ink))",
+          muted: "hsl(var(--color-ink-muted))",
+          inverted: "hsl(var(--color-ink-inverted))",
+        },
+        edge: {
+          DEFAULT: "hsl(var(--color-edge))",
+          strong: "hsl(var(--color-edge-strong))",
+        },
+        brand: {
+          DEFAULT: "hsl(var(--color-accent))",
+          quiet: "hsl(var(--color-accent-quiet))",
+          strong: "hsl(var(--color-accent-strong))",
+          foreground: "hsl(var(--color-ink-inverted))",
+        },
+        heritage: {
+          DEFAULT: "hsl(var(--color-heritage))",
+          quiet: "hsl(var(--color-heritage-quiet))",
+        },
       },
       fontFamily: {
         serif: ['"Fraunces Variable"', 'Fraunces', 'Georgia', 'Cambria', '"Times New Roman"', 'Times', 'serif'],


### PR DESCRIPTION
ADR-0011 **Wave 3 of 10**. Migrates the two most-used primitives — Card and Button — to the v2 semantic class vocabulary. Pixels are identical today via the tokens-bridge layer; the swap pays off in Wave 9 when the bridge flips to OKLCH and these components inherit the new palette without any further code edits.

## Tailwind config

Adds v2 palette aliases: `surface`, `ink`, `edge`, `brand`, `heritage`.

**Naming note:** v1 already owns `accent` (sage heritage) and `primary` (violet); v2's brand-violet lands as `brand` to avoid the collision; v2's heritage-sage lands as `heritage`.

## Card

* Root: `border-border bg-card text-card-foreground` → `border-edge bg-surface-elevated text-ink`
* CardDescription: `text-muted-foreground` → `text-ink-muted`

## Button variants

| Variant | Before | After |
|---|---|---|
| default | `bg-primary text-primary-foreground hover:bg-primary/90` | `bg-brand text-brand-foreground hover:bg-brand/90` |
| outline | `border-input bg-background hover:bg-accent hover:text-accent-foreground` | `border-edge-strong bg-surface hover:bg-heritage hover:text-ink` |
| secondary | `bg-secondary text-secondary-foreground hover:bg-secondary/80` | `bg-brand-quiet text-ink hover:bg-brand-quiet/80` |
| ghost | `hover:bg-accent hover:text-accent-foreground` | `hover:bg-heritage hover:text-ink` |
| link | `text-primary underline-offset-4 hover:underline` | `text-brand underline-offset-4 hover:underline` |
| destructive | unchanged (no v2 equivalent yet — that's wave 6) | unchanged |
| disabled | unchanged (`muted` — that's wave 4) | unchanged |

## Sentinel

`src/styles/__tests__/wave3-card-button.test.ts` pins:
- tailwind.config exposes the v2 palette names
- Card source uses v2 classes AND v1 names are absent from the non-comment code (regression net for an accidental revert)
- Button uses brand / heritage / edge / surface AND v1 primary/secondary/accent/input/background classes are absent

## Test plan

- [x] +3 sentinel tests
- [x] Full frontend suite (**340 total**) green
- [x] eslint clean
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)