### PR TITLE
feat(design): visual overhaul v2 Wave 10 — course cards + admin + editor remnants

### DIFF
--- a/frontend/src/components/admin/RoleSelector.tsx
+++ b/frontend/src/components/admin/RoleSelector.tsx
@@ -45,7 +45,7 @@ export function RoleSelector({ role, disabled = false, onChange, ariaLabel }: Pr
         "gap-1.5 select-none",
         disabled && "cursor-default",
         !disabled &&
-          "cursor-pointer transition-shadow hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "cursor-pointer transition-shadow hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
       )}
     >
       {t(ROLE_I18N_KEY[role])}
@@ -62,7 +62,7 @@ export function RoleSelector({ role, disabled = false, onChange, ariaLabel }: Pr
       <DropdownMenuTrigger asChild aria-label={ariaLabel}>
         <button
           type="button"
-          className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
         >
           {badge}
         </button>
@@ -78,12 +78,12 @@ export function RoleSelector({ role, disabled = false, onChange, ariaLabel }: Pr
               }}
               className={cn(
                 "justify-between",
-                selected && "font-medium text-foreground",
+                selected && "font-medium text-ink",
               )}
             >
               <span>{t(ROLE_I18N_KEY[value])}</span>
               {selected && (
-                <Check className="h-3.5 w-3.5 text-primary" strokeWidth={1.75} aria-hidden />
+                <Check className="h-3.5 w-3.5 text-brand" strokeWidth={1.75} aria-hidden />
               )}
             </DropdownMenuItem>
           )

--- a/frontend/src/components/admin/UserAvatar.tsx
+++ b/frontend/src/components/admin/UserAvatar.tsx
@@ -76,7 +76,7 @@ export function UserAvatar({
     <div
       className={cn(
         dimensionClass,
-        "flex shrink-0 items-center justify-center rounded-full bg-muted font-medium text-muted-foreground",
+        "flex shrink-0 items-center justify-center rounded-full bg-muted font-medium text-ink-muted",
         size === "md" ? "text-sm" : "text-xs",
         className,
       )}

--- a/frontend/src/components/course/CertificateCard.tsx
+++ b/frontend/src/components/course/CertificateCard.tsx
@@ -87,13 +87,13 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
         <CardContent className="py-6">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-muted">
-              <Award className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+              <Award className="h-6 w-6 text-ink-muted" strokeWidth={1.75} />
             </div>
             <div className="flex-1">
               <h3 className="font-serif text-base font-semibold">
                 {t("certificates.card.completedTitle")}
               </h3>
-              <p className="mt-0.5 text-sm text-muted-foreground">
+              <p className="mt-0.5 text-sm text-ink-muted">
                 {t("certificates.card.completedDescription")}
               </p>
             </div>
@@ -117,7 +117,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
             </div>
             <div className="flex-1">
               <h3 className="font-serif text-base font-semibold">{t("certificates.card.pendingTitle")}</h3>
-              <p className="mt-0.5 text-sm text-muted-foreground">
+              <p className="mt-0.5 text-sm text-ink-muted">
                 {t("certificates.card.pendingDescription")}
               </p>
             </div>
@@ -137,7 +137,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
             </div>
             <div className="flex-1">
               <h3 className="font-serif text-base font-semibold">{t("certificates.card.adminPendingTitle")}</h3>
-              <p className="mt-0.5 text-sm text-muted-foreground">
+              <p className="mt-0.5 text-sm text-ink-muted">
                 {t("certificates.card.adminPendingDescription")}
               </p>
             </div>
@@ -164,18 +164,18 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
                 <h3 className="font-serif text-xl font-semibold tracking-tight">
                   {t("certificates.card.approvedTitle")}
                 </h3>
-                <p className="mt-1 text-sm text-muted-foreground">
+                <p className="mt-1 text-sm text-ink-muted">
                   {t("certificates.card.approvedDescription")}
                 </p>
               </div>
 
-              <div className="grid gap-4 rounded-md border border-border bg-muted/20 p-4 sm:grid-cols-2">
+              <div className="grid gap-4 rounded-md border border-edge bg-muted/20 p-4 sm:grid-cols-2">
                 <div>
-                  <p className="mb-1.5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  <p className="mb-1.5 text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
                     {t("certificates.card.certificateNumber")}
                   </p>
                   <div className="flex items-center gap-2">
-                    <code className="select-all rounded border border-border bg-background px-2.5 py-1 font-mono text-sm">
+                    <code className="select-all rounded border border-edge bg-surface px-2.5 py-1 font-mono text-sm">
                       {certificate.certificate_number}
                     </code>
                     <Button
@@ -194,7 +194,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
                   </div>
                 </div>
                 <div>
-                  <p className="mb-1.5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                  <p className="mb-1.5 text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
                     {t("certificates.card.issueDate")}
                   </p>
                   <p className="text-sm font-medium">
@@ -208,8 +208,8 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
           </div>
 
           {user && !reviewDone && (
-            <div className="space-y-3 border-t border-border pt-5">
-              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <div className="space-y-3 border-t border-edge pt-5">
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
                 {t("certificates.card.review.eyebrow")}
               </p>
               <h4 className="font-serif text-base font-semibold tracking-tight">{t("certificates.card.review.heading")}</h4>
@@ -228,13 +228,13 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
                       className={`h-6 w-6 transition-colors ${
                         value <= (reviewHover || reviewRating)
                           ? "fill-warning text-warning"
-                          : "text-muted-foreground/30"
+                          : "text-ink-muted/30"
                       }`}
                     strokeWidth={1.75} />
                   </button>
                 ))}
                 {reviewRating > 0 && (
-                  <span className="ml-2 text-sm text-muted-foreground">
+                  <span className="ml-2 text-sm text-ink-muted">
                     {reviewRating}/5
                   </span>
                 )}
@@ -244,7 +244,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
                 onChange={(e) => setReviewComment(e.target.value)}
                 placeholder={t("certificates.card.review.commentPlaceholder")}
                 rows={3}
-                className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="flex min-h-[80px] w-full rounded-md border border-edge-strong bg-surface px-3 py-2 text-sm placeholder:text-ink-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
               />
               <Button onClick={handleReviewSubmit} disabled={reviewSubmitting} size="sm">
                 {reviewSubmitting ? t("certificates.card.review.submitting") : t("certificates.card.review.submit")}
@@ -253,7 +253,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
           )}
 
           {reviewDone && (
-            <div className="flex items-center gap-2 border-t border-border pt-4 text-sm text-success">
+            <div className="flex items-center gap-2 border-t border-edge pt-4 text-sm text-success">
               <CheckCircle className="h-4 w-4" strokeWidth={1.75} />
               {t("certificates.card.review.thanks")}
             </div>
@@ -275,7 +275,7 @@ export default function CertificateCard({ courseId, progress, certificate, onCer
               <h3 className="font-serif text-base font-semibold">
                 {t("certificates.card.rejectedTitle")}
               </h3>
-              <p className="mt-0.5 text-sm text-muted-foreground">
+              <p className="mt-0.5 text-sm text-ink-muted">
                 {t("certificates.card.rejectedDescription")}
               </p>
             </div>

--- a/frontend/src/components/course/CompletionDialog.tsx
+++ b/frontend/src/components/course/CompletionDialog.tsx
@@ -86,10 +86,10 @@ export default function CompletionDialog({
               styles with the editorial vocabulary used on
               ``<WelcomeCard>`` so the two first-time moments share a
               voice. */}
-          <DialogTitle className="max-w-md text-balance font-serif text-2xl font-semibold leading-tight tracking-tight text-foreground sm:text-3xl">
+          <DialogTitle className="max-w-md text-balance font-serif text-2xl font-semibold leading-tight tracking-tight text-ink sm:text-3xl">
             {t("completion.title", { courseTitle })}
           </DialogTitle>
-          <p className="max-w-md text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p className="max-w-md text-sm leading-relaxed text-ink-muted sm:text-base">
             {hasCertificate ? t("completion.bodyHasCert") : t("completion.body")}
           </p>
           <div className="flex flex-col gap-2 pt-2 sm:flex-row">

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -60,7 +60,7 @@ function CourseCard({ course, style }: CourseCardProps) {
   const moduleCount = course.modules?.length ?? 0
 
   const cardInner = (
-    <Card className="flex h-full flex-col overflow-hidden border-border/60 transition-colors hover:border-primary/40">
+    <Card className="flex h-full flex-col overflow-hidden border-edge/60 transition-colors hover:border-brand/40">
       <div className="relative">
         {course.access_mode === "institute" ? (
           <Badge variant="muted" className="absolute right-3 top-3 z-10">
@@ -82,7 +82,7 @@ function CourseCard({ course, style }: CourseCardProps) {
           </div>
         ) : (
           <div className="flex aspect-[16/10] w-full items-center justify-center bg-muted">
-            <BookOpen className="h-10 w-10 text-muted-foreground/30" strokeWidth={1.75} aria-hidden />
+            <BookOpen className="h-10 w-10 text-ink-muted/30" strokeWidth={1.75} aria-hidden />
           </div>
         )}
       </div>
@@ -96,9 +96,9 @@ function CourseCard({ course, style }: CourseCardProps) {
           </CardDescription>
         )}
       </CardHeader>
-      <CardContent className="mt-auto flex items-center justify-between pt-2 text-xs text-muted-foreground">
+      <CardContent className="mt-auto flex items-center justify-between pt-2 text-xs text-ink-muted">
         <span className="uppercase tracking-wide">{t("courseCard.modulesLabel", { count: moduleCount })}</span>
-        <span className="inline-flex items-center gap-1 text-foreground/80 transition-colors group-hover:text-primary">
+        <span className="inline-flex items-center gap-1 text-ink/80 transition-colors group-hover:text-brand">
           {t("courseCard.openCourse")}
           <ArrowRight
             className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5"
@@ -114,7 +114,7 @@ function CourseCard({ course, style }: CourseCardProps) {
     <Link
       to={`/courses/${course.id}`}
       style={style}
-      className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      className="group block rounded-md outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       {prefersReducedMotion ? (
         cardInner

--- a/frontend/src/components/course/CourseReviews.tsx
+++ b/frontend/src/components/course/CourseReviews.tsx
@@ -73,7 +73,7 @@ export default function CourseReviews({ courseId }: Props) {
           <MessageSquare className="h-5 w-5" strokeWidth={1.75} />
           {t("reviews.heading")}
           {reviews.length > 0 && (
-            <span className="text-sm font-normal text-muted-foreground ml-1">
+            <span className="text-sm font-normal text-ink-muted ml-1">
               ({reviews.length})
             </span>
           )}
@@ -82,7 +82,7 @@ export default function CourseReviews({ courseId }: Props) {
           <div className="flex items-center gap-2 mt-2">
             <StarDisplay rating={avgRating} size="lg" />
             <span className="text-sm font-medium">{avgRating.toFixed(1)}</span>
-            <span className="text-xs text-muted-foreground">
+            <span className="text-xs text-ink-muted">
               {t("reviews.outOf5")} · {t("reviews.reviewCount", { count: reviews.length })}
             </span>
           </div>
@@ -93,7 +93,7 @@ export default function CourseReviews({ courseId }: Props) {
           <PageSpinner variant="section" />
         ) : loadError ? (
           <div className="flex flex-col items-center gap-2 py-8">
-            <p className="text-sm text-muted-foreground">{t("reviews.loadFailedInline")}</p>
+            <p className="text-sm text-ink-muted">{t("reviews.loadFailedInline")}</p>
             <Button variant="outline" size="sm" onClick={() => loadReviews()}>
               {t("reviews.retry")}
             </Button>
@@ -117,13 +117,13 @@ export default function CourseReviews({ courseId }: Props) {
                     </span>
                   </div>
                   <div className="flex items-center gap-1">
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-xs text-ink-muted">
                       {formatDate(review.created_at)}
                     </span>
                     {review.user_id === user?.id && (
                       confirmDeleteId === review.id ? (
                         <div className="flex items-center gap-1">
-                          <span className="text-xs text-muted-foreground">{t("reviews.confirmDeletePrefix")}</span>
+                          <span className="text-xs text-ink-muted">{t("reviews.confirmDeletePrefix")}</span>
                           <Button
                             variant="ghost"
                             size="sm"
@@ -158,7 +158,7 @@ export default function CourseReviews({ courseId }: Props) {
                   </div>
                 </div>
                 {review.comment && (
-                  <p className="text-sm leading-relaxed text-muted-foreground text-wrap-safe whitespace-pre-line">
+                  <p className="text-sm leading-relaxed text-ink-muted text-wrap-safe whitespace-pre-line">
                     {review.comment}
                   </p>
                 )}
@@ -184,7 +184,7 @@ function StarDisplay({ rating, size = "sm" }: { rating: number; size?: "sm" | "l
             className={`${iconClass} ${
               filled
                 ? "fill-warning text-warning"
-                : "text-muted-foreground/30"
+                : "text-ink-muted/30"
             }`}
           strokeWidth={1.75} />
         )

--- a/frontend/src/components/editor/CalloutDropdown.tsx
+++ b/frontend/src/components/editor/CalloutDropdown.tsx
@@ -113,7 +113,7 @@ export function CalloutDropdown({
           role="menu"
           aria-label={t("blockEditor.callout.trigger")}
           className={cn(
-            // ADR-0011 Wave 7 — bg-background -> bg-surface-elevated.
+            // ADR-0011 Wave 7 — bg-surface -> bg-surface-elevated.
             "absolute top-full z-20 mt-1 w-52 rounded-md border bg-surface-elevated py-1 shadow-lg",
             alignClass,
           )}

--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -53,10 +53,10 @@ function ToolbarButton({
       aria-label={title}
       aria-pressed={pressable ? active : undefined}
       // ADR-0011 Wave 7 — migrated to v2 vocabulary.
-      // ring-ring -> ring-brand, bg-primary/20 -> bg-brand/20,
-      // text-primary -> text-brand, ring-primary/30 -> ring-brand/30,
-      // text-muted-foreground -> text-ink-muted, hover:bg-accent ->
-      // hover:bg-heritage, hover:text-accent-foreground -> hover:text-ink.
+      // ring-brand -> ring-brand, bg-brand/20 -> bg-brand/20,
+      // text-brand -> text-brand, ring-primary/30 -> ring-brand/30,
+      // text-ink-muted -> text-ink-muted, hover:bg-heritage ->
+      // hover:bg-heritage, hover:text-ink -> hover:text-ink.
       className={cn(
         "rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
         active
@@ -109,7 +109,7 @@ export function EditorToolbar({
       aria-label={t("blockEditor.toolbar.ariaLabel")}
       // ``sticky top-0`` keeps the toolbar visible while teachers
       // scroll long chapters. ``z-20`` sits above prose content but
-      // below modal/dialog overlays (z-50). ``bg-background`` is
+      // below modal/dialog overlays (z-50). ``bg-surface`` is
       // required for sticky semi-transparent flicker over the
       // ProseMirror surface below.
       //
@@ -119,7 +119,7 @@ export function EditorToolbar({
       // the original wrap behaviour above the ``sm`` breakpoint where
       // there's enough room. ``no-scrollbar`` (utility added in
       // index.css) hides the visible bar — touch scroll still works.
-      // ADR-0011 Wave 7 — border-input -> border-edge-strong, bg-background -> bg-surface.
+      // ADR-0011 Wave 7 — border-edge-strong -> border-edge-strong, bg-surface -> bg-surface.
       className="sticky top-0 z-20 flex flex-nowrap items-center gap-0.5 overflow-x-auto border-b border-edge-strong bg-surface px-2 py-1.5 no-scrollbar sm:flex-wrap sm:overflow-x-visible"
     >
       <ToolbarButton

--- a/frontend/src/components/patterns/InlineEdit.tsx
+++ b/frontend/src/components/patterns/InlineEdit.tsx
@@ -142,7 +142,7 @@ export function InlineEdit({
       disabled: saving,
       "aria-label": ariaLabel,
       className: cn(
-        "w-full rounded-md border border-input bg-background px-2 py-1 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "w-full rounded-md border border-edge-strong bg-surface px-2 py-1 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
         sizeClasses[size],
         textClassName,
       ),
@@ -165,12 +165,12 @@ export function InlineEdit({
         )}
         <span className="flex shrink-0 items-center gap-1 pt-1">
           {saving ? (
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" strokeWidth={1.75} />
+            <Loader2 className="h-4 w-4 animate-spin text-ink-muted" strokeWidth={1.75} />
           ) : (
             <>
               <button
                 type="button"
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-heritage hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => void commit()}
                 aria-label={t("inlineEdit.save")}
@@ -179,7 +179,7 @@ export function InlineEdit({
               </button>
               <button
                 type="button"
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-heritage hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={cancel}
                 aria-label={t("inlineEdit.cancel")}
@@ -211,7 +211,7 @@ export function InlineEdit({
             "text-wrap-safe",
             multiline && "whitespace-pre-line",
             sizeClasses[size],
-            isEmpty && "text-muted-foreground italic",
+            isEmpty && "text-ink-muted italic",
             textClassName,
           )}
         >
@@ -238,17 +238,17 @@ export function InlineEdit({
         onClick={start}
         aria-label={ariaLabel ?? t("inlineEdit.editAria", { what: resolvedPlaceholder.toLowerCase() })}
         className={cn(
-          "flex-1 min-w-0 cursor-text rounded-md px-2 py-1 text-left transition-colors text-wrap-safe hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "flex-1 min-w-0 cursor-text rounded-md px-2 py-1 text-left transition-colors text-wrap-safe hover:bg-heritage/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
           multiline && "whitespace-pre-line",
           sizeClasses[size],
-          isEmpty && "text-muted-foreground italic",
+          isEmpty && "text-ink-muted italic",
           textClassName,
         )}
       >
         {displayText}
       </button>
       <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/edit:opacity-100 group-focus-within/edit:opacity-100">
-        <span className="inline-flex h-6 w-6 items-center justify-center rounded-md bg-background/80 text-muted-foreground shadow-sm ring-1 ring-border">
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-md bg-surface/80 text-ink-muted shadow-sm ring-1 ring-border">
           <Pencil className="h-3.5 w-3.5" strokeWidth={1.75} />
         </span>
       </span>

--- a/frontend/src/components/patterns/InlineEditCover.tsx
+++ b/frontend/src/components/patterns/InlineEditCover.tsx
@@ -98,9 +98,9 @@ export function InlineEditCover({
   return (
     <div
       className={cn(
-        "relative w-full overflow-hidden rounded-lg border border-border bg-muted",
+        "relative w-full overflow-hidden rounded-lg border border-edge bg-muted",
         aspectClasses[aspect],
-        dragOver && "ring-2 ring-ring ring-offset-2",
+        dragOver && "ring-2 ring-brand ring-offset-2",
         className,
       )}
       onDragOver={(e) => {
@@ -116,7 +116,7 @@ export function InlineEditCover({
           type="button"
           onClick={() => inputRef.current?.click()}
           disabled={disabled || busy}
-          className="group flex h-full w-full flex-col items-center justify-center gap-2 text-muted-foreground transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="group flex h-full w-full flex-col items-center justify-center gap-2 text-ink-muted transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
         >
           {busy ? (
             <Loader2 className="h-6 w-6 animate-spin" strokeWidth={1.75} />
@@ -144,7 +144,7 @@ export function InlineEditCover({
                 type="button"
                 onClick={() => inputRef.current?.click()}
                 disabled={busy}
-                className="inline-flex items-center gap-1.5 rounded-md bg-background/90 px-2.5 py-1 text-xs font-medium text-foreground shadow-sm ring-1 ring-border hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                className="inline-flex items-center gap-1.5 rounded-md bg-surface/90 px-2.5 py-1 text-xs font-medium text-ink shadow-sm ring-1 ring-border hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
               >
                 {busy ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.75} />
@@ -158,7 +158,7 @@ export function InlineEditCover({
                   type="button"
                   onClick={remove}
                   disabled={busy}
-                  className="inline-flex items-center gap-1.5 rounded-md bg-background/90 px-2.5 py-1 text-xs font-medium text-foreground shadow-sm ring-1 ring-border hover:bg-destructive hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  className="inline-flex items-center gap-1.5 rounded-md bg-surface/90 px-2.5 py-1 text-xs font-medium text-ink shadow-sm ring-1 ring-border hover:bg-destructive hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
                 >
                   <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />
                   {t("inlineEdit.cover.remove")}

--- a/frontend/src/styles/__tests__/wave10-course-cards.test.ts
+++ b/frontend/src/styles/__tests__/wave10-course-cards.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Sentinel for ADR-0011 Wave 10 — course cards, course modals,
+ * admin atoms, remaining editor surfaces, and the InlineEdit
+ * pattern.
+ *
+ * Brings the public-facing course-browsing surface, the
+ * editor-toolbar / callout dropdown remnants, and the InlineEdit
+ * primitive onto v2. After this wave the catalog + course detail
+ * page are end-to-end on the v2 vocabulary.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "..", "..");
+
+function readNonComment(path: string): string {
+  return readFileSync(path, "utf-8")
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`).test(code);
+}
+
+const FILES = [
+  resolve(SRC, "components/course/CertificateCard.tsx"),
+  resolve(SRC, "components/course/CompletionDialog.tsx"),
+  resolve(SRC, "components/course/CourseCard.tsx"),
+  resolve(SRC, "components/course/CourseReviews.tsx"),
+  resolve(SRC, "components/admin/RoleSelector.tsx"),
+  resolve(SRC, "components/admin/UserAvatar.tsx"),
+  resolve(SRC, "components/editor/CalloutDropdown.tsx"),
+  resolve(SRC, "components/editor/EditorToolbar.tsx"),
+  resolve(SRC, "components/patterns/InlineEdit.tsx"),
+  resolve(SRC, "components/patterns/InlineEditCover.tsx"),
+];
+
+const V1_LOCKED_OUT = [
+  "bg-background",
+  "text-foreground",
+  "text-muted-foreground",
+  "border-border",
+  "border-input",
+  "bg-primary",
+  "text-primary",
+  "border-primary",
+  "hover:bg-accent",
+  "hover:text-accent-foreground",
+  "ring-ring",
+  "bg-muted-foreground",
+];
+
+describe("ADR-0011 Wave 10 — course cards + admin atoms + editor remnants migration", () => {
+  for (const path of FILES) {
+    const name = path.split(/[\\/]/).slice(-2).join("/");
+
+    it(`${name} retired the v1 names`, () => {
+      const code = readNonComment(path);
+      for (const cls of V1_LOCKED_OUT) {
+        expect(
+          containsClass(code, cls),
+          `${name} still references ${cls}`,
+        ).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
ADR-0011 **Wave 10**. Brings the course-browsing surface, the last editor-toolbar / callout dropdown remnants, and the InlineEdit primitive onto v2.

## Scope (10 files, 55 v1 refs)

| File | v1 refs |
|---|---:|
| `course/CertificateCard.tsx` | 16 |
| `course/CompletionDialog.tsx` | 2 |
| `course/CourseCard.tsx` | 5 |
| `course/CourseReviews.tsx` | 7 |
| `admin/RoleSelector.tsx` | 4 |
| `admin/UserAvatar.tsx` | 1 |
| `editor/CalloutDropdown.tsx` | 1 |
| `editor/EditorToolbar.tsx` | 6 |
| `patterns/InlineEdit.tsx` | 8 |
| `patterns/InlineEditCover.tsx` | 5 |

## Sentinel

`wave10-course-cards.test.ts` — 10-file per-file lock-out using the word-boundary `containsClass` helper.

## Test plan

- [x] +10 sentinel tests
- [x] Full frontend suite green (374 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)