### PR TITLE
docs(runbooks): mark backup-restore.md as planning-only — Free Plan, no backups

### DIFF
--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,8 +1,32 @@
 # Supabase backup + restore runbook
 
-Equip's database lives on Supabase managed Postgres with WAL-G
-point-in-time recovery (PITR) enabled. This runbook covers the two
-operational scenarios that matter:
+> ⚠️ **STATUS — 2026-06-02: NO BACKUPS ACTIVE ON PROD.**
+>
+> Equip prod is on Supabase **Free Plan**. Free Plan has no
+> scheduled backups, no PITR, no cross-project restore. If prod is
+> lost today, **there is no recovery path** — everything in the
+> Equip Supabase project disappears with it.
+>
+> This is a **deliberate decision** (2026-06-02, Vadym): no real
+> users yet → not worth the $25/mo Pro tier. See
+> [`docs/runbooks/backup-smoke-2026-06-02.md`](./backup-smoke-2026-06-02.md)
+> for the read-only baseline that will let a future restore prove
+> itself.
+>
+> **Trigger to act:** first real pilot enrollment → upgrade to Pro
+> within 24h, then run the smoke against the post-upgrade project to
+> seed a fresh baseline. The drill below becomes runnable at that
+> point, **not before**.
+>
+> Until then this runbook is **planning material only** — the steps
+> describe what we'll do once Pro is active; do not try to follow
+> them against the current Free-tier project, the UI options
+> described won't be visible.
+
+Equip's database lives on Supabase managed Postgres. Once on Pro,
+WAL-G point-in-time recovery (PITR) becomes available as a paid
+add-on. This runbook covers the two operational scenarios that
+matter:
 
 1. **Routine drill** — a quarterly restore of the latest backup into
    a throwaway target, to prove the backup is actually usable.


### PR DESCRIPTION
**Honest correction.** The runbook's opening prose claimed 'WAL-G PITR enabled' but Equip prod is on Supabase **Free Plan** — no scheduled backups, no PITR, no cross-project restore. Following the runbook today would fail at step 1 because the UI options it describes aren't visible on Free.

## What changed

Adds a clear ⚠️ warning header at the top of `backup-restore.md`:
- States the actual current state (Free Plan, no backups)
- Names the deliberate decision (2026-06-02, Vadym: defer Pro until pilot day)
- Points to `backup-smoke-2026-06-02.md` for the post-upgrade baseline
- Names the trigger to revisit: first real pilot enrollment → upgrade Pro within 24h → drill becomes runnable

## What stays

The body of the runbook is the right plan, just not runnable until Pro is bought. Marked as 'planning material only' so future readers don't try to follow it against the Free tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)