### PR TITLE
feat(design): visual overhaul v2 Wave 4 — form primitives

### DIFF
--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -19,13 +19,18 @@ const Checkbox = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CheckboxPrimitive.Root
     ref={ref}
+    // ADR-0011 Wave 4 — migrated to v2 semantic vocabulary.
+    // border-input / bg-background -> border-edge-strong / bg-surface
+    // ring-ring -> ring-brand
+    // checked: border-primary bg-primary text-primary-foreground ->
+    //          border-brand bg-brand text-brand-foreground
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-input bg-background shadow-sm",
+      "peer h-4 w-4 shrink-0 rounded-sm border border-edge-strong bg-surface shadow-sm",
       "ring-offset-background transition-colors",
-      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
       "disabled:cursor-not-allowed disabled:opacity-50",
-      "data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
-      "data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
+      "data-[state=checked]:border-brand data-[state=checked]:bg-brand data-[state=checked]:text-brand-foreground",
+      "data-[state=indeterminate]:border-brand data-[state=indeterminate]:bg-brand data-[state=indeterminate]:text-brand-foreground",
       className,
     )}
     {...props}

--- a/frontend/src/components/ui/inputVariants.ts
+++ b/frontend/src/components/ui/inputVariants.ts
@@ -1,7 +1,13 @@
 import { cva } from "class-variance-authority"
 
+// ADR-0011 Wave 4 — migrated to v2 vocabulary.
+// border-input -> border-edge-strong, bg-background -> bg-surface,
+// placeholder text-muted-foreground -> text-ink-muted,
+// ring-ring -> ring-brand. Disabled state still reaches for v1
+// `muted` — a dedicated `--color-disabled` token will land in a
+// later wave once the design has it specified.
 export const inputVariants = cva(
-  "flex w-full rounded-md border border-input bg-background shadow-sm ring-offset-background transition-[color,box-shadow,border-color] duration-200 ease-editorial file:border-0 file:bg-transparent file:font-medium placeholder:text-muted-foreground/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/80 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted/40 aria-[invalid=true]:border-destructive focus-visible:aria-[invalid=true]:ring-destructive/35 dark:shadow-none",
+  "flex w-full rounded-md border border-edge-strong bg-surface shadow-sm ring-offset-background transition-[color,box-shadow,border-color] duration-200 ease-editorial file:border-0 file:bg-transparent file:font-medium placeholder:text-ink-muted/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/80 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted/40 aria-[invalid=true]:border-destructive focus-visible:aria-[invalid=true]:ring-destructive/35 dark:shadow-none",
   {
     variants: {
       fieldSize: {

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -3,8 +3,9 @@ import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
+// ADR-0011 Wave 4 — text-foreground -> text-ink.
 const labelVariants = cva(
-  "text-sm font-medium leading-snug tracking-tight text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "text-sm font-medium leading-snug tracking-tight text-ink peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
 
 const Label = React.forwardRef<

--- a/frontend/src/styles/__tests__/wave4-forms.test.ts
+++ b/frontend/src/styles/__tests__/wave4-forms.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Sentinel for ADR-0011 Wave 4 — form primitives migration.
+ *
+ * Asserts that Label, Input (via inputVariants), and Checkbox have
+ * been swapped to the v2 semantic vocabulary. Pixels stay identical
+ * via the tokens-bridge layer; this sentinel just locks the swap in
+ * source.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const COMPONENT = (...parts: string[]) =>
+  resolve(HERE, "..", "..", "components", "ui", ...parts);
+
+function readNonComment(path: string): string {
+  const raw = readFileSync(path, "utf-8");
+  return raw.replace(/\/\/[^\n]*\n/g, "\n").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+describe("ADR-0011 Wave 4 — form primitives migration", () => {
+  it("Label uses text-ink (v2) instead of text-foreground (v1)", () => {
+    const code = readNonComment(COMPONENT("label.tsx"));
+    expect(code.includes("text-ink")).toBe(true);
+    expect(code.includes("text-foreground")).toBe(false);
+  });
+
+  it("Input variants use v2 surface / edge / ink-muted / brand classes", () => {
+    const code = readNonComment(COMPONENT("inputVariants.ts"));
+    expect(code.includes("border-edge-strong")).toBe(true);
+    expect(code.includes("bg-surface")).toBe(true);
+    expect(code.includes("text-ink-muted")).toBe(true);
+    expect(code.includes("ring-brand")).toBe(true);
+    // v1 names retired from the source (still appear in the migration
+    // comment, but readNonComment strips those out).
+    expect(code.includes("border-input")).toBe(false);
+    expect(code.includes("bg-background")).toBe(false);
+    expect(code.includes("text-muted-foreground")).toBe(false);
+    // ``ring-ring`` is the v1 focus ring — check no spaced/non-comment
+    // usage remains.
+    expect(code.includes("ring-ring")).toBe(false);
+  });
+
+  it("Checkbox uses v2 brand / surface / edge classes", () => {
+    const code = readNonComment(COMPONENT("checkbox.tsx"));
+    expect(code.includes("border-edge-strong")).toBe(true);
+    expect(code.includes("bg-surface")).toBe(true);
+    expect(code.includes("data-[state=checked]:bg-brand")).toBe(true);
+    expect(code.includes("data-[state=checked]:text-brand-foreground")).toBe(true);
+    expect(code.includes("focus-visible:ring-brand")).toBe(true);
+    // v1 names retired from source.
+    expect(code.includes("border-input")).toBe(false);
+    expect(code.includes("bg-background")).toBe(false);
+    expect(code.includes("bg-primary")).toBe(false);
+    expect(code.includes("text-primary-foreground")).toBe(false);
+  });
+});


### PR DESCRIPTION
ADR-0011 **Wave 4 of 10**. Migrates Label, Input, and Checkbox to v2 semantic vocabulary. Select + RadioGroup wrap Radix's own primitives without inline color classes — they inherit from Input's vocabulary through their trigger surface and need no separate edit in this wave.

## Changes

* `label.tsx` — `text-foreground` → `text-ink`.
* `inputVariants.ts` — `border-input` → `border-edge-strong`, `bg-background` → `bg-surface`, placeholder `text-muted-foreground` → `text-ink-muted`, `ring-ring` → `ring-brand`. Disabled state stays on v1 `muted` (a dedicated `--color-disabled` token lands later).
* `checkbox.tsx` — same surface vocabulary, plus the checked + indeterminate states swap `border-primary` / `bg-primary` / `text-primary-foreground` → `border-brand` / `bg-brand` / `text-brand-foreground`.

## Test plan

- [x] +3 sentinel tests (`wave4-forms.test.ts`) lock the swaps
- [x] Full frontend suite (**343 total**) green
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds

Pixels identical today via the tokens-bridge layer; will flip to OKLCH in Wave 9 with no further component edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)