### PR TITLE
feat(e2e): auth fixtures + global setup scaffolding

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,3 +34,4 @@ coverage
 test-results/
 playwright-report/
 playwright/.cache/
+playwright/.auth/

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -132,6 +132,11 @@ export const test = base.extend<{
   // For each role, return a page with the role's storage state
   // already loaded. Wired here as a stub; the global setup will fill
   // the storageState files in a follow-up.
+  // The ``use`` callback is Playwright's fixture lifecycle hook, not a
+  // React hook — ESLint's ``react-hooks/rules-of-hooks`` mis-identifies
+  // it. Disable the rule for the file rather than scattering inline
+  // exceptions on every fixture.
+  /* eslint-disable react-hooks/rules-of-hooks */
   studentPage: async ({ browser }, use) => {
     const ctx = await browser.newContext({
       storageState: "playwright/.auth/student.json",
@@ -156,6 +161,7 @@ export const test = base.extend<{
     await use(page);
     await ctx.close();
   },
+  /* eslint-enable react-hooks/rules-of-hooks */
 });
 
 export { expect } from "@playwright/test";

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -1,0 +1,161 @@
+/**
+ * Auth fixtures for Playwright E2E.
+ *
+ * The smoke spec hits public-only routes. Anything testing the
+ * student / teacher / admin golden paths needs a logged-in browser
+ * context. These fixtures cover two strategies:
+ *
+ * 1. **Storage state from a sign-in flow.** Used by the global
+ *    setup (``global.setup.ts``) — exercises the real login form
+ *    against the test Supabase project, then saves the session
+ *    cookies / localStorage to a JSON file. Every subsequent test
+ *    reuses that file. Two perks: fewer sign-in calls hammering
+ *    Supabase, and the login form itself is covered by the setup
+ *    even when individual specs skip it.
+ *
+ * 2. **Programmatic session injection.** When a spec wants to
+ *    cover a specific user state (e.g. an admin running a
+ *    moderation flow) without going through the login UI, the
+ *    fixture writes the Supabase session straight into
+ *    localStorage. Faster and decoupled from any login-form
+ *    regressions in the SUT.
+ *
+ * Neither path is wired into the CI workflow yet — the CI preview
+ * has no real Supabase project. The fixtures land as a structured
+ * placeholder so the first golden-path spec can use them once the
+ * test Supabase project is provisioned.
+ */
+import { test as base } from "@playwright/test";
+import type { Page, BrowserContext } from "@playwright/test";
+
+export type AuthRole = "student" | "teacher" | "admin";
+
+interface TestUser {
+  email: string;
+  password: string;
+  /** Pre-existing user id in the test project so seed data can
+   * reference it without hitting Supabase auth on every spec. */
+  id: string;
+  role: AuthRole;
+}
+
+/**
+ * Read the test credentials for a role from env vars. The CI
+ * workflow will need to set these once a test Supabase project
+ * exists. Local dev can copy them from
+ * ``Memory/equip-e2e-test-users.md``.
+ */
+export function getTestUser(role: AuthRole): TestUser {
+  const prefix = `E2E_${role.toUpperCase()}`;
+  const email = process.env[`${prefix}_EMAIL`];
+  const password = process.env[`${prefix}_PASSWORD`];
+  const id = process.env[`${prefix}_ID`];
+  if (!email || !password || !id) {
+    throw new Error(
+      `Missing ${prefix}_EMAIL / _PASSWORD / _ID. ` +
+        "These come from the test Supabase project; populate them in CI " +
+        "via repository secrets and locally via frontend/.env.local.",
+    );
+  }
+  return { email, password, id, role };
+}
+
+/**
+ * Sign in through the real login form and return the page in a
+ * post-login state. Used by the global setup to mint a storage-state
+ * file. Individual specs should NOT call this — they should rely on
+ * the storage-state baked into ``playwright.config.ts`` (added once
+ * global setup is wired).
+ */
+export async function signInViaForm(
+  page: Page,
+  user: TestUser,
+): Promise<void> {
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill(user.email);
+  await page.getByLabel(/password|пароль/i).fill(user.password);
+  await page.getByRole("button", { name: /sign in|войти/i }).click();
+  // After a successful sign-in the auth gate replaces the root with
+  // the dashboard. The header carries an Equip wordmark.
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"));
+}
+
+/**
+ * Inject a Supabase session into localStorage so the SPA boots
+ * already authenticated. Faster than the form sign-in and isolated
+ * from any login-form regression in the SUT.
+ *
+ * Constructs a minimal session shape the supabase-js client expects;
+ * the access_token MUST be a valid JWT signed by the test project's
+ * key. The setup script signs one ahead of time and stuffs it into
+ * the env var.
+ */
+export async function injectSession(
+  context: BrowserContext,
+  user: TestUser,
+  accessToken: string,
+): Promise<void> {
+  const session = {
+    access_token: accessToken,
+    refresh_token: "test-refresh-token",
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    token_type: "bearer",
+    user: {
+      id: user.id,
+      email: user.email,
+      role: "authenticated",
+    },
+  };
+  await context.addInitScript((s) => {
+    // supabase-js v2 keys the session under
+    // ``sb-<project-ref>-auth-token``. The test project's ref must
+    // be supplied at injection time.
+    const key = "sb-equip-test-auth-token";
+    window.localStorage.setItem(key, JSON.stringify(s));
+  }, session);
+}
+
+/**
+ * Extend Playwright's base test fixture with a couple of helpers
+ * that derive a role-bound page object. Usage in a spec:
+ *
+ *   import { test } from "../fixtures/auth";
+ *
+ *   test("student can enroll", async ({ studentPage }) => { ... });
+ */
+export const test = base.extend<{
+  studentPage: Page;
+  teacherPage: Page;
+  adminPage: Page;
+}>({
+  // For each role, return a page with the role's storage state
+  // already loaded. Wired here as a stub; the global setup will fill
+  // the storageState files in a follow-up.
+  studentPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext({
+      storageState: "playwright/.auth/student.json",
+    });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+  teacherPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext({
+      storageState: "playwright/.auth/teacher.json",
+    });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+  adminPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext({
+      storageState: "playwright/.auth/admin.json",
+    });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/frontend/e2e/global.setup.ts
+++ b/frontend/e2e/global.setup.ts
@@ -1,0 +1,54 @@
+import { test as setup } from "@playwright/test";
+import { mkdirSync, existsSync } from "node:fs";
+
+import { getTestUser, signInViaForm } from "./fixtures/auth";
+
+/**
+ * Global setup for the Playwright suite.
+ *
+ * Signs in as each role-test user against the test Supabase project
+ * and saves the resulting browser storage state to
+ * ``playwright/.auth/<role>.json``. Each subsequent test reuses the
+ * file via the role-bound fixtures in ``fixtures/auth.ts``.
+ *
+ * This file currently only runs when the env vars
+ * ``E2E_STUDENT_EMAIL`` / ``E2E_TEACHER_EMAIL`` / ``E2E_ADMIN_EMAIL``
+ * (etc.) are set. Until the test Supabase project lands in CI, the
+ * setup is a no-op: it logs the skip reason and exits cleanly so the
+ * smoke specs can still run.
+ */
+
+const AUTH_DIR = "playwright/.auth";
+
+setup("authenticate as student", async ({ page }) => {
+  if (!process.env.E2E_STUDENT_EMAIL) {
+    setup.skip(true, "E2E_STUDENT_EMAIL not set — skipping student auth setup");
+    return;
+  }
+  if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true });
+  const user = getTestUser("student");
+  await signInViaForm(page, user);
+  await page.context().storageState({ path: `${AUTH_DIR}/student.json` });
+});
+
+setup("authenticate as teacher", async ({ page }) => {
+  if (!process.env.E2E_TEACHER_EMAIL) {
+    setup.skip(true, "E2E_TEACHER_EMAIL not set — skipping teacher auth setup");
+    return;
+  }
+  if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true });
+  const user = getTestUser("teacher");
+  await signInViaForm(page, user);
+  await page.context().storageState({ path: `${AUTH_DIR}/teacher.json` });
+});
+
+setup("authenticate as admin", async ({ page }) => {
+  if (!process.env.E2E_ADMIN_EMAIL) {
+    setup.skip(true, "E2E_ADMIN_EMAIL not set — skipping admin auth setup");
+    return;
+  }
+  if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true });
+  const user = getTestUser("admin");
+  await signInViaForm(page, user);
+  await page.context().storageState({ path: `${AUTH_DIR}/admin.json` });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -36,9 +36,17 @@ export default defineConfig({
   },
 
   projects: [
+    // Global setup project — mints storage-state files for the
+    // role-bound fixtures in ``fixtures/auth.ts``. No-ops cleanly
+    // when the E2E_*_EMAIL env vars are unset (current CI state).
+    {
+      name: "setup",
+      testMatch: /global\.setup\.ts/,
+    },
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      dependencies: ["setup"],
     },
   ],
 });


### PR DESCRIPTION
Item **2 of 8** follow-up to PR #651 scaffolding. Adds the infrastructure for role-bound E2E specs without making them runnable yet (a test Supabase project is the remaining dep).

## What's added

* `e2e/fixtures/auth.ts`
  - `getTestUser(role)` reads `E2E_<ROLE>_EMAIL` / `_PASSWORD` / `_ID` from env. Throws with a runbook-style hint if any are missing.
  - `signInViaForm(page, user)` drives the real login form so the global setup mints a storage state that exercises auth.
  - `injectSession(context, user, accessToken)` — programmatic Supabase localStorage seed for specs that don't want to depend on the login form's stability.
  - Extended test fixture with role-bound page properties: `studentPage`, `teacherPage`, `adminPage`. Each loads the matching storage-state file at context creation.

* `e2e/global.setup.ts` — three setup tests, one per role. Each calls `signInViaForm` and writes the resulting storageState to `playwright/.auth/<role>.json`. **Skips cleanly when the env vars aren't set** (current CI state), so the smoke suite still passes.

* `playwright.config.ts` — adds the `setup` project (matches `global.setup.ts`) and makes `chromium` depend on it so storage state is fresh before any spec runs.

* `.gitignore` — `playwright/.auth/` kept out of source control (each file holds a real Supabase access token).

## Test plan

- [x] `npx playwright test --list` enumerates 5 tests cleanly (3 setup + 2 smoke)
- [x] `tsc --noEmit` clean
- [x] Setup tests skip gracefully without env vars (today's CI)

## Next

Provision the test Supabase project, populate `E2E_*_EMAIL` / `_PASSWORD` / `_ID` in repo secrets, then start landing the student / teacher golden-path specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)