### PR TITLE
docs(datadog): wire translation queue health widgets

### DIFF
--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -58,6 +58,12 @@ Live emission today (sites tagged with the route file that wires them):
 * **`equip.reviews.rating_latest`** — `app/api/v1/reviews.py` emits
   per (user, course) on review create/update; the dashboard takes
   `avg` to produce the rating tile.
+* **`equip.translation.queue_depth`** + **`queue_processing`** +
+  **`queue_failed_permanent`** — `app/api/v1/
+  internal_translation_worker.py::_emit_queue_gauges` fires three
+  per-status gauges on every cron tick. Drives the Course
+  Engagement dashboard's *Translation queue health* group and the
+  `translation-queue-backlog` monitor.
 
 Drop-off rate is computed in the dashboard query as:
 

--- a/docs/datadog/course-engagement-dashboard.json
+++ b/docs/datadog/course-engagement-dashboard.json
@@ -174,6 +174,81 @@
     {
       "definition": {
         "type": "group",
+        "title": "Translation queue health",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Backlog (queued + failed)",
+              "requests": [
+                {
+                  "q": "avg:equip.translation.queue_depth{env:$env.value}",
+                  "aggregator": "last",
+                  "conditional_formats": [
+                    { "comparator": "<", "value": 10, "palette": "white_on_green" },
+                    { "comparator": "<", "value": 50, "palette": "white_on_yellow" },
+                    { "comparator": ">=", "value": 50, "palette": "white_on_red" }
+                  ]
+                }
+              ],
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "In-flight (processing)",
+              "requests": [
+                {
+                  "q": "avg:equip.translation.queue_processing{env:$env.value}",
+                  "aggregator": "last"
+                }
+              ],
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Dead-lettered (failed_permanent)",
+              "requests": [
+                {
+                  "q": "avg:equip.translation.queue_failed_permanent{env:$env.value}",
+                  "aggregator": "last",
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 0, "palette": "white_on_red" }
+                  ]
+                }
+              ],
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Queue depth over time",
+              "requests": [
+                {
+                  "q": "avg:equip.translation.queue_depth{env:$env.value}",
+                  "display_type": "area",
+                  "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
+                },
+                {
+                  "q": "avg:equip.translation.queue_processing{env:$env.value}",
+                  "display_type": "line",
+                  "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "include_zero": true }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "group",
         "title": "Quality signals",
         "layout_type": "ordered",
         "widgets": [


### PR DESCRIPTION
Adds a **Translation queue health** widget group to the Course Engagement dashboard, sourced from the gauges shipped in #704.

## Widgets

| Widget | Metric | Thresholds |
|---|---|---|
| Backlog | `equip.translation.queue_depth` | green <10 / yellow <50 / red ≥50 |
| In-flight | `equip.translation.queue_processing` | none |
| Dead-lettered | `equip.translation.queue_failed_permanent` | red on >0 |
| Queue depth over time | depth (area) + processing (line) | none |

Thresholds match the `translation-queue-backlog` monitor (#703) so dashboard + monitor stay coherent.

## README

`Required metrics` section gains a stanza on the queue gauges mirroring the existing per-metric site map.

## Test plan

- [x] JSON validates via `python json.load`
- [x] No new metric names introduced — only consumes existing emissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)