### PR TITLE
fix(ui): drop resting border from Card

### DIFF
--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -8,17 +8,22 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      // `transition-[border-color,background-color]` (not just `transition-colors`)
-      // keeps the hover handoff smooth on cards that change border tint on hover
-      // — multiple call sites use `hover:border-primary/25..40`. Without this the
-      // border jumps; with it, the hue settles over ~200ms, which reads as the
-      // card "noticing" the cursor instead of toggling.
+      // 2026-06-02 UX call (Vadym): default Card drops the resting
+      // border — bg-surface-elevated alone separates from the page,
+      // and the all-bordered look read as cheap HTML chrome. Call
+      // sites that need a frame (selected state, dnd-drop zone,
+      // hover handoff via `hover:border-primary/40`) opt back in
+      // explicitly via `className="border border-edge"`.
+      //
+      // `transition-[border-color,background-color]` (kept) so the
+      // opt-in border-tint transitions stay smooth.
       //
       // ADR-0011 Wave 3 — migrated from `border-border bg-card
-      // text-card-foreground` to the v2 semantic vocabulary (`border-edge
-      // bg-surface-elevated text-ink`). Identical pixels today via the
-      // tokens-bridge layer; flips to OKLCH in Wave 9 with no code change.
-      "rounded-md border border-edge bg-surface-elevated text-ink shadow-none transition-[border-color,background-color] duration-200 ease-editorial",
+      // text-card-foreground` to the v2 semantic vocabulary
+      // (`bg-surface-elevated text-ink`). Identical pixels today via
+      // the tokens-bridge layer; flips to OKLCH in Wave 9 with no
+      // code change.
+      "rounded-md bg-surface-elevated text-ink shadow-none transition-[border-color,background-color] duration-200 ease-editorial",
       className
     )}
     {...props}

--- a/frontend/src/styles/__tests__/wave3-card-button.test.ts
+++ b/frontend/src/styles/__tests__/wave3-card-button.test.ts
@@ -49,10 +49,13 @@ describe("ADR-0011 Wave 3 — Card + Button migration", () => {
     }
   });
 
-  it("Card uses v2 classes (bg-surface-elevated / border-edge / text-ink)", () => {
+  it("Card uses v2 classes (bg-surface-elevated / text-ink) — no resting border by default", () => {
+    // 2026-06-02 UX call (Vadym): Card dropped its resting
+    // ``border border-edge``; the bg-surface-elevated tone alone
+    // separates the card from the page. Call sites that want a
+    // frame opt back in explicitly.
     const code = readNonComment(CARD_FILE);
     expect(code.includes("bg-surface-elevated")).toBe(true);
-    expect(code.includes("border-edge")).toBe(true);
     expect(code.includes("text-ink")).toBe(true);
     expect(code.includes("text-ink-muted")).toBe(true);
     // v1 names removed (word-boundary lock-out so suffix forms like


### PR DESCRIPTION
**UX call (Vadym, 2026-06-02):** the `border border-edge` on every Card read as cheap HTML chrome — every tile framed, no breathing room, layout looked like a 90s admin table.

## What

* Default `<Card/>` renders **without a border**.
* The `bg-surface-elevated` tone (`--card` vs `--background`, ~2% L separation) already distinguishes the card from the page.
* Call sites that *need* a frame — selected/active state, dnd-drop zone hover, the `hover:border-primary/40` handoff used by the catalog cards — opt back in by passing `className="border border-edge"` (or whatever variant they already use). No site needs to change because they all already pass their own className with the variant they want.
* `transition-[border-color,background-color]` stays so the opt-in border-tint transitions still feel right.

## Sentinel

`wave3-card-button.test.ts` no longer requires `border-edge` on Card; the bg + text assertions stay.

## Test plan

- [x] Full frontend suite green (518 tests)
- [x] eslint + tsc clean
- [ ] Eyeball review in browser (Vadym)

🤖 Generated with [Claude Code](https://claude.com/claude-code)