### PR TITLE
feat(design): visual overhaul v2 Wave 8 — layout & navigation surface

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -104,13 +104,13 @@ function AppRoutes() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-background text-foreground">
+    <div className="min-h-screen flex flex-col bg-surface text-ink">
       {/* Skip link — hidden until focused via Tab. First focusable element on
           every authenticated page so keyboard / screen-reader users can jump
           past the persistent Header + banners straight to page content. */}
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-brand focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-brand-foreground focus:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
       >
         {t("common.skipToContent")}
       </a>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -103,19 +103,19 @@ export default class ErrorBoundary extends Component<Props, State> {
             </svg>
           </div>
           <h2 className="text-xl font-semibold mb-2">{i18n.t("errors.boundary.heading")}</h2>
-          <p className="text-sm text-muted-foreground mb-4 max-w-md">
+          <p className="text-sm text-ink-muted mb-4 max-w-md">
             {i18n.t("errors.boundary.body")}
           </p>
           <div className="flex gap-3">
             <button
               onClick={this.handleReset}
-              className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+              className="inline-flex items-center justify-center rounded-md border border-edge-strong bg-surface px-4 py-2 text-sm font-medium hover:bg-heritage hover:text-ink transition-colors"
             >
               {i18n.t("errors.boundary.tryAgain")}
             </button>
             <button
               onClick={() => window.location.reload()}
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              className="inline-flex items-center justify-center rounded-md bg-brand px-4 py-2 text-sm font-medium text-brand-foreground hover:bg-brand/90 transition-colors"
             >
               {i18n.t("errors.boundary.refresh")}
             </button>

--- a/frontend/src/components/announcements/AnnouncementBanner.tsx
+++ b/frontend/src/components/announcements/AnnouncementBanner.tsx
@@ -50,13 +50,13 @@ export default function AnnouncementBanner() {
     // banner mounts mid-session whenever the user finishes loading or a new
     // announcement is published, and a screen-reader user shouldn't have to
     // re-Tab past the page just to discover it.
-    <div role="status" aria-live="polite" className="border-b border-border bg-muted/40">
+    <div role="status" aria-live="polite" className="border-b border-edge bg-muted/40">
       <div className="container mx-auto flex items-center gap-3 px-4 py-2.5">
-        <Megaphone className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
+        <Megaphone className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden="true" />
         <div className="min-w-0 flex-1 text-wrap-safe">
-          <span className="text-sm font-medium text-foreground">{announcement.title}</span>
+          <span className="text-sm font-medium text-ink">{announcement.title}</span>
           {announcement.content && (
-            <span className="ml-2 text-sm text-muted-foreground">
+            <span className="ml-2 text-sm text-ink-muted">
               {announcement.content.length > 150
                 ? `${announcement.content.slice(0, 150).trimEnd()}…`
                 : announcement.content}
@@ -66,7 +66,7 @@ export default function AnnouncementBanner() {
         <button
           type="button"
           onClick={() => setDismissedId(announcement.id)}
-          className="rounded p-1 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="rounded p-1 text-ink-muted hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
           aria-label={t("common.dismissAnnouncement")}
         >
           <X className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />

--- a/frontend/src/components/announcements/AnnouncementPager.tsx
+++ b/frontend/src/components/announcements/AnnouncementPager.tsx
@@ -97,11 +97,11 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
             {current.title}
           </p>
           {current.content && (
-            <p className="mt-0.5 text-xs text-muted-foreground text-wrap-safe whitespace-pre-line">
+            <p className="mt-0.5 text-xs text-ink-muted text-wrap-safe whitespace-pre-line">
               {current.content}
             </p>
           )}
-          <time className="mt-1 block text-xs text-muted-foreground/60">
+          <time className="mt-1 block text-xs text-ink-muted/60">
             {formatDateTime(current.created_at)}
           </time>
         </div>
@@ -136,14 +136,14 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
                   key={a.id}
                   className={cn(
                     "h-1.5 w-1.5 rounded-full transition-colors duration-150",
-                    i === index ? "bg-primary" : "bg-muted-foreground/30",
+                    i === index ? "bg-brand" : "bg-ink-muted/30",
                   )}
                 />
               ))}
             </div>
           ) : (
             <span
-              className="text-[10px] leading-none tabular-nums text-muted-foreground"
+              className="text-[10px] leading-none tabular-nums text-ink-muted"
               aria-hidden
             >
               {t("teacherEditor.modals.announcements.position", {

--- a/frontend/src/components/layout/AuthLayout.tsx
+++ b/frontend/src/components/layout/AuthLayout.tsx
@@ -57,10 +57,10 @@ export default function AuthLayout({ children, heading, subheading }: AuthLayout
 
       {/* Form panel */}
       <div className="flex flex-1 flex-col">
-        <div className="flex items-center justify-between border-b border-border/60 bg-background/90 px-4 py-2 backdrop-blur-sm lg:hidden">
+        <div className="flex items-center justify-between border-b border-edge/60 bg-surface/90 px-4 py-2 backdrop-blur-sm lg:hidden">
           <Link
             to="/"
-            className="-mx-1 inline-flex min-h-[44px] items-center gap-2.5 px-1 text-foreground transition-opacity hover:opacity-80"
+            className="-mx-1 inline-flex min-h-[44px] items-center gap-2.5 px-1 text-ink transition-opacity hover:opacity-80"
           >
             <BookOpen className="h-5 w-5 shrink-0 text-accent" strokeWidth={1.75} aria-hidden />
             <span className="font-serif text-base font-bold leading-none tracking-tight">{t("common.appName")}</span>
@@ -102,7 +102,7 @@ export default function AuthLayout({ children, heading, subheading }: AuthLayout
           <div className="w-full max-w-[420px] space-y-8">
             <div className="space-y-2 text-center lg:text-left">
               <h1 className="font-serif text-2xl font-bold tracking-tight sm:text-3xl">{heading}</h1>
-              {subheading && <p className="font-sans text-sm text-muted-foreground">{subheading}</p>}
+              {subheading && <p className="font-sans text-sm text-ink-muted">{subheading}</p>}
             </div>
             {children}
           </div>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -17,32 +17,32 @@ export default function Footer() {
   const year = new Date().getFullYear()
 
   const linkClass =
-    "text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+    "text-ink-muted transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 rounded-sm"
 
   return (
-    <footer className="mt-auto border-t border-border bg-background/95">
+    <footer className="mt-auto border-t border-edge bg-surface/95">
       <div className="container mx-auto max-w-[1400px] px-4 py-5 md:px-6">
         <div className="flex flex-col items-start justify-between gap-3 text-xs sm:flex-row sm:items-center sm:gap-x-6 sm:text-sm">
           <div className="flex min-w-0 flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2">
             <Link
               to="/"
-              className="shrink-0 font-serif text-sm font-semibold tracking-tight text-foreground transition-opacity hover:opacity-85"
+              className="shrink-0 font-serif text-sm font-semibold tracking-tight text-ink transition-opacity hover:opacity-85"
             >
               {t("common.appName")}
             </Link>
-            <span className="hidden text-muted-foreground/50 sm:inline" aria-hidden>
+            <span className="hidden text-ink-muted/50 sm:inline" aria-hidden>
               ·
             </span>
-            <p className="max-w-prose text-xs leading-snug text-muted-foreground sm:truncate">
+            <p className="max-w-prose text-xs leading-snug text-ink-muted sm:truncate">
               {t("footer.tagline")}
             </p>
           </div>
 
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-ink-muted">
             <a href={`mailto:${SUPPORT_EMAIL}`} className={linkClass}>
               {t("footer.support")}
             </a>
-            <span aria-hidden className="text-muted-foreground/40">
+            <span aria-hidden className="text-ink-muted/40">
               ·
             </span>
             <span>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -43,12 +43,12 @@ export default function Header() {
   }, [location.pathname])
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/90 bg-background/90 backdrop-blur-md supports-[backdrop-filter]:bg-background/75">
+    <header className="sticky top-0 z-50 border-b border-edge/90 bg-surface/90 backdrop-blur-md supports-[backdrop-filter]:bg-surface/75">
       <div className="container mx-auto max-w-[1400px] px-4">
         <div className="flex h-11 items-stretch justify-between gap-2 md:h-12 md:gap-4">
           <Link
             to="/"
-            className="flex shrink-0 items-center font-serif text-sm font-semibold leading-none tracking-tight text-foreground transition-opacity hover:opacity-85 md:text-base"
+            className="flex shrink-0 items-center font-serif text-sm font-semibold leading-none tracking-tight text-ink transition-opacity hover:opacity-85 md:text-base"
           >
             {t("common.appName")}
           </Link>

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -98,7 +98,7 @@ export default function NotificationBell({
     >
       {isNavRow ? (
         <>
-          <span className="text-sm font-medium text-foreground">{t("notifications.title")}</span>
+          <span className="text-sm font-medium text-ink">{t("notifications.title")}</span>
           <span className="flex min-w-[1.25rem] items-center justify-end">
             {unreadCount > 0 ? (
               <span className="rounded-full bg-destructive px-2 py-0.5 text-xs font-semibold tabular-nums text-destructive-foreground">

--- a/frontend/src/components/layout/ScrollToTop.tsx
+++ b/frontend/src/components/layout/ScrollToTop.tsx
@@ -39,9 +39,9 @@ export default function ScrollToTop() {
         fixed bottom-6 right-6 z-50
         flex items-center justify-center
         w-12 h-12 rounded-full
-        bg-primary text-primary-foreground
-        hover:bg-primary/90
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+        bg-brand text-brand-foreground
+        hover:bg-brand/90
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2
         transition-opacity duration-300
         ${
           visible

--- a/frontend/src/components/layout/header/HeaderMobileMenuTrigger.tsx
+++ b/frontend/src/components/layout/header/HeaderMobileMenuTrigger.tsx
@@ -27,7 +27,7 @@ export function HeaderMobileMenuTrigger({ onOpen, isOpen }: Props) {
               type="button"
               variant="ghost"
               size="sm"
-              className="h-8 min-w-8 px-1 text-muted-foreground hover:text-foreground"
+              className="h-8 min-w-8 px-1 text-ink-muted hover:text-ink"
               onClick={onOpen}
               aria-label={t("header.menu")}
               aria-expanded={isOpen}

--- a/frontend/src/components/layout/header/HeaderMobileSheet.tsx
+++ b/frontend/src/components/layout/header/HeaderMobileSheet.tsx
@@ -35,7 +35,7 @@ export function HeaderMobileSheet({ open, onOpenChange, user, isTeacher }: Props
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="flex max-h-[100dvh] flex-col gap-0 overflow-hidden p-0">
         <SheetHeader className="shrink-0 px-5 pb-3 pt-5">
-          <SheetTitle className="font-sans text-sm font-semibold tracking-normal text-foreground">
+          <SheetTitle className="font-sans text-sm font-semibold tracking-normal text-ink">
             {t("header.mobileMenuTitle")}
           </SheetTitle>
           <SheetDescription className="sr-only">{t("header.mobileMenuDescription")}</SheetDescription>
@@ -74,7 +74,7 @@ export function HeaderMobileSheet({ open, onOpenChange, user, isTeacher }: Props
                     {t("header.adminPanel")}
                   </HeaderNavLink>
                 )}
-                <div className="mt-2 border-t border-border/80 pt-2">
+                <div className="mt-2 border-t border-edge/80 pt-2">
                   <Suspense fallback={null}>
                     <NotificationBell
                       triggerVariant="navRow"
@@ -87,7 +87,7 @@ export function HeaderMobileSheet({ open, onOpenChange, user, isTeacher }: Props
                   to="/profile"
                   className={cn(
                     "flex min-h-10 w-full items-center rounded-md px-3 text-sm font-medium transition-colors hover:bg-muted active:bg-muted/80",
-                    isActive("/profile") ? "bg-muted/60 text-foreground" : "text-foreground",
+                    isActive("/profile") ? "bg-muted/60 text-ink" : "text-ink",
                   )}
                   aria-current={isActive("/profile") ? "page" : undefined}
                   onClick={closeMobile}
@@ -105,7 +105,7 @@ export function HeaderMobileSheet({ open, onOpenChange, user, isTeacher }: Props
                 </HeaderNavLink>
                 <Link
                   to="/register"
-                  className="flex min-h-10 w-full items-center rounded-md px-3 text-sm font-semibold text-primary transition-colors hover:bg-muted active:bg-muted/80"
+                  className="flex min-h-10 w-full items-center rounded-md px-3 text-sm font-semibold text-brand transition-colors hover:bg-muted active:bg-muted/80"
                   onClick={closeMobile}
                 >
                   {t("common.register")}
@@ -113,8 +113,8 @@ export function HeaderMobileSheet({ open, onOpenChange, user, isTeacher }: Props
               </>
             )}
           </nav>
-          <div className="mt-auto border-t border-border/80 px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3">
-            <p className="text-xs text-muted-foreground">{t("common.appName")}</p>
+          <div className="mt-auto border-t border-edge/80 px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3">
+            <p className="text-xs text-ink-muted">{t("common.appName")}</p>
           </div>
         </div>
       </SheetContent>

--- a/frontend/src/components/layout/header/HeaderNavLink.tsx
+++ b/frontend/src/components/layout/header/HeaderNavLink.tsx
@@ -44,10 +44,10 @@ export function HeaderNavLink({
           : "relative flex h-full items-center px-3 text-sm",
         isSheet &&
           (active
-            ? "border-primary bg-muted/25 font-medium text-foreground"
-            : "text-foreground hover:border-border hover:bg-muted/40"),
+            ? "border-brand bg-muted/25 font-medium text-ink"
+            : "text-ink hover:border-edge hover:bg-muted/40"),
         !isSheet &&
-          (active ? "text-foreground" : "text-muted-foreground hover:text-foreground"),
+          (active ? "text-ink" : "text-ink-muted hover:text-ink"),
       )}
     >
       {children}
@@ -55,13 +55,13 @@ export function HeaderNavLink({
         active &&
         (prefersReducedMotion ? (
           <span
-            className="pointer-events-none absolute inset-x-3 bottom-0 h-0.5 rounded-sm bg-primary"
+            className="pointer-events-none absolute inset-x-3 bottom-0 h-0.5 rounded-sm bg-brand"
             aria-hidden
           />
         ) : (
           <motion.span
             layoutId={HEADER_UNDERLINE_LAYOUT_ID}
-            className="pointer-events-none absolute inset-x-3 bottom-0 h-0.5 rounded-sm bg-primary"
+            className="pointer-events-none absolute inset-x-3 bottom-0 h-0.5 rounded-sm bg-brand"
             transition={{ duration: 0.32, ease: EDITORIAL_EASE }}
             aria-hidden
           />

--- a/frontend/src/components/layout/notifications/NotificationItem.tsx
+++ b/frontend/src/components/layout/notifications/NotificationItem.tsx
@@ -21,13 +21,13 @@ interface Props {
 export function NotificationItem({ notification, onActivate, onDelete }: Props) {
   const { t } = useTranslation()
   const Icon = NOTIFICATION_ICONS[notification.type] ?? Bell
-  const color = NOTIFICATION_COLORS[notification.type] ?? "text-muted-foreground"
+  const color = NOTIFICATION_COLORS[notification.type] ?? "text-ink-muted"
 
   return (
     <div
       className={cn(
-        "flex gap-3 px-4 py-3 transition-colors hover:bg-muted/50 group border-b border-border/50 last:border-0",
-        !notification.is_read && "bg-primary/[0.03]",
+        "flex gap-3 px-4 py-3 transition-colors hover:bg-muted/50 group border-b border-edge/50 last:border-0",
+        !notification.is_read && "bg-brand/[0.03]",
       )}
     >
       <button
@@ -44,20 +44,20 @@ export function NotificationItem({ notification, onActivate, onDelete }: Props) 
               className={cn(
                 "text-sm leading-snug",
                 !notification.is_read
-                  ? "font-medium text-foreground"
-                  : "text-muted-foreground",
+                  ? "font-medium text-ink"
+                  : "text-ink-muted",
               )}
             >
               {notification.title}
             </p>
             {!notification.is_read && (
-              <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />
+              <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-brand" />
             )}
           </div>
-          <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
+          <p className="mt-0.5 text-xs text-ink-muted line-clamp-2">
             {notification.message}
           </p>
-          <p className="mt-1 text-xs text-muted-foreground/70">
+          <p className="mt-1 text-xs text-ink-muted/70">
             {timeAgo(notification.created_at, t)}
           </p>
         </div>
@@ -67,7 +67,7 @@ export function NotificationItem({ notification, onActivate, onDelete }: Props) 
           e.stopPropagation()
           onDelete(notification.id)
         }}
-        className="mt-0.5 shrink-0 opacity-60 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
+        className="mt-0.5 shrink-0 opacity-60 group-hover:opacity-100 transition-opacity text-ink-muted hover:text-destructive"
         aria-label={t("notifications.deleteAriaLabel")}
       >
         <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />

--- a/frontend/src/components/layout/notifications/NotificationPanel.tsx
+++ b/frontend/src/components/layout/notifications/NotificationPanel.tsx
@@ -54,7 +54,7 @@ export const NotificationPanel = forwardRef<HTMLDivElement, Props>(
         role="region"
         aria-label={t("notifications.panelAriaLabel")}
         className={cn(
-          "mt-2 overflow-hidden rounded-lg border border-border shadow-lg",
+          "mt-2 overflow-hidden rounded-lg border border-edge shadow-lg",
           // Sheet variant: live in the flex flow so it pushes the
           // "Profile" link below it instead of floating over the next
           // nav row as a phantom overlay (the original
@@ -67,17 +67,17 @@ export const NotificationPanel = forwardRef<HTMLDivElement, Props>(
           // content. The frosted layer separates the dropdown from the
           // busy course/admin pages it floats over.
           isSheet
-            ? "w-full bg-background"
-            : "absolute right-0 top-full z-50 w-80 bg-background/85 backdrop-blur-md sm:w-96 supports-[backdrop-filter]:bg-background/75",
+            ? "w-full bg-surface"
+            : "absolute right-0 top-full z-50 w-80 bg-surface/85 backdrop-blur-md sm:w-96 supports-[backdrop-filter]:bg-surface/75",
         )}
       >
-        <div className="flex items-center justify-between border-b border-border px-4 py-3">
-          <h3 className="text-sm font-semibold text-foreground">{t("notifications.title")}</h3>
+        <div className="flex items-center justify-between border-b border-edge px-4 py-3">
+          <h3 className="text-sm font-semibold text-ink">{t("notifications.title")}</h3>
           {unreadCount > 0 && (
             <button
               type="button"
               onClick={onMarkAllRead}
-              className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              className="flex items-center gap-1 text-xs text-ink-muted transition-colors hover:text-ink"
             >
               <CheckCheck className="h-3.5 w-3.5" strokeWidth={1.75} />
               {t("notifications.markAllRead")}
@@ -94,19 +94,19 @@ export const NotificationPanel = forwardRef<HTMLDivElement, Props>(
           {loading ? (
             <PageSpinner variant="section" />
           ) : loadError ? (
-            <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
+            <div className="flex flex-col items-center gap-2 py-10 text-ink-muted">
               <AlertCircle className="h-8 w-8 text-destructive/70" strokeWidth={1.75} />
               <p className="text-sm text-destructive">{t("notifications.loadFailed")}</p>
               <button
                 type="button"
                 onClick={onRetry}
-                className="text-xs text-primary hover:underline"
+                className="text-xs text-brand hover:underline"
               >
                 {t("notifications.tryAgain")}
               </button>
             </div>
           ) : notifications.length === 0 ? (
-            <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
+            <div className="flex flex-col items-center gap-2 py-10 text-ink-muted">
               <Bell className="h-8 w-8 opacity-30" strokeWidth={1.75} />
               <p className="text-sm">{t("notifications.empty")}</p>
             </div>
@@ -121,7 +121,7 @@ export const NotificationPanel = forwardRef<HTMLDivElement, Props>(
                 />
               ))}
               {hasMore && (
-                <div className="border-t border-border/50 p-2">
+                <div className="border-t border-edge/50 p-2">
                   <Button
                     type="button"
                     variant="ghost"

--- a/frontend/src/components/layout/notifications/notificationMeta.ts
+++ b/frontend/src/components/layout/notifications/notificationMeta.ts
@@ -32,7 +32,7 @@ export const NOTIFICATION_COLORS: Record<NotificationType, string> = {
   certificate_rejected: "text-destructive",
   assignment_graded: "text-info",
   new_announcement: "text-warning",
-  course_update: "text-muted-foreground",
+  course_update: "text-ink-muted",
   enrollment_confirmed: "text-success",
 }
 

--- a/frontend/src/styles/__tests__/wave8-layout.test.ts
+++ b/frontend/src/styles/__tests__/wave8-layout.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Sentinel for ADR-0011 Wave 8 — layout & navigation surface
+ * migrated to v2.
+ *
+ * Covers the high-traffic shell every page renders inside of:
+ * AuthLayout / Footer / Header (+ subcomponents) / NotificationBell
+ * (+ panel + items + meta) / ScrollToTop, plus AnnouncementBanner /
+ * AnnouncementPager, ErrorBoundary, and the root App.tsx.
+ *
+ * If any of these regresses to a v1 token, the entire app's chrome
+ * goes off-palette — the Wave 8 surface is the single most visible
+ * area in the product.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "..", "..");
+
+function readNonComment(path: string): string {
+  return readFileSync(path, "utf-8")
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`).test(code);
+}
+
+const FILES = [
+  resolve(SRC, "App.tsx"),
+  resolve(SRC, "components/ErrorBoundary.tsx"),
+  resolve(SRC, "components/announcements/AnnouncementBanner.tsx"),
+  resolve(SRC, "components/announcements/AnnouncementPager.tsx"),
+  resolve(SRC, "components/layout/AuthLayout.tsx"),
+  resolve(SRC, "components/layout/Footer.tsx"),
+  resolve(SRC, "components/layout/Header.tsx"),
+  resolve(SRC, "components/layout/NotificationBell.tsx"),
+  resolve(SRC, "components/layout/ScrollToTop.tsx"),
+  resolve(SRC, "components/layout/header/HeaderMobileMenuTrigger.tsx"),
+  resolve(SRC, "components/layout/header/HeaderMobileSheet.tsx"),
+  resolve(SRC, "components/layout/header/HeaderNavLink.tsx"),
+  resolve(SRC, "components/layout/notifications/NotificationItem.tsx"),
+  resolve(SRC, "components/layout/notifications/notificationMeta.ts"),
+  resolve(SRC, "components/layout/notifications/NotificationPanel.tsx"),
+];
+
+const V1_LOCKED_OUT = [
+  "bg-background",
+  "text-foreground",
+  "text-muted-foreground",
+  "border-border",
+  "border-input",
+  "bg-primary",
+  "text-primary",
+  "border-primary",
+  "hover:bg-accent",
+  "hover:text-accent-foreground",
+  "ring-ring",
+  "bg-muted-foreground",
+];
+
+describe("ADR-0011 Wave 8 — layout & navigation surface migration", () => {
+  for (const path of FILES) {
+    const name = path.split(/[\\/]/).slice(-2).join("/");
+
+    it(`${name} retired the v1 names`, () => {
+      const code = readNonComment(path);
+      for (const cls of V1_LOCKED_OUT) {
+        expect(
+          containsClass(code, cls),
+          `${name} still references ${cls}`,
+        ).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
ADR-0011 **Wave 8**. Migrates the high-traffic shell every page renders inside of — the chrome a user sees on every screen.

## Surface scope (15 files)

| File | What changed |
|---|---|
| `App.tsx` | root surface bg |
| `ErrorBoundary.tsx` | fallback page (bg + headings + body) |
| `announcements/AnnouncementBanner.tsx` | banner bg/border/text |
| `announcements/AnnouncementPager.tsx` | pagination buttons |
| `layout/AuthLayout.tsx` | login/register shell |
| `layout/Footer.tsx` | full footer (bg, links, borders) |
| `layout/Header.tsx` | header bg + border |
| `layout/NotificationBell.tsx` | bell button hover |
| `layout/ScrollToTop.tsx` | back-to-top button |
| `layout/header/HeaderMobileMenuTrigger.tsx` | hamburger button |
| `layout/header/HeaderMobileSheet.tsx` | slide-in panel |
| `layout/header/HeaderNavLink.tsx` | nav item active/hover |
| `layout/notifications/NotificationItem.tsx` | per-row chrome |
| `layout/notifications/NotificationPanel.tsx` | panel + empty state |
| `layout/notifications/notificationMeta.ts` | icon tone map |

## Sentinel

`wave8-layout.test.ts` — 15-file per-file lock-out using the word-boundary `containsClass` helper.

## Test plan

- [x] +15 sentinel tests
- [x] Full frontend suite green (379 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)