### PR TITLE
fix(auth): dedupe simultaneous enrichProfile() calls for same user

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -22,8 +22,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true)
   const mounted = useRef(true)
   const activeUserId = useRef<string | null>(null)
+  // ``inflightUserId`` deduplicates *simultaneous* enrichProfile() calls
+  // for the same user. The activeUserId guards at the onAuthStateChange
+  // callsites short-circuit *sequential* duplicates (SIGNED_IN after
+  // INITIAL_SESSION), but they don't help when two events fire in the
+  // same render tick — both setting activeUserId.current = uid before
+  // either's supabase request lands. Production /rest/v1/profiles logs
+  // showed duplicate GETs 2µs apart for every tab focus.
+  const inflightUserId = useRef<string | null>(null)
 
   const enrichProfile = useCallback((userId: string, email: string) => {
+    // Same userId already in flight — second caller piggybacks on the
+    // first result (which will setUser + setLoading(false) once).
+    if (inflightUserId.current === userId) return
+    inflightUserId.current = userId
     activeUserId.current = userId
     // Supabase resolves with `{ data, error }` even for failures — it does NOT
     // reject the promise — so relying on the `.then` rejection handler only
@@ -36,6 +48,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       .single()
       .then(
         ({ data, error }) => {
+          // Clear inflight regardless of outcome — a failed fetch
+          // should still allow a fresh retry on the next tab focus.
+          if (inflightUserId.current === userId) inflightUserId.current = null
           if (!mounted.current || activeUserId.current !== userId) return
           if (error || !data) {
             setLoading(false)
@@ -72,6 +87,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           setLoading(false)
         },
         () => {
+          if (inflightUserId.current === userId) inflightUserId.current = null
           if (mounted.current && activeUserId.current === userId) {
             setLoading(false)
           }


### PR DESCRIPTION
**Discovered in production logs.**

Supabase `/rest/v1/profiles` logs showed duplicate `GET profiles?select=*&id=eq.<UUID>` requests fired **2µs apart** on every tab focus. Same user, same JWT, two identical round-trips per resume.

## Root cause

`onAuthStateChange` fires both `INITIAL_SESSION` and `SIGNED_IN` for the same session moments apart on tab focus. Each event calls `enrichProfile`, which sets `activeUserId.current = userId` THEN starts the supabase request. The `activeUserId` guard at the **callsites** short-circuits *sequential* duplicates (SIGNED_IN after INITIAL_SESSION already set the ref), but doesn't help when both events fire in the same render tick — both pass through the guard and start parallel requests.

## Fix

Add an `inflightUserId` ref. `enrichProfile` bails immediately if a request for the same userId is already in flight. Cleared in **both** success and error handlers of the supabase promise so a failed fetch can be retried on the next focus.

## Impact

- No functional change for users — both responses would've populated the same user state.
- 50% fewer profile fetches at steady-state.
- One less log line per focus in the production Supabase REST logs.

## Test plan

- [x] Full frontend suite green (518 tests)
- [x] AuthContext tests pass (7 tests)
- [x] eslint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)