### PR TITLE
feat(metrics): wire equip.enrollments.created_total

### DIFF
--- a/backend/app/services/course_service/_enrollment.py
+++ b/backend/app/services/course_service/_enrollment.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from app.constants import GRADABLE_CHAPTER_TYPES
+from app.core.metrics import increment
 from app.models.chapter_progress import ChapterProgress
 from app.models.course import Chapter, Course, Module
 from app.models.enrollment import Enrollment
@@ -51,6 +52,17 @@ def enroll_user_in_course(
             return existing
         raise
     db.refresh(enrollment)
+    # equip.enrollments.created_total feeds the Course Engagement
+    # dashboard's enrollment-rate tile + the dropoff_count derived
+    # metric (denominator = sum(enrollments.created_total) - sum(
+    # chapter_completed_total{first_chapter}) over the same window).
+    # Counter fires once per *new* enrollment — the existing-row early
+    # return above guarantees idempotency for re-enroll attempts.
+    increment(
+        "equip.enrollments.created_total",
+        course_id=str(course_id),
+        cohort_id=str(cohort_id) if cohort_id else "",
+    )
     return enrollment
 
 

--- a/backend/tests/test_enrollment_metrics.py
+++ b/backend/tests/test_enrollment_metrics.py
@@ -1,0 +1,120 @@
+"""Tests for ``equip.enrollments.created_total`` emission.
+
+The Course Engagement dashboard's enrollment-rate tile reads from
+this counter; the dropoff_count derived metric uses it as a
+denominator. The metric MUST fire exactly once per *new* enrollment
+and MUST NOT fire when the existing-row early return path is taken
+(idempotent re-enroll).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from app.models.user import User, UserRole
+from app.services.course_service import enroll_user_in_course
+
+from ._cv_helpers import make_course_with_text
+from .conftest import STUDENT_ID, TEACHER_ID
+
+if TYPE_CHECKING:
+    import pytest
+    from sqlalchemy.orm import Session
+
+
+def _seed_users(db: Session) -> None:
+    for user_id, role, email in [
+        (TEACHER_ID, UserRole.TEACHER.value, "t@e.com"),
+        (STUDENT_ID, UserRole.STUDENT.value, "s@e.com"),
+    ]:
+        if db.query(User).filter(User.id == user_id).first() is None:
+            db.add(User(id=user_id, email=email, full_name="X", role=role))
+    db.flush()
+
+
+class TestEnrollmentMetricEmission:
+    def test_emits_created_total_on_new_enrollment(
+        self,
+        db: Session,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _seed_users(db)
+        course = make_course_with_text(
+            db,
+            course_id="enr-new",
+            title="Enr New",
+            status="published",
+            created_by=TEACHER_ID,
+        )
+        db.commit()
+
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            enrollment = enroll_user_in_course(db, STUDENT_ID, course.id)
+
+        assert enrollment.course_id == course.id
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.enrollments.created_total" in m]
+        assert events, "expected one created_total event"
+        assert any("value=1.0" in m for m in events)
+        assert any(f"course_id={course.id}" in m for m in events)
+
+    def test_does_not_re_emit_on_idempotent_reenroll(
+        self,
+        db: Session,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The existing-row early-return path MUST be silent — counting
+        a re-enroll would inflate the enrollment denominator and skew
+        the drop-off computation."""
+        _seed_users(db)
+        course = make_course_with_text(
+            db,
+            course_id="enr-idem",
+            title="Enr Idem",
+            status="published",
+            created_by=TEACHER_ID,
+        )
+        db.commit()
+
+        # First enrollment writes the row + fires the counter.
+        enroll_user_in_course(db, STUDENT_ID, course.id)
+        # Clear what setup emitted; the assertion is about the SECOND call.
+        caplog.clear()
+
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            again = enroll_user_in_course(db, STUDENT_ID, course.id)
+
+        # Same row returned, no new emission.
+        assert again is not None
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.enrollments.created_total" in m]
+        assert events == [], "re-enroll must NOT re-fire the counter"
+
+    def test_omits_cohort_id_tag_when_not_provided(
+        self,
+        db: Session,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Missing cohort_id must NOT produce a ``cohort_id=`` attribute —
+        Datadog treats empty tag values as malformed. ``emit`` drops
+        empty-string tags, so the wire line should not contain the key
+        at all."""
+        _seed_users(db)
+        course = make_course_with_text(
+            db,
+            course_id="enr-no-cohort",
+            title="Enr",
+            status="published",
+            created_by=TEACHER_ID,
+        )
+        db.commit()
+
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            enroll_user_in_course(db, STUDENT_ID, course.id)
+
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.enrollments.created_total" in m]
+        assert events
+        for m in events:
+            assert "cohort_id=" not in m, f"unexpected cohort_id attribute in: {m}"


### PR DESCRIPTION
Course Engagement dashboard's enrollment-rate tile needs an authoritative counter for *new* enrollments. The `dropoff_count` derived metric uses this as a denominator:

`drop-off rate = (enrolled - chapter_completed_unique) / enrolled`

A malformed or double-counted enrollment denominator skews the entire tile.

## Emission contract

- Fires **once per new Enrollment row** written by `enroll_user_in_course` (the only enrollment writer that goes through the unique-key-collision guard).
- The existing-row early-return path stays silent — idempotent re-enroll attempts must not inflate the counter.
- `cohort_id` tag emitted when present; omitted entirely when None (the metrics emitter drops empty tag values).

## Tests

`test_enrollment_metrics.py` (3 tests):
- emits on new enrollment
- does NOT re-emit on idempotent re-enroll
- omits `cohort_id` tag when not provided

## Test plan

- [x] +3 enrollment metric tests
- [x] 32 metrics tests green
- [x] Full backend suite green (1396 tests)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)