### PR TITLE
feat(design): visual overhaul v2 Wave 9 — dashboard & first-run

### DIFF
--- a/frontend/src/components/dashboard/DailyChallengeCard.tsx
+++ b/frontend/src/components/dashboard/DailyChallengeCard.tsx
@@ -56,10 +56,10 @@ function OptionButton({ option, reveal, disabled, onClick }: OptionButtonProps) 
       className={cn(
         "group flex w-full items-center gap-2.5 rounded-md border px-3 py-2 text-left text-xs transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-        reveal === null && "border-border bg-background hover:border-primary/30 hover:bg-muted/30",
-        showAsCorrect && "border-success/40 bg-success/10 text-foreground",
-        showAsWrong && "border-destructive/40 bg-destructive/10 text-foreground",
-        reveal !== null && !showAsCorrect && !showAsWrong && "border-border bg-background text-muted-foreground",
+        reveal === null && "border-edge bg-surface hover:border-brand/30 hover:bg-muted/30",
+        showAsCorrect && "border-success/40 bg-success/10 text-ink",
+        showAsWrong && "border-destructive/40 bg-destructive/10 text-ink",
+        reveal !== null && !showAsCorrect && !showAsWrong && "border-edge bg-surface text-ink-muted",
         disabled && "cursor-default",
       )}
     >
@@ -67,10 +67,10 @@ function OptionButton({ option, reveal, disabled, onClick }: OptionButtonProps) 
         aria-hidden
         className={cn(
           "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold",
-          reveal === null && "border-border text-muted-foreground group-hover:border-primary/40",
+          reveal === null && "border-edge text-ink-muted group-hover:border-brand/40",
           showAsCorrect && "border-success bg-success text-success-foreground",
           showAsWrong && "border-destructive bg-destructive text-destructive-foreground",
-          reveal !== null && !showAsCorrect && !showAsWrong && "border-border text-muted-foreground",
+          reveal !== null && !showAsCorrect && !showAsWrong && "border-edge text-ink-muted",
         )}
       >
         {showAsCorrect ? (
@@ -94,10 +94,10 @@ interface CandleStreakProps {
 function CandleStreak({ count, label }: CandleStreakProps) {
   return (
     <span
-      className="inline-flex items-center gap-1 rounded-full border border-border bg-background/80 px-2 py-0.5 text-[11px] font-medium text-foreground"
+      className="inline-flex items-center gap-1 rounded-full border border-edge bg-surface/80 px-2 py-0.5 text-[11px] font-medium text-ink"
       aria-label={label}
     >
-      <Flame className="h-3 w-3 text-primary" strokeWidth={1.75} aria-hidden />
+      <Flame className="h-3 w-3 text-brand" strokeWidth={1.75} aria-hidden />
       <span className="tabular-nums">{count}</span>
     </span>
   )
@@ -228,18 +228,18 @@ export function DailyChallengeCard() {
   return (
     <section
       aria-labelledby="dc-card-heading"
-      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-border bg-card transition-[border-color] duration-300 hover:border-primary/25"
+      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-edge bg-card transition-[border-color] duration-300 hover:border-brand/25"
     >
-      <header className="flex items-center justify-between gap-3 border-b border-border bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
+      <header className="flex items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <div className="flex min-w-0 items-center gap-2.5">
-          <Sparkles className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+          <Sparkles className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
           <div className="min-w-0">
-            <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted">
               {t("dailyChallenge.eyebrow")}
             </p>
             <h2
               id="dc-card-heading"
-              className="truncate font-serif text-sm font-semibold tracking-tight text-foreground"
+              className="truncate font-serif text-sm font-semibold tracking-tight text-ink"
             >
               {data ? verseLabel : t("dailyChallenge.title")}
             </h2>
@@ -251,7 +251,7 @@ export function DailyChallengeCard() {
           )}
           <Link
             to="/daily-challenge/archive"
-            className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-primary transition-opacity hover:opacity-80"
+            className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-brand transition-opacity hover:opacity-80"
           >
             {t("dailyChallenge.openArchive")}
             <ArrowRight className="h-3 w-3" strokeWidth={1.75} aria-hidden />
@@ -277,7 +277,7 @@ export function DailyChallengeCard() {
           />
         ) : data ? (
           <>
-            <p className="text-sm font-medium leading-snug text-foreground">{data.question_text}</p>
+            <p className="text-sm font-medium leading-snug text-ink">{data.question_text}</p>
             <ul className="space-y-1.5">
               {[...data.options]
                 .sort((a, b) => a.order_index - b.order_index)
@@ -293,11 +293,11 @@ export function DailyChallengeCard() {
                 ))}
             </ul>
             {reveal !== null && (
-              <div className="space-y-1.5 rounded-md border border-border/80 bg-muted/20 px-3 py-2.5">
+              <div className="space-y-1.5 rounded-md border border-edge/80 bg-muted/20 px-3 py-2.5">
                 <p
                   className={cn(
                     "text-[11px] font-semibold uppercase tracking-[0.14em]",
-                    reveal.is_correct ? "text-success" : "text-muted-foreground",
+                    reveal.is_correct ? "text-success" : "text-ink-muted",
                   )}
                 >
                   {reveal.is_correct
@@ -305,7 +305,7 @@ export function DailyChallengeCard() {
                     : t("dailyChallenge.reveal.wrong")}
                 </p>
                 {reveal.explanation && (
-                  <p className="text-xs leading-snug text-foreground">{reveal.explanation}</p>
+                  <p className="text-xs leading-snug text-ink">{reveal.explanation}</p>
                 )}
               </div>
             )}

--- a/frontend/src/components/dashboard/TodayCard.tsx
+++ b/frontend/src/components/dashboard/TodayCard.tsx
@@ -80,18 +80,18 @@ export function TodayCard() {
   return (
     <section
       aria-labelledby="today-card-heading"
-      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-border bg-card transition-[border-color] duration-300 hover:border-primary/25"
+      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-edge bg-card transition-[border-color] duration-300 hover:border-brand/25"
     >
-      <header className="flex items-center justify-between gap-3 border-b border-border bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
+      <header className="flex items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <div className="flex min-w-0 items-center gap-2.5">
-          <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+          <CalendarDays className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
           <div className="min-w-0">
-            <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted">
               {t("dashboard.today.eyebrow")}
             </p>
             <h2
               id="today-card-heading"
-              className="truncate font-serif text-sm font-semibold capitalize tracking-tight text-foreground"
+              className="truncate font-serif text-sm font-semibold capitalize tracking-tight text-ink"
             >
               {dateLabel}
             </h2>
@@ -99,7 +99,7 @@ export function TodayCard() {
         </div>
         <Link
           to="/calendar"
-          className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-primary transition-opacity hover:opacity-80"
+          className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-brand transition-opacity hover:opacity-80"
         >
           {t("dashboard.today.openFull")}
           <ArrowRight className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
@@ -125,12 +125,12 @@ export function TodayCard() {
               <li key={e.id} className="flex items-start gap-2.5 text-xs">
                 <span
                   aria-hidden
-                  className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+                  className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-brand"
                 />
                 <div className="min-w-0">
-                  <p className="truncate font-medium text-foreground">{e.title}</p>
+                  <p className="truncate font-medium text-ink">{e.title}</p>
                   {e.course_title && (
-                    <p className="truncate text-muted-foreground">{e.course_title}</p>
+                    <p className="truncate text-ink-muted">{e.course_title}</p>
                   )}
                 </div>
               </li>

--- a/frontend/src/components/dashboard/WelcomeCard.tsx
+++ b/frontend/src/components/dashboard/WelcomeCard.tsx
@@ -42,11 +42,11 @@ export function WelcomeCard({ eyebrow, title, description, action, className }: 
           {eyebrow}
         </p>
       )}
-      <h2 className="max-w-md font-serif text-2xl font-semibold leading-tight tracking-tight text-foreground sm:text-3xl">
+      <h2 className="max-w-md font-serif text-2xl font-semibold leading-tight tracking-tight text-ink sm:text-3xl">
         {title}
       </h2>
       {description && (
-        <p className="max-w-md text-sm leading-relaxed text-muted-foreground sm:text-base">
+        <p className="max-w-md text-sm leading-relaxed text-ink-muted sm:text-base">
           {description}
         </p>
       )}

--- a/frontend/src/components/firstRun/CoursePickerStep.tsx
+++ b/frontend/src/components/firstRun/CoursePickerStep.tsx
@@ -160,12 +160,12 @@ export function CoursePickerStep({ firstName, onEnrolled, onBrowse, onSkip }: Pr
       <p className="text-[11px] font-medium uppercase tracking-[0.22em] text-accent">
         {t("firstRun.picker.eyebrow")}
       </p>
-      <h1 className="font-serif text-2xl font-semibold leading-tight tracking-tight text-foreground sm:text-3xl">
+      <h1 className="font-serif text-2xl font-semibold leading-tight tracking-tight text-ink sm:text-3xl">
         {firstName
           ? t("firstRun.picker.titleNamed", { name: firstName })
           : t("firstRun.picker.title")}
       </h1>
-      <p className="max-w-md text-sm leading-relaxed text-muted-foreground sm:text-base">
+      <p className="max-w-md text-sm leading-relaxed text-ink-muted sm:text-base">
         {t("firstRun.picker.intro")}
       </p>
 
@@ -177,8 +177,8 @@ export function CoursePickerStep({ firstName, onEnrolled, onBrowse, onSkip }: Pr
             ))}
           </div>
         ) : error ? (
-          <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border bg-muted/20 p-6 text-center">
-            <p className="text-sm text-muted-foreground">
+          <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-edge bg-muted/20 p-6 text-center">
+            <p className="text-sm text-ink-muted">
               {t("firstRun.picker.loadFailed")}
             </p>
             <Button
@@ -204,10 +204,10 @@ export function CoursePickerStep({ firstName, onEnrolled, onBrowse, onSkip }: Pr
                     aria-pressed={selected}
                     disabled={enrolling}
                     className={cn(
-                      "group relative flex h-full w-full items-start gap-3 rounded-md border-2 p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                      "group relative flex h-full w-full items-start gap-3 rounded-md border-2 p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
                       selected
-                        ? "border-primary bg-primary/[0.06]"
-                        : "border-transparent bg-muted/30 hover:border-primary/30 hover:bg-muted/50",
+                        ? "border-brand bg-brand/[0.06]"
+                        : "border-transparent bg-muted/30 hover:border-brand/30 hover:bg-muted/50",
                       enrolling && "opacity-60",
                     )}
                   >
@@ -216,28 +216,28 @@ export function CoursePickerStep({ firstName, onEnrolled, onBrowse, onSkip }: Pr
                         src={cover}
                         alt=""
                         loading="lazy"
-                        className="h-16 w-16 shrink-0 rounded-sm border border-border object-cover"
+                        className="h-16 w-16 shrink-0 rounded-sm border border-edge object-cover"
                       />
                     ) : (
-                      <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-sm border border-border bg-muted text-muted-foreground">
+                      <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-sm border border-edge bg-muted text-ink-muted">
                         <BookOpen className="h-5 w-5" strokeWidth={1.75} aria-hidden />
                       </div>
                     )}
                     <div className="min-w-0 flex-1">
-                      <h2 className="line-clamp-2 font-serif text-base font-semibold leading-tight tracking-tight text-foreground">
+                      <h2 className="line-clamp-2 font-serif text-base font-semibold leading-tight tracking-tight text-ink">
                         {course.title}
                       </h2>
                       {course.description && (
-                        <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                        <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-ink-muted">
                           {course.description}
                         </p>
                       )}
-                      <p className="mt-2 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground/80">
+                      <p className="mt-2 text-[10px] font-medium uppercase tracking-[0.14em] text-ink-muted/80">
                         {t("firstRun.picker.modulesCount", { count: moduleCount })}
                       </p>
                     </div>
                     {selected && (
-                      <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                      <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-brand text-brand-foreground">
                         <Check className="h-3 w-3" strokeWidth={3} aria-hidden />
                       </span>
                     )}
@@ -274,7 +274,7 @@ export function CoursePickerStep({ firstName, onEnrolled, onBrowse, onSkip }: Pr
               size="sm"
               onClick={handleBrowse}
               disabled={enrolling}
-              className="text-muted-foreground hover:text-foreground"
+              className="text-ink-muted hover:text-ink"
             >
               {t("firstRun.picker.browseAll")}
             </Button>
@@ -284,7 +284,7 @@ export function CoursePickerStep({ firstName, onEnrolled, onBrowse, onSkip }: Pr
               size="sm"
               onClick={onSkip}
               disabled={enrolling}
-              className="text-muted-foreground hover:text-foreground"
+              className="text-ink-muted hover:text-ink"
             >
               {t("firstRun.picker.skip")}
             </Button>

--- a/frontend/src/components/firstRun/EnrollSplash.tsx
+++ b/frontend/src/components/firstRun/EnrollSplash.tsx
@@ -60,7 +60,7 @@ export function EnrollSplash({ course, firstName, onComplete }: Props) {
       // unmounts a moment before this mounts, so there's no
       // overlap, but using the same z-index keeps the splash above
       // any latent driver.js overlay just in case.
-      className="fixed inset-0 z-[2147483646] flex flex-col items-center justify-center gap-6 overflow-hidden bg-background px-6 text-center"
+      className="fixed inset-0 z-[2147483646] flex flex-col items-center justify-center gap-6 overflow-hidden bg-surface px-6 text-center"
     >
       <motion.span
         className="block h-px w-12 bg-accent/70"
@@ -90,19 +90,19 @@ export function EnrollSplash({ course, firstName, onComplete }: Props) {
           <img
             src={cover}
             alt=""
-            className="h-28 w-28 rounded-md border border-border object-cover shadow-[0_18px_45px_hsl(var(--foreground)/0.18)] sm:h-32 sm:w-32"
+            className="h-28 w-28 rounded-md border border-edge object-cover shadow-[0_18px_45px_hsl(var(--foreground)/0.18)] sm:h-32 sm:w-32"
           />
         ) : (
-          <div className="flex h-28 w-28 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground shadow-[0_18px_45px_hsl(var(--foreground)/0.12)] sm:h-32 sm:w-32">
+          <div className="flex h-28 w-28 items-center justify-center rounded-md border border-edge bg-muted text-ink-muted shadow-[0_18px_45px_hsl(var(--foreground)/0.12)] sm:h-32 sm:w-32">
             <BookOpen className="h-10 w-10" strokeWidth={1.5} aria-hidden />
           </div>
         )}
-        <h1 className="max-w-2xl text-balance font-serif text-3xl font-semibold leading-tight tracking-tight text-foreground sm:text-4xl">
+        <h1 className="max-w-2xl text-balance font-serif text-3xl font-semibold leading-tight tracking-tight text-ink sm:text-4xl">
           {course.title}
         </h1>
       </motion.div>
       <motion.p
-        className="max-w-md text-sm leading-relaxed text-muted-foreground sm:text-base"
+        className="max-w-md text-sm leading-relaxed text-ink-muted sm:text-base"
         initial={prefersReducedMotion ? false : { opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.55, delay: 0.45, ease: EDITORIAL_EASE }}

--- a/frontend/src/components/firstRun/FirstRunFlow.tsx
+++ b/frontend/src/components/firstRun/FirstRunFlow.tsx
@@ -250,7 +250,7 @@ export function FirstRunFlow() {
       role="dialog"
       aria-modal="true"
       aria-labelledby="first-run-heading"
-      className="fixed inset-0 z-[2147483646] flex items-start justify-center overflow-y-auto bg-background/95 px-4 py-10 backdrop-blur-sm sm:items-center sm:py-16"
+      className="fixed inset-0 z-[2147483646] flex items-start justify-center overflow-y-auto bg-surface/95 px-4 py-10 backdrop-blur-sm sm:items-center sm:py-16"
     >
       <h1 id="first-run-heading" className="sr-only">
         {step === "privacy"

--- a/frontend/src/components/firstRun/PrivacyPolicyStep.tsx
+++ b/frontend/src/components/firstRun/PrivacyPolicyStep.tsx
@@ -30,29 +30,29 @@ export function PrivacyPolicyStep({ onAccept }: Props) {
       <p className="text-[11px] font-medium uppercase tracking-[0.22em] text-accent">
         {t("firstRun.privacy.eyebrow")}
       </p>
-      <h1 className="font-serif text-2xl font-semibold leading-tight tracking-tight text-foreground sm:text-3xl">
+      <h1 className="font-serif text-2xl font-semibold leading-tight tracking-tight text-ink sm:text-3xl">
         {t("firstRun.privacy.title")}
       </h1>
-      <p className="max-w-md text-sm leading-relaxed text-muted-foreground sm:text-base">
+      <p className="max-w-md text-sm leading-relaxed text-ink-muted sm:text-base">
         {t("firstRun.privacy.intro")}
       </p>
 
-      <ul className="mt-2 w-full space-y-3 text-left text-sm leading-relaxed text-muted-foreground">
-        <li className="flex gap-3 rounded-md border border-border/60 bg-muted/20 p-3">
+      <ul className="mt-2 w-full space-y-3 text-left text-sm leading-relaxed text-ink-muted">
+        <li className="flex gap-3 rounded-md border border-edge/60 bg-muted/20 p-3">
           <span aria-hidden className="mt-1.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
           <span>{t("firstRun.privacy.bullets.collect")}</span>
         </li>
-        <li className="flex gap-3 rounded-md border border-border/60 bg-muted/20 p-3">
+        <li className="flex gap-3 rounded-md border border-edge/60 bg-muted/20 p-3">
           <span aria-hidden className="mt-1.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
           <span>{t("firstRun.privacy.bullets.share")}</span>
         </li>
-        <li className="flex gap-3 rounded-md border border-border/60 bg-muted/20 p-3">
+        <li className="flex gap-3 rounded-md border border-edge/60 bg-muted/20 p-3">
           <span aria-hidden className="mt-1.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
           <span>{t("firstRun.privacy.bullets.control")}</span>
         </li>
       </ul>
 
-      <div className="mt-2 flex w-full items-start gap-3 rounded-md border border-border bg-background p-3 text-left">
+      <div className="mt-2 flex w-full items-start gap-3 rounded-md border border-edge bg-surface p-3 text-left">
         <Checkbox
           id={checkboxId}
           checked={accepted}
@@ -61,7 +61,7 @@ export function PrivacyPolicyStep({ onAccept }: Props) {
         />
         <label
           htmlFor={checkboxId}
-          className="cursor-pointer text-sm leading-snug text-foreground"
+          className="cursor-pointer text-sm leading-snug text-ink"
         >
           {t("firstRun.privacy.checkbox")}
         </label>

--- a/frontend/src/components/firstRun/SetupStep.tsx
+++ b/frontend/src/components/firstRun/SetupStep.tsx
@@ -28,10 +28,10 @@ import { initialsOf } from "@/lib/names"
  */
 function toggleButtonClasses(active: boolean): string {
   return cn(
-    "flex items-center rounded-md border-2 px-3 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    "flex items-center rounded-md border-2 px-3 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
     active
-      ? "border-primary bg-primary/10 text-foreground"
-      : "border-transparent bg-muted/30 text-muted-foreground hover:border-primary/30 hover:bg-muted/50",
+      ? "border-brand bg-brand/10 text-ink"
+      : "border-transparent bg-muted/30 text-ink-muted hover:border-brand/30 hover:bg-muted/50",
   )
 }
 
@@ -229,12 +229,12 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
       <p className="text-[11px] font-medium uppercase tracking-[0.22em] text-accent">
         {t("firstRun.setup.eyebrow")}
       </p>
-      <h1 className="font-serif text-2xl font-semibold leading-tight tracking-tight text-foreground sm:text-3xl">
+      <h1 className="font-serif text-2xl font-semibold leading-tight tracking-tight text-ink sm:text-3xl">
         {firstName
           ? t("firstRun.setup.titleNamed", { name: firstName })
           : t("firstRun.setup.title")}
       </h1>
-      <p className="max-w-md text-sm leading-relaxed text-muted-foreground sm:text-base">
+      <p className="max-w-md text-sm leading-relaxed text-ink-muted sm:text-base">
         {t("firstRun.setup.intro")}
       </p>
 
@@ -246,18 +246,18 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
               <img
                 src={toProxyImage(avatarUrl)}
                 alt=""
-                className="h-16 w-16 rounded-full border border-border object-cover"
+                className="h-16 w-16 rounded-full border border-edge object-cover"
               />
             ) : (
-              <div className="flex h-16 w-16 items-center justify-center rounded-full border border-border bg-muted font-serif text-base font-semibold text-foreground">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full border border-edge bg-muted font-serif text-base font-semibold text-ink">
                 {initials || (
-                  <UserIcon className="h-7 w-7 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+                  <UserIcon className="h-7 w-7 text-ink-muted" strokeWidth={1.75} aria-hidden />
                 )}
               </div>
             )}
           </div>
           <div className="flex-1">
-            <Label className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <Label className="text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
               {t("firstRun.setup.avatar.label")}
             </Label>
             <div className="mt-2">
@@ -291,7 +291,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
         <div>
           <Label
             htmlFor={nameId}
-            className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground"
+            className="text-xs font-medium uppercase tracking-[0.18em] text-ink-muted"
           >
             {t("firstRun.setup.name.label")}
           </Label>
@@ -305,7 +305,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
             aria-describedby={`${nameId}-hint`}
             className="mt-2"
           />
-          <p id={`${nameId}-hint`} className="mt-1.5 text-xs text-muted-foreground/80">
+          <p id={`${nameId}-hint`} className="mt-1.5 text-xs text-ink-muted/80">
             {t("firstRun.setup.name.hint")}
           </p>
         </div>
@@ -314,7 +314,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
         <div>
           <Label
             htmlFor={emailId}
-            className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground"
+            className="text-xs font-medium uppercase tracking-[0.18em] text-ink-muted"
           >
             {t("firstRun.setup.email.label")}
           </Label>
@@ -325,9 +325,9 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
             // Skipped by the focus trap — typing is impossible, so
             // landing a Tab cursor here just confuses keyboard users.
             tabIndex={-1}
-            className="mt-2 cursor-not-allowed bg-muted/40 text-muted-foreground"
+            className="mt-2 cursor-not-allowed bg-muted/40 text-ink-muted"
           />
-          <p className="mt-1.5 text-xs text-muted-foreground/80">
+          <p className="mt-1.5 text-xs text-ink-muted/80">
             {t("firstRun.setup.email.hint")}
           </p>
         </div>
@@ -335,7 +335,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
         {/* Theme — visual toggle, preview-on-click via the live
             useTheme hook (same context that powers the header toggle). */}
         <div>
-          <Label className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <Label className="text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
             {t("firstRun.setup.theme.label")}
           </Label>
           <div className="mt-2 grid grid-cols-2 gap-2">
@@ -348,7 +348,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
               <Sun className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
               <span className="flex-1 text-left">{t("firstRun.setup.theme.light")}</span>
               {theme === "light" && (
-                <Check className="h-4 w-4 shrink-0 text-primary" strokeWidth={2.25} aria-hidden />
+                <Check className="h-4 w-4 shrink-0 text-brand" strokeWidth={2.25} aria-hidden />
               )}
             </button>
             <button
@@ -360,7 +360,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
               <Moon className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
               <span className="flex-1 text-left">{t("firstRun.setup.theme.dark")}</span>
               {theme === "dark" && (
-                <Check className="h-4 w-4 shrink-0 text-primary" strokeWidth={2.25} aria-hidden />
+                <Check className="h-4 w-4 shrink-0 text-brand" strokeWidth={2.25} aria-hidden />
               )}
             </button>
           </div>
@@ -368,7 +368,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
 
         {/* Language — same preview pattern */}
         <div>
-          <Label className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <Label className="text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
             {t("firstRun.setup.language.label")}
           </Label>
           <div className="mt-2 grid grid-cols-2 gap-2">
@@ -380,7 +380,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
             >
               <span className="flex-1 text-left">{t("firstRun.setup.language.en")}</span>
               {locale === "en" && (
-                <Check className="h-4 w-4 shrink-0 text-primary" strokeWidth={2.25} aria-hidden />
+                <Check className="h-4 w-4 shrink-0 text-brand" strokeWidth={2.25} aria-hidden />
               )}
             </button>
             <button
@@ -391,7 +391,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
             >
               <span className="flex-1 text-left">{t("firstRun.setup.language.ru")}</span>
               {locale === "ru" && (
-                <Check className="h-4 w-4 shrink-0 text-primary" strokeWidth={2.25} aria-hidden />
+                <Check className="h-4 w-4 shrink-0 text-brand" strokeWidth={2.25} aria-hidden />
               )}
             </button>
           </div>
@@ -415,7 +415,7 @@ export function SetupStep({ firstName, onComplete, onSkip }: Props) {
           size="sm"
           onClick={handleSkip}
           disabled={isBusy}
-          className="text-muted-foreground hover:text-foreground"
+          className="text-ink-muted hover:text-ink"
         >
           {t("firstRun.setup.skip")}
         </Button>

--- a/frontend/src/components/home/VerseOfTheDayCard.tsx
+++ b/frontend/src/components/home/VerseOfTheDayCard.tsx
@@ -54,26 +54,26 @@ export function VerseOfTheDayCard() {
   return (
     <section
       aria-labelledby="verse-of-the-day-heading"
-      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-border bg-card transition-[border-color] duration-300 hover:border-primary/25"
+      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-edge bg-card transition-[border-color] duration-300 hover:border-brand/25"
     >
       {/* Compact header to match MiniCalendar / MyCoursesSection rhythm on
           the dashboard side rail. Icon dropped from a framed 10×10 box to
           an inline 4×4 lucide — saves ~32px vertical, the difference
           between fitting and not fitting the single-viewport contract on
           a 13" laptop. */}
-      <header className="flex items-center gap-2.5 border-b border-border bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
+      <header className="flex items-center gap-2.5 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <BookOpenText
-          className="h-4 w-4 shrink-0 text-muted-foreground"
+          className="h-4 w-4 shrink-0 text-ink-muted"
           strokeWidth={1.75}
           aria-hidden
         />
         <div className="min-w-0">
-          <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted">
             {t("dashboard.votd.eyebrow")}
           </p>
           <h2
             id="verse-of-the-day-heading"
-            className="font-serif text-sm font-semibold leading-tight tracking-tight text-foreground"
+            className="font-serif text-sm font-semibold leading-tight tracking-tight text-ink"
           >
             {t("dashboard.votd.title")}
           </h2>
@@ -90,11 +90,11 @@ export function VerseOfTheDayCard() {
           </div>
         ) : (
           <figure className="space-y-2.5">
-            <blockquote className="font-serif text-sm leading-relaxed text-foreground">
+            <blockquote className="font-serif text-sm leading-relaxed text-ink">
               &ldquo;{verse.text}&rdquo;
             </blockquote>
-            <figcaption className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs text-muted-foreground">
-              <cite className="not-italic font-medium text-foreground">{verse.reference}</cite>
+            <figcaption className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs text-ink-muted">
+              <cite className="not-italic font-medium text-ink">{verse.reference}</cite>
               <span aria-hidden>·</span>
               <span>{verse.version}</span>
             </figcaption>

--- a/frontend/src/styles/__tests__/wave9-dashboard.test.ts
+++ b/frontend/src/styles/__tests__/wave9-dashboard.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Sentinel for ADR-0011 Wave 9 — dashboard & first-run surfaces
+ * migrated to v2.
+ *
+ * Covers the next-most-visible surface after the layout chrome:
+ * the dashboard cards a student sees every visit, the home page
+ * Verse-of-the-Day card, and the entire first-run onboarding flow.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "..", "..");
+
+function readNonComment(path: string): string {
+  return readFileSync(path, "utf-8")
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`).test(code);
+}
+
+const FILES = [
+  resolve(SRC, "components/dashboard/DailyChallengeCard.tsx"),
+  resolve(SRC, "components/dashboard/TodayCard.tsx"),
+  resolve(SRC, "components/dashboard/WelcomeCard.tsx"),
+  resolve(SRC, "components/home/VerseOfTheDayCard.tsx"),
+  resolve(SRC, "components/firstRun/CoursePickerStep.tsx"),
+  resolve(SRC, "components/firstRun/EnrollSplash.tsx"),
+  resolve(SRC, "components/firstRun/FirstRunFlow.tsx"),
+  resolve(SRC, "components/firstRun/PrivacyPolicyStep.tsx"),
+  resolve(SRC, "components/firstRun/SetupStep.tsx"),
+];
+
+const V1_LOCKED_OUT = [
+  "bg-background",
+  "text-foreground",
+  "text-muted-foreground",
+  "border-border",
+  "border-input",
+  "bg-primary",
+  "text-primary",
+  "border-primary",
+  "hover:bg-accent",
+  "hover:text-accent-foreground",
+  "ring-ring",
+  "bg-muted-foreground",
+];
+
+describe("ADR-0011 Wave 9 — dashboard & first-run surface migration", () => {
+  for (const path of FILES) {
+    const name = path.split(/[\\/]/).slice(-2).join("/");
+
+    it(`${name} retired the v1 names`, () => {
+      const code = readNonComment(path);
+      for (const cls of V1_LOCKED_OUT) {
+        expect(
+          containsClass(code, cls),
+          `${name} still references ${cls}`,
+        ).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
ADR-0011 **Wave 9**. Migrates the next-most-visible surface after the layout chrome.

## Scope (9 files, 87 v1 refs replaced)

| File | v1 refs |
|---|---:|
| `dashboard/DailyChallengeCard.tsx` | 18 |
| `dashboard/TodayCard.tsx` | 9 |
| `dashboard/WelcomeCard.tsx` | 2 |
| `home/VerseOfTheDayCard.tsx` | 8 |
| `firstRun/CoursePickerStep.tsx` | 15 |
| `firstRun/EnrollSplash.tsx` | 5 |
| `firstRun/FirstRunFlow.tsx` | 1 |
| `firstRun/PrivacyPolicyStep.tsx` | 8 |
| `firstRun/SetupStep.tsx` | 21 |

## Sentinel

`wave9-dashboard.test.ts` — 9-file per-file lock-out using the word-boundary `containsClass` helper.

## Test plan

- [x] +9 sentinel tests
- [x] Full frontend suite green (364 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)