### PR TITLE
test(a11y): fold axe assertions into existing high-traffic component tests

### DIFF
--- a/frontend/src/components/course/__tests__/CompletionDialog.test.tsx
+++ b/frontend/src/components/course/__tests__/CompletionDialog.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { I18nextProvider } from "react-i18next"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import i18n from "@/i18n/config"
+import { axe } from "@/test/a11y"
 import CompletionDialog from "../CompletionDialog"
 import type { Certificate } from "@/types"
 
@@ -119,5 +120,16 @@ describe("CompletionDialog", () => {
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled()
     })
+  })
+
+  it("renders without a11y violations in the open / unrequested state", async () => {
+    // Dialog is a high-stakes moment (course completion) — a labeling
+    // regression here is more visible than on a side card. Pin the
+    // open-state axe scan against baseElement since Radix portals
+    // the content outside the test container.
+    const { baseElement } = render(<CompletionDialog {...baseProps} />, {
+      wrapper: Wrapper,
+    })
+    expect(await axe(baseElement)).toHaveNoViolations()
   })
 })

--- a/frontend/src/components/course/__tests__/CourseCard.test.tsx
+++ b/frontend/src/components/course/__tests__/CourseCard.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom"
 import { I18nextProvider } from "react-i18next"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import i18n from "@/i18n/config"
+import { axe } from "@/test/a11y"
 import CourseCard from "../CourseCard"
 import type { Course } from "@/types"
 
@@ -139,5 +140,26 @@ describe("CourseCard", () => {
     )
     expect(screen.getByText(/by invitation/i)).toBeInTheDocument()
     expect(screen.queryByText(/enrolling now/i)).not.toBeInTheDocument()
+  })
+
+  it("renders without any a11y violations (open enrollment + cover image)", async () => {
+    // CourseCard is rendered up to ~50 times in the catalog grid; a
+    // violation here is a violation 50x. Pin axe-clean rendering for
+    // the representative state.
+    const futureEnd = new Date(Date.now() + 86_400_000).toISOString()
+    const { container } = renderCard(
+      makeCourse({
+        title: "Genesis Foundations",
+        description: "A 12-lesson intro to the book of Genesis.",
+        image_url: "https://abc.supabase.co/storage/v1/object/public/covers/g.jpg",
+        enrollment_start: new Date(Date.now() - 86_400_000).toISOString(),
+        enrollment_end: futureEnd,
+        modules: [
+          { id: "m1", course_id: "c-1", title: "A", description: null, order_index: 0, due_date: null },
+          { id: "m2", course_id: "c-1", title: "B", description: null, order_index: 1, due_date: null },
+        ],
+      }),
+    )
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/components/dashboard/__tests__/DailyChallengeCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DailyChallengeCard.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { AxiosError } from "axios"
 import i18n from "@/i18n/config"
+import { axe } from "@/test/a11y"
 import { DailyChallengeCard } from "../DailyChallengeCard"
 import { dailyChallengeService } from "@/services/dailyChallenge"
 
@@ -159,5 +160,35 @@ describe("DailyChallengeCard", () => {
     const button = screen.getByRole("button", { name: /the law/i })
     await userEvent.click(button)
     expect(submitAttempt).not.toHaveBeenCalled()
+  })
+
+  it("renders without a11y violations in the answered/reveal state", async () => {
+    // The daily challenge card sits on the dashboard for every
+    // logged-in student, every day. A WCAG violation here is the
+    // highest-traffic regression we can ship; pin axe-clean for the
+    // representative "already answered" state which renders the
+    // most components (option list + streak chip + archive link).
+    stub({
+      getToday: vi.fn().mockResolvedValue(
+        todayPayload({
+          user_attempt: {
+            id: "att-1",
+            question_id: "q-1",
+            selected_option_id: "o-1",
+            is_correct: true,
+            attempted_at: new Date().toISOString(),
+            current_streak: 3,
+          },
+        }),
+      ),
+      getStreak: vi.fn().mockResolvedValue({
+        current_streak: 3,
+        longest_streak: 10,
+        last_engaged_date: new Date().toISOString().slice(0, 10),
+      }),
+    })
+    const { container } = render(<DailyChallengeCard />, { wrapper: Wrapper })
+    await screen.findByLabelText(/3-day streak/i)
+    expect(await axe(container)).toHaveNoViolations()
   })
 })


### PR DESCRIPTION
Closes the gap noted by `a11y-features.test.tsx`'s 'intentional exclusions' — folds an axe scan into the per-component test files that already build the right provider harness (i18n + Router + service mocks), instead of duplicating that harness in a separate file.

## What

| Test file | Added scan |
|---|---|
| `CourseCard.test.tsx` | open-enrollment + cover-image state (rendered ~50x in the catalog grid; a violation here is 50x violations) |
| `DailyChallengeCard.test.tsx` | answered/reveal state (dashboard card every logged-in student sees daily) |
| `CompletionDialog.test.tsx` | open/unrequested state via `baseElement` (Radix portals content outside the test container) |

## Test plan

- [x] +3 new a11y assertions inside existing tests
- [x] Full frontend suite green (516 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)