### PR TITLE
feat(observability): equip.translation.duration_ms timing per job + dashboard widgets

### DIFF
--- a/backend/app/api/v1/internal_translation_worker.py
+++ b/backend/app/api/v1/internal_translation_worker.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import hmac
 import logging
 import secrets
+import time
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, Header, status
@@ -34,7 +35,7 @@ from sqlalchemy.orm import Session  # noqa: TC002 — used by FastAPI Depends at
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
-from app.core.metrics import gauge
+from app.core.metrics import gauge, timing
 from app.services.course_service import get_course
 from app.services.translation.course_pipeline import translate_course_content
 from app.services.translation.queue import (
@@ -125,6 +126,23 @@ def _emit_queue_gauges(db: Session) -> None:
         return
 
 
+def _emit_translation_duration(start_monotonic: float, *, outcome: str) -> None:
+    """Emit ``equip.translation.duration_ms`` keyed by outcome.
+
+    Tagged with ``outcome={done,failed}`` so the dashboard can split
+    the latency curve by success vs failure — a sustained gap between
+    the two distributions usually means the failure path is timing
+    out on an upstream call.
+
+    Wrapped in try/except so a metric failure cannot break the worker.
+    """
+    try:
+        elapsed_ms = (time.monotonic() - start_monotonic) * 1000.0
+        timing("equip.translation.duration_ms", elapsed_ms, outcome=outcome)
+    except Exception:
+        return
+
+
 def _run_one_tick(db: Session) -> WorkerTickResponse:
     """One claim → process → mark cycle. Extracted so tests can drive
     it directly without going through the FastAPI dependency stack."""
@@ -154,6 +172,10 @@ def _run_one_tick(db: Session) -> WorkerTickResponse:
             attempts=attempts,
         )
 
+    # Measure end-to-end translate_course_content time. ``time.monotonic``
+    # is correct here (not affected by NTP / system clock jumps); we want
+    # elapsed wall time, not absolute timestamps.
+    tick_start = time.monotonic()
     try:
         translate_course_content(db, course)
     except SQLAlchemyError as exc:
@@ -162,6 +184,10 @@ def _run_one_tick(db: Session) -> WorkerTickResponse:
         # commit would itself raise on the still-poisoned session.
         db.rollback()
         mark_job_failed(db, job, error=f"sqlalchemy: {exc}")
+        # Emit duration even on failure so the dashboard's p50/p95
+        # tile includes the cost of failed work (the operator needs
+        # to see if failures are also slow → upstream timeout).
+        _emit_translation_duration(tick_start, outcome="failed")
         logger.exception("translation_worker: SQLAlchemyError on job %s course %s", job_id, course_id)
         return WorkerTickResponse(
             status="failed",
@@ -171,6 +197,7 @@ def _run_one_tick(db: Session) -> WorkerTickResponse:
         )
     except Exception as exc:
         mark_job_failed(db, job, error=f"{type(exc).__name__}: {exc}")
+        _emit_translation_duration(tick_start, outcome="failed")
         logger.exception(
             "translation_worker: unexpected error on job %s course %s",
             job_id,
@@ -183,6 +210,7 @@ def _run_one_tick(db: Session) -> WorkerTickResponse:
             attempts=attempts,
         )
 
+    _emit_translation_duration(tick_start, outcome="done")
     mark_job_done(db, job)
     return WorkerTickResponse(
         status="done",
@@ -276,7 +304,13 @@ def queue_health(
 
 
 # Public surface for tests + future admin tooling.
-__all__ = ["_emit_queue_gauges", "_require_worker_secret", "_run_one_tick", "router"]
+__all__ = [
+    "_emit_queue_gauges",
+    "_emit_translation_duration",
+    "_require_worker_secret",
+    "_run_one_tick",
+    "router",
+]
 
 
 def generate_worker_secret() -> str:

--- a/backend/tests/test_translation_duration_metric.py
+++ b/backend/tests/test_translation_duration_metric.py
@@ -1,0 +1,80 @@
+"""Tests for ``equip.translation.duration_ms`` emission.
+
+Pinned because the Course Engagement dashboard's p50/p95 widget
+splits the latency curve by outcome — a sustained gap between
+``done`` and ``failed`` distributions is the cue that the failure
+path is timing out on Gemini or the YouVersion API. Emission must:
+
+* Fire on every translate_course_content invocation (success + both
+  failure branches).
+* Carry the outcome tag (done / failed) so the dashboard can split.
+* Be non-raising so a metric failure can't break the worker tick.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from app.api.v1.internal_translation_worker import _emit_translation_duration
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestDurationEmission:
+    def test_emits_value_in_milliseconds_with_outcome_tag(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Patch monotonic to return a controlled "now" 2.5 seconds
+        # after start.
+        with (
+            patch("app.api.v1.internal_translation_worker.time.monotonic", return_value=12.5),
+            caplog.at_level(logging.INFO, logger="equip.metric"),
+        ):
+            _emit_translation_duration(start_monotonic=10.0, outcome="done")
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.translation.duration_ms" in m]
+        assert events, "expected duration_ms event"
+        # 2.5 s = 2500 ms.
+        assert any("value=2500.0" in m for m in events)
+        assert any("outcome=done" in m for m in events)
+
+    def test_failed_outcome_keeps_tag_distinct(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with (
+            patch("app.api.v1.internal_translation_worker.time.monotonic", return_value=5.0),
+            caplog.at_level(logging.INFO, logger="equip.metric"),
+        ):
+            _emit_translation_duration(start_monotonic=4.7, outcome="failed")
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.translation.duration_ms" in m]
+        assert events
+        assert any("outcome=failed" in m for m in events)
+        # ~300 ms (floating-point arithmetic: 5.0 - 4.7 yields
+        # 0.29999... so allow a tolerance).
+        assert any(("value=29" in m or "value=30" in m) for m in events)
+
+    def test_swallows_emit_failures(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A logger failure on the timing path MUST NOT propagate —
+        the worker tick must finish even when Datadog forwarder is
+        down."""
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("simulated logger failure")
+
+        # Patch the metrics.timing function (used by the worker) so
+        # the call site raises; the worker helper must catch it.
+        import app.api.v1.internal_translation_worker as worker_module
+
+        monkeypatch.setattr(worker_module, "timing", boom)
+
+        # No assertion — passes if this call doesn't raise.
+        _emit_translation_duration(start_monotonic=0.0, outcome="done")

--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -65,12 +65,19 @@ Live emission today (sites tagged with the route file that wires them):
   `path_prefix` (first 4 url segments), and `exception_type` (class
   name, never the message — message could carry PII). Drives the
   P1 `backend-unhandled-exception-rate` monitor.
-* **`equip.translation.queue_depth`** + **`queue_processing`** +
-  **`queue_failed_permanent`** — `app/api/v1/
+* **`equip.translation.queue_depth`** +
+  **`equip.translation.queue_processing`** +
+  **`equip.translation.queue_failed_permanent`** — `app/api/v1/
   internal_translation_worker.py::_emit_queue_gauges` fires three
   per-status gauges on every cron tick. Drives the Course
   Engagement dashboard's *Translation queue health* group and the
   `translation-queue-backlog` monitor.
+* **`equip.translation.duration_ms`** — `app/api/v1/
+  internal_translation_worker.py::_emit_translation_duration` times
+  each `translate_course_content` run. Tagged with
+  `outcome={done,failed}` so the dashboard can split the latency
+  curve by success vs failure — a sustained gap usually means the
+  failure path is timing out on an upstream call.
 * **`equip.gemini.calls_total`** + **`equip.gemini.tokens_input_total`**
   + **`equip.gemini.tokens_output_total`** —
   `app/services/translation/gemini.py::translate` emits per Gemini

--- a/docs/datadog/course-engagement-dashboard.json
+++ b/docs/datadog/course-engagement-dashboard.json
@@ -226,6 +226,49 @@
           },
           {
             "definition": {
+              "type": "query_value",
+              "title": "Translation p50 (5m)",
+              "requests": [
+                {
+                  "q": "p50:equip.translation.duration_ms{env:$env.value,outcome:done}.rollup(p50, 300)",
+                  "aggregator": "last",
+                  "conditional_formats": [
+                    { "comparator": "<", "value": 5000, "palette": "white_on_green" },
+                    { "comparator": "<", "value": 15000, "palette": "white_on_yellow" },
+                    { "comparator": ">=", "value": 15000, "palette": "white_on_red" }
+                  ]
+                }
+              ],
+              "custom_unit": "ms",
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Translation duration (done vs failed)",
+              "requests": [
+                {
+                  "q": "p50:equip.translation.duration_ms{env:$env.value,outcome:done}",
+                  "display_type": "line",
+                  "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
+                },
+                {
+                  "q": "p95:equip.translation.duration_ms{env:$env.value,outcome:done}",
+                  "display_type": "line",
+                  "style": { "palette": "cool", "line_type": "dashed", "line_width": "normal" }
+                },
+                {
+                  "q": "p50:equip.translation.duration_ms{env:$env.value,outcome:failed}",
+                  "display_type": "line",
+                  "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "include_zero": true }
+            }
+          },
+          {
+            "definition": {
               "type": "timeseries",
               "title": "Queue depth over time",
               "requests": [


### PR DESCRIPTION
Adds the **latency dimension** that the queue depth gauges from #704 were missing. Without duration we can see 'backlog is growing' but not 'growing because new work is coming faster or because each job is slower.'

## Backend

`_emit_translation_duration` fires `equip.translation.duration_ms` tagged with `outcome={done,failed}` around every `translate_course_content` invocation. All three branches (success + SQLAlchemyError + bare Exception) emit so the dashboard's p50/p95 tile can split the curve by outcome — **a sustained gap between done and failed distributions = failure path timing out on Gemini / YouVersion**.

`time.monotonic()` (not `time.time()`) — wall-clock elapsed, immune to NTP / system-clock jumps. Wrapped in try/except — metric failure cannot break the worker.

## Tests (3 new)

- Emits with `outcome=done` tag, value matches mocked elapsed time
- Emits with `outcome=failed` from the failure helper
- Swallows logger failures (worker must finish even if Datadog forwarder is down)

## Dashboard

Two new widgets in the existing `Translation queue health` group:

| Widget | What |
|---|---|
| Translation p50 (5m) | query_value with traffic-light bands (green <5s, yellow <15s, red ≥15s) |
| Translation duration (done vs failed) | p50 + p95 done (cool palette) overlaid on p50 failed (warm). Divergence catches upstream timeouts |

## Test plan

- [x] +3 duration tests
- [x] Full backend suite green (1402+3 tests)
- [x] ruff + mypy clean
- [x] Dashboard JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)