### PR TITLE
docs(datadog): wire shipped metrics into Course Engagement dashboard

### DIFF
--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -32,29 +32,47 @@ sync with prod is the fastest way for dashboards to silently rot.
 ## Required metrics
 
 Both dashboards reference custom metrics with the `equip.*` namespace.
-They're emitted by:
+They're emitted via **log-based metrics** — structured INFO lines
+under the `equip.metric` logger that Datadog parses into time series.
+See `app/core/metrics.py` for the emitter contract.
 
-* **`equip.grading.*`** — `app/api/v1/grades.py` and the manual-
-  grading flow in `app/api/v1/quizzes/grading.py` push a Datadog
-  StatsD metric every time a pending item enters or leaves the queue.
-* **`equip.questions.*`** — the course Q&A surface (when it lands)
-  will emit these; for now the panels render "no data" gracefully.
-* **`equip.activity.*`** — the request-logging middleware in
-  `app/main.py` tags every request with `course_id` and `locale`
-  when available; the DAU metric is derived from unique
-  `user_id` per day.
-* **`equip.completion.*`** — `app/services/student_progress_service.py`
-  updates a per-course/per-chapter completion rate on each
-  `mark_chapter_complete` call.
-* **`equip.engagement.first_dropoff.*`** — `dropoff_count` is the
-  count of enrollments where activity stopped without completion;
-  computed by a scheduled Datadog query.
+Live emission today (sites tagged with the route file that wires them):
 
-The teacher-load dashboard's grading queue tile + the course-
-engagement DAU tile are both live as of this PR; the others need
-the metric emission to be wired in subsequent PRs. The dashboards
-ship now so we can see the no-data tiles + know which metrics are
-still TODO.
+* **`equip.grading.graded_total`** + **`equip.grading.time_to_grade.p50`**
+  — `app/api/v1/quizzes/grading.py` fires on the
+  `pending → graded` transition (guarded against re-grade
+  double-count).
+* **`equip.activity.requests_total`** + **`equip.activity.duration_ms`**
+  — the request-logging middleware in `app/main.py` tags every
+  request with `course_id`, `locale`, `status_code`.
+* **`equip.completion.course_avg_pct`** — `app/services/course_service/
+  _enrollment.py::sync_enrollment_progress` emits a gauge on every
+  progress recompute.
+* **`equip.engagement.chapter_completed_total`** — emitted by all
+  three chapter-completion paths (teacher-mark / quiz-pass /
+  assignment-submit), tagged with `completion_type`, idempotent on
+  no-op re-completion.
+* **`equip.enrollments.created_total`** — `app/services/
+  course_service/_enrollment.py::enroll_user_in_course` emits once
+  per *new* row (idempotent on re-enroll).
+* **`equip.reviews.rating_latest`** — `app/api/v1/reviews.py` emits
+  per (user, course) on review create/update; the dashboard takes
+  `avg` to produce the rating tile.
+
+Drop-off rate is computed in the dashboard query as:
+
+```
+100 * (1 - (chapter_completed_total / enrollments.created_total))
+```
+
+over the chosen window — no separate emitter required.
+
+Still TODO (panels render "no data" gracefully):
+
+* `equip.questions.*` — course Q&A surface when it lands.
+* `equip.completion.chapter_avg_pct` — per-chapter aggregate.
+* `equip.engagement.first_dropoff.p50` — needs session-window
+  computation; deferred until session_id tagging lands.
 
 ## See also
 

--- a/docs/datadog/course-engagement-dashboard.json
+++ b/docs/datadog/course-engagement-dashboard.json
@@ -61,14 +61,27 @@
           {
             "definition": {
               "type": "query_value",
-              "title": "Active enrollments (7d)",
+              "title": "New enrollments (7d)",
               "requests": [
                 {
-                  "q": "sum:equip.enrollments.active_7d{env:$env.value,course_id:$course_id.value}",
+                  "q": "sum:equip.enrollments.created_total{env:$env.value,course_id:$course_id.value}.rollup(sum, 604800)",
                   "aggregator": "last"
                 }
               ],
               "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Enrollments per day (by course)",
+              "requests": [
+                {
+                  "q": "sum:equip.enrollments.created_total{env:$env.value,course_id:$course_id.value} by {course_id}.rollup(sum, 86400)",
+                  "display_type": "bars"
+                }
+              ],
+              "yaxis": { "min": "0", "include_zero": true }
             }
           }
         ]
@@ -115,25 +128,44 @@
           {
             "definition": {
               "type": "query_value",
-              "title": "Median time to first drop-off",
+              "title": "Chapter completions (7d)",
               "requests": [
                 {
-                  "q": "avg:equip.engagement.first_dropoff.p50{env:$env.value,course_id:$course_id.value}",
-                  "aggregator": "avg"
+                  "q": "sum:equip.engagement.chapter_completed_total{env:$env.value,course_id:$course_id.value}.rollup(sum, 604800)",
+                  "aggregator": "last"
                 }
               ],
-              "custom_unit": "s"
+              "precision": 0
             }
           },
           {
             "definition": {
               "type": "toplist",
-              "title": "Drop-off chapters (top 10)",
+              "title": "Completion paths (by type, last 7d)",
               "requests": [
                 {
-                  "q": "top(sum:equip.engagement.dropoff_count{env:$env.value,course_id:$course_id.value} by {chapter_id}.rollup(last_7d), 10, 'sum', 'desc')"
+                  "q": "top(sum:equip.engagement.chapter_completed_total{env:$env.value,course_id:$course_id.value} by {completion_type}.rollup(sum, 604800), 5, 'sum', 'desc')"
                 }
               ]
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Drop-off rate (7d, derived)",
+              "requests": [
+                {
+                  "q": "100 * (1 - (sum:equip.engagement.chapter_completed_total{env:$env.value,course_id:$course_id.value}.rollup(sum, 604800) / sum:equip.enrollments.created_total{env:$env.value,course_id:$course_id.value}.rollup(sum, 604800)))",
+                  "aggregator": "last",
+                  "conditional_formats": [
+                    { "comparator": "<", "value": 30, "palette": "white_on_green" },
+                    { "comparator": "<", "value": 60, "palette": "white_on_yellow" },
+                    { "comparator": ">=", "value": 60, "palette": "white_on_red" }
+                  ]
+                }
+              ],
+              "custom_unit": "%",
+              "precision": 1
             }
           }
         ]
@@ -151,7 +183,7 @@
               "title": "Average rating (out of 5)",
               "requests": [
                 {
-                  "q": "avg:equip.reviews.rating_avg{env:$env.value,course_id:$course_id.value}",
+                  "q": "avg:equip.reviews.rating_latest{env:$env.value,course_id:$course_id.value}",
                   "aggregator": "avg",
                   "conditional_formats": [
                     { "comparator": ">", "value": 4, "palette": "white_on_green" },


### PR DESCRIPTION
Dashboard JSON referenced metric names that didn't exist yet (`equip.enrollments.active_7d`, `equip.engagement.dropoff_count`, `equip.reviews.rating_avg`). This PR replaces them with the names actually emitted by `app/core/metrics.py` callers (PRs #671 through #692).

## Dashboard changes

| Section | Change |
|---|---|
| Active usage | "Active enrollments" tile → "New enrollments (7d)" + per-day bars sourced from `equip.enrollments.created_total` |
| Drop-off | `median time to first drop-off` tile removed (needs session-window computation; deferred until `session_id` tagging lands) |
| Drop-off | New "Chapter completions (7d)" query_value tile |
| Drop-off | New "Completion paths (by type, 7d)" toplist keyed on `completion_type` (teacher / quiz / assignment) |
| Drop-off | New "Drop-off rate (7d, derived)" tile computing `100 * (1 - chapter_completed / enrollments)` with traffic-light bands |
| Quality | Rating tile query `equip.reviews.rating_avg` → `equip.reviews.rating_latest` (actual emitted gauge; Datadog takes `avg` over window) |

## README changes

`README.md` "Required metrics" section rewritten to match the log-based metric reality — replaces the stale StatsD-era prose with a 6-line per-metric site map + the drop-off derivation formula + the still-TODO list.

## Test plan

- [x] Dashboard JSON validates via `python json.load`
- [x] All referenced metric names now exist (cross-checked against backend emission sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)