### PR TITLE
feat(design): visual overhaul v2 Wave 7 follow-up — block editor surfaces

### DIFF
--- a/frontend/src/components/editor/ChapterBlockEditor.tsx
+++ b/frontend/src/components/editor/ChapterBlockEditor.tsx
@@ -144,7 +144,7 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-6">
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" strokeWidth={1.75} />
+        <Loader2 className="h-5 w-5 animate-spin text-ink-muted" strokeWidth={1.75} />
       </div>
     )
   }
@@ -152,10 +152,10 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        <Label className="text-xs font-semibold text-ink-muted uppercase tracking-wide">
           {t("blockEditor.contentBlocks")}
         </Label>
-        <span className="text-xs text-muted-foreground">
+        <span className="text-xs text-ink-muted">
           {t("blockEditor.blocksCount", { count: blocks.length })}
         </span>
       </div>
@@ -165,11 +165,11 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
         // dashed border + soft surface communicates "drop zone /
         // start-here" and reduces the "this UI is broken" reaction
         // when a teacher first sees an empty chapter.
-        <div className="rounded-md border border-dashed border-border bg-muted/30 px-5 py-8 text-center">
-          <p className="text-sm font-medium text-foreground">
+        <div className="rounded-md border border-dashed border-edge bg-muted/30 px-5 py-8 text-center">
+          <p className="text-sm font-medium text-ink">
             {t("blockEditor.empty")}
           </p>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-xs text-ink-muted">
             {t("blockEditor.emptyHint")}
           </p>
         </div>

--- a/frontend/src/components/editor/RichTextEditor.tsx
+++ b/frontend/src/components/editor/RichTextEditor.tsx
@@ -59,7 +59,7 @@ export default function RichTextEditor({
       }),
       Link.configure({
         openOnClick: false,
-        HTMLAttributes: { class: "text-primary underline cursor-pointer" },
+        HTMLAttributes: { class: "text-brand underline cursor-pointer" },
       }),
       Placeholder.configure({ placeholder }),
       Image.configure({
@@ -162,7 +162,7 @@ export default function RichTextEditor({
   if (!editor) return null;
 
   return (
-    <div className="relative rounded-md border border-input bg-background">
+    <div className="relative rounded-md border border-edge-strong bg-surface">
       {editable && (
         <EditorToolbar
           editor={editor}
@@ -185,7 +185,7 @@ export default function RichTextEditor({
             type="button"
             aria-label={t("blockEditor.toolbar.dragHandle")}
             title={t("blockEditor.toolbar.dragHandle")}
-            className="flex h-6 w-5 cursor-grab items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            className="flex h-6 w-5 cursor-grab items-center justify-center rounded text-ink-muted transition-colors hover:bg-muted hover:text-ink active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             <GripVertical size={14} strokeWidth={1.75} aria-hidden="true" />
           </button>
@@ -226,7 +226,7 @@ function CharacterCounter({
   // strings ("23.4%") each keystroke even when visually unchanged.
   const percent = Math.round(ratio * 100);
   return (
-    <div className="border-t border-input">
+    <div className="border-t border-edge-strong">
       <div
         className="h-0.5 w-full bg-muted/60"
         role="presentation"
@@ -235,7 +235,7 @@ function CharacterCounter({
         <div
           className={cn(
             "h-full transition-[width] duration-150 ease-out",
-            tone === "muted" && "bg-muted-foreground/40",
+            tone === "muted" && "bg-ink-muted/40",
             tone === "warning" && "bg-warning",
             tone === "destructive" && "bg-destructive",
           )}
@@ -252,7 +252,7 @@ function CharacterCounter({
         <span
           className={cn(
             "transition-colors",
-            tone === "muted" && "text-muted-foreground",
+            tone === "muted" && "text-ink-muted",
             tone === "warning" && "text-warning font-medium",
             tone === "destructive" && "text-destructive font-medium",
           )}

--- a/frontend/src/components/editor/blocks/AddBlockMenu.tsx
+++ b/frontend/src/components/editor/blocks/AddBlockMenu.tsx
@@ -87,7 +87,7 @@ export function AddBlockMenu({ onAdd, adding }: Props) {
           role="menu"
           aria-label={t("blockEditor.addBlock")}
           className={cn(
-            "absolute top-full z-20 mt-1 w-full min-w-[240px] rounded-md border bg-background py-1 shadow-lg",
+            "absolute top-full z-20 mt-1 w-full min-w-[240px] rounded-md border bg-surface py-1 shadow-lg",
             alignClass,
           )}
         >
@@ -101,7 +101,7 @@ export function AddBlockMenu({ onAdd, adding }: Props) {
                 onClick={() => pick(bt.value)}
                 className="flex w-full items-center gap-2 px-3 py-2 text-sm transition-colors hover:bg-muted text-left focus-visible:outline-none focus-visible:bg-muted"
               >
-                <Icon className="h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
+                <Icon className="h-4 w-4 text-ink-muted" strokeWidth={1.75} aria-hidden="true" />
                 {t(BLOCK_TYPE_LABEL_KEYS[bt.value])}
               </button>
             )

--- a/frontend/src/components/editor/blocks/BlockRow.tsx
+++ b/frontend/src/components/editor/blocks/BlockRow.tsx
@@ -64,22 +64,22 @@ export function BlockRow({
       onDrop={onDrop}
       onDragEnd={onDragEnd}
       className={`rounded-md border transition-colors ${
-        isDragOver ? "border-primary bg-primary/5" : "bg-background"
+        isDragOver ? "border-brand bg-brand/5" : "bg-surface"
       }`}
     >
       <div
         className="flex items-center gap-2 px-3 py-2 cursor-pointer select-none"
         onClick={onExpandToggle}
       >
-        <GripVertical className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0 cursor-grab" strokeWidth={1.75} />
+        <GripVertical className="h-3.5 w-3.5 text-ink-muted/40 shrink-0 cursor-grab" strokeWidth={1.75} />
         {expanded ? (
-          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" strokeWidth={1.75} />
+          <ChevronDown className="h-3.5 w-3.5 text-ink-muted shrink-0" strokeWidth={1.75} />
         ) : (
-          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" strokeWidth={1.75} />
+          <ChevronRight className="h-3.5 w-3.5 text-ink-muted shrink-0" strokeWidth={1.75} />
         )}
-        <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        <Icon className="h-3.5 w-3.5 text-ink-muted shrink-0" />
         <span className="text-sm font-medium flex-1">{label}</span>
-        <span className="text-xs text-muted-foreground">#{index + 1}</span>
+        <span className="text-xs text-ink-muted">#{index + 1}</span>
         <Button
           variant="ghost"
           size="sm"

--- a/frontend/src/components/editor/blocks/FileBlockEditor.tsx
+++ b/frontend/src/components/editor/blocks/FileBlockEditor.tsx
@@ -66,7 +66,7 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
       </Label>
       {hasFile ? (
         <div className="flex items-center gap-2 rounded-md border px-3 py-2 bg-muted/30">
-          <FileText className="h-4 w-4 text-muted-foreground shrink-0" strokeWidth={1.75} />
+          <FileText className="h-4 w-4 text-ink-muted shrink-0" strokeWidth={1.75} />
           <span className="text-sm flex-1 truncate">
             {block.file_name ?? block.file_path}
           </span>
@@ -84,7 +84,7 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
             variant="ghost"
             onClick={clear}
             disabled={uploading}
-            className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+            className="h-7 w-7 p-0 text-ink-muted hover:text-destructive"
             aria-label={t("blockEditor.file.removeAria")}
           >
             <X className="h-3.5 w-3.5" strokeWidth={1.75} />

--- a/frontend/src/components/editor/blocks/TextBlockEditor.tsx
+++ b/frontend/src/components/editor/blocks/TextBlockEditor.tsx
@@ -115,12 +115,12 @@ export function TextBlockEditor({ block, onSaved }: Props) {
           {t("blockEditor.text.saveButton")}
         </Button>
         {autoSaveStatus === "pending" && (
-          <span className="text-xs text-muted-foreground">
+          <span className="text-xs text-ink-muted">
             {t("blockEditor.text.statusUnsaved")}
           </span>
         )}
         {autoSaveStatus === "saving" && (
-          <span className="flex items-center gap-1 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1 text-xs text-ink-muted">
             <Loader2 className="h-3 w-3 animate-spin" strokeWidth={1.75} />
             {t("blockEditor.text.statusAutoSaving")}
           </span>

--- a/frontend/src/styles/__tests__/wave7-followup-blocks.test.ts
+++ b/frontend/src/styles/__tests__/wave7-followup-blocks.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Sentinel for ADR-0011 Wave 7 follow-up — block-editor surface
+ * migrated to v2.
+ *
+ * Covers the remaining editor files that the first Wave 7 PR (#670)
+ * left for later: RichTextEditor, ChapterBlockEditor, blocks/BlockRow,
+ * blocks/TextBlockEditor, blocks/FileBlockEditor, blocks/AddBlockMenu.
+ *
+ * Note: ``bg-muted`` / ``hover:bg-muted`` stay on v1 in some places
+ * because the v2 vocabulary doesn't expose a ``muted`` alias in
+ * tailwind.config yet (deferred to a later wave). The locks below
+ * only check the migrated tokens.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function rel(...parts: string[]): string {
+  return resolve(HERE, "..", "..", "components", "editor", ...parts);
+}
+
+function readNonComment(path: string): string {
+  return readFileSync(path, "utf-8")
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`).test(code);
+}
+
+const FILES = [
+  rel("RichTextEditor.tsx"),
+  rel("ChapterBlockEditor.tsx"),
+  rel("blocks", "BlockRow.tsx"),
+  rel("blocks", "TextBlockEditor.tsx"),
+  rel("blocks", "FileBlockEditor.tsx"),
+  rel("blocks", "AddBlockMenu.tsx"),
+];
+
+const V1_LOCKED_OUT = [
+  "bg-background",
+  "text-foreground",
+  "text-muted-foreground",
+  "border-border",
+  "border-input",
+  "bg-primary",
+  "text-primary",
+  "border-primary",
+  "hover:bg-accent",
+  "hover:text-accent-foreground",
+  "ring-ring",
+  "bg-muted-foreground",
+];
+
+describe("ADR-0011 Wave 7 follow-up — block editor surface migration", () => {
+  for (const path of FILES) {
+    const name = path.split(/[\\/]/).slice(-1)[0];
+
+    it(`${name} retired the v1 names`, () => {
+      const code = readNonComment(path);
+      for (const cls of V1_LOCKED_OUT) {
+        expect(
+          containsClass(code, cls),
+          `${name} still references ${cls}`,
+        ).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
ADR-0011 **Wave 7 second slice**. Completes the editor surface migration started in #670.

## Per-file changes

* **RichTextEditor.tsx** — Link mark color, editor container border/bg, drag-handle button + ring + hover, divider border, tone='muted' icon classes — all migrated to v2.
* **ChapterBlockEditor.tsx** — loading spinner + section labels + empty-state copy migrated (`text-muted-foreground` → `text-ink-muted`, `border-border` → `border-edge`, `text-foreground` → `text-ink`).
* **blocks/BlockRow.tsx** — drag-over state `border-primary bg-primary/5` → `border-brand bg-brand/5`, idle state `bg-background` → `bg-surface`, all 4 icons + index label migrated to `text-ink-muted`.
* **blocks/TextBlockEditor.tsx + FileBlockEditor.tsx + AddBlockMenu.tsx** — remaining 2 v1 refs each.

## Sentinel

`wave7-followup-blocks.test.ts` — per-file lock-out using the word-boundary `containsClass` helper. **6 tests** (one per file).

## Deliberately deferred

`bg-muted` / `hover:bg-muted` stay on v1 in a few places because the v2 vocabulary doesn't expose a `muted` alias in `tailwind.config` yet — deferred until a dedicated `--color-disabled` / `--color-muted` token lands.

## Test plan

- [x] +6 sentinel tests
- [x] Full frontend suite green
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)