### PR TITLE
feat(design): visual overhaul v2 Wave 6 — Editorial primitives

### DIFF
--- a/frontend/src/components/patterns/EmptyState.tsx
+++ b/frontend/src/components/patterns/EmptyState.tsx
@@ -34,13 +34,13 @@ export function EmptyState({
         )}
       >
         {icon && (
-          <span className="text-muted-foreground/80 [&_svg]:h-5 [&_svg]:w-5">
+          <span className="text-ink-muted/80 [&_svg]:h-5 [&_svg]:w-5">
             {icon}
           </span>
         )}
-        <p className="text-sm text-muted-foreground">{title}</p>
+        <p className="text-sm text-ink-muted">{title}</p>
         {description && (
-          <p className="max-w-md text-xs text-muted-foreground/80">
+          <p className="max-w-md text-xs text-ink-muted/80">
             {description}
           </p>
         )}
@@ -52,19 +52,19 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "animate-fade-in flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-background px-6 py-12 text-center",
+        "animate-fade-in flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-edge bg-surface px-6 py-12 text-center",
         className,
       )}
     >
       {icon && (
-        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-muted-foreground [&_svg]:h-5 [&_svg]:w-5">
+        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-ink-muted [&_svg]:h-5 [&_svg]:w-5">
           {icon}
         </span>
       )}
       <div className="space-y-1">
-        <p className="font-serif text-base font-semibold text-foreground">{title}</p>
+        <p className="font-serif text-base font-semibold text-ink">{title}</p>
         {description && (
-          <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+          <p className="max-w-md text-sm text-ink-muted">{description}</p>
         )}
       </div>
       {action && <div className="pt-1">{action}</div>}

--- a/frontend/src/components/patterns/ErrorState.tsx
+++ b/frontend/src/components/patterns/ErrorState.tsx
@@ -47,9 +47,9 @@ export function ErrorState({
         {icon ?? <AlertTriangle strokeWidth={1.75} aria-hidden />}
       </span>
       <div className="space-y-1">
-        <h2 className="font-serif text-base font-semibold tracking-tight text-foreground">{resolvedTitle}</h2>
+        <h2 className="font-serif text-base font-semibold tracking-tight text-ink">{resolvedTitle}</h2>
         {description && (
-          <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+          <p className="max-w-md text-sm text-ink-muted">{description}</p>
         )}
       </div>
       {(action || secondaryAction) && (

--- a/frontend/src/components/patterns/PageHeader.tsx
+++ b/frontend/src/components/patterns/PageHeader.tsx
@@ -29,7 +29,7 @@ export function PageHeader({
       {backTo && (
         <Link
           to={backTo}
-          className="-mx-2 inline-flex min-h-[44px] items-center gap-1 rounded-md px-2 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:mx-0 sm:min-h-0 sm:px-0"
+          className="-mx-2 inline-flex min-h-[44px] items-center gap-1 rounded-md px-2 text-xs text-ink-muted transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 sm:mx-0 sm:min-h-0 sm:px-0"
         >
           <ChevronLeft className="h-3.5 w-3.5" strokeWidth={1.75} />
           {backLabel}
@@ -43,7 +43,7 @@ export function PageHeader({
         )}
       </div>
       {description && (
-        <div className="max-w-3xl text-sm text-muted-foreground text-wrap-safe">
+        <div className="max-w-3xl text-sm text-ink-muted text-wrap-safe">
           {description}
         </div>
       )}

--- a/frontend/src/components/patterns/StatCard.tsx
+++ b/frontend/src/components/patterns/StatCard.tsx
@@ -38,10 +38,10 @@ export function StatCard({
       <Card>
         <CardContent className="flex items-center gap-4 p-5">
           <div className="rounded-md bg-muted p-3">
-            <Icon className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+            <Icon className="h-6 w-6 text-ink-muted" strokeWidth={1.75} aria-hidden />
           </div>
           <div>
-            <p className="text-sm text-muted-foreground">{label}</p>
+            <p className="text-sm text-ink-muted">{label}</p>
             <p className={cn("text-2xl font-bold tabular-nums", valueClassName)}>{value}</p>
           </div>
         </CardContent>
@@ -54,10 +54,10 @@ export function StatCard({
       <CardContent className="pt-6">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm text-muted-foreground">{label}</p>
+            <p className="text-sm text-ink-muted">{label}</p>
             <p className={cn("text-2xl font-bold tabular-nums mt-1", valueClassName)}>{value}</p>
           </div>
-          <Icon className="h-6 w-6 text-muted-foreground/60" strokeWidth={1.75} aria-hidden />
+          <Icon className="h-6 w-6 text-ink-muted/60" strokeWidth={1.75} aria-hidden />
         </div>
       </CardContent>
     </Card>

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -2,16 +2,24 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
+// ADR-0011 Wave 6 — editorial primitives migration.
+// Migrated to v2 vocabulary: primary -> brand, secondary -> brand-quiet,
+// accent -> heritage, foreground -> ink, ring-ring -> ring-brand.
+// destructive / success / warning / info / muted stay on v1 — no v2
+// equivalents are in the bridge or tailwind config yet (the tokens-v2
+// CSS has --color-{success,warning,danger,info} but they aren't aliased
+// in tailwind.config.js, so the v1 classes are still the only working
+// path for those semantic tones).
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/90",
+          "border-transparent bg-brand text-brand-foreground hover:bg-brand/90",
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        outline: "text-foreground",
+          "border-transparent bg-brand-quiet text-ink hover:bg-brand-quiet/80",
+        outline: "text-ink",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/90",
         success:
@@ -22,13 +30,13 @@ const badgeVariants = cva(
         muted:
           "border-transparent bg-muted text-muted-foreground hover:bg-muted/80",
         accent:
-          "border-transparent bg-accent text-accent-foreground hover:bg-accent/80",
+          "border-transparent bg-heritage text-ink hover:bg-heritage/80",
         successSubtle: "border-transparent bg-success/15 text-success",
         warningSubtle: "border-transparent bg-warning/15 text-warning",
         infoSubtle: "border-transparent bg-info/15 text-info",
         destructiveSubtle:
           "border-transparent bg-destructive/15 text-destructive",
-        primarySubtle: "border-transparent bg-primary/15 text-primary",
+        primarySubtle: "border-transparent bg-brand/15 text-brand",
       },
     },
     defaultVariants: { variant: "default" },

--- a/frontend/src/styles/__tests__/wave6-editorial.test.ts
+++ b/frontend/src/styles/__tests__/wave6-editorial.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Sentinel for ADR-0011 Wave 6 — Editorial primitives migration.
+ *
+ * Locks Badge, EmptyState, ErrorState, PageHeader, StatCard onto the
+ * v2 semantic vocabulary. Uses the word-boundary `containsClass`
+ * helper from Wave 5 to avoid the brittle substring lock-out that
+ * Wave 3's sentinel had.
+ *
+ * Notable: success / warning / info / destructive / muted variants
+ * stay on v1 because the bridge doesn't (yet) expose v2 aliases for
+ * those semantic tones in tailwind.config.js. Locks here only
+ * assert the migrated portion.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const COMPONENT_UI = (...parts: string[]) =>
+  resolve(HERE, "..", "..", "components", "ui", ...parts);
+const COMPONENT_PATTERN = (...parts: string[]) =>
+  resolve(HERE, "..", "..", "components", "patterns", ...parts);
+
+function readNonComment(path: string): string {
+  return readFileSync(path, "utf-8")
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`).test(code);
+}
+
+describe("ADR-0011 Wave 6 — Editorial primitives migration", () => {
+  it("Badge default variant uses brand vocabulary", () => {
+    const code = readNonComment(COMPONENT_UI("badge.tsx"));
+    expect(code.includes("bg-brand")).toBe(true);
+    expect(code.includes("text-brand-foreground")).toBe(true);
+    expect(code.includes("bg-brand-quiet")).toBe(true);
+    expect(code.includes("bg-heritage")).toBe(true);
+    expect(code.includes("focus-visible:ring-brand")).toBe(true);
+    expect(code.includes("text-ink")).toBe(true);
+    // v1 names retired for the migrated variants. The v1 success/
+    // warning/info/destructive/muted variants stay (no v2 aliases
+    // in tailwind config yet); their classes are NOT locked out
+    // here.
+    expect(containsClass(code, "bg-primary")).toBe(false);
+    expect(containsClass(code, "text-primary-foreground")).toBe(false);
+    expect(containsClass(code, "bg-secondary")).toBe(false);
+    expect(containsClass(code, "text-secondary-foreground")).toBe(false);
+    expect(containsClass(code, "bg-accent")).toBe(false);
+    expect(containsClass(code, "text-accent-foreground")).toBe(false);
+    expect(containsClass(code, "ring-ring")).toBe(false);
+    expect(containsClass(code, "text-foreground")).toBe(false);
+  });
+
+  it("EmptyState uses surface + edge + ink vocabulary", () => {
+    const code = readNonComment(COMPONENT_PATTERN("EmptyState.tsx"));
+    expect(code.includes("bg-surface")).toBe(true);
+    expect(code.includes("border-edge")).toBe(true);
+    expect(code.includes("text-ink")).toBe(true);
+    expect(code.includes("text-ink-muted")).toBe(true);
+    expect(containsClass(code, "bg-background")).toBe(false);
+    expect(containsClass(code, "border-border")).toBe(false);
+    expect(containsClass(code, "text-foreground")).toBe(false);
+    expect(containsClass(code, "text-muted-foreground")).toBe(false);
+  });
+
+  it("ErrorState uses ink vocabulary", () => {
+    const code = readNonComment(COMPONENT_PATTERN("ErrorState.tsx"));
+    expect(code.includes("text-ink")).toBe(true);
+    expect(code.includes("text-ink-muted")).toBe(true);
+    expect(containsClass(code, "text-foreground")).toBe(false);
+    expect(containsClass(code, "text-muted-foreground")).toBe(false);
+  });
+
+  it("PageHeader back-link uses v2 focus ring + ink-muted vocabulary", () => {
+    const code = readNonComment(COMPONENT_PATTERN("PageHeader.tsx"));
+    expect(code.includes("text-ink-muted")).toBe(true);
+    expect(code.includes("hover:text-ink")).toBe(true);
+    expect(code.includes("focus-visible:ring-brand")).toBe(true);
+    expect(containsClass(code, "text-muted-foreground")).toBe(false);
+    expect(containsClass(code, "ring-ring")).toBe(false);
+  });
+
+  it("StatCard uses ink-muted for labels", () => {
+    const code = readNonComment(COMPONENT_PATTERN("StatCard.tsx"));
+    expect(code.includes("text-ink-muted")).toBe(true);
+    expect(containsClass(code, "text-muted-foreground")).toBe(false);
+  });
+});


### PR DESCRIPTION
ADR-0011 **Wave 6 of 10**. Migrates Badge + EmptyState + ErrorState + PageHeader + StatCard onto v2 vocabulary.

## What changed

* **badge.tsx** — default/secondary/accent → brand/brand-quiet/heritage; outline + primarySubtle → text-ink + text-brand. ring-ring → ring-brand. **NOTE:** success/warning/info/destructive/muted variants stay on v1 because the bridge doesn't expose v2 aliases for those semantic tones in tailwind.config yet — follow-up wave should add `--color-{success,warning,danger,info}` aliases.
* **EmptyState.tsx** — border-border/bg-background → border-edge/bg-surface; text-foreground → text-ink; text-muted-foreground → text-ink-muted (4×).
* **ErrorState.tsx** — text-foreground → text-ink; text-muted-foreground → text-ink-muted.
* **PageHeader.tsx** — back-link migrated to text-ink-muted + hover:text-ink + focus-visible:ring-brand; description block text-muted-foreground → text-ink-muted.
* **StatCard.tsx** — text-muted-foreground → text-ink-muted (3×).

* **wave6-editorial.test.ts** — sentinel using the word-boundary `containsClass` helper from Wave 5.

## Test plan

- [x] +5 sentinel tests
- [x] Full frontend suite (**353 total**) green
- [x] eslint + tsc clean
- [x] Pixel-identical via tokens-bridge today

🤖 Generated with [Claude Code](https://claude.com/claude-code)