### PR TITLE
feat(design): visual overhaul v2 Wave 14 — Course pages + Dashboard

### DIFF
--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -183,23 +183,23 @@ function FileBlockLink({
       type="button"
       onClick={handleClick}
       disabled={opening}
-      className="group flex w-full items-center gap-3 rounded-md border border-border bg-card px-4 py-3 text-left transition-colors hover:border-primary/40 hover:bg-muted/40 disabled:opacity-60"
+      className="group flex w-full items-center gap-3 rounded-md border border-edge bg-card px-4 py-3 text-left transition-colors hover:border-brand/40 hover:bg-muted/40 disabled:opacity-60"
       aria-label={t("chapter.downloadFileAria", { name: label })}
     >
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
         {opening ? (
-          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" strokeWidth={1.75} aria-hidden />
+          <Loader2 className="h-4 w-4 animate-spin text-ink-muted" strokeWidth={1.75} aria-hidden />
         ) : (
-          <File className="h-4 w-4 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+          <File className="h-4 w-4 text-ink-muted" strokeWidth={1.75} aria-hidden />
         )}
       </div>
       <div className="min-w-0 flex-1">
-        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">
           {t("chapter.attachmentEyebrow")}
         </p>
-        <p className="mt-0.5 truncate text-sm font-medium text-foreground">{label}</p>
+        <p className="mt-0.5 truncate text-sm font-medium text-ink">{label}</p>
       </div>
-      <Download className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" strokeWidth={1.75} aria-hidden />
+      <Download className="h-4 w-4 shrink-0 text-ink-muted transition-colors group-hover:text-brand" strokeWidth={1.75} aria-hidden />
     </button>
   )
 }
@@ -245,8 +245,8 @@ function ChapterBodyBlocks({
   }
   if (blocks.length === 0) {
     return (
-      <div className="rounded-md border border-dashed border-border bg-muted/20 px-5 py-12 text-center">
-        <p className="text-sm text-muted-foreground">
+      <div className="rounded-md border border-dashed border-edge bg-muted/20 px-5 py-12 text-center">
+        <p className="text-sm text-ink-muted">
           {t("chapter.emptyContent")}
         </p>
       </div>
@@ -291,19 +291,19 @@ function ChapterNavLink({
   const justify = side === "prev" ? "justify-start" : "justify-end"
 
   const disabledClass =
-    "flex min-w-0 flex-1 cursor-not-allowed flex-col rounded-md border border-border bg-muted/20 px-3 py-2 opacity-60"
+    "flex min-w-0 flex-1 cursor-not-allowed flex-col rounded-md border border-edge bg-muted/20 px-3 py-2 opacity-60"
   const enabledClass =
-    "group flex min-w-0 flex-1 flex-col rounded-md border border-border bg-card px-3 py-2 transition-colors hover:border-primary/40 hover:bg-muted/40"
+    "group flex min-w-0 flex-1 flex-col rounded-md border border-edge bg-card px-3 py-2 transition-colors hover:border-brand/40 hover:bg-muted/40"
 
   if (!chapter) {
     return (
       <div className={`${disabledClass} ${alignment}`} aria-hidden="true">
-        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground ${justify}`}>
+        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted ${justify}`}>
           {side === "prev" && <ArrowLeft className="h-3.5 w-3.5" strokeWidth={1.75} />}
           {eyebrow}
           {side === "next" && <ArrowRight className="h-3.5 w-3.5" strokeWidth={1.75} />}
         </span>
-        <span className="mt-0.5 truncate text-sm text-muted-foreground/70">
+        <span className="mt-0.5 truncate text-sm text-ink-muted/70">
           {fallbackLabel}
         </span>
       </div>
@@ -313,11 +313,11 @@ function ChapterNavLink({
   if (locked) {
     return (
       <div className={`${disabledClass} ${alignment}`} aria-label={fallbackLabel}>
-        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground ${justify}`}>
+        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted ${justify}`}>
           <Lock className="h-3.5 w-3.5" strokeWidth={1.75} />
           {eyebrow}
         </span>
-        <span className="mt-0.5 truncate text-sm font-medium text-muted-foreground">
+        <span className="mt-0.5 truncate text-sm font-medium text-ink-muted">
           {chapter.title}
         </span>
       </div>
@@ -334,12 +334,12 @@ function ChapterNavLink({
         className={`${enabledClass} ${alignment}`}
         aria-label={`${eyebrow}: ${chapter.title}`}
       >
-        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground transition-colors group-hover:text-primary ${justify}`}>
+        <span className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted transition-colors group-hover:text-brand ${justify}`}>
           {side === "prev" && <ArrowLeft className="h-3.5 w-3.5" strokeWidth={1.75} />}
           {eyebrow}
           {side === "next" && <ArrowRight className="h-3.5 w-3.5" strokeWidth={1.75} />}
         </span>
-        <span className="mt-0.5 truncate text-sm font-medium text-foreground">
+        <span className="mt-0.5 truncate text-sm font-medium text-ink">
           {chapter.title}
         </span>
       </button>
@@ -369,9 +369,9 @@ function ChapterNav({
   return (
     <nav
       aria-label={t("chapter.navAriaLabel")}
-      className="mt-10 border-t border-border pt-6"
+      className="mt-10 border-t border-edge pt-6"
     >
-      <p className="mb-3 text-center text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground tabular-nums">
+      <p className="mb-3 text-center text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted tabular-nums">
         {t("chapter.positionEyebrow", { current: currentIdx + 1, total })}
       </p>
       <div className="flex items-stretch gap-2 sm:gap-3">
@@ -570,9 +570,9 @@ export default function ChapterView() {
         </Link>
 
         <div className="text-center py-16">
-          <Lock className="h-12 w-12 text-muted-foreground mx-auto mb-4" strokeWidth={1.75} />
+          <Lock className="h-12 w-12 text-ink-muted mx-auto mb-4" strokeWidth={1.75} />
           <h2 className="font-serif text-xl font-semibold mb-2">{t("chapter.lockedTitle")}</h2>
-          <p className="text-muted-foreground">{t("chapter.lockedHint")}</p>
+          <p className="text-ink-muted">{t("chapter.lockedHint")}</p>
           {prevChapter && (
             <Link to={`/courses/${courseId}/modules/${moduleId}/chapters/${prevChapter.id}`}>
               <Button className="mt-4">{t("chapter.goToPreviousChapter")}</Button>
@@ -597,19 +597,19 @@ export default function ChapterView() {
       </Link>
 
       <header data-tour="chapter-header" className="mb-10">
-        <p className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <p className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">
           <span className="inline-flex items-center gap-1.5">
             <ChapterTypeIcon className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
             {t(CHAPTER_TYPE_LABEL_KEYS[chapterType])}
           </span>
-          <span aria-hidden className="text-muted-foreground/40">·</span>
+          <span aria-hidden className="text-ink-muted/40">·</span>
           <span className="tabular-nums">
             {t("chapter.positionEyebrow", { current: currentIdx + 1, total: sortedChapters.length })}
           </span>
           {mod.title && (
             <>
-              <span aria-hidden className="text-muted-foreground/40">·</span>
-              <span className="normal-case tracking-normal text-muted-foreground/80 text-wrap-safe">
+              <span aria-hidden className="text-ink-muted/40">·</span>
+              <span className="normal-case tracking-normal text-ink-muted/80 text-wrap-safe">
                 {mod.title}
               </span>
             </>
@@ -646,14 +646,14 @@ export default function ChapterView() {
       </div>
 
       {hasAssignments && (
-        <div className="mt-6 border-t border-border pt-5">
+        <div className="mt-6 border-t border-edge pt-5">
           {isCompleted ? (
             <p className="flex items-center gap-2 text-sm font-medium text-success">
               <CheckCircle className="h-4 w-4 shrink-0" strokeWidth={1.75} />
               {t("chapter.completed")}
             </p>
           ) : (
-            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <p className="flex items-center gap-2 text-sm text-ink-muted">
               <Circle className="h-4 w-4 shrink-0" strokeWidth={1.75} />
               {t("chapter.submitAssignmentToComplete")}
             </p>

--- a/frontend/src/pages/Course/ModuleView.tsx
+++ b/frontend/src/pages/Course/ModuleView.tsx
@@ -124,7 +124,7 @@ export default function ModuleView() {
       <div className="mb-4">
         <h1 className="mb-1 font-serif text-2xl font-bold tracking-tight text-wrap-safe">{module.title}</h1>
         {module.description && (
-          <p className="text-sm leading-relaxed text-muted-foreground text-wrap-safe whitespace-pre-line">
+          <p className="text-sm leading-relaxed text-ink-muted text-wrap-safe whitespace-pre-line">
             {module.description}
           </p>
         )}
@@ -138,18 +138,18 @@ export default function ModuleView() {
         return (
           <div className={`mb-4 flex items-center gap-2 rounded-md border px-3 py-2 ${
             isOverdue
-              ? "border-l-stripe border-l-destructive border-border bg-destructive/5"
+              ? "border-l-stripe border-l-destructive border-edge bg-destructive/5"
               : isUpcoming
-                ? "border-l-stripe border-l-warning border-border bg-warning/10"
-                : "border-border bg-muted/50"
+                ? "border-l-stripe border-l-warning border-edge bg-warning/10"
+                : "border-edge bg-muted/50"
           }`}>
             {isOverdue ? (
               <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" strokeWidth={1.75} aria-hidden />
             ) : (
-              <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+              <CalendarDays className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
             )}
             <span className={`text-sm font-medium ${
-              isOverdue ? "text-destructive" : isUpcoming ? "text-warning" : "text-foreground"
+              isOverdue ? "text-destructive" : isUpcoming ? "text-warning" : "text-ink"
             }`}>
               {isOverdue ? t("module.overdue") : t("module.due")}:{" "}
               {formatDateLong(dueDate, {
@@ -164,7 +164,7 @@ export default function ModuleView() {
       })()}
 
       {allComplete && (
-        <div className="mb-4 flex items-center gap-2 rounded-md border border-border border-l-stripe border-l-success bg-success/10 px-3 py-2">
+        <div className="mb-4 flex items-center gap-2 rounded-md border border-edge border-l-stripe border-l-success bg-success/10 px-3 py-2">
           <CheckCircle className="h-4 w-4 shrink-0 text-success" strokeWidth={1.75} aria-hidden />
           <span className="text-sm font-medium text-success">{t("module.moduleComplete")}</span>
         </div>
@@ -176,11 +176,11 @@ export default function ModuleView() {
             <span className="font-medium">
               {t("module.completedProgress", { done: completedCount, total: gradableChapters.length })}
             </span>
-            <span className="text-muted-foreground">{progressPercent}%</span>
+            <span className="text-ink-muted">{progressPercent}%</span>
           </div>
           <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
             <div
-              className="h-full rounded-full bg-primary transition-all duration-500 ease-out"
+              className="h-full rounded-full bg-brand transition-all duration-500 ease-out"
               style={{ width: `${progressPercent}%` }}
             />
           </div>
@@ -191,7 +191,7 @@ export default function ModuleView() {
         <h2 className="mb-3 flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
           <Book className="h-4 w-4" strokeWidth={1.75} aria-hidden />
           {t("module.chaptersHeading")}
-          <span className="text-sm font-normal text-muted-foreground">
+          <span className="text-sm font-normal text-ink-muted">
             ({sortedChapters.length})
           </span>
         </h2>
@@ -215,14 +215,14 @@ export default function ModuleView() {
                   >
                     <CardHeader className="pb-2">
                       <CardTitle className="flex min-w-0 items-center gap-2 font-serif text-base font-semibold tracking-tight">
-                        <Lock className="h-5 w-5 text-muted-foreground/50 shrink-0" strokeWidth={1.75} aria-hidden />
-                        <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                        <Lock className="h-5 w-5 text-ink-muted/50 shrink-0" strokeWidth={1.75} aria-hidden />
+                        <span className="min-w-0 flex-1 truncate text-ink-muted">
                           {chapter.title}
                         </span>
                         {chapter.chapter_type && (
                           <ChapterTypeBadge type={chapter.chapter_type} size="sm" />
                         )}
-                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/30" strokeWidth={1.75} aria-hidden />
+                        <ChevronRight className="h-4 w-4 shrink-0 text-ink-muted/30" strokeWidth={1.75} aria-hidden />
                       </CardTitle>
                     </CardHeader>
                   </Card>
@@ -236,7 +236,7 @@ export default function ModuleView() {
                   className="block"
                 >
                   <Card
-                    className={`animate-fade-in transition-colors hover:border-primary/40 ${isCompleted ? "border-success/40 bg-success/5" : ""}`}
+                    className={`animate-fade-in transition-colors hover:border-brand/40 ${isCompleted ? "border-success/40 bg-success/5" : ""}`}
                     style={{ animationDelay: `${idx * 50}ms` }}
                   >
                     <CardHeader className="pb-2">
@@ -247,16 +247,16 @@ export default function ModuleView() {
                           ) : requiresTeacher ? (
                             <Lock className="h-5 w-5 shrink-0 text-warning" strokeWidth={1.75} aria-hidden />
                           ) : (
-                            <Circle className="h-5 w-5 shrink-0 text-muted-foreground/40" strokeWidth={1.75} aria-hidden />
+                            <Circle className="h-5 w-5 shrink-0 text-ink-muted/40" strokeWidth={1.75} aria-hidden />
                           )
                         ) : null}
-                        <span className={`min-w-0 flex-1 truncate ${isCompleted ? "text-muted-foreground" : ""}`}>
+                        <span className={`min-w-0 flex-1 truncate ${isCompleted ? "text-ink-muted" : ""}`}>
                           {chapter.title}
                         </span>
                         {chapter.chapter_type && (
                           <ChapterTypeBadge type={chapter.chapter_type} size="sm" />
                         )}
-                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" strokeWidth={1.75} aria-hidden />
+                        <ChevronRight className="h-4 w-4 shrink-0 text-ink-muted/40" strokeWidth={1.75} aria-hidden />
                       </CardTitle>
                     </CardHeader>
                   </Card>
@@ -266,7 +266,7 @@ export default function ModuleView() {
           </div>
         ) : (
           <Card className="border-dashed">
-            <CardContent className="py-12 text-center text-muted-foreground text-sm">
+            <CardContent className="py-12 text-center text-ink-muted text-sm">
               {t("module.noChaptersYet")}
             </CardContent>
           </Card>

--- a/frontend/src/pages/Course/detail/CohortSelectModal.tsx
+++ b/frontend/src/pages/Course/detail/CohortSelectModal.tsx
@@ -27,7 +27,7 @@ export function CohortSelectModal({
   return (
     <Modal open={open} onClose={onClose} title={t("courseDetail.cohortSelect.title")}>
       <div className="space-y-3">
-        <p className="text-sm text-muted-foreground">
+        <p className="text-sm text-ink-muted">
           {t("courseDetail.cohortSelect.intro")}
         </p>
         {cohorts.map((cohort) => (
@@ -35,7 +35,7 @@ export function CohortSelectModal({
             key={cohort.id}
             className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
               selectedCohortId === cohort.id
-                ? "border-primary bg-primary/[0.08] dark:bg-primary/15"
+                ? "border-brand bg-brand/[0.08] dark:bg-brand/15"
                 : "hover:bg-muted/40"
             }`}
           >
@@ -48,11 +48,11 @@ export function CohortSelectModal({
             />
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium">{cohort.name}</p>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-xs text-ink-muted">
                 {formatDate(cohort.start_date)} &mdash; {formatDate(cohort.end_date)}
               </p>
               {cohort.max_students && (
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-ink-muted">
                   {t("courseDetail.cohortSelect.spotsFilled", {
                     enrolled: cohort.student_count,
                     max: cohort.max_students,

--- a/frontend/src/pages/Course/detail/EnrolledHeader.tsx
+++ b/frontend/src/pages/Course/detail/EnrolledHeader.tsx
@@ -54,9 +54,9 @@ export function EnrolledHeader({
           <h1 className="mb-1 font-serif text-xl font-semibold tracking-tight text-wrap-safe sm:text-2xl">
             {course.title}
           </h1>
-          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-3 text-xs text-ink-muted">
             {enrolledCohort && (
-              <span className="flex items-center gap-1 font-medium text-primary">
+              <span className="flex items-center gap-1 font-medium text-brand">
                 <CalendarDays className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
                 {enrolledCohort.name}
               </span>

--- a/frontend/src/pages/Course/detail/ModuleList.tsx
+++ b/frontend/src/pages/Course/detail/ModuleList.tsx
@@ -34,7 +34,7 @@ export function ModuleList({ courseId, modules, completedChapterIds }: Props) {
       <h2 className="mb-3 flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
         <BookOpen className="h-4 w-4" strokeWidth={1.75} aria-hidden />
         {t("courseDetail.modulesHeading")}
-        <span className="text-sm font-normal text-muted-foreground">({modules.length})</span>
+        <span className="text-sm font-normal text-ink-muted">({modules.length})</span>
       </h2>
 
       {modules.length > 0 ? (
@@ -99,17 +99,17 @@ function ModuleRow({
   const completedInModule = gradable.filter((ch) => completedChapterIds.has(ch.id)).length
 
   return (
-    <Card className={`group transition-colors ${isLocked ? "opacity-60" : "hover:border-primary/25"}`}>
+    <Card className={`group transition-colors ${isLocked ? "opacity-60" : "hover:border-brand/25"}`}>
       <CardHeader className="py-3 px-4">
         <div className="flex items-center justify-between gap-2">
           <CardTitle className="flex min-w-0 items-center gap-2 font-serif text-sm font-semibold tracking-tight">
             <span
               className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${
                 isLocked
-                  ? "bg-muted text-muted-foreground"
+                  ? "bg-muted text-ink-muted"
                   : allComplete
                     ? "bg-success/15 text-success"
-                    : "bg-primary/10 text-primary"
+                    : "bg-brand/10 text-brand"
               }`}
             >
               {isLocked ? (
@@ -121,7 +121,7 @@ function ModuleRow({
               )}
             </span>
             <span className="min-w-0 flex-1 truncate">{module.title}</span>
-            <span className="shrink-0 whitespace-nowrap text-xs font-normal text-muted-foreground">
+            <span className="shrink-0 whitespace-nowrap text-xs font-normal text-ink-muted">
               {gradableCount > 0
                 ? `${completedInModule}/${gradableCount}`
                 : `${chapters.length} ch.`}
@@ -139,14 +139,14 @@ function ModuleRow({
             </Link>
           )}
           {isLocked && (
-            <span className="text-xs text-muted-foreground flex items-center gap-1">
+            <span className="text-xs text-ink-muted flex items-center gap-1">
               <Lock className="h-3 w-3" strokeWidth={1.75} aria-hidden />
               {t("courseDetail.moduleLocked")}
             </span>
           )}
         </div>
         {isLocked && (
-          <p className="text-xs text-muted-foreground ml-8 mt-1">
+          <p className="text-xs text-ink-muted ml-8 mt-1">
             {t("courseDetail.moduleLockHint")}
           </p>
         )}
@@ -162,7 +162,7 @@ function ModuleRow({
           return (
             <div
               className={`ml-8 mt-1 flex items-center gap-1 text-xs ${
-                overdue ? "text-destructive" : "text-muted-foreground"
+                overdue ? "text-destructive" : "text-ink-muted"
               }`}
             >
               {overdue ? (

--- a/frontend/src/pages/Course/detail/NotEnrolledView.tsx
+++ b/frontend/src/pages/Course/detail/NotEnrolledView.tsx
@@ -123,14 +123,14 @@ export function NotEnrolledView({
           eager-loaded list from /courses/:id). Keeps the surface honest
           when a course is still a stub — no fake "0 modules" line. */}
       {moduleCount > 0 && (
-        <p className="mb-5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <p className="mb-5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
           <span className="inline-flex items-center gap-1.5">
             <Layers className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
             {t("courseDetail.moduleCount", { count: moduleCount })}
           </span>
           {chapterCount > 0 && (
             <>
-              <span aria-hidden className="text-muted-foreground/40">·</span>
+              <span aria-hidden className="text-ink-muted/40">·</span>
               <span>{t("courseDetail.chapterCount", { count: chapterCount })}</span>
             </>
           )}
@@ -138,7 +138,7 @@ export function NotEnrolledView({
       )}
 
       {course.description && (
-        <p className="text-muted-foreground leading-relaxed mb-6 whitespace-pre-line text-wrap-safe">
+        <p className="text-ink-muted leading-relaxed mb-6 whitespace-pre-line text-wrap-safe">
           {course.description}
         </p>
       )}
@@ -147,17 +147,17 @@ export function NotEnrolledView({
         <Card className="mb-6">
           <CardContent className="py-4">
             <div className="flex flex-wrap items-center gap-2 mb-1">
-              <CalendarDays className="h-4 w-4 text-primary" strokeWidth={1.75} aria-hidden />
+              <CalendarDays className="h-4 w-4 text-brand" strokeWidth={1.75} aria-hidden />
               <span className="font-medium">{activeCohort.name}</span>
               <Badge variant={COHORT_STATUS_BADGE[activeCohort.status]}>
                 {t(COHORT_STATUS_KEY[activeCohort.status])}
               </Badge>
             </div>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-ink-muted">
               {formatDate(activeCohort.start_date)} &mdash; {formatDate(activeCohort.end_date)}
             </p>
             {activeCohort.enrollment_start && activeCohort.enrollment_end && (
-              <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
+              <p className="text-xs text-ink-muted mt-1 flex items-center gap-1">
                 <Clock className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
                 {t("courseDetail.enrollmentRangeLabel", {
                   start: formatDate(activeCohort.enrollment_start),
@@ -166,7 +166,7 @@ export function NotEnrolledView({
               </p>
             )}
             {activeCohort.max_students && (
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-xs text-ink-muted mt-1">
                 {t("courseDetail.studentsEnrolledOfMax", {
                   enrolled: activeCohort.student_count,
                   max: activeCohort.max_students,
@@ -181,9 +181,9 @@ export function NotEnrolledView({
         cohorts.length === 0 &&
         (course.enrollment_start || course.enrollment_end) && (
           <div className="flex flex-wrap items-center gap-2 text-sm mb-6">
-            <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
+            <CalendarDays className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
             {course.enrollment_start && course.enrollment_end && (
-              <span className="text-muted-foreground text-xs">
+              <span className="text-ink-muted text-xs">
                 {t("courseDetail.enrollmentRangeLabel", {
                   start: formatDate(course.enrollment_start),
                   end: formatDate(course.enrollment_end),
@@ -225,7 +225,7 @@ export function NotEnrolledView({
               <Users className="mr-2 h-4 w-4" strokeWidth={1.75} aria-hidden />
               {t("courseDetail.byInvitationOnly")}
             </Button>
-            <p className="text-sm text-muted-foreground mt-2 max-w-prose">
+            <p className="text-sm text-ink-muted mt-2 max-w-prose">
               {t("courseDetail.byInvitationOnlyHint")}
             </p>
           </div>
@@ -245,7 +245,7 @@ export function NotEnrolledView({
                   : t("courseDetail.enrollInCourse")}
             </Button>
             {!canEnroll && (
-              <p className="text-sm text-muted-foreground mt-2">
+              <p className="text-sm text-ink-muted mt-2">
                 {cohorts.length > 0
                   ? t("courseDetail.enrollmentClosedAllCohorts")
                   : t("courseDetail.noCohortsAvailable")}

--- a/frontend/src/pages/Course/detail/UpcomingEvents.tsx
+++ b/frontend/src/pages/Course/detail/UpcomingEvents.tsx
@@ -24,7 +24,7 @@ export function UpcomingEvents({ events }: Props) {
 
   return (
     <div className="mb-5">
-      <h2 className="mb-2 flex items-center gap-2 font-serif text-sm font-semibold tracking-tight text-muted-foreground">
+      <h2 className="mb-2 flex items-center gap-2 font-serif text-sm font-semibold tracking-tight text-ink-muted">
         <CalendarDays className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
         {t("courseDetail.upcoming.heading")}
       </h2>
@@ -37,8 +37,8 @@ export function UpcomingEvents({ events }: Props) {
               key={evt.id}
               className={`flex items-center gap-2 px-3 py-2 rounded-md border text-sm ${
                 overdue
-                  ? "border-l-stripe border-l-destructive border-border bg-destructive/5"
-                  : "border-border hover:bg-muted/40"
+                  ? "border-l-stripe border-l-destructive border-edge bg-destructive/5"
+                  : "border-edge hover:bg-muted/40"
               }`}
             >
               {overdue ? (
@@ -52,14 +52,14 @@ export function UpcomingEvents({ events }: Props) {
                         ? "bg-info"
                         : evt.event_type === "exam"
                           ? "bg-warning"
-                          : "bg-muted-foreground/50"
+                          : "bg-ink-muted/50"
                   }`}
                 />
               )}
               <span className={`flex-1 truncate ${overdue ? "text-destructive" : ""}`}>
                 {evt.title}
               </span>
-              <span className="text-xs text-muted-foreground whitespace-nowrap">
+              <span className="text-xs text-ink-muted whitespace-nowrap">
                 {formatDateLong(evtDate, { year: undefined, month: "short", day: "numeric" })}
               </span>
             </div>

--- a/frontend/src/pages/Courses/CoursesPage.tsx
+++ b/frontend/src/pages/Courses/CoursesPage.tsx
@@ -64,7 +64,7 @@ export default function CoursesPage() {
           <div className="bg-home-hero-glow h-full w-full blur-3xl" aria-hidden />
         </div>
         <div className="relative z-10 mx-auto max-w-2xl px-4 pb-2 pt-6 text-center md:pt-10">
-          <p className="animate-fade-in text-xs font-medium uppercase tracking-[0.22em] text-primary/90 mb-3">
+          <p className="animate-fade-in text-xs font-medium uppercase tracking-[0.22em] text-brand/90 mb-3">
             {t("courses.academicPrograms")}
           </p>
           <h1
@@ -73,12 +73,12 @@ export default function CoursesPage() {
           >
             {user ? t("courses.pageTitleAuthed") : t("courses.pageTitle")}
           </h1>
-          <p className="animate-fade-in animate-delay-200 mt-3 text-balance text-sm leading-relaxed text-muted-foreground md:text-base">
+          <p className="animate-fade-in animate-delay-200 mt-3 text-balance text-sm leading-relaxed text-ink-muted md:text-base">
             {user ? t("courses.pageSubtitleAuthed") : t("courses.pageSubtitle")}
           </p>
           <div data-tour="catalog-search" className="animate-fade-in animate-delay-300 relative mx-auto mt-8 max-w-md">
             <Search
-              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-muted"
               strokeWidth={1.75}
               aria-hidden
             />
@@ -87,7 +87,7 @@ export default function CoursesPage() {
               onChange={(e) => setInput(e.target.value.slice(0, maxLength))}
               maxLength={maxLength}
               placeholder={t("courses.searchPlaceholder")}
-              className="rounded-md border-border/80 bg-background/85 pl-9 backdrop-blur-sm focus-visible:ring-2"
+              className="rounded-md border-edge/80 bg-surface/85 pl-9 backdrop-blur-sm focus-visible:ring-2"
               aria-label={t("courses.searchPlaceholder")}
             />
           </div>
@@ -95,9 +95,9 @@ export default function CoursesPage() {
       </section>
 
       {!user && (
-        <div className="mb-8 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 rounded-md border border-border border-l-[3px] border-l-info bg-info/5 px-4 py-3 text-center sm:text-left">
+        <div className="mb-8 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 rounded-md border border-edge border-l-[3px] border-l-info bg-info/5 px-4 py-3 text-center sm:text-left">
           <LogIn className="h-4 w-4 shrink-0 text-info" strokeWidth={1.75} aria-hidden="true" />
-          <p className="text-sm text-foreground">
+          <p className="text-sm text-ink">
             <Link
               to="/login"
               className="-my-2 inline-flex min-h-[44px] items-center font-medium underline underline-offset-2 hover:no-underline sm:my-0 sm:min-h-0"

--- a/frontend/src/pages/DailyChallengeArchive/DailyChallengeArchivePage.tsx
+++ b/frontend/src/pages/DailyChallengeArchive/DailyChallengeArchivePage.tsx
@@ -90,12 +90,12 @@ export default function DailyChallengeArchivePage() {
       <PageHeader
         title={
           <h1 className="flex items-center gap-2 font-serif text-2xl font-bold tracking-tight sm:text-3xl">
-            <Sparkles className="h-6 w-6 text-primary" strokeWidth={1.75} aria-hidden />
+            <Sparkles className="h-6 w-6 text-brand" strokeWidth={1.75} aria-hidden />
             {t("dailyChallenge.archive.title")}
           </h1>
         }
         description={
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-ink-muted">
             {t("dailyChallenge.archive.description")}
           </p>
         }
@@ -104,24 +104,24 @@ export default function DailyChallengeArchivePage() {
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,360px)]">
         <section
           aria-labelledby="dc-archive-grid-heading"
-          className="rounded-md border border-border bg-card"
+          className="rounded-md border border-edge bg-card"
         >
-          <header className="flex items-center justify-between gap-3 border-b border-border bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
+          <header className="flex items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
             <div className="flex items-center gap-2.5">
               <Calendar
-                className="h-4 w-4 shrink-0 text-muted-foreground"
+                className="h-4 w-4 shrink-0 text-ink-muted"
                 strokeWidth={1.75}
                 aria-hidden
               />
               <h2
                 id="dc-archive-grid-heading"
-                className="font-serif text-sm font-semibold tracking-tight text-foreground"
+                className="font-serif text-sm font-semibold tracking-tight text-ink"
               >
                 {t("dailyChallenge.archive.gridHeading")}
               </h2>
             </div>
             {!loading && !loadError && entries.length > 0 && (
-              <div className="text-xs tabular-nums text-muted-foreground">
+              <div className="text-xs tabular-nums text-ink-muted">
                 {t("dailyChallenge.archive.gridStats", {
                   correct: correctCount,
                   attempted: attemptedCount,
@@ -220,7 +220,7 @@ function CalendarGrid({ entries, selectedDate, onSelect, t }: CalendarGridProps)
         )
         return (
           <div key={monthKey} className="space-y-2">
-            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">
               {monthLabel}
             </p>
             <div className="grid grid-cols-7 gap-1.5 sm:gap-2">
@@ -274,11 +274,11 @@ function DayCell({ entry, selected, onSelect, t }: DayCellProps) {
       className={cn(
         "group relative flex h-10 flex-col items-center justify-center rounded-md border text-[11px] font-medium tabular-nums transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-        correct && !replay && "border-success/50 bg-success/15 text-foreground",
-        correct && replay && "border-success/30 bg-success/5 text-foreground",
-        wrong && !replay && "border-destructive/40 bg-destructive/10 text-foreground",
-        wrong && replay && "border-destructive/30 bg-destructive/5 text-foreground",
-        !correct && !wrong && "border-border bg-muted/30 text-muted-foreground",
+        correct && !replay && "border-success/50 bg-success/15 text-ink",
+        correct && replay && "border-success/30 bg-success/5 text-ink",
+        wrong && !replay && "border-destructive/40 bg-destructive/10 text-ink",
+        wrong && replay && "border-destructive/30 bg-destructive/5 text-ink",
+        !correct && !wrong && "border-edge bg-muted/30 text-ink-muted",
         selected && "ring-2 ring-primary ring-offset-1 ring-offset-card",
       )}
     >
@@ -388,7 +388,7 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
 
   if (!challengeDate) {
     return (
-      <section className="rounded-md border border-border bg-card p-6 text-center">
+      <section className="rounded-md border border-edge bg-card p-6 text-center">
         <EmptyState
           variant="compact"
           title={t("dailyChallenge.archive.detail.pickDate")}
@@ -401,9 +401,9 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
   return (
     <section
       aria-labelledby="dc-archive-detail-heading"
-      className="rounded-md border border-border bg-card"
+      className="rounded-md border border-edge bg-card"
     >
-      <header className="flex items-center gap-2.5 border-b border-border bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
+      <header className="flex items-center gap-2.5 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <Button
           type="button"
           variant="ghost"
@@ -416,7 +416,7 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
         </Button>
         <h2
           id="dc-archive-detail-heading"
-          className="font-serif text-sm font-semibold tracking-tight text-foreground"
+          className="font-serif text-sm font-semibold tracking-tight text-ink"
         >
           {data
             ? `${data.bible_book_label} ${data.bible_chapter}${
@@ -430,7 +430,7 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
               }`
             : challengeDate}
         </h2>
-        <span className="ml-auto text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+        <span className="ml-auto text-[11px] uppercase tracking-[0.14em] text-ink-muted">
           {t("dailyChallenge.archive.detail.replayBadge")}
         </span>
       </header>
@@ -453,7 +453,7 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
           />
         ) : data ? (
           <>
-            <p className="text-sm font-medium leading-snug text-foreground">{data.question_text}</p>
+            <p className="text-sm font-medium leading-snug text-ink">{data.question_text}</p>
             <ul className="space-y-1.5">
               {[...data.options]
                 .sort((a, b) => a.order_index - b.order_index)
@@ -472,10 +472,10 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
                         className={cn(
                           "flex w-full items-center gap-2.5 rounded-md border px-3 py-2 text-left text-xs transition-colors",
                           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                          reveal === null && "border-border bg-background hover:border-primary/30 hover:bg-muted/30",
-                          showCorrect && "border-success/40 bg-success/10 text-foreground",
-                          showWrong && "border-destructive/40 bg-destructive/10 text-foreground",
-                          reveal !== null && !showCorrect && !showWrong && "border-border bg-background text-muted-foreground",
+                          reveal === null && "border-edge bg-surface hover:border-brand/30 hover:bg-muted/30",
+                          showCorrect && "border-success/40 bg-success/10 text-ink",
+                          showWrong && "border-destructive/40 bg-destructive/10 text-ink",
+                          reveal !== null && !showCorrect && !showWrong && "border-edge bg-surface text-ink-muted",
                           (reveal !== null || submitting) && "cursor-default",
                         )}
                       >
@@ -483,10 +483,10 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
                           aria-hidden
                           className={cn(
                             "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold",
-                            reveal === null && "border-border text-muted-foreground",
+                            reveal === null && "border-edge text-ink-muted",
                             showCorrect && "border-success bg-success text-success-foreground",
                             showWrong && "border-destructive bg-destructive text-destructive-foreground",
-                            reveal !== null && !showCorrect && !showWrong && "border-border text-muted-foreground",
+                            reveal !== null && !showCorrect && !showWrong && "border-edge text-ink-muted",
                           )}
                         >
                           {showCorrect ? (
@@ -504,11 +504,11 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
                 })}
             </ul>
             {reveal !== null && (
-              <div className="space-y-1.5 rounded-md border border-border/80 bg-muted/20 px-3 py-2.5">
+              <div className="space-y-1.5 rounded-md border border-edge/80 bg-muted/20 px-3 py-2.5">
                 <p
                   className={cn(
                     "text-[11px] font-semibold uppercase tracking-[0.14em]",
-                    reveal.is_correct ? "text-success" : "text-muted-foreground",
+                    reveal.is_correct ? "text-success" : "text-ink-muted",
                   )}
                 >
                   {reveal.is_correct
@@ -516,7 +516,7 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
                     : t("dailyChallenge.reveal.wrong")}
                 </p>
                 {reveal.explanation && (
-                  <p className="text-xs leading-snug text-foreground">{reveal.explanation}</p>
+                  <p className="text-xs leading-snug text-ink">{reveal.explanation}</p>
                 )}
               </div>
             )}

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -83,18 +83,18 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
   const shell = (body: React.ReactNode, centered = false) => (
     <section
       data-tour="my-courses"
-      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-border bg-card transition-[border-color] duration-300 hover:border-primary/25"
+      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-edge bg-card transition-[border-color] duration-300 hover:border-brand/25"
     >
-      <header className="flex items-center justify-between gap-3 border-b border-border bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
+      <header className="flex items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <div className="flex min-w-0 items-center gap-2.5">
-          <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden />
-          <h2 className="truncate font-serif text-sm font-semibold tracking-tight text-foreground">
+          <BookOpen className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
+          <h2 className="truncate font-serif text-sm font-semibold tracking-tight text-ink">
             {headerLabel}
           </h2>
         </div>
         <Link
           to="/courses"
-          className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-primary transition-opacity hover:opacity-80"
+          className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-brand transition-opacity hover:opacity-80"
         >
           {t("dashboard.browseAllCta")}
           <ArrowRight className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
@@ -119,7 +119,7 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
     return shell(
       <div className="w-full space-y-3">
         {Array.from({ length: 2 }).map((_, i) => (
-          <div key={i} className="rounded-md border border-border/80 bg-muted/10 px-3 py-3">
+          <div key={i} className="rounded-md border border-edge/80 bg-muted/10 px-3 py-3">
             <Skeleton className="h-4 w-3/5" />
             <Skeleton className="mt-2.5 h-1.5 w-2/3 rounded-full" />
           </div>
@@ -164,7 +164,7 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
               size="sm"
               variant="ghost"
               onClick={onTourStart}
-              className="text-muted-foreground hover:text-foreground"
+              className="text-ink-muted hover:text-ink"
             >
               {t("tour.takeATour")}
             </Button>
@@ -181,7 +181,7 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
         .filter((e) => e.course?.id)
         .map((enrollment, index) => {
           const grade = grades.find((g) => g.course_id === enrollment.course_id)
-          const progressColor = enrollment.progress >= 100 ? "bg-success" : "bg-primary"
+          const progressColor = enrollment.progress >= 100 ? "bg-success" : "bg-brand"
           const courseId = enrollment.course!.id
 
           return (
@@ -189,12 +189,12 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
               key={enrollment.id}
               to={`/courses/${courseId}`}
               style={{ "--stagger-index": index } as React.CSSProperties}
-              className="group block rounded-md border border-border bg-muted/10 px-3 py-2.5 transition-colors hover:border-primary/30 hover:bg-muted/40"
+              className="group block rounded-md border border-edge bg-muted/10 px-3 py-2.5 transition-colors hover:border-brand/30 hover:bg-muted/40"
             >
               <div className="flex items-center gap-3">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-start gap-2">
-                    <h3 className="min-w-0 flex-1 truncate font-serif text-sm font-medium leading-tight text-foreground transition-colors duration-200 group-hover:text-primary">
+                    <h3 className="min-w-0 flex-1 truncate font-serif text-sm font-medium leading-tight text-ink transition-colors duration-200 group-hover:text-brand">
                       {enrollment.course?.title || t("dashboard.course")}
                     </h3>
                     {enrollment.progress >= 100 && (
@@ -221,18 +221,18 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
                         />
                       )}
                     </div>
-                    <span className="shrink-0 text-[11px] font-medium tabular-nums text-muted-foreground">
+                    <span className="shrink-0 text-[11px] font-medium tabular-nums text-ink-muted">
                       {enrollment.progress}%
                     </span>
                     {grade?.grade ? (
-                      <span className="rounded-sm border border-border bg-background/80 px-1.5 py-0 text-[10px] font-medium text-foreground">
+                      <span className="rounded-sm border border-edge bg-surface/80 px-1.5 py-0 text-[10px] font-medium text-ink">
                         {grade.grade}
                       </span>
                     ) : null}
                   </div>
                 </div>
                 <ArrowRight
-                  className="h-4 w-4 shrink-0 text-primary transition-transform duration-200 group-hover:translate-x-1"
+                  className="h-4 w-4 shrink-0 text-brand transition-transform duration-200 group-hover:translate-x-1"
                   strokeWidth={1.75}
                   aria-hidden
                 />

--- a/frontend/src/pages/Dashboard/PublicLanding.tsx
+++ b/frontend/src/pages/Dashboard/PublicLanding.tsx
@@ -43,10 +43,10 @@ export function PublicLanding() {
     <div className="container mx-auto max-w-5xl px-4 pb-24">
       {/* ── Hero ────────────────────────────────────────────────── */}
       <section className="flex flex-col items-center pt-16 text-center sm:pt-24">
-        <h1 className="font-serif text-4xl font-bold tracking-tight text-foreground sm:text-5xl md:text-6xl">
+        <h1 className="font-serif text-4xl font-bold tracking-tight text-ink sm:text-5xl md:text-6xl">
           {t("common.appName")}
         </h1>
-        <p className="mt-4 max-w-2xl text-balance text-base leading-relaxed text-muted-foreground sm:text-lg">
+        <p className="mt-4 max-w-2xl text-balance text-base leading-relaxed text-ink-muted sm:text-lg">
           {t("footer.tagline")}
         </p>
         <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
@@ -80,7 +80,7 @@ export function PublicLanding() {
         >
           {t("landing.features.heading")}
         </h2>
-        <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+        <p className="mt-2 max-w-2xl text-sm text-ink-muted">
           {t("landing.features.subheading")}
         </p>
         <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -169,7 +169,7 @@ export function PublicLanding() {
         <h2 className="font-serif text-2xl font-semibold tracking-tight sm:text-3xl">
           {t("landing.finalCta.heading")}
         </h2>
-        <p className="mt-3 max-w-xl text-balance text-sm text-muted-foreground sm:text-base">
+        <p className="mt-3 max-w-xl text-balance text-sm text-ink-muted sm:text-base">
           {t("landing.finalCta.body")}
         </p>
         <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
@@ -199,11 +199,11 @@ interface FeatureCardProps {
 function FeatureCard({ icon, title, body }: FeatureCardProps) {
   return (
     <div className="flex flex-col rounded-lg border bg-card p-5">
-      <span className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-primary/10 text-primary">
+      <span className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-brand/10 text-brand">
         {icon}
       </span>
-      <h3 className="mt-4 text-base font-semibold text-foreground">{title}</h3>
-      <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">{body}</p>
+      <h3 className="mt-4 text-base font-semibold text-ink">{title}</h3>
+      <p className="mt-1.5 text-sm leading-relaxed text-ink-muted">{body}</p>
     </div>
   )
 }
@@ -216,10 +216,10 @@ interface StepProps {
 function Step({ n, text }: StepProps) {
   return (
     <li className="flex items-start gap-3">
-      <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+      <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-brand text-sm font-semibold text-brand-foreground">
         {n}
       </span>
-      <p className="pt-0.5 text-sm leading-relaxed text-foreground">{text}</p>
+      <p className="pt-0.5 text-sm leading-relaxed text-ink">{text}</p>
     </li>
   )
 }
@@ -236,14 +236,14 @@ function QuickLink({ to, icon, title, body }: QuickLinkProps) {
     <li>
       <Link
         to={to}
-        className="group flex items-start gap-3 rounded-md border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        className="group flex items-start gap-3 rounded-md border bg-card p-4 transition-colors hover:border-brand/40 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
       >
-        <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
+        <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted text-ink-muted transition-colors group-hover:bg-brand/10 group-hover:text-brand">
           {icon}
         </span>
         <span className="min-w-0">
-          <span className="block text-sm font-medium text-foreground">{title}</span>
-          <span className="mt-0.5 block text-xs text-muted-foreground">{body}</span>
+          <span className="block text-sm font-medium text-ink">{title}</span>
+          <span className="mt-0.5 block text-xs text-ink-muted">{body}</span>
         </span>
       </Link>
     </li>

--- a/frontend/src/styles/__tests__/wave14-course-pages.test.ts
+++ b/frontend/src/styles/__tests__/wave14-course-pages.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Sentinel for ADR-0011 Wave 14 — Course detail/listing pages,
+ * Chapter & Module views, DailyChallenge archive, student Dashboard
+ * (+ public landing) migrated to v2.
+ *
+ * This is the heart of the student-facing surface: the catalog, the
+ * course detail page (both enrolled and not-enrolled states), the
+ * inside-a-course chapter + module reading views, the
+ * DailyChallengeArchive history, and the logged-in dashboard root.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "..", "..");
+
+function readNonComment(path: string): string {
+  return readFileSync(path, "utf-8")
+    .replace(/\/\/[^\n]*\n/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+}
+
+function containsClass(code: string, className: string): boolean {
+  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`).test(code);
+}
+
+const FILES = [
+  resolve(SRC, "pages/Course/ChapterView.tsx"),
+  resolve(SRC, "pages/Course/ModuleView.tsx"),
+  resolve(SRC, "pages/Course/detail/CohortSelectModal.tsx"),
+  resolve(SRC, "pages/Course/detail/EnrolledHeader.tsx"),
+  resolve(SRC, "pages/Course/detail/ModuleList.tsx"),
+  resolve(SRC, "pages/Course/detail/NotEnrolledView.tsx"),
+  resolve(SRC, "pages/Course/detail/UpcomingEvents.tsx"),
+  resolve(SRC, "pages/Courses/CoursesPage.tsx"),
+  resolve(SRC, "pages/DailyChallengeArchive/DailyChallengeArchivePage.tsx"),
+  resolve(SRC, "pages/Dashboard/DashboardPage.tsx"),
+  resolve(SRC, "pages/Dashboard/PublicLanding.tsx"),
+];
+
+const V1_LOCKED_OUT = [
+  "bg-background",
+  "text-foreground",
+  "text-muted-foreground",
+  "border-border",
+  "border-input",
+  "bg-primary",
+  "text-primary",
+  "border-primary",
+  "hover:bg-accent",
+  "hover:text-accent-foreground",
+  "ring-ring",
+  "bg-muted-foreground",
+];
+
+describe("ADR-0011 Wave 14 — Course pages + Dashboard + DailyChallengeArchive", () => {
+  for (const path of FILES) {
+    const name = path.split(/[\\/]/).slice(-3).join("/");
+
+    it(`${name} retired the v1 names`, () => {
+      const code = readNonComment(path);
+      for (const cls of V1_LOCKED_OUT) {
+        expect(
+          containsClass(code, cls),
+          `${name} still references ${cls}`,
+        ).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
ADR-0011 **Wave 14**. The heart of the student-facing surface.

## Scope (11 files)

**Course detail flow**
* `Course/ChapterView.tsx`
* `Course/ModuleView.tsx`
* `Course/detail/CohortSelectModal.tsx`
* `Course/detail/EnrolledHeader.tsx`
* `Course/detail/ModuleList.tsx`
* `Course/detail/NotEnrolledView.tsx`
* `Course/detail/UpcomingEvents.tsx`

**Catalog + dashboard**
* `Courses/CoursesPage.tsx`
* `DailyChallengeArchive/DailyChallengeArchivePage.tsx`
* `Dashboard/DashboardPage.tsx`
* `Dashboard/PublicLanding.tsx`

## Sentinel

`wave14-course-pages.test.ts` — 11-file per-file lock-out.

## Test plan

- [x] +11 sentinel tests
- [x] Full frontend suite green (423 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)