### PR TITLE
test(a11y): fold axe into QuizTaker + FirstRunFlow component tests

### DIFF
--- a/frontend/src/components/firstRun/__tests__/FirstRunFlow.test.tsx
+++ b/frontend/src/components/firstRun/__tests__/FirstRunFlow.test.tsx
@@ -5,6 +5,7 @@ import { I18nextProvider } from "react-i18next"
 import { MotionConfig } from "motion/react"
 import { MemoryRouter } from "react-router-dom"
 import i18n from "@/i18n/config"
+import { axe } from "@/test/a11y"
 import { AuthContext } from "@/context/auth-context"
 import { ThemeContext } from "@/context/theme-context"
 import { FirstRunFlow } from "../FirstRunFlow"
@@ -231,5 +232,18 @@ describe("FirstRunFlow", () => {
       unmount()
     })
     expect(getFirstRunActive()).toBe(false)
+  })
+
+  it("renders the initial Privacy step without a11y violations", async () => {
+    // The first-run flow is the first thing a newly-registered user
+    // sees; an a11y failure here is the literal worst first
+    // impression. Pin the entry-state axe scan.
+    const { container } = render(
+      <Wrapper>
+        <FirstRunFlow />
+      </Wrapper>,
+    )
+    expect(screen.getByText(i18n.t("firstRun.privacy.title"))).toBeInTheDocument()
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/components/quiz/__tests__/QuizTaker.test.tsx
+++ b/frontend/src/components/quiz/__tests__/QuizTaker.test.tsx
@@ -5,6 +5,7 @@ import { I18nextProvider } from "react-i18next"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Quiz, QuizAttempt } from "@/types"
 import i18n from "@/i18n/config"
+import { axe } from "@/test/a11y"
 
 const getChapterQuiz = vi.fn()
 const getMyQuizAttempts = vi.fn()
@@ -236,5 +237,19 @@ describe("QuizTaker", () => {
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /submit exam/i })).toBeInTheDocument(),
     )
+  })
+
+  it("renders without a11y violations in the unanswered active-attempt state", async () => {
+    // QuizTaker is the highest-stakes student surface — wrong a11y
+    // here means a student literally can't complete a graded module.
+    // Pin axe-clean for the post-load, all-options-rendered state.
+    getChapterQuiz.mockResolvedValue(makeQuiz())
+    getMyQuizAttempts.mockResolvedValue([])
+
+    const { container } = render(<QuizTaker chapterId="chap-1" />, renderOpts)
+    await waitFor(() => {
+      expect(screen.getByText("Genesis 1 Quiz")).toBeInTheDocument()
+    })
+    expect(await axe(container)).toHaveNoViolations()
   })
 })


### PR DESCRIPTION
Extends the 'axe in existing tests' pattern (#693) with the two highest-stakes student-facing flows.

## What

| Test | Added scan |
|---|---|
| `QuizTaker.test.tsx` | unanswered active-attempt state — wrong a11y here means a student literally can't complete a graded module |
| `FirstRunFlow.test.tsx` | initial Privacy step — the first thing a newly-registered user sees; literal worst first impression if it fails |

Both reuse the existing test files' provider harnesses (i18n + Router + AuthContext + ThemeContext + MotionConfig as needed), so no new harness duplication.

## Test plan

- [x] +2 new a11y assertions inside existing tests
- [x] Full frontend suite green (515 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)