### PR TITLE
fix(db): Supabase advisors sweep + translation-worker cron restored

### DIFF
--- a/supabase/migrations/20260603140000_lock_function_search_paths_v2.sql
+++ b/supabase/migrations/20260603140000_lock_function_search_paths_v2.sql
@@ -1,0 +1,16 @@
+-- Supabase migration: lock_function_search_paths_v2
+-- Version: 20260603140000
+--
+-- Follow-up to 20260422215624. Two functions added after that
+-- migration carry mutable search_path (Supabase security advisor
+-- 0011_function_search_path_mutable). Lock them to the same
+-- ``pg_catalog, public`` scope the earlier batch used.
+--
+-- Why this matters: a mutable search_path on a SECURITY-sensitive
+-- function (or any function called from a trigger that touches
+-- privileged tables) is a privilege-escalation hazard. Even though
+-- these two are SECURITY INVOKER, future maintenance could flip
+-- them — locking the search_path now is cheap insurance.
+
+ALTER FUNCTION public.content_versions_set_updated_at() SET search_path = pg_catalog, public;
+ALTER FUNCTION public.dc_schedule_assert_publishable() SET search_path = pg_catalog, public;

--- a/supabase/migrations/20260603140100_missing_fk_indexes_v2.sql
+++ b/supabase/migrations/20260603140100_missing_fk_indexes_v2.sql
@@ -1,0 +1,59 @@
+-- Supabase migration: missing_fk_indexes_v2
+-- Version: 20260603140100
+--
+-- Follow-up to 20260521230202_missing_fk_indexes.sql. Tables added
+-- after that batch (content_versions, daily_challenge_*, the new
+-- translation_jobs) carry FK constraints without covering indexes,
+-- per Supabase performance advisor 0001.
+--
+-- Same opinion as the prior migration: at pre-pilot row counts the
+-- planner picks seq_scan and the indexes look unused — but every FK
+-- without an index is a 100ms ceiling waiting to break the moment
+-- the parent table hits 10k+ rows. Each index here is a few KB on
+-- disk; cheap insurance.
+
+-- content_versions — authored_by + superseded_by are user FKs hit by
+-- the editorial audit views.
+CREATE INDEX IF NOT EXISTS ix_content_versions_authored_by
+    ON content_versions(authored_by)
+    WHERE authored_by IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ix_content_versions_superseded_by
+    ON content_versions(superseded_by)
+    WHERE superseded_by IS NOT NULL;
+
+-- daily_challenge_attempts — selected_option_id is what answer-correctness
+-- joins on at result-render time.
+CREATE INDEX IF NOT EXISTS ix_dc_attempts_selected_option_id
+    ON daily_challenge_attempts(selected_option_id)
+    WHERE selected_option_id IS NOT NULL;
+
+-- daily_challenge_question_events — actor_id powers the editorial
+-- audit-log "what did X do" filter.
+CREATE INDEX IF NOT EXISTS ix_dc_q_events_actor_id
+    ON daily_challenge_question_events(actor_id)
+    WHERE actor_id IS NOT NULL;
+
+-- daily_challenge_questions — created_by / published_by / rejected_by
+-- all power the editorial dashboards (the questions tab filters by
+-- "who wrote this", "who shipped this", "who pulled this").
+CREATE INDEX IF NOT EXISTS ix_dc_questions_created_by
+    ON daily_challenge_questions(created_by)
+    WHERE created_by IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ix_dc_questions_published_by
+    ON daily_challenge_questions(published_by)
+    WHERE published_by IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ix_dc_questions_rejected_by
+    ON daily_challenge_questions(rejected_by)
+    WHERE rejected_by IS NOT NULL;
+
+-- daily_challenge_schedule — scheduled_by powers the same editorial
+-- audit cuts.
+CREATE INDEX IF NOT EXISTS ix_dc_schedule_scheduled_by
+    ON daily_challenge_schedule(scheduled_by)
+    WHERE scheduled_by IS NOT NULL;
+
+-- translation_jobs — requested_by is filtered when an admin views
+-- "translations I queued".
+CREATE INDEX IF NOT EXISTS ix_translation_jobs_requested_by
+    ON translation_jobs(requested_by)
+    WHERE requested_by IS NOT NULL;

--- a/supabase/migrations/20260603140200_dc_questions_consolidate_select_policies.sql
+++ b/supabase/migrations/20260603140200_dc_questions_consolidate_select_policies.sql
@@ -1,0 +1,45 @@
+-- Supabase migration: dc_questions_consolidate_select_policies
+-- Version: 20260603140200
+--
+-- Supabase performance advisor 0006_multiple_permissive_policies:
+-- ``daily_challenge_questions`` carries TWO permissive SELECT
+-- policies for the ``authenticated`` role
+-- (``dc_questions_select_archive`` + ``dc_questions_select_editorial``).
+-- Postgres has to evaluate BOTH per query, OR them, then apply the
+-- result — that's avoidable overhead.
+--
+-- Fix: collapse to one policy whose USING expression is the same OR
+-- the two used to compute implicitly. Semantics unchanged:
+--   * Published, scheduled, non-rejected questions visible to everyone
+--     authenticated (the archive surface).
+--   * Teachers + admins see everything (the editorial dashboard).
+
+DROP POLICY IF EXISTS dc_questions_select_archive ON public.daily_challenge_questions;
+DROP POLICY IF EXISTS dc_questions_select_editorial ON public.daily_challenge_questions;
+
+CREATE POLICY dc_questions_select
+    ON public.daily_challenge_questions
+    FOR SELECT
+    TO authenticated
+    USING (
+        -- Editorial: teachers + admins always see all rows.
+        (EXISTS (
+            SELECT 1
+            FROM public.profiles p
+            WHERE p.id = (SELECT auth.uid())
+              AND p.role = ANY (ARRAY['teacher'::text, 'admin'::text])
+        ))
+        OR
+        -- Public archive: published + not-rejected, on or after a
+        -- scheduled day that already arrived.
+        (
+            status = 'published'
+            AND rejected = false
+            AND EXISTS (
+                SELECT 1
+                FROM public.daily_challenge_schedule s
+                WHERE s.question_id = daily_challenge_questions.id
+                  AND s.challenge_date <= ((now() AT TIME ZONE 'UTC')::date)
+            )
+        )
+    );


### PR DESCRIPTION
**Stability sweep.** Pulled Supabase advisors + Vercel logs; shipped fixes for every actionable item.

## 🔴 Headline find: translation-worker cron was 401 for ~37 minutes

`GET /api/v1/internal/translation-worker` returned **401 every minute** since at least 09:23 UTC. Translation queue completely stalled.

**Root cause:** Vercel Cron auto-attaches `Authorization: Bearer $\{CRON_SECRET\}`, but the project had **no `CRON_SECRET` env var set**. With no value, Vercel sent **no auth header at all**; the worker's `hmac.compare_digest` rejected the empty string.

**Fix:** `vercel env add CRON_SECRET production` = same value as the existing `TRANSLATION_WORKER_SECRET`. Redeployed prod backend. Confirmed: 10:07 last 401, 10:08+ all **200**.

## Supabase advisors cleared

| Migration | Advisory |
|---|---|
| `lock_function_search_paths_v2` | 2 functions added after the original lockdown carried mutable `search_path` — locked to `pg_catalog, public` |
| `missing_fk_indexes_v2` | 9 FK columns without covering indexes (content_versions × 2, daily_challenge × 7, translation_jobs × 1) — partial indexes `WHERE col IS NOT NULL` |
| `dc_questions_consolidate_select_policies` | 2 permissive SELECT policies on daily_challenge_questions collapsed into one with the same OR semantics |

## Not in this PR (require dashboard / flagged for Vadym)

- `auth_leaked_password_protection` WARN — toggle in Supabase dashboard → Authentication → Settings (enables HaveIBeenPwned check on new passwords).

## Deliberately not actioned

- 27 `unused_index` INFO entries — pre-pilot traffic means none of these indexes have been hit yet. Removing now would just have to be re-added when traffic comes. See [[project-equip-prerelease-risk-window]].

🤖 Generated with [Claude Code](https://claude.com/claude-code)