### PR TITLE
feat(datadog): source-controlled monitors — translation-worker 401, cron silent, backend 5xx

### DIFF
--- a/docs/datadog/monitors/README.md
+++ b/docs/datadog/monitors/README.md
@@ -1,0 +1,63 @@
+# Datadog monitors — Equip
+
+Source-controlled monitor definitions for the Datadog log-alert
+monitors that watch Equip's prod surface. Same pattern as the
+dashboard JSON files in `../`: tweak in the Datadog UI when needed,
+re-export the JSON back into this directory in the same PR so the
+source of truth stays in git.
+
+## Why monitors live here in JSON
+
+We hit a real outage on 2026-06-03: the translation-worker cron
+returned 401 every minute for ~37 minutes (`CRON_SECRET` env var
+missing, Vercel sent no auth header). No monitor caught it — we
+noticed only when sweeping logs by hand. These JSON files exist so
+the next missing-secret regression pages on minute 6, not minute 37.
+
+## Inventory
+
+| File | What it catches | Priority |
+|---|---|---|
+| `translation-worker-401-rate.json` | Cron is firing but auth fails (≥ 5 401s in 15 min) | P2 |
+| `worker-cron-silent.json` | Cron is NOT firing at all (≥ 15 min with no log line) | P2 |
+| `backend-5xx-rate.json` | Backend 5xx rate > 5% over 10 min | P1 |
+
+## Importing into Datadog
+
+1. Datadog UI → `Monitors` → `New Monitor` → `Import` (bottom right).
+2. Paste the file contents.
+3. Confirm the slack handle in the `message` field matches the
+   actual on-call channel (each monitor uses `@slack-equip-oncall`
+   as a placeholder; rename when wiring).
+4. Save.
+
+## Editing convention
+
+When tuning a threshold in the UI:
+
+1. Open the monitor → `Edit JSON` (right side of the edit form).
+2. Copy the JSON back into the matching file in this directory.
+3. Same PR that ships the new threshold value to prod.
+
+Out-of-band tweaks rot fast — within a month nobody remembers why
+the threshold is 7 instead of 5.
+
+## Open follow-ups
+
+- **`equip.engagement.drop_off_rate` monitor** — once the dashboard
+  derived-metric stabilizes, add a P3 monitor that pages on a 30%
+  drop-off ceiling per course.
+- **`equip.translation.queue_depth` saturation monitor** — when
+  `translation_jobs` queued > 50 for > 1h, page; queue isn't draining
+  fast enough. (Requires adding a gauge emitter in
+  `app/services/translation/queue.py` first.)
+- **Vercel-side cron health check via Vercel Cron Audit log** —
+  belt + braces over the Datadog log-presence check; Vercel's own
+  cron history page surfaces failures even if Datadog forwarder
+  breaks.
+
+## Related
+
+- `../course-engagement-dashboard.json` and `../teacher-load-dashboard.json` — the dashboards these monitors complement.
+- [[reference-equip-vercel-cron-secret]] in personal memory — the
+  trap the 401-rate monitor is built to catch.

--- a/docs/datadog/monitors/backend-5xx-rate.json
+++ b/docs/datadog/monitors/backend-5xx-rate.json
@@ -1,0 +1,22 @@
+{
+  "name": "[Equip] Backend 5xx error rate exceeds 5%",
+  "type": "log alert",
+  "query": "formula(\"a / (a + b) * 100\", queries=[logs(\"service:equip-backend @http.status_code:5*\").index(\"*\").rollup(\"count\").last(\"10m\"), logs(\"service:equip-backend @http.status_code:2*\").index(\"*\").rollup(\"count\").last(\"10m\")]) > 5",
+  "message": "## Backend 5xx error rate above 5%\n\nFastAPI on `api.equipbible.com` is returning 5xx for more than 5% of requests over the last 10 minutes. Real users (or the Vercel Cron / Synthetics) are seeing failures.\n\n## First-look triage\n\n1. Open the most-recent failing request in Datadog Logs (filter `service:equip-backend @http.status_code:5*`).\n2. Inspect the `traceback` attribute — Sentry-style stack lives there.\n3. Common culprits:\n   - **DB connection failures** (`asyncpg`/`sqlalchemy` timeout) → check Supabase project status page first.\n   - **Vercel cold-start timeout** (10s on hobby tier) → flapping is acceptable; sustained failures are not.\n   - **Code regression** in the last deployment → `vercel rollback` to the previous prod deploy if the trace points at a recent commit.\n\n## Why this threshold\n\n5% over 10 min = roughly 1-in-20 requests failing for a sustained window. Below that, individual flakes (network resets, occasional Supabase rebalance) are normal; above it, something is structurally wrong.\n\n@slack-equip-oncall",
+  "tags": [
+    "service:equip-backend",
+    "team:equip",
+    "env:prod"
+  ],
+  "options": {
+    "thresholds": { "critical": 5, "warning": 2 },
+    "notify_audit": false,
+    "notify_no_data": false,
+    "renotify_interval": 60,
+    "include_tags": true,
+    "evaluation_delay": 60,
+    "new_host_delay": 300
+  },
+  "priority": 1,
+  "restricted_roles": null
+}

--- a/docs/datadog/monitors/translation-worker-401-rate.json
+++ b/docs/datadog/monitors/translation-worker-401-rate.json
@@ -1,0 +1,24 @@
+{
+  "name": "[Equip] Translation worker auth failures (401 on cron)",
+  "type": "log alert",
+  "query": "logs(\"service:equip-backend @http.url_details.path:/api/v1/internal/translation-worker @http.status_code:401\").index(\"*\").rollup(\"count\").last(\"15m\") > 5",
+  "message": "## Translation worker cron is 401'ing\n\nThe Vercel Cron tick at `/api/v1/internal/translation-worker` is returning **401 Unauthorized** instead of 200. Translation queue draining has stopped — every minute that this stays broken, the queue backlog grows by however many courses are queued.\n\n## Most common root cause\n\nThe `CRON_SECRET` env var on Vercel is missing or doesn't match `TRANSLATION_WORKER_SECRET`. Vercel auto-attaches `Authorization: Bearer ${CRON_SECRET}` — if the env var is unset, Vercel sends no auth header and the worker's `hmac.compare_digest` rejects the empty string.\n\nFix (~2 min wall-clock):\n```bash\ncd equip/backend\nvercel env ls | grep -E 'CRON_SECRET|TRANSLATION_WORKER_SECRET'\n# Confirm CRON_SECRET present and value matches TRANSLATION_WORKER_SECRET.\n# If missing or wrong:\necho \"<value of TRANSLATION_WORKER_SECRET>\" | vercel env add CRON_SECRET production\nvercel deploy --prod --yes\n```\n\nSee [[reference-equip-vercel-cron-secret]] in personal memory.\n\n## Why this paging threshold\n\nCron fires once per minute. 5 consecutive 401s in 15 minutes = the queue has been stalled for at least 5 cron ticks. Below 5, we tolerate transient cold-start hiccups; above 5, the stall is structural.\n\n@slack-equip-oncall",
+  "tags": [
+    "service:equip-backend",
+    "team:equip",
+    "feature:translation-queue",
+    "env:prod"
+  ],
+  "options": {
+    "thresholds": { "critical": 5 },
+    "notify_audit": false,
+    "notify_no_data": false,
+    "no_data_timeframe": 30,
+    "renotify_interval": 60,
+    "include_tags": true,
+    "evaluation_delay": 60,
+    "new_host_delay": 300
+  },
+  "priority": 2,
+  "restricted_roles": null
+}

--- a/docs/datadog/monitors/worker-cron-silent.json
+++ b/docs/datadog/monitors/worker-cron-silent.json
@@ -1,0 +1,24 @@
+{
+  "name": "[Equip] Vercel Cron not firing translation worker (silent)",
+  "type": "log alert",
+  "query": "logs(\"service:equip-backend @http.url_details.path:/api/v1/internal/translation-worker\").index(\"*\").rollup(\"count\").last(\"15m\") < 1",
+  "message": "## Vercel Cron stopped firing\n\nThe `/api/v1/internal/translation-worker` endpoint hasn't received **any** request in the last 15 minutes. The cron schedule is `*/1 * * * *` (every minute), so this should never happen during a healthy deploy.\n\nPossible causes:\n\n1. **Vercel Cron is disabled or misconfigured.** Open https://vercel.com/vadyms-projects-dfb6f76f/equip-backend/settings/cron-jobs and confirm the cron is enabled + the path matches `vercel.json`.\n2. **Deploy in flight stuck.** A new prod deploy that's failing to promote leaves the previous one running but with the new build's cron config — if the new build broke cron, jobs disappear.\n3. **Datadog log forwarder broken.** If Datadog stopped receiving Vercel logs entirely, this alert fires but the cron itself is fine. Cross-check with `vercel logs --project equip-backend --since 5m` from the CLI before paging.\n\n## Why this distinct from the 401-rate alert\n\n401-rate monitor catches \"cron fires but auth is wrong.\" This monitor catches \"cron doesn't fire at all.\" Both are independent failure modes that need different fixes.\n\n@slack-equip-oncall",
+  "tags": [
+    "service:equip-backend",
+    "team:equip",
+    "feature:translation-queue",
+    "env:prod"
+  ],
+  "options": {
+    "thresholds": { "critical": 1 },
+    "notify_audit": false,
+    "notify_no_data": true,
+    "no_data_timeframe": 20,
+    "renotify_interval": 120,
+    "include_tags": true,
+    "evaluation_delay": 60,
+    "new_host_delay": 300
+  },
+  "priority": 2,
+  "restricted_roles": null
+}


### PR DESCRIPTION
**Born from the 2026-06-03 outage.** Translation-worker cron returned 401 every minute for ~37 minutes (`CRON_SECRET` env var missing, Vercel sent no auth header). No monitor caught it — we noticed only when sweeping logs by hand.

These JSON files exist so the next missing-secret regression pages on minute 6, not minute 37.

## What

| File | What it catches | Priority |
|---|---|---|
| `translation-worker-401-rate.json` | Cron is firing but auth fails (≥ 5 401s in 15 min) | **P2** |
| `worker-cron-silent.json` | Cron is NOT firing at all (≥ 15 min with no log line) | **P2** |
| `backend-5xx-rate.json` | Backend 5xx rate > 5% over 10 min | **P1** |

The first two are deliberately separate — #1 is 'fires but auth wrong', #2 is 'doesn't fire at all'. Different fixes.

## Import flow

`Datadog UI → Monitors → New Monitor → Import` → paste file contents → save. README has full instructions + the editing convention (tweak in UI, re-export JSON to git in same PR).

## Follow-ups

- `equip.engagement.drop_off_rate` monitor (P3) — once the derived-metric on the Course Engagement dashboard stabilizes
- `equip.translation.queue_depth` saturation monitor — needs a new gauge emitter in `app/services/translation/queue.py` first
- Vercel Cron Audit log webhook as belt-and-braces over the Datadog log-presence check

## Test plan

- [x] All 3 JSON files validate via `python json.load`
- [ ] Import into Datadog UI (Vadym)
- [ ] Rename `@slack-equip-oncall` to the actual channel handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)