### PR TITLE
test(a11y): component-level jest-axe coverage for overlays + form controls

### DIFF
--- a/frontend/src/components/ui/__tests__/a11y-form-controls.test.tsx
+++ b/frontend/src/components/ui/__tests__/a11y-form-controls.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Component-level a11y coverage for form-control primitives.
+ *
+ * Companion to ``a11y-overlays.test.tsx``. Pins:
+ *   - Checkbox with associated <Label>.
+ *   - RadioGroup with multiple items + group label.
+ *   - Select (Radix) with associated <Label>.
+ *   - Textarea with associated <Label>.
+ *
+ * The pattern that breaks most often is the htmlFor/id pair getting
+ * desynced when a field is renamed. axe catches it; this test pins
+ * the catch so the regression surfaces in CI not in QA.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+
+import { axe } from "@/test/a11y";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+describe("a11y — form-control primitives", () => {
+  it("Checkbox paired with Label has no violations", async () => {
+    const { container } = render(
+      <div className="flex items-center gap-2">
+        <Checkbox id="terms" />
+        <Label htmlFor="terms">I agree to the terms</Label>
+      </div>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("RadioGroup with labelled options has no violations", async () => {
+    const { container } = render(
+      <fieldset>
+        <legend>Difficulty</legend>
+        <RadioGroup defaultValue="easy">
+          <div>
+            <RadioGroupItem id="r-easy" value="easy" />
+            <Label htmlFor="r-easy">Easy</Label>
+          </div>
+          <div>
+            <RadioGroupItem id="r-medium" value="medium" />
+            <Label htmlFor="r-medium">Medium</Label>
+          </div>
+          <div>
+            <RadioGroupItem id="r-hard" value="hard" />
+            <Label htmlFor="r-hard">Hard</Label>
+          </div>
+        </RadioGroup>
+      </fieldset>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("Select with associated Label has no violations", async () => {
+    const { baseElement } = render(
+      <div>
+        <Label htmlFor="locale">Locale</Label>
+        <Select>
+          <SelectTrigger id="locale">
+            <SelectValue placeholder="Pick a locale" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="en">English</SelectItem>
+            <SelectItem value="ru">Russian</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>,
+    );
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+
+  it("Textarea with associated Label has no violations", async () => {
+    const { container } = render(
+      <div>
+        <Label htmlFor="bio">About you</Label>
+        <Textarea id="bio" placeholder="A few sentences..." />
+      </div>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("Checkbox WITHOUT a label IS flagged (sentinel)", async () => {
+    // Mirror of the unlabeled-input sentinel in ``a11y.test.tsx`` —
+    // proves the form-control rules are actually firing on this
+    // primitive set.
+    const { container } = render(<Checkbox id="orphan" />);
+    const result = await axe(container);
+    expect(result.violations.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/ui/__tests__/a11y-overlays.test.tsx
+++ b/frontend/src/components/ui/__tests__/a11y-overlays.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Component-level a11y coverage for the overlay primitives.
+ *
+ * The page-level Playwright a11y spec catches the static surface; this
+ * test pins the harder-to-cover overlay components which (a) render
+ * via portal and (b) frequently regress when devs forget the
+ * Title / aria-label triple. Each test renders the component in its
+ * OPEN state via ``defaultOpen`` so the portaled content lands in the
+ * DOM for axe to scan.
+ *
+ * NOTE: Only components actually exported from the project's ui
+ * wrappers are tested — Dialog exports a narrow public surface, and
+ * AlertDialog primitives are private (consumed via useConfirm /
+ * ConfirmProvider). The component tests for those higher-level
+ * patterns live alongside their feature consumers.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+
+import { axe } from "@/test/a11y";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+
+describe("a11y — overlay primitives", () => {
+  it("Dialog with header + title has no violations", async () => {
+    const { baseElement } = render(
+      <Dialog defaultOpen>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete course</DialogTitle>
+          </DialogHeader>
+          <p>
+            This action cannot be undone. The course and its enrollments will
+            be permanently removed.
+          </p>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+
+  it("Sheet with title + description has no violations", async () => {
+    const { baseElement } = render(
+      <Sheet defaultOpen>
+        <SheetContent side="right">
+          <SheetHeader>
+            <SheetTitle>Filters</SheetTitle>
+            <SheetDescription>
+              Adjust how courses are listed.
+            </SheetDescription>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>,
+    );
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+
+  it("Popover with aria-label has no violations", async () => {
+    // Radix renders PopoverContent as role="dialog"; axe's
+    // ``aria-dialog-name`` rule requires an accessible name. Real
+    // call sites either pass aria-label or wrap a heading. Pin the
+    // aria-label path here so a future refactor that drops the
+    // attribute surfaces a violation.
+    const { baseElement } = render(
+      <Popover defaultOpen>
+        <PopoverTrigger asChild>
+          <Button>Open</Button>
+        </PopoverTrigger>
+        <PopoverContent aria-label="Quick options">
+          <p>Quick options panel.</p>
+        </PopoverContent>
+      </Popover>,
+    );
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+
+  it("Tooltip with aria-labeled icon trigger has no violations", async () => {
+    const { baseElement } = render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger asChild>
+            <Button aria-label="Settings">
+              <svg aria-hidden="true" focusable="false" width="14" height="14" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Settings</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
Extends the foundation a11y suite (`a11y.test.tsx` — Button/Card/Badge/Label-Input pair) with two more files that pin failure modes the page-level Playwright scan can't easily hit.

## What

**`a11y-overlays.test.tsx` (4 tests)**
- Dialog with header + title in open state
- Sheet with title + description in open state
- Popover with `aria-label` in open state
- Tooltip with aria-labeled icon trigger

**`a11y-form-controls.test.tsx` (5 tests)**
- Checkbox paired with Label
- RadioGroup with multiple labelled options under a fieldset
- Select with associated Label
- Textarea with associated Label
- **Sentinel**: orphan Checkbox WITHOUT a label IS flagged by axe (proves the form-control rules actually fire — a future jest-axe mis-wire would silently mask issues)

## Why baseElement vs container

Overlays use `baseElement` because Radix portals them outside the test root; a `container`-scoped scan would never see the overlay content.

## Test plan

- [x] +9 new a11y tests
- [x] Full frontend suite green (506 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)