### PR TITLE
feat(design): visual overhaul v2 Wave 5 — Surfaces

### DIFF
--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -35,8 +35,9 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
       ref={ref}
+      // ADR-0011 Wave 5 — border-border -> border-edge, bg-background -> bg-surface.
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-background p-6 shadow-lg sm:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 border border-edge bg-surface p-6 shadow-lg sm:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}
@@ -76,7 +77,8 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    // ADR-0011 Wave 5 — text-muted-foreground -> text-ink-muted.
+    className={cn("text-sm text-ink-muted", className)}
     {...props}
   />
 ))
@@ -206,10 +208,10 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
                 </AlertDialogDescription>
               )}
               {confirmState.bulletList && confirmState.bulletList.length > 0 && (
-                <ul className="mt-3 space-y-1 rounded-md border border-border bg-muted/30 px-4 py-3 text-sm text-foreground">
+                <ul className="mt-3 space-y-1 rounded-md border border-edge bg-muted/30 px-4 py-3 text-sm text-ink">
                   {confirmState.bulletList.map((item, i) => (
                     <li key={i} className="flex items-start gap-2 text-wrap-safe">
-                      <span aria-hidden className="mt-2 h-1 w-1 shrink-0 rounded-full bg-muted-foreground" />
+                      <span aria-hidden className="mt-2 h-1 w-1 shrink-0 rounded-full bg-ink-muted" />
                       <span>{item}</span>
                     </li>
                   ))}
@@ -258,7 +260,7 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
                 // Use the dialog title as the accessible name — the prompt
                 // input is the dialog's sole field, so the title IS its label.
                 aria-label={promptState.title}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                className="flex h-10 w-full rounded-md border border-edge-strong bg-surface px-3 py-2 text-sm ring-offset-background placeholder:text-ink-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
               />
               <AlertDialogFooter className="mt-4">
                 <AlertDialogCancel type="button" onClick={() => handlePromptDone(null)}>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -35,7 +35,9 @@ const DialogContent = React.forwardRef<
         className={cn(
           // Mobile-first: bottom-sheet drawer that slides up from the
           // bottom edge, full-width, rounded top only, safe-area aware.
-          "fixed inset-x-0 bottom-0 z-50 grid w-full max-h-[90dvh] gap-4 overflow-y-auto rounded-t-xl border bg-background p-6 pb-[calc(env(safe-area-inset-bottom)+1.5rem)] shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          //
+          // ADR-0011 Wave 5 — bg-background -> bg-surface.
+          "fixed inset-x-0 bottom-0 z-50 grid w-full max-h-[90dvh] gap-4 overflow-y-auto rounded-t-xl border bg-surface p-6 pb-[calc(env(safe-area-inset-bottom)+1.5rem)] shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
           // sm+: classic centered modal restored.
           "sm:inset-x-auto sm:bottom-auto sm:left-[50%] sm:top-[50%] sm:max-h-none sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] sm:overflow-visible sm:rounded-lg sm:pb-6 sm:data-[state=closed]:slide-out-to-left-1/2 sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:slide-in-from-left-1/2 sm:data-[state=open]:slide-in-from-top-[48%] sm:data-[state=open]:zoom-in-95",
           className,
@@ -43,7 +45,9 @@ const DialogContent = React.forwardRef<
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        {/* ADR-0011 Wave 5 — ring-ring -> ring-brand, bg-accent ->
+            bg-heritage (sage), text-muted-foreground -> text-ink-muted. */}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-heritage data-[state=open]:text-ink-muted">
           <X className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
           <span className="sr-only">{t("common.close")}</span>
         </DialogPrimitive.Close>

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -15,12 +15,13 @@ const PopoverContent = React.forwardRef<
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      // Matches the existing dropdown-menu surface treatment: bg-popover
-      // with text-popover-foreground from the semantic token set, soft
-      // shadow (overlays-only is in our shadow rules), 1px border, and
-      // rounded-md per the radius rule in DESIGN.md.
+      // ADR-0011 Wave 5 — migrated to v2 vocabulary.
+      // border-border -> border-edge, bg-popover -> bg-surface-elevated,
+      // text-popover-foreground -> text-ink. v1's --popover and --card
+      // are the same HSL value so bg-surface-elevated (which the
+      // bridge maps to --card) renders identically.
       className={cn(
-        "z-50 rounded-md border border-border bg-popover p-3 text-popover-foreground shadow-md outline-none",
+        "z-50 rounded-md border border-edge bg-surface-elevated p-3 text-ink shadow-md outline-none",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -29,13 +29,14 @@ const SheetOverlay = React.forwardRef<
 ))
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
+// ADR-0011 Wave 5 — bg-background -> bg-surface, border-border -> border-edge.
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
+  "fixed z-50 gap-4 bg-surface shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
   {
     variants: {
       side: {
         right:
-          "inset-y-0 right-0 h-full w-[min(100vw-1rem,20rem)] border-l border-border p-0 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-md",
+          "inset-y-0 right-0 h-full w-[min(100vw-1rem,20rem)] border-l border-edge p-0 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-md",
       },
     },
     defaultVariants: {
@@ -58,7 +59,8 @@ const SheetContent = React.forwardRef<
       <SheetOverlay />
       <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
         {children}
-        <SheetPrimitive.Close className="absolute right-3 top-3 rounded-md p-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+        {/* ADR-0011 Wave 5 — ring-ring -> ring-brand. */}
+        <SheetPrimitive.Close className="absolute right-3 top-3 rounded-md p-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2">
           <X className="h-4 w-4" strokeWidth={1.75} aria-hidden />
           <span className="sr-only">{t("common.close")}</span>
         </SheetPrimitive.Close>
@@ -68,8 +70,9 @@ const SheetContent = React.forwardRef<
 })
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
+// ADR-0011 Wave 5 — border-border -> border-edge.
 const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col gap-1 border-b border-border px-6 pb-4 pt-6 text-left", className)} {...props} />
+  <div className={cn("flex flex-col gap-1 border-b border-edge px-6 pb-4 pt-6 text-left", className)} {...props} />
 )
 SheetHeader.displayName = "SheetHeader"
 
@@ -79,7 +82,8 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn("font-serif text-lg font-semibold tracking-tight text-foreground", className)}
+    // ADR-0011 Wave 5 — text-foreground -> text-ink.
+    className={cn("font-serif text-lg font-semibold tracking-tight text-ink", className)}
     {...props}
   />
 ))
@@ -91,7 +95,8 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    // ADR-0011 Wave 5 — text-muted-foreground -> text-ink-muted.
+    className={cn("text-sm text-ink-muted", className)}
     {...props}
   />
 ))

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -36,8 +36,10 @@ function TooltipContent({
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         sideOffset={sideOffset}
+        // ADR-0011 Wave 5 — bg-primary -> bg-brand, text-primary-foreground
+        // -> text-brand-foreground. Pixel-identical via tokens-bridge.
         className={cn(
-          "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 overflow-hidden rounded-md bg-brand px-3 py-1.5 text-xs text-brand-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className
         )}
         {...props}

--- a/frontend/src/styles/__tests__/wave5-surfaces.test.ts
+++ b/frontend/src/styles/__tests__/wave5-surfaces.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Sentinel for ADR-0011 Wave 5 — Surfaces migration.
+ *
+ * Locks Modal (dialog.tsx), AlertDialog, Sheet, Popover, and Tooltip
+ * onto the v2 semantic vocabulary. Pixels are identical via the
+ * tokens-bridge today. Each lock-out below uses `\b` word boundary
+ * regex (Wave 3 used a brittle substring check that missed
+ * `bg-primary/90` and `hover:bg-accent/40`; that lesson is applied
+ * here).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const COMPONENT = (...parts: string[]) =>
+  resolve(HERE, "..", "..", "components", "ui", ...parts);
+
+function readNonComment(path: string): string {
+  const raw = readFileSync(path, "utf-8");
+  return raw
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+/** Stronger lock-out: matches the class name regardless of suffix
+ *  (`/90`, `/40`, `:hover`, etc.). The v1 class name appearing
+ *  anywhere as a Tailwind class is a regression we want to catch. */
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`\\b${escaped}\\b`);
+  return re.test(code);
+}
+
+describe("ADR-0011 Wave 5 — Surfaces migration", () => {
+  it("popover uses v2 surface-elevated + edge + ink", () => {
+    const code = readNonComment(COMPONENT("popover.tsx"));
+    expect(code.includes("bg-surface-elevated")).toBe(true);
+    expect(code.includes("border-edge")).toBe(true);
+    expect(code.includes("text-ink")).toBe(true);
+    expect(containsClass(code, "bg-popover")).toBe(false);
+    expect(containsClass(code, "text-popover-foreground")).toBe(false);
+    expect(containsClass(code, "border-border")).toBe(false);
+  });
+
+  it("tooltip uses bg-brand (matches primary, not ink)", () => {
+    const code = readNonComment(COMPONENT("tooltip.tsx"));
+    expect(code.includes("bg-brand")).toBe(true);
+    expect(code.includes("text-brand-foreground")).toBe(true);
+    expect(containsClass(code, "bg-primary")).toBe(false);
+    expect(containsClass(code, "text-primary-foreground")).toBe(false);
+  });
+
+  it("dialog uses v2 surface + brand-ring + heritage open-state", () => {
+    const code = readNonComment(COMPONENT("dialog.tsx"));
+    expect(code.includes("bg-surface")).toBe(true);
+    expect(code.includes("focus-visible:ring-brand")).toBe(true);
+    expect(code.includes("data-[state=open]:bg-heritage")).toBe(true);
+    expect(code.includes("data-[state=open]:text-ink-muted")).toBe(true);
+    expect(containsClass(code, "bg-background")).toBe(false);
+    expect(containsClass(code, "ring-ring")).toBe(false);
+    expect(containsClass(code, "bg-accent")).toBe(false);
+    expect(containsClass(code, "text-muted-foreground")).toBe(false);
+  });
+
+  it("sheet uses v2 surface + edge + ink + brand-ring", () => {
+    const code = readNonComment(COMPONENT("sheet.tsx"));
+    expect(code.includes("bg-surface")).toBe(true);
+    expect(code.includes("border-edge")).toBe(true);
+    expect(code.includes("text-ink")).toBe(true);
+    expect(code.includes("text-ink-muted")).toBe(true);
+    expect(code.includes("focus-visible:ring-brand")).toBe(true);
+    expect(containsClass(code, "bg-background")).toBe(false);
+    expect(containsClass(code, "border-border")).toBe(false);
+    expect(containsClass(code, "text-foreground")).toBe(false);
+    expect(containsClass(code, "text-muted-foreground")).toBe(false);
+    expect(containsClass(code, "ring-ring")).toBe(false);
+  });
+
+  it("alert-dialog uses v2 edge + surface + ink classes", () => {
+    const code = readNonComment(COMPONENT("alert-dialog.tsx"));
+    expect(code.includes("border-edge")).toBe(true);
+    expect(code.includes("bg-surface")).toBe(true);
+    expect(code.includes("text-ink")).toBe(true);
+    expect(code.includes("text-ink-muted")).toBe(true);
+    expect(code.includes("bg-ink-muted")).toBe(true);
+    expect(code.includes("focus-visible:ring-brand")).toBe(true);
+    expect(containsClass(code, "border-border")).toBe(false);
+    expect(containsClass(code, "border-input")).toBe(false);
+    expect(containsClass(code, "bg-background")).toBe(false);
+    expect(containsClass(code, "text-foreground")).toBe(false);
+    expect(containsClass(code, "text-muted-foreground")).toBe(false);
+    expect(containsClass(code, "bg-muted-foreground")).toBe(false);
+    expect(containsClass(code, "ring-ring")).toBe(false);
+  });
+});


### PR DESCRIPTION
ADR-0011 **Wave 5 of 10**. Migrates the overlay primitives (Popover, Tooltip, Dialog, Sheet, AlertDialog) to v2 semantic vocabulary.

## Per-component summary

* **popover.tsx** — `border-border bg-popover text-popover-foreground` → `border-edge bg-surface-elevated text-ink`. v1 popover and card share the same HSL value so surface-elevated renders identically.
* **tooltip.tsx** — `bg-primary text-primary-foreground` → `bg-brand text-brand-foreground`. **Mapping trap avoided:** `text-ink` would have looked wrong in light mode (primary-foreground is white, ink is dark).
* **dialog.tsx** — `bg-background` → `bg-surface`, `ring-ring` → `ring-brand`, `data-[state=open]:bg-accent` → `bg-heritage`, `data-[state=open]:text-muted-foreground` → `text-ink-muted`.
* **sheet.tsx** — same drill across overlay surface + border + foreground + close-button ring.
* **alert-dialog.tsx** — including the embedded prompt input which mirrors Wave 4's input vocabulary (`border-edge-strong`, `bg-surface`, `placeholder:text-ink-muted`, `ring-brand`).

## Stronger sentinel

`wave5-surfaces.test.ts` uses **word-boundary regex** (`\b...\b`) for lock-outs after Wave 3's brittle substring match missed `bg-primary/90` and `hover:bg-accent/40`. Wave 3 + 4 sentinel files will be retrofitted in a follow-up.

## Test plan

- [x] +5 sentinel tests
- [x] Full frontend suite (**348 total**) green
- [x] `eslint` + `tsc --noEmit` clean
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)