### PR TITLE
feat(design): visual overhaul v2 Wave 7 (editor toolbar slice)

### DIFF
--- a/frontend/src/components/editor/CalloutDropdown.tsx
+++ b/frontend/src/components/editor/CalloutDropdown.tsx
@@ -25,7 +25,7 @@ const CALLOUT_VARIANTS: CalloutChoice[] = [
   { value: "verse", icon: BookOpen, color: "text-accent" },
   { value: "takeaway", icon: Lightbulb, color: "text-success" },
   { value: "warning", icon: AlertTriangle, color: "text-warning" },
-  { value: "toggle", icon: ChevronsUpDown, color: "text-muted-foreground" },
+  { value: "toggle", icon: ChevronsUpDown, color: "text-ink-muted" },
 ];
 
 // Static i18n key lookup — exposes each literal to the keyCoverage
@@ -97,11 +97,12 @@ export function CalloutDropdown({
         aria-label={t("blockEditor.callout.trigger")}
         aria-haspopup="menu"
         aria-expanded={open}
+        // ADR-0011 Wave 7 — toolbar-button vocabulary migrated to v2.
         className={cn(
-          "flex items-center gap-0.5 rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "flex items-center gap-0.5 rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
           isActive
-            ? "bg-primary/20 text-primary ring-1 ring-inset ring-primary/30"
-            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            ? "bg-brand/20 text-brand ring-1 ring-inset ring-brand/30"
+            : "text-ink-muted hover:bg-heritage hover:text-ink",
         )}
       >
         <Info size={iconSize} strokeWidth={1.75} aria-hidden="true" />
@@ -112,7 +113,8 @@ export function CalloutDropdown({
           role="menu"
           aria-label={t("blockEditor.callout.trigger")}
           className={cn(
-            "absolute top-full z-20 mt-1 w-52 rounded-md border bg-background py-1 shadow-lg",
+            // ADR-0011 Wave 7 — bg-background -> bg-surface-elevated.
+            "absolute top-full z-20 mt-1 w-52 rounded-md border bg-surface-elevated py-1 shadow-lg",
             alignClass,
           )}
         >
@@ -124,7 +126,7 @@ export function CalloutDropdown({
                 type="button"
                 role="menuitem"
                 onClick={() => insertCallout(v.value)}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
                 <Icon size={16} className={v.color} aria-hidden="true" />
                 {t(CALLOUT_LABEL_KEYS[v.value])}
@@ -138,7 +140,7 @@ export function CalloutDropdown({
                 type="button"
                 role="menuitem"
                 onClick={removeCallout}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
                 {t("blockEditor.callout.remove")}
               </button>

--- a/frontend/src/components/editor/CodeBlockDropdown.tsx
+++ b/frontend/src/components/editor/CodeBlockDropdown.tsx
@@ -84,11 +84,12 @@ export function CodeBlockDropdown({
         }
         aria-haspopup={isInCodeBlock ? "menu" : undefined}
         aria-expanded={isInCodeBlock ? open : undefined}
+        // ADR-0011 Wave 7 — same toolbar-button vocabulary as Callout/Table dropdowns.
         className={cn(
-          "flex items-center gap-0.5 rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "flex items-center gap-0.5 rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
           isInCodeBlock
-            ? "bg-primary/20 text-primary ring-1 ring-inset ring-primary/30"
-            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            ? "bg-brand/20 text-brand ring-1 ring-inset ring-brand/30"
+            : "text-ink-muted hover:bg-heritage hover:text-ink",
         )}
       >
         <Code2 size={iconSize} strokeWidth={1.75} aria-hidden="true" />
@@ -99,7 +100,7 @@ export function CodeBlockDropdown({
           role="menu"
           aria-label={t("blockEditor.codeBlock.changeLanguage")}
           className={cn(
-            "absolute top-full z-20 mt-1 w-44 rounded-md border bg-background py-1 shadow-lg",
+            "absolute top-full z-20 mt-1 w-44 rounded-md border bg-surface-elevated py-1 shadow-lg",
             alignClass,
           )}
         >
@@ -111,13 +112,13 @@ export function CodeBlockDropdown({
               aria-checked={lang === currentLanguage}
               onClick={() => pickLanguage(lang)}
               className={cn(
-                "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted",
+                "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage",
                 lang === currentLanguage && "font-medium",
               )}
             >
               <span>{CODE_LANGUAGE_LABELS[lang]}</span>
               {lang === currentLanguage && (
-                <Check size={14} strokeWidth={1.75} aria-hidden="true" className="text-primary" />
+                <Check size={14} strokeWidth={1.75} aria-hidden="true" className="text-brand" />
               )}
             </button>
           ))}

--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -52,11 +52,16 @@ function ToolbarButton({
       title={title}
       aria-label={title}
       aria-pressed={pressable ? active : undefined}
+      // ADR-0011 Wave 7 — migrated to v2 vocabulary.
+      // ring-ring -> ring-brand, bg-primary/20 -> bg-brand/20,
+      // text-primary -> text-brand, ring-primary/30 -> ring-brand/30,
+      // text-muted-foreground -> text-ink-muted, hover:bg-accent ->
+      // hover:bg-heritage, hover:text-accent-foreground -> hover:text-ink.
       className={cn(
-        "rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
         active
-          ? "bg-primary/20 text-primary ring-1 ring-inset ring-primary/30"
-          : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+          ? "bg-brand/20 text-brand ring-1 ring-inset ring-brand/30"
+          : "text-ink-muted hover:bg-heritage hover:text-ink",
         disabled && "cursor-not-allowed opacity-40",
       )}
     >
@@ -68,7 +73,8 @@ function ToolbarButton({
 function ToolbarDivider() {
   // role="separator" so AT treats the divider as a group boundary rather
   // than as a visible-but-unannounced element.
-  return <div role="separator" aria-orientation="vertical" className="mx-1 h-5 w-px bg-border" />;
+  // ADR-0011 Wave 7 — bg-border -> bg-edge.
+  return <div role="separator" aria-orientation="vertical" className="mx-1 h-5 w-px bg-edge" />;
 }
 
 interface EditorToolbarProps {
@@ -113,7 +119,8 @@ export function EditorToolbar({
       // the original wrap behaviour above the ``sm`` breakpoint where
       // there's enough room. ``no-scrollbar`` (utility added in
       // index.css) hides the visible bar — touch scroll still works.
-      className="sticky top-0 z-20 flex flex-nowrap items-center gap-0.5 overflow-x-auto border-b border-input bg-background px-2 py-1.5 no-scrollbar sm:flex-wrap sm:overflow-x-visible"
+      // ADR-0011 Wave 7 — border-input -> border-edge-strong, bg-background -> bg-surface.
+      className="sticky top-0 z-20 flex flex-nowrap items-center gap-0.5 overflow-x-auto border-b border-edge-strong bg-surface px-2 py-1.5 no-scrollbar sm:flex-wrap sm:overflow-x-visible"
     >
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleBold().run()}

--- a/frontend/src/components/editor/TableDropdown.tsx
+++ b/frontend/src/components/editor/TableDropdown.tsx
@@ -75,11 +75,12 @@ export function TableDropdown({
         aria-label={t("blockEditor.table.trigger")}
         aria-haspopup="menu"
         aria-expanded={open}
+        // ADR-0011 Wave 7 — toolbar-button vocabulary.
         className={cn(
-          "flex items-center gap-0.5 rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "flex items-center gap-0.5 rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
           isInTable
-            ? "bg-primary/20 text-primary ring-1 ring-inset ring-primary/30"
-            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            ? "bg-brand/20 text-brand ring-1 ring-inset ring-brand/30"
+            : "text-ink-muted hover:bg-heritage hover:text-ink",
         )}
       >
         <TableIcon size={iconSize} strokeWidth={1.75} aria-hidden="true" />
@@ -90,7 +91,7 @@ export function TableDropdown({
           role="menu"
           aria-label={t("blockEditor.table.trigger")}
           className={cn(
-            "absolute top-full z-20 mt-1 w-56 rounded-md border bg-background py-1 shadow-lg",
+            "absolute top-full z-20 mt-1 w-56 rounded-md border bg-surface-elevated py-1 shadow-lg",
             alignClass,
           )}
         >
@@ -107,9 +108,9 @@ export function TableDropdown({
                     .run(),
                 )
               }
-              className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
             >
-              <TableIcon size={16} strokeWidth={1.75} aria-hidden="true" className="text-muted-foreground" />
+              <TableIcon size={16} strokeWidth={1.75} aria-hidden="true" className="text-ink-muted" />
               {t("blockEditor.table.insert")}
             </button>
           )}
@@ -119,36 +120,36 @@ export function TableDropdown({
                 type="button"
                 role="menuitem"
                 onClick={() => run(() => editor.chain().focus().addRowBefore().run())}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
-                <ArrowUpToLine size={16} strokeWidth={1.75} aria-hidden="true" className="text-muted-foreground" />
+                <ArrowUpToLine size={16} strokeWidth={1.75} aria-hidden="true" className="text-ink-muted" />
                 {t("blockEditor.table.addRowBefore")}
               </button>
               <button
                 type="button"
                 role="menuitem"
                 onClick={() => run(() => editor.chain().focus().addRowAfter().run())}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
-                <ArrowDownToLine size={16} strokeWidth={1.75} aria-hidden="true" className="text-muted-foreground" />
+                <ArrowDownToLine size={16} strokeWidth={1.75} aria-hidden="true" className="text-ink-muted" />
                 {t("blockEditor.table.addRowAfter")}
               </button>
               <button
                 type="button"
                 role="menuitem"
                 onClick={() => run(() => editor.chain().focus().addColumnBefore().run())}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
-                <ArrowLeftToLine size={16} strokeWidth={1.75} aria-hidden="true" className="text-muted-foreground" />
+                <ArrowLeftToLine size={16} strokeWidth={1.75} aria-hidden="true" className="text-ink-muted" />
                 {t("blockEditor.table.addColumnBefore")}
               </button>
               <button
                 type="button"
                 role="menuitem"
                 onClick={() => run(() => editor.chain().focus().addColumnAfter().run())}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
-                <ArrowRightToLine size={16} strokeWidth={1.75} aria-hidden="true" className="text-muted-foreground" />
+                <ArrowRightToLine size={16} strokeWidth={1.75} aria-hidden="true" className="text-ink-muted" />
                 {t("blockEditor.table.addColumnAfter")}
               </button>
               <div className="my-1 border-t" role="separator" />
@@ -156,9 +157,9 @@ export function TableDropdown({
                 type="button"
                 role="menuitem"
                 onClick={() => run(() => editor.chain().focus().toggleHeaderRow().run())}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
-                <Columns3 size={16} strokeWidth={1.75} aria-hidden="true" className="text-muted-foreground" />
+                <Columns3 size={16} strokeWidth={1.75} aria-hidden="true" className="text-ink-muted" />
                 {t("blockEditor.table.toggleHeaderRow")}
               </button>
               <div className="my-1 border-t" role="separator" />
@@ -166,18 +167,18 @@ export function TableDropdown({
                 type="button"
                 role="menuitem"
                 onClick={() => run(() => editor.chain().focus().deleteRow().run())}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
-                <Rows3 size={16} strokeWidth={1.75} aria-hidden="true" className="text-muted-foreground" />
+                <Rows3 size={16} strokeWidth={1.75} aria-hidden="true" className="text-ink-muted" />
                 {t("blockEditor.table.deleteRow")}
               </button>
               <button
                 type="button"
                 role="menuitem"
                 onClick={() => run(() => editor.chain().focus().deleteColumn().run())}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
-                <Columns3 size={16} strokeWidth={1.75} aria-hidden="true" className="text-muted-foreground" />
+                <Columns3 size={16} strokeWidth={1.75} aria-hidden="true" className="text-ink-muted" />
                 {t("blockEditor.table.deleteColumn")}
               </button>
               <div className="my-1 border-t" role="separator" />
@@ -185,7 +186,7 @@ export function TableDropdown({
                 type="button"
                 role="menuitem"
                 onClick={() => run(() => editor.chain().focus().deleteTable().run())}
-                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-muted transition-colors text-left focus-visible:outline-none focus-visible:bg-muted"
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-heritage transition-colors text-left focus-visible:outline-none focus-visible:bg-heritage"
               >
                 <Trash2 size={16} strokeWidth={1.75} aria-hidden="true" />
                 {t("blockEditor.table.deleteTable")}

--- a/frontend/src/styles/__tests__/wave7-editor-toolbar.test.ts
+++ b/frontend/src/styles/__tests__/wave7-editor-toolbar.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Sentinel for ADR-0011 Wave 7 (initial slice) — editor toolbar +
+ * dropdowns migrated to v2 semantic vocabulary.
+ *
+ * Wave 7 in the ADR is "Rich text + media" — the TipTap editor
+ * surface, BlockRenderer, Callout, table styling, code-block
+ * highlighting. This first slice covers the four contained
+ * components (EditorToolbar, CalloutDropdown, CodeBlockDropdown,
+ * TableDropdown) that share the toolbar-button + menu visual
+ * vocabulary. BlockRenderer (in pages/Course/ChapterView) and the
+ * lower-level prose styling (index.css table + code styling) ship
+ * in a follow-up.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const COMPONENT = (...parts: string[]) =>
+  resolve(HERE, "..", "..", "components", "editor", ...parts);
+
+function readNonComment(path: string): string {
+  return readFileSync(path, "utf-8")
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`).test(code);
+}
+
+describe("ADR-0011 Wave 7 — editor toolbar slice", () => {
+  it("EditorToolbar uses v2 brand + heritage + ink + edge + surface classes", () => {
+    const code = readNonComment(COMPONENT("EditorToolbar.tsx"));
+    expect(code.includes("ring-brand")).toBe(true);
+    expect(code.includes("bg-brand/20")).toBe(true);
+    expect(code.includes("text-brand")).toBe(true);
+    expect(code.includes("hover:bg-heritage")).toBe(true);
+    expect(code.includes("hover:text-ink")).toBe(true);
+    expect(code.includes("text-ink-muted")).toBe(true);
+    expect(code.includes("border-edge-strong")).toBe(true);
+    expect(code.includes("bg-surface")).toBe(true);
+    expect(code.includes("bg-edge")).toBe(true);
+    // v1 names retired
+    expect(containsClass(code, "ring-ring")).toBe(false);
+    expect(containsClass(code, "bg-primary")).toBe(false);
+    expect(containsClass(code, "text-primary")).toBe(false);
+    expect(containsClass(code, "text-muted-foreground")).toBe(false);
+    expect(containsClass(code, "hover:bg-accent")).toBe(false);
+    expect(containsClass(code, "hover:text-accent-foreground")).toBe(false);
+    expect(containsClass(code, "border-input")).toBe(false);
+    expect(containsClass(code, "bg-background")).toBe(false);
+    expect(containsClass(code, "bg-border")).toBe(false);
+  });
+
+  it("CalloutDropdown / CodeBlockDropdown / TableDropdown share v2 vocabulary", () => {
+    for (const file of ["CalloutDropdown.tsx", "CodeBlockDropdown.tsx", "TableDropdown.tsx"]) {
+      const code = readNonComment(COMPONENT(file));
+      expect(code.includes("ring-brand"), `${file} missing ring-brand`).toBe(true);
+      expect(code.includes("bg-brand/20"), `${file} missing bg-brand/20`).toBe(true);
+      expect(code.includes("bg-surface-elevated"), `${file} missing bg-surface-elevated`).toBe(true);
+      expect(code.includes("hover:bg-heritage"), `${file} missing hover:bg-heritage`).toBe(true);
+      // v1 names retired
+      expect(containsClass(code, "ring-ring"), `${file} still has ring-ring`).toBe(false);
+      expect(containsClass(code, "bg-primary"), `${file} still has bg-primary`).toBe(false);
+      expect(containsClass(code, "bg-background"), `${file} still has bg-background`).toBe(false);
+      expect(containsClass(code, "hover:bg-muted"), `${file} still has hover:bg-muted`).toBe(false);
+      expect(containsClass(code, "focus-visible:bg-muted"), `${file} still has focus-visible:bg-muted`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
ADR-0011 **Wave 7 of 10 — first slice**. Migrates the editor toolbar + the three shared toolbar-dropdowns (Callout / CodeBlock / Table) to v2.

## Migrated

* **EditorToolbar.tsx** — ToolbarButton active state `bg-primary/20 text-primary ring-primary/30` → `bg-brand/20 text-brand ring-brand/30`. Inactive state `text-muted-foreground hover:bg-accent hover:text-accent-foreground` → `text-ink-muted hover:bg-heritage hover:text-ink`. ToolbarDivider `bg-border` → `bg-edge`. Sticky bar `border-input bg-background` → `border-edge-strong bg-surface`. All focus rings `ring-ring` → `ring-brand`.
* **CalloutDropdown.tsx / CodeBlockDropdown.tsx / TableDropdown.tsx** — identical toolbar-button vocabulary on triggers, `bg-background` → `bg-surface-elevated` on the dropdown panel, menu items `hover:bg-muted focus-visible:bg-muted` → `hover:bg-heritage focus-visible:bg-heritage`. Icon classes `text-muted-foreground` → `text-ink-muted` throughout (TableDropdown has 9+ menu items each carrying an icon).

## Deferred to Wave 7 follow-up

- BlockRenderer (lives in `pages/Course/ChapterView.tsx`)
- `index.css` table + code-block highlighting styles
- RichTextEditor.tsx body classes (3 v1 refs left)
- ChapterBlockEditor.tsx + blocks/BlockRow.tsx (6 v1 refs each)

## Test plan

- [x] +2 sentinel tests (`wave7-editor-toolbar.test.ts`) — uses the word-boundary `containsClass` lock-out
- [x] Full frontend suite green
- [x] eslint + tsc clean, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)