### PR TITLE
fix(design): soften --border token — dividers fade to hint, inputs stay sharp

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -44,7 +44,11 @@
     --warning-foreground: 265 28% 13%;
     --info: 215 75% 42%;
     --info-foreground: 0 0% 98%;
-    --border: 265 12% 87%;
+    /* 2026-06-03 UX call (Vadym): --border softened from 87% L to
+     * 94% L so directional dividers + remaining edge lines fade to
+     * a hint instead of an HTML-table grid. --input stays sharp at
+     * 87% L because field affordance IS the border. */
+    --border: 265 8% 94%;
     --input: 265 12% 87%;
     --ring: 262 56% 38%;
     --radius: 0.5rem;
@@ -93,7 +97,11 @@
     --warning-foreground: 240 12% 10%;
     --info: 215 72% 58%;
     --info-foreground: 240 12% 10%;
-    --border: 240 5% 19%;
+    /* Dark-mode counterpart of the light-mode softening: --border
+     * drops from 19% L to 13% L so it's nearly bg-card (12% L),
+     * dividers fade to a hint. --input stays at 19% L so form
+     * fields keep a visible boundary. */
+    --border: 240 5% 13%;
     --input: 240 5% 19%;
     --ring: 262 58% 72%;
 


### PR DESCRIPTION
**Vadym's UX call (2026-06-03).** After #696 + #699 removed full-perimeter borders from cards, the **directional dividers** (`border-b border-edge` section headers, `border-t border-edge` footer separators, tab underlines) still read as too prominent — HTML-table-grid energy across the app.

## Root-cause fix at the token layer

Instead of sweeping ~40 more files to remove individual directional borders, this PR decouples the two semantic tokens that used to share a value.

| Token | Before | After | Drives |
|---|---|---|---|
| `--border` (light) | `265 12% 87%` | `265 8% 94%` | dividers, section underlines, optional card frames |
| `--input` (light) | `265 12% 87%` | (unchanged) | form field borders |
| `--border` (dark) | `240 5% 19%` | `240 5% 13%` | as above |
| `--input` (dark) | `240 5% 19%` | (unchanged) | form field borders |

## Why two tokens diverge

- `--border` (== `--color-edge` after bridge) drives dividers, section underlines, panel headers, optional card frames. **Decorative — should be a hint, not a frame.**
- `--input` (== `--color-edge-strong`) drives form field borders. **The border IS the field affordance** — a user must see where the input starts.

The two tokens used to be identical; decoupling them is the principled v2 design. The bridge already exposes them as separate semantic names — this PR just finally gives them different visual weight.

## Test plan

- [x] Full frontend suite green (518 tests)
- [x] eslint + tsc clean
- [x] No component code changed — single CSS token tweak in `src/index.css`
- [ ] Eyeball review in both light + dark mode (Vadym)

🤖 Generated with [Claude Code](https://claude.com/claude-code)