### PR TITLE
feat(design): visual overhaul v2 Wave 12 — Admin pages

### DIFF
--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -75,12 +75,12 @@ export default function AdminDashboard() {
   return (
     <div className="animate-fade-in container mx-auto max-w-6xl px-4 py-6 sm:py-8">
       <header className="mb-6 space-y-2">
-        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">
           {t("admin.eyebrow")}
         </p>
         <div className="flex items-center gap-3">
-          <div className="rounded-md bg-primary/10 p-2">
-            <Shield className="h-6 w-6 text-primary" strokeWidth={1.75} aria-hidden />
+          <div className="rounded-md bg-brand/10 p-2">
+            <Shield className="h-6 w-6 text-brand" strokeWidth={1.75} aria-hidden />
           </div>
           <h1 className="font-serif text-2xl font-bold tracking-tight sm:text-3xl">
             {t("admin.title")}

--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -53,7 +53,7 @@ function UserRow({
       role="row"
       style={style}
       className={`grid grid-cols-[40px_2fr_2fr_2fr_1fr_40px] items-center border-b px-3 text-sm transition-colors hover:bg-muted/40 ${
-        selected ? "border-primary/40 bg-primary/[0.08] dark:bg-primary/15" : ""
+        selected ? "border-brand/40 bg-brand/[0.08] dark:bg-brand/15" : ""
       }`}
     >
       <div role="cell" className="flex items-center justify-center">
@@ -75,7 +75,7 @@ function UserRow({
           {u.full_name?.trim() || t("admin.users.missingName")}
         </span>
       </div>
-      <div role="cell" className="truncate px-3 text-muted-foreground" title={u.email}>
+      <div role="cell" className="truncate px-3 text-ink-muted" title={u.email}>
         {u.email}
       </div>
       <div role="cell" className="px-3 flex items-center gap-2">
@@ -86,14 +86,14 @@ function UserRow({
           ariaLabel={t("admin.users.changeRoleAria", { name: displayName })}
         />
       </div>
-      <div role="cell" className="px-3 text-muted-foreground">
+      <div role="cell" className="px-3 text-ink-muted">
         {formatDate(u.created_at)}
       </div>
       <div role="cell" className="flex items-center justify-center">
         <Button
           variant="ghost"
           size="sm"
-          className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+          className="h-8 w-8 p-0 text-ink-muted hover:text-destructive"
           disabled={updatingId === u.id || u.id === currentUserId}
           onClick={() => onDeleteUser(u)}
           aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
@@ -129,7 +129,7 @@ export default function VirtualAdminUsers({
     <div role="table" aria-rowcount={users.length} className="-mx-5">
       <div
         role="row"
-        className="grid grid-cols-[40px_2fr_2fr_2fr_1fr_40px] items-center border-b px-3 py-3 text-xs font-medium text-muted-foreground"
+        className="grid grid-cols-[40px_2fr_2fr_2fr_1fr_40px] items-center border-b px-3 py-3 text-xs font-medium text-ink-muted"
       >
         <div role="columnheader" />
         <div role="columnheader" className="px-3">{t("admin.users.thName")}</div>

--- a/frontend/src/pages/Admin/cohorts/AddStudentDialog.tsx
+++ b/frontend/src/pages/Admin/cohorts/AddStudentDialog.tsx
@@ -60,7 +60,7 @@ export function AddStudentDialog({ open, onClose, cohortId, onAdded }: Props) {
   return (
     <Modal open={open} onClose={handleClose} title={t("admin.cohorts.addStudentTitle")}>
       <div className="space-y-4">
-        <p className="text-xs text-muted-foreground">
+        <p className="text-xs text-ink-muted">
           {t("admin.cohorts.addStudentHint")}
         </p>
         <div className="space-y-1.5">

--- a/frontend/src/pages/Admin/cohorts/AttachCourseDialog.tsx
+++ b/frontend/src/pages/Admin/cohorts/AttachCourseDialog.tsx
@@ -95,9 +95,9 @@ export function AttachCourseDialog({
     <Modal open={open} onClose={onClose} title={t("admin.cohorts.attachCourseTitle")}>
       <div className="space-y-4">
         {loading ? (
-          <p className="text-sm text-muted-foreground py-4">{t("common.loading")}</p>
+          <p className="text-sm text-ink-muted py-4">{t("common.loading")}</p>
         ) : courses.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-4">
+          <p className="text-sm text-ink-muted py-4">
             {t("admin.cohorts.noMoreCourses")}
           </p>
         ) : (

--- a/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
@@ -239,7 +239,7 @@ export default function CohortDetailPage() {
         backLabel={t("admin.cohorts.backToList")}
         title={
           <div className="space-y-2">
-            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">
               {t("admin.cohorts.eyebrow")}
             </p>
             <div className="flex flex-wrap items-center gap-3">
@@ -253,7 +253,7 @@ export default function CohortDetailPage() {
                 ariaLabel={t("admin.cohorts.fieldStatus")}
               />
             </div>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-ink-muted">
               {formatDate(cohort.start_date)} &mdash; {formatDate(cohort.end_date)}
             </p>
             {cohort.max_students != null && (
@@ -394,12 +394,12 @@ export default function CohortDetailPage() {
               {courses.map((c) => (
                 <li
                   key={c.id}
-                  className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/10 px-3 py-2 transition-colors hover:border-primary/30 hover:bg-muted/40"
+                  className="flex items-center justify-between gap-3 rounded-md border border-edge bg-muted/10 px-3 py-2 transition-colors hover:border-brand/30 hover:bg-muted/40"
                 >
                   <div className="flex min-w-0 items-center gap-2">
                     <Link
                       to={`/teacher/courses/${c.id}`}
-                      className="truncate text-sm font-medium text-foreground hover:text-primary"
+                      className="truncate text-sm font-medium text-ink hover:text-brand"
                     >
                       {c.title}
                     </Link>
@@ -412,7 +412,7 @@ export default function CohortDetailPage() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-8 w-8 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+                    className="h-8 w-8 shrink-0 p-0 text-ink-muted hover:text-destructive"
                     onClick={() => detachCourse(c.id)}
                     aria-label={t("admin.cohorts.detachAriaPrefix", { name: c.title })}
                   >
@@ -573,14 +573,14 @@ function CapacityMeter({ current, cap }: { current: number; cap: number }) {
   const { t } = useTranslation()
   const safeCap = Math.max(cap, 1)
   const pct = Math.min(100, Math.round((current / safeCap) * 100))
-  const tone = pct >= 95 ? "bg-destructive" : pct >= 75 ? "bg-warning" : "bg-primary"
+  const tone = pct >= 95 ? "bg-destructive" : pct >= 75 ? "bg-warning" : "bg-brand"
   return (
     <div className="mt-3 max-w-xs">
       <div className="flex items-baseline justify-between gap-3 text-xs">
-        <span className="font-medium tabular-nums text-foreground">
+        <span className="font-medium tabular-nums text-ink">
           {current} / {cap}
         </span>
-        <span className="text-muted-foreground">
+        <span className="text-ink-muted">
           {t("admin.cohorts.capacityLabel", { pct })}
         </span>
       </div>
@@ -638,7 +638,7 @@ function StudentsCard({
         {students.length > 0 && (
           <div className="relative">
             <Search
-              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-muted"
               strokeWidth={1.75}
               aria-hidden
             />
@@ -687,13 +687,13 @@ function StudentsCard({
               </colgroup>
               <thead className="sticky top-0 z-10 bg-card">
                 <tr className="border-b text-left">
-                  <th className="px-5 py-3 font-medium text-muted-foreground">
+                  <th className="px-5 py-3 font-medium text-ink-muted">
                     {t("admin.cohorts.thStudentName")}
                   </th>
-                  <th className="px-5 py-3 font-medium text-muted-foreground">
+                  <th className="px-5 py-3 font-medium text-ink-muted">
                     {t("admin.cohorts.thStudentEmail")}
                   </th>
-                  <th className="px-5 py-3 font-medium text-muted-foreground">
+                  <th className="px-5 py-3 font-medium text-ink-muted">
                     {t("admin.cohorts.thEnrolledCourses")}
                   </th>
                   <th className="px-5 py-3" aria-label={t("admin.cohorts.thActions")} />
@@ -712,19 +712,19 @@ function StudentsCard({
                         {nameDisplay}
                       </span>
                     </td>
-                    <td className="px-5 py-3 text-xs text-muted-foreground">
+                    <td className="px-5 py-3 text-xs text-ink-muted">
                       <span className="block truncate" title={s.email}>
                         {s.email}
                       </span>
                     </td>
-                    <td className="px-5 py-3 text-muted-foreground tabular-nums">
+                    <td className="px-5 py-3 text-ink-muted tabular-nums">
                       {Object.keys(s.per_course).length}
                     </td>
                     <td className="px-3 py-3">
                       <Button
                         variant="ghost"
                         size="sm"
-                        className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                        className="h-8 w-8 p-0 text-ink-muted hover:text-destructive"
                         onClick={() => onRemove(s)}
                         aria-label={t("admin.cohorts.removeStudentAriaPrefix", {
                           name: s.full_name ?? s.email,

--- a/frontend/src/pages/Admin/cohorts/CohortStatusPicker.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortStatusPicker.tsx
@@ -65,7 +65,7 @@ export function CohortStatusPicker({ status, disabled = false, onChange, ariaLab
         "gap-1.5 select-none capitalize",
         disabled && "cursor-default",
         !disabled &&
-          "cursor-pointer transition-shadow hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "cursor-pointer transition-shadow hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
       )}
     >
       {t(STATUS_I18N_KEY[status])}
@@ -82,7 +82,7 @@ export function CohortStatusPicker({ status, disabled = false, onChange, ariaLab
       <DropdownMenuTrigger asChild aria-label={ariaLabel}>
         <button
           type="button"
-          className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
         >
           {badge}
         </button>
@@ -98,12 +98,12 @@ export function CohortStatusPicker({ status, disabled = false, onChange, ariaLab
               }}
               className={cn(
                 "justify-between",
-                selected && "font-medium text-foreground",
+                selected && "font-medium text-ink",
               )}
             >
               <span>{t(STATUS_I18N_KEY[value])}</span>
               {selected && (
-                <Check className="h-3.5 w-3.5 text-primary" strokeWidth={1.75} aria-hidden />
+                <Check className="h-3.5 w-3.5 text-brand" strokeWidth={1.75} aria-hidden />
               )}
             </DropdownMenuItem>
           )

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -216,7 +216,7 @@ export function CohortsTab() {
                   size="sm"
                   className={cn(
                     "h-9 w-full sm:w-44",
-                    statusFilter && "border-primary/40 ring-1 ring-primary/40",
+                    statusFilter && "border-brand/40 ring-1 ring-primary/40",
                   )}
                 >
                   <SelectValue />
@@ -243,7 +243,7 @@ export function CohortsTab() {
             {({ id }) => (
               <div className="relative">
                 <Search
-                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-muted"
                   strokeWidth={1.75}
                   aria-hidden
                 />
@@ -264,7 +264,7 @@ export function CohortsTab() {
               variant="ghost"
               size="sm"
               onClick={resetFilters}
-              className="h-9 self-end text-muted-foreground hover:text-foreground"
+              className="h-9 self-end text-ink-muted hover:text-ink"
             >
               <X className="mr-1 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
               {t("admin.pagination.filterClear")}
@@ -292,8 +292,8 @@ export function CohortsTab() {
           <CohortsTable items={pageItems} />
         )}
 
-        <div className="flex shrink-0 flex-col items-stretch gap-2 border-t border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex shrink-0 flex-col items-stretch gap-2 border-t border-edge px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2 text-xs text-ink-muted">
             <label htmlFor="cohort-page-size">{t("admin.pagination.pageSizeLabel")}</label>
             <Select
               value={String(pageSize)}
@@ -315,7 +315,7 @@ export function CohortsTab() {
             </span>
           </div>
           <div className="flex items-center justify-between gap-3 sm:justify-end">
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-ink-muted">
               {t("admin.pagination.page", { page: safePage, total: totalPages })}
             </p>
             <div className="flex items-center gap-1.5">
@@ -368,12 +368,12 @@ function CohortsTable({ items }: { items: Cohort[] }) {
           <Link
             key={c.id}
             to={`/admin/cohorts/${c.id}`}
-            className="block rounded-md border border-border bg-card p-3 transition-colors hover:border-primary/30 hover:bg-muted/40"
+            className="block rounded-md border border-edge bg-card p-3 transition-colors hover:border-brand/30 hover:bg-muted/40"
           >
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium text-foreground">{c.name}</p>
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p className="truncate text-sm font-medium text-ink">{c.name}</p>
+                <p className="mt-1 text-xs text-ink-muted">
                   {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
                 </p>
               </div>
@@ -381,14 +381,14 @@ function CohortsTable({ items }: { items: Cohort[] }) {
                 {t(STATUS_LABEL_KEYS[c.status])}
               </Badge>
             </div>
-            <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+            <div className="mt-3 flex items-center gap-4 text-xs text-ink-muted">
               <span>
                 {t("admin.cohorts.thCourses")}:{" "}
-                <span className="text-foreground">{c.course_ids.length}</span>
+                <span className="text-ink">{c.course_ids.length}</span>
               </span>
               <span>
                 {t("admin.cohorts.thStudents")}:{" "}
-                <span className="text-foreground">
+                <span className="text-ink">
                   {c.student_count}
                   {c.max_students ? ` / ${c.max_students}` : ""}
                 </span>
@@ -416,11 +416,11 @@ function CohortsTable({ items }: { items: Cohort[] }) {
           </colgroup>
           <thead className="sticky top-0 z-10 bg-card">
             <tr className="border-b text-left">
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thName")}</th>
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thStatus")}</th>
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thDates")}</th>
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thCourses")}</th>
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.cohorts.thStudents")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.cohorts.thName")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.cohorts.thStatus")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.cohorts.thDates")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.cohorts.thCourses")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.cohorts.thStudents")}</th>
             </tr>
           </thead>
           <tbody className="divide-y">
@@ -429,7 +429,7 @@ function CohortsTable({ items }: { items: Cohort[] }) {
                 <td className="px-5 py-3">
                   <Link
                     to={`/admin/cohorts/${c.id}`}
-                    className="block truncate font-medium hover:text-primary"
+                    className="block truncate font-medium hover:text-brand"
                     title={c.name}
                   >
                     {c.name}
@@ -440,11 +440,11 @@ function CohortsTable({ items }: { items: Cohort[] }) {
                     {t(STATUS_LABEL_KEYS[c.status])}
                   </Badge>
                 </td>
-                <td className="px-5 py-3 text-xs text-muted-foreground">
+                <td className="px-5 py-3 text-xs text-ink-muted">
                   {formatDate(c.start_date)} &mdash; {formatDate(c.end_date)}
                 </td>
-                <td className="px-5 py-3 text-muted-foreground">{c.course_ids.length}</td>
-                <td className="px-5 py-3 text-muted-foreground">
+                <td className="px-5 py-3 text-ink-muted">{c.course_ids.length}</td>
+                <td className="px-5 py-3 text-ink-muted">
                   {c.student_count}
                   {c.max_students ? ` / ${c.max_students}` : ""}
                 </td>
@@ -482,7 +482,7 @@ function CohortsTableSkeleton() {
     <div aria-busy="true">
       <div className="space-y-2 px-4 py-3 sm:hidden">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="rounded-md border border-border bg-card p-3">
+          <div key={i} className="rounded-md border border-edge bg-card p-3">
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0 flex-1 space-y-2">
                 <Skeleton className="h-4 w-2/3" />

--- a/frontend/src/pages/Admin/dailyChallenge/DailyChallengeReviewDetailPage.tsx
+++ b/frontend/src/pages/Admin/dailyChallenge/DailyChallengeReviewDetailPage.tsx
@@ -109,7 +109,7 @@ export default function DailyChallengeReviewDetailPage() {
         backLabel={t("admin.dailyChallenge.review.backToQueue")}
         title={
           <h1 className="flex items-center gap-2 font-serif text-xl font-bold tracking-tight sm:text-2xl">
-            <Languages className="h-5 w-5 text-primary" strokeWidth={1.75} aria-hidden />
+            <Languages className="h-5 w-5 text-brand" strokeWidth={1.75} aria-hidden />
             {view
               ? `${view.bible_book} ${view.bible_chapter}${
                   view.bible_verse_from != null ? `:${view.bible_verse_from}` : ""
@@ -174,7 +174,7 @@ export default function DailyChallengeReviewDetailPage() {
             onSave={saveCv}
           />
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-ink-muted">
               {t("admin.dailyChallenge.review.options")}
             </h3>
             {view.options.map((opt) => (
@@ -221,8 +221,8 @@ interface FieldEditorProps {
 
 function FieldEditor({ label, field, cells, optionId, saving, onSave }: FieldEditorProps) {
   return (
-    <div className="rounded-md border border-border bg-card p-4">
-      <div className="mb-3 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">{label}</div>
+    <div className="rounded-md border border-edge bg-card p-4">
+      <div className="mb-3 text-xs font-medium uppercase tracking-[0.14em] text-ink-muted">{label}</div>
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
         <LocaleCellEditor
           locale="en"
@@ -264,7 +264,7 @@ function LocaleCellEditor({ locale, cell, saving, onSave }: LocaleCellEditorProp
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-muted">
           {locale.toUpperCase()}
         </span>
         {missing ? (
@@ -286,7 +286,7 @@ function LocaleCellEditor({ locale, cell, saving, onSave }: LocaleCellEditorProp
         }}
         rows={3}
         placeholder={missing ? t("admin.dailyChallenge.review.fillPlaceholder") : undefined}
-        className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        className="w-full rounded-md border border-edge bg-surface px-2 py-1.5 text-sm text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
       />
       {(editing || dirty) && (
         <div className="flex justify-end gap-2">

--- a/frontend/src/pages/Admin/dailyChallenge/DailyChallengeReviewPage.tsx
+++ b/frontend/src/pages/Admin/dailyChallenge/DailyChallengeReviewPage.tsx
@@ -80,12 +80,12 @@ export default function DailyChallengeReviewPage() {
       <PageHeader
         title={
           <h1 className="flex items-center gap-2 font-serif text-2xl font-bold tracking-tight sm:text-3xl">
-            <Languages className="h-6 w-6 text-primary" strokeWidth={1.75} aria-hidden />
+            <Languages className="h-6 w-6 text-brand" strokeWidth={1.75} aria-hidden />
             {t("admin.dailyChallenge.review.title")}
           </h1>
         }
         description={
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-ink-muted">
             {t("admin.dailyChallenge.review.description")}
           </p>
         }
@@ -97,16 +97,16 @@ export default function DailyChallengeReviewPage() {
         }
       />
 
-      <section className="mt-6 rounded-md border border-border bg-card">
-        <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
+      <section className="mt-6 rounded-md border border-edge bg-card">
+        <header className="flex flex-wrap items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">
               {t("admin.dailyChallenge.review.filterStatus")}
             </span>
             <select
               value={status}
               onChange={(e) => setStatusFilter(e.target.value as DailyChallengeStatus)}
-              className="h-7 rounded-md border border-border bg-background px-2 text-xs"
+              className="h-7 rounded-md border border-edge bg-surface px-2 text-xs"
             >
               {STATUS_OPTIONS.map((s) => (
                 <option key={s} value={s}>
@@ -114,7 +114,7 @@ export default function DailyChallengeReviewPage() {
                 </option>
               ))}
             </select>
-            <label className="ml-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+            <label className="ml-3 flex items-center gap-1.5 text-xs text-ink-muted">
               <input
                 type="checkbox"
                 checked={missingRu}
@@ -124,7 +124,7 @@ export default function DailyChallengeReviewPage() {
             </label>
           </div>
           {!loading && !loadError && (
-            <span className="text-xs tabular-nums text-muted-foreground">
+            <span className="text-xs tabular-nums text-ink-muted">
               {t("admin.dailyChallenge.review.totalCount", { count: total })}
             </span>
           )}
@@ -163,7 +163,7 @@ export default function DailyChallengeReviewPage() {
                 className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:bg-muted/40"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="truncate font-serif text-sm font-semibold tracking-tight text-foreground">
+                  <p className="truncate font-serif text-sm font-semibold tracking-tight text-ink">
                     {item.bible_book} {item.bible_chapter}
                     {item.bible_verse_from != null
                       ? `:${item.bible_verse_from}${
@@ -173,12 +173,12 @@ export default function DailyChallengeReviewPage() {
                         }`
                       : ""}
                   </p>
-                  <p className="mt-0.5 text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                  <p className="mt-0.5 text-[11px] uppercase tracking-[0.14em] text-ink-muted">
                     {t(`admin.dailyChallenge.review.status.${item.status}`)}
                   </p>
                 </div>
                 <CvBadges item={item} t={t} />
-                <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+                <ArrowRight className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
               </button>
             ))
           )}

--- a/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
+++ b/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
@@ -19,7 +19,7 @@ interface Props {
 export function AdminTabs({ active, onChange }: Props) {
   const { t } = useTranslation()
   return (
-    <div className="mb-6 flex gap-1 border-b border-border sm:mb-8" role="tablist">
+    <div className="mb-6 flex gap-1 border-b border-edge sm:mb-8" role="tablist">
       <TabButton
         name="overview"
         active={active === "overview"}
@@ -64,10 +64,10 @@ function TabButton({ name, active, onClick, icon, label }: TabButtonProps) {
       onClick={onClick}
       className={cn(
         "relative min-h-[44px] px-3 py-2.5 text-sm font-medium transition-colors sm:min-h-0 sm:px-4",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-t-sm",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 rounded-t-sm",
         active
-          ? "text-primary"
-          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+          ? "text-brand"
+          : "text-ink-muted hover:bg-muted/40 hover:text-ink",
       )}
     >
       <div className="flex items-center gap-2">
@@ -79,7 +79,7 @@ function TabButton({ name, active, onClick, icon, label }: TabButtonProps) {
         // of the ``border-b`` of the parent strip — without it, the
         // underline floats one pixel above the border and the active
         // tab reads as detached from the content card below.
-        <div className="absolute -bottom-px left-0 right-0 h-0.5 rounded-t bg-primary" />
+        <div className="absolute -bottom-px left-0 right-0 h-0.5 rounded-t bg-brand" />
       )}
     </button>
   )

--- a/frontend/src/pages/Admin/dashboard/AuditDetailsCell.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditDetailsCell.tsx
@@ -22,7 +22,7 @@ interface Props {
 export function AuditDetailsCell({ details }: Props) {
   const { t } = useTranslation()
   if (!details || typeof details !== "object" || Object.keys(details).length === 0) {
-    return <span className="text-muted-foreground/60">—</span>
+    return <span className="text-ink-muted/60">—</span>
   }
 
   const entries = Object.entries(details)
@@ -43,10 +43,10 @@ export function AuditDetailsCell({ details }: Props) {
     const newVal = formatValue(details.new ?? details.after)
     return (
       <div className="flex flex-wrap items-baseline gap-1.5 text-xs">
-        <span className="font-medium text-foreground">{field}:</span>
-        <span className="font-mono text-muted-foreground line-through">{oldVal}</span>
-        <span aria-hidden className="text-muted-foreground/60">→</span>
-        <span className="font-mono text-foreground">{newVal}</span>
+        <span className="font-medium text-ink">{field}:</span>
+        <span className="font-mono text-ink-muted line-through">{oldVal}</span>
+        <span aria-hidden className="text-ink-muted/60">→</span>
+        <span className="font-mono text-ink">{newVal}</span>
       </div>
     )
   }
@@ -55,12 +55,12 @@ export function AuditDetailsCell({ details }: Props) {
     <ul className="space-y-0.5 text-xs">
       {entries.map(([key, raw]) => (
         <li key={key} className="flex flex-wrap items-baseline gap-1.5">
-          <span className="font-medium text-foreground">{key}:</span>
-          <span className="font-mono text-muted-foreground">{formatValue(raw)}</span>
+          <span className="font-medium text-ink">{key}:</span>
+          <span className="font-mono text-ink-muted">{formatValue(raw)}</span>
         </li>
       ))}
       {entries.length === 0 && (
-        <li className="text-muted-foreground/60">{t("admin.audit.detailsEmpty")}</li>
+        <li className="text-ink-muted/60">{t("admin.audit.detailsEmpty")}</li>
       )}
     </ul>
   )

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -97,7 +97,7 @@ export function AuditLogTab({
         <CardTitle className="flex items-center gap-2 font-serif text-xl font-semibold tracking-tight">
           <FileText className="h-5 w-5 shrink-0" strokeWidth={1.75} aria-hidden />
           {t("admin.audit.title")}
-          <span className="ml-1.5 text-sm font-normal text-muted-foreground">
+          <span className="ml-1.5 text-sm font-normal text-ink-muted">
             {t("admin.audit.entriesCount", { count: total })}
           </span>
         </CardTitle>
@@ -113,7 +113,7 @@ export function AuditLogTab({
                   size="sm"
                   className={cn(
                     "h-9 w-full sm:w-44",
-                    action && "border-primary/40 ring-1 ring-primary/40",
+                    action && "border-brand/40 ring-1 ring-primary/40",
                   )}
                 >
                   <SelectValue />
@@ -140,7 +140,7 @@ export function AuditLogTab({
                   size="sm"
                   className={cn(
                     "h-9 w-full sm:w-44",
-                    resource && "border-primary/40 ring-1 ring-primary/40",
+                    resource && "border-brand/40 ring-1 ring-primary/40",
                   )}
                 >
                   <SelectValue />
@@ -170,7 +170,7 @@ export function AuditLogTab({
               variant="ghost"
               size="sm"
               onClick={onReset}
-              className="h-9 self-end text-muted-foreground hover:text-foreground"
+              className="h-9 self-end text-ink-muted hover:text-ink"
             >
               <X className="mr-1 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
               {t("admin.audit.filterClear")}
@@ -196,8 +196,8 @@ export function AuditLogTab({
           </>
         )}
 
-        <div className="flex shrink-0 flex-col items-stretch gap-2 border-t border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex shrink-0 flex-col items-stretch gap-2 border-t border-edge px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2 text-xs text-ink-muted">
             <label htmlFor="audit-page-size">{t("admin.audit.pageSizeLabel")}</label>
             <Select
               value={String(pageSize)}
@@ -216,7 +216,7 @@ export function AuditLogTab({
             </Select>
           </div>
           <div className="flex items-center justify-between gap-3 sm:justify-end">
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-ink-muted">
               {t("admin.audit.page", { page, total: totalPages })}
             </p>
             <div className="flex items-center gap-1.5">
@@ -265,19 +265,19 @@ function AuditTable({
       <table className="w-full text-sm">
         <thead className="sticky top-0 z-10 bg-card">
           <tr className="border-b text-left">
-            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thDate")}</th>
-            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thUser")}</th>
-            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thAction")}</th>
-            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thResource")}</th>
-            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thDetails")}</th>
-            <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.audit.thIp")}</th>
+            <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.audit.thDate")}</th>
+            <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.audit.thUser")}</th>
+            <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.audit.thAction")}</th>
+            <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.audit.thResource")}</th>
+            <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.audit.thDetails")}</th>
+            <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.audit.thIp")}</th>
           </tr>
         </thead>
         <tbody className="divide-y">
           {logs.map((log) => (
             <tr key={log.id} className="align-top transition-colors hover:bg-muted/40">
               <td
-                className="whitespace-nowrap px-5 py-3 text-xs text-muted-foreground"
+                className="whitespace-nowrap px-5 py-3 text-xs text-ink-muted"
                 title={formatDateTime(log.created_at)}
               >
                 {formatRelative(log.created_at)}
@@ -296,7 +296,7 @@ function AuditTable({
               <td className="max-w-[320px] px-5 py-3">
                 <AuditDetailsCell details={log.details} />
               </td>
-              <td className="px-5 py-3 text-xs text-muted-foreground">{log.ip_address || "—"}</td>
+              <td className="px-5 py-3 text-xs text-ink-muted">{log.ip_address || "—"}</td>
             </tr>
           ))}
         </tbody>
@@ -319,18 +319,18 @@ function AuditResourceCell({ type, id }: { type: string; id: string }) {
   const href = resourceHref(type, id)
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-muted-foreground">{label}</span>
+      <span className="text-ink-muted">{label}</span>
       {href ? (
         <Link
           to={href}
-          className="max-w-[160px] truncate font-mono text-[10px] text-primary hover:underline"
+          className="max-w-[160px] truncate font-mono text-[10px] text-brand hover:underline"
           title={id}
         >
           {shortId}
         </Link>
       ) : (
         <span
-          className="max-w-[160px] truncate font-mono text-[10px] text-muted-foreground/70"
+          className="max-w-[160px] truncate font-mono text-[10px] text-ink-muted/70"
           title={id}
         >
           {shortId}

--- a/frontend/src/pages/Admin/dashboard/AuditSummaryRow.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditSummaryRow.tsx
@@ -32,8 +32,8 @@ export function AuditSummaryRow({ logs }: Props) {
   if (counts.length === 0) return null
 
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-border bg-muted/20 px-5 py-2.5 text-xs">
-      <span className="font-medium uppercase tracking-[0.18em] text-muted-foreground">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-edge bg-muted/20 px-5 py-2.5 text-xs">
+      <span className="font-medium uppercase tracking-[0.18em] text-ink-muted">
         {t("admin.audit.summaryLabel")}
       </span>
       {counts.map(([action, count]) => {
@@ -44,8 +44,8 @@ export function AuditSummaryRow({ logs }: Props) {
         return (
           <span key={action} className="inline-flex items-center gap-1.5">
             <span className={cn("h-1.5 w-1.5 rounded-full", DOT_TONE[variant])} aria-hidden />
-            <span className="font-medium tabular-nums text-foreground">{count}</span>
-            <span className="text-muted-foreground">
+            <span className="font-medium tabular-nums text-ink">{count}</span>
+            <span className="text-ink-muted">
               {t(`admin.audit.actionValue.${action}`, { defaultValue: action })}
             </span>
           </span>
@@ -59,7 +59,7 @@ const DOT_TONE: Record<string, string> = {
   successSubtle: "bg-success",
   infoSubtle: "bg-info",
   destructiveSubtle: "bg-destructive",
-  primarySubtle: "bg-primary",
+  primarySubtle: "bg-brand",
   warningSubtle: "bg-warning",
-  muted: "bg-muted-foreground/60",
+  muted: "bg-ink-muted/60",
 }

--- a/frontend/src/pages/Admin/dashboard/FilterField.tsx
+++ b/frontend/src/pages/Admin/dashboard/FilterField.tsx
@@ -43,7 +43,7 @@ export function FilterField({ label, children, hideLabel = false, className }: P
       <label
         htmlFor={id}
         className={cn(
-          "text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground",
+          "text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted",
           hideLabel && "sr-only",
         )}
       >

--- a/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
+++ b/frontend/src/pages/Admin/dashboard/OverviewStats.tsx
@@ -108,21 +108,21 @@ export function OverviewStats({ stats, loading, pendingActions }: Props) {
           <CardContent className="flex items-start gap-4 p-5">
             <div
               className={cn(
-                "flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-border bg-card",
+                "flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-edge bg-card",
                 warningTint && "border-warning/40 bg-warning/10",
               )}
             >
               <Icon
                 className={cn(
                   "h-5 w-5",
-                  warningTint ? "text-warning" : "text-muted-foreground",
+                  warningTint ? "text-warning" : "text-ink-muted",
                 )}
                 strokeWidth={1.75}
                 aria-hidden
               />
             </div>
             <div className="min-w-0 flex-1">
-              <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">
                 {label}
               </p>
               {loading ? (
@@ -131,7 +131,7 @@ export function OverviewStats({ stats, loading, pendingActions }: Props) {
                 <p
                   className={cn(
                     "mt-0.5 font-serif text-3xl font-semibold tabular-nums leading-tight",
-                    warningTint ? "text-warning" : "text-foreground",
+                    warningTint ? "text-warning" : "text-ink",
                   )}
                 >
                   {value.toLocaleString()}
@@ -141,7 +141,7 @@ export function OverviewStats({ stats, loading, pendingActions }: Props) {
                 <p
                   className={cn(
                     "mt-1.5 inline-flex items-center gap-1 text-xs",
-                    warningTint ? "text-warning/90" : "text-muted-foreground",
+                    warningTint ? "text-warning/90" : "text-ink-muted",
                   )}
                 >
                   {trending && (

--- a/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
@@ -24,7 +24,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
     <Card className="mb-6 border-l-stripe border-l-primary">
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
-          <Award className="h-4 w-4 text-primary" strokeWidth={1.75} aria-hidden />
+          <Award className="h-4 w-4 text-brand" strokeWidth={1.75} aria-hidden />
           {t("admin.pendingCerts.title")}
           <Badge variant="default" className="font-normal">
             {certs.length}
@@ -36,32 +36,32 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
           {certs.map((cert) => (
             <article
               key={cert.id}
-              className="flex flex-col gap-3 rounded-md border border-l-stripe border-l-primary/60 bg-primary/5 p-4 sm:flex-row sm:items-stretch sm:gap-4"
+              className="flex flex-col gap-3 rounded-md border border-l-stripe border-l-primary/60 bg-brand/5 p-4 sm:flex-row sm:items-stretch sm:gap-4"
             >
               {/* Identity column — student + course as the two top-level
                   facts the admin needs to recognise this request. */}
               <div className="min-w-0 flex-1 space-y-2">
                 <div>
-                  <p className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
-                    <GraduationCap className="h-3.5 w-3.5 text-primary shrink-0" strokeWidth={1.75} aria-hidden />
+                  <p className="flex items-center gap-1.5 text-sm font-semibold text-ink">
+                    <GraduationCap className="h-3.5 w-3.5 text-brand shrink-0" strokeWidth={1.75} aria-hidden />
                     <span className="truncate">{cert.student_name || t("admin.pendingCerts.studentFallback")}</span>
                   </p>
                   {cert.student_email && (
-                    <p className="ml-5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <p className="ml-5 flex items-center gap-1.5 text-xs text-ink-muted">
                       <Mail className="h-3 w-3 shrink-0" strokeWidth={1.75} aria-hidden />
                       <span className="truncate">{cert.student_email}</span>
                     </p>
                   )}
                 </div>
-                <p className="flex items-center gap-1.5 text-xs text-foreground/80">
-                  <BookOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+                <p className="flex items-center gap-1.5 text-xs text-ink/80">
+                  <BookOpen className="h-3.5 w-3.5 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
                   <span className="truncate">{cert.course_title || t("admin.pendingCerts.courseFallback")}</span>
                 </p>
                 {/* Timeline of the request lifecycle so the admin knows
                     how long this has been waiting and who's already
                     signed off (the teacher must approve before this
                     list shows the row). */}
-                <dl className="grid grid-cols-1 gap-x-4 gap-y-1 text-[11px] text-muted-foreground/90 sm:grid-cols-2">
+                <dl className="grid grid-cols-1 gap-x-4 gap-y-1 text-[11px] text-ink-muted/90 sm:grid-cols-2">
                   {cert.requested_at && (
                     <div className="flex items-center gap-1.5">
                       <Clock className="h-3 w-3 shrink-0" strokeWidth={1.75} aria-hidden />
@@ -85,7 +85,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
                   )}
                   {cert.requested_at && (
                     <div
-                      className="hidden text-[10px] text-muted-foreground/60 sm:col-span-2 sm:block"
+                      className="hidden text-[10px] text-ink-muted/60 sm:col-span-2 sm:block"
                       title={cert.requested_at}
                     >
                       {t("admin.pendingCerts.requestedAtPrefix", {
@@ -117,7 +117,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
                   <XCircle className="mr-1.5 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
                   {t("admin.pendingCerts.reject")}
                 </Button>
-                <p className="text-[10px] leading-tight text-muted-foreground/80">
+                <p className="text-[10px] leading-tight text-ink-muted/80">
                   {t("admin.pendingCerts.approveHint")}
                 </p>
               </div>

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -126,7 +126,7 @@ export function UsersCard({
               aria-label={t("admin.users.roleFilterAria")}
               className={cn(
                 "h-9 w-full sm:w-44",
-                roleFilter && "border-primary/40 ring-1 ring-primary/40",
+                roleFilter && "border-brand/40 ring-1 ring-primary/40",
               )}
             >
               <SelectValue />
@@ -140,7 +140,7 @@ export function UsersCard({
           </Select>
           <div className="relative w-full sm:max-w-xs sm:flex-1">
             <Search
-              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-muted"
               strokeWidth={1.75}
               aria-hidden
             />
@@ -170,15 +170,15 @@ export function UsersCard({
                 className={cn(
                   "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 transition-colors",
                   active
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border hover:border-primary/40 hover:bg-muted",
+                    ? "border-brand bg-brand text-brand-foreground"
+                    : "border-edge hover:border-brand/40 hover:bg-muted",
                 )}
               >
                 <span>{t(ROLE_I18N_KEY[role])}</span>
                 <span
                   className={cn(
                     "tabular-nums",
-                    active ? "opacity-90" : "text-muted-foreground",
+                    active ? "opacity-90" : "text-ink-muted",
                   )}
                 >
                   {roleCounts[role]}
@@ -194,7 +194,7 @@ export function UsersCard({
             selected. Full-width tinted card makes the "selection
             mode" state obvious. */}
         {selectedIds.size > 0 && (
-          <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2">
+          <div className="flex flex-wrap items-center gap-2 rounded-md border border-brand/30 bg-brand/5 px-3 py-2">
             <span className="text-xs font-medium">
               {t("admin.users.selected", { count: selectedIds.size })}
             </span>
@@ -240,7 +240,7 @@ export function UsersCard({
                 onCheckedChange={onToggleSelectAll}
                 aria-label={t("admin.users.selectAllAria")}
               />
-              <span className="text-xs text-muted-foreground">
+              <span className="text-xs text-ink-muted">
                 {t("admin.users.selectAllN", { count: filtered.length })}
               </span>
             </div>
@@ -269,7 +269,7 @@ export function UsersCard({
           />
         )}
         {!loading && filtered.length > 0 && (
-          <p className="mt-4 text-xs text-muted-foreground">
+          <p className="mt-4 text-xs text-ink-muted">
             {t("admin.users.showing", { shown: filtered.length, total: users.length })}
           </p>
         )}
@@ -329,7 +329,7 @@ function UsersTable({
           inner divs cancelled out (net 0) and just made the layout
           harder to read. */}
       <div className="space-y-2 sm:hidden">
-        <label className="flex min-h-[44px] items-center gap-2 text-xs text-muted-foreground">
+        <label className="flex min-h-[44px] items-center gap-2 text-xs text-ink-muted">
           <Checkbox
             checked={selectAllState}
             onCheckedChange={onToggleSelectAll}
@@ -395,10 +395,10 @@ function UsersTable({
                   aria-label={t("admin.users.selectAllAria")}
                 />
               </th>
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.users.thName")}</th>
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.users.thEmail")}</th>
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.users.thRole")}</th>
-              <th className="px-5 py-3 font-medium text-muted-foreground">{t("admin.users.thJoined")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.users.thName")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.users.thEmail")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.users.thRole")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.users.thJoined")}</th>
               <th className="px-3 py-3" aria-label={t("admin.users.thActions")} />
             </tr>
           </thead>
@@ -436,8 +436,8 @@ function UserCard({
   return (
     <div
       className={cn(
-        "rounded-md border border-border bg-card p-3 transition-colors",
-        selected && "border-primary/40 bg-primary/[0.08] dark:bg-primary/15",
+        "rounded-md border border-edge bg-card p-3 transition-colors",
+        selected && "border-brand/40 bg-brand/[0.08] dark:bg-brand/15",
       )}
     >
       <div className="flex items-start gap-3">
@@ -455,18 +455,18 @@ function UserCard({
           alt={t("admin.users.avatarAltPrefix", { name: displayName })}
         />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-foreground">
+          <p className="truncate text-sm font-medium text-ink">
             {user.full_name?.trim() || t("admin.users.missingName")}
           </p>
-          <p className="truncate text-xs text-muted-foreground">{user.email}</p>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="truncate text-xs text-ink-muted">{user.email}</p>
+          <p className="mt-1 text-xs text-ink-muted">
             {formatDate(user.created_at)}
           </p>
         </div>
         <Button
           variant="ghost"
           size="sm"
-          className="h-11 w-11 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+          className="h-11 w-11 shrink-0 p-0 text-ink-muted hover:text-destructive"
           disabled={updating || isSelf}
           onClick={() => onDeleteUser(user)}
           aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
@@ -512,7 +512,7 @@ function UserRow({
     <tr
       className={cn(
         "transition-colors hover:bg-muted/40",
-        selected && "bg-primary/[0.08] dark:bg-primary/15",
+        selected && "bg-brand/[0.08] dark:bg-brand/15",
       )}
     >
       <td className="px-3 py-3">
@@ -536,7 +536,7 @@ function UserRow({
           </span>
         </div>
       </td>
-      <td className="px-5 py-3 text-muted-foreground">
+      <td className="px-5 py-3 text-ink-muted">
         <span className="block truncate" title={user.email}>{user.email}</span>
       </td>
       <td className="px-5 py-3">
@@ -547,14 +547,14 @@ function UserRow({
           ariaLabel={t("admin.users.changeRoleAria", { name: displayName })}
         />
       </td>
-      <td className="whitespace-nowrap px-5 py-3 text-xs text-muted-foreground tabular-nums">
+      <td className="whitespace-nowrap px-5 py-3 text-xs text-ink-muted tabular-nums">
         {formatDate(user.created_at)}
       </td>
       <td className="px-3 py-3 text-right">
         <Button
           variant="ghost"
           size="sm"
-          className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+          className="h-8 w-8 p-0 text-ink-muted hover:text-destructive"
           disabled={updating || isSelf}
           onClick={() => onDeleteUser(user)}
           aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}

--- a/frontend/src/styles/__tests__/wave12-admin-pages.test.ts
+++ b/frontend/src/styles/__tests__/wave12-admin-pages.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Sentinel for ADR-0011 Wave 12 — Admin pages migrated to v2.
+ *
+ * Covers the entire Admin surface: AdminDashboard root + the
+ * cohorts pages (detail, status picker, attach-course, add-student,
+ * tab), the Daily Challenge review pages, and the dashboard tab
+ * subcomponents (audit-log, audit-details, overview stats, pending
+ * certs card, users card, filter field).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "..", "..");
+
+function readNonComment(path: string): string {
+  return readFileSync(path, "utf-8")
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`).test(code);
+}
+
+const FILES = [
+  resolve(SRC, "pages/Admin/AdminDashboard.tsx"),
+  resolve(SRC, "pages/Admin/VirtualAdminUsers.tsx"),
+  resolve(SRC, "pages/Admin/cohorts/AddStudentDialog.tsx"),
+  resolve(SRC, "pages/Admin/cohorts/AttachCourseDialog.tsx"),
+  resolve(SRC, "pages/Admin/cohorts/CohortDetailPage.tsx"),
+  resolve(SRC, "pages/Admin/cohorts/CohortStatusPicker.tsx"),
+  resolve(SRC, "pages/Admin/cohorts/CohortsTab.tsx"),
+  resolve(SRC, "pages/Admin/dailyChallenge/DailyChallengeReviewDetailPage.tsx"),
+  resolve(SRC, "pages/Admin/dailyChallenge/DailyChallengeReviewPage.tsx"),
+  resolve(SRC, "pages/Admin/dashboard/AdminTabs.tsx"),
+  resolve(SRC, "pages/Admin/dashboard/AuditDetailsCell.tsx"),
+  resolve(SRC, "pages/Admin/dashboard/AuditLogTab.tsx"),
+  resolve(SRC, "pages/Admin/dashboard/AuditSummaryRow.tsx"),
+  resolve(SRC, "pages/Admin/dashboard/FilterField.tsx"),
+  resolve(SRC, "pages/Admin/dashboard/OverviewStats.tsx"),
+  resolve(SRC, "pages/Admin/dashboard/PendingCertsCard.tsx"),
+  resolve(SRC, "pages/Admin/dashboard/UsersCard.tsx"),
+];
+
+const V1_LOCKED_OUT = [
+  "bg-background",
+  "text-foreground",
+  "text-muted-foreground",
+  "border-border",
+  "border-input",
+  "bg-primary",
+  "text-primary",
+  "border-primary",
+  "hover:bg-accent",
+  "hover:text-accent-foreground",
+  "ring-ring",
+  "bg-muted-foreground",
+];
+
+describe("ADR-0011 Wave 12 — Admin pages migration", () => {
+  for (const path of FILES) {
+    const name = path.split(/[\\/]/).slice(-3).join("/");
+
+    it(`${name} retired the v1 names`, () => {
+      const code = readNonComment(path);
+      for (const cls of V1_LOCKED_OUT) {
+        expect(
+          containsClass(code, cls),
+          `${name} still references ${cls}`,
+        ).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
ADR-0011 **Wave 12**. Covers the entire Admin surface end-to-end.

## Scope (17 files)

**Root + table**
* `Admin/AdminDashboard.tsx`
* `Admin/VirtualAdminUsers.tsx`

**Cohorts**
* `Admin/cohorts/AddStudentDialog.tsx`
* `Admin/cohorts/AttachCourseDialog.tsx`
* `Admin/cohorts/CohortDetailPage.tsx`
* `Admin/cohorts/CohortStatusPicker.tsx`
* `Admin/cohorts/CohortsTab.tsx`

**Daily Challenge review**
* `Admin/dailyChallenge/DailyChallengeReviewDetailPage.tsx`
* `Admin/dailyChallenge/DailyChallengeReviewPage.tsx`

**Dashboard tabs**
* `Admin/dashboard/AdminTabs.tsx`
* `Admin/dashboard/AuditDetailsCell.tsx`
* `Admin/dashboard/AuditLogTab.tsx`
* `Admin/dashboard/AuditSummaryRow.tsx`
* `Admin/dashboard/FilterField.tsx`
* `Admin/dashboard/OverviewStats.tsx`
* `Admin/dashboard/PendingCertsCard.tsx`
* `Admin/dashboard/UsersCard.tsx`

## Sentinel

`wave12-admin-pages.test.ts` — 17-file per-file lock-out.

## Test plan

- [x] +17 sentinel tests
- [x] Full frontend suite green (415 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)