### PR TITLE
feat(observability): equip.errors.unhandled_total counter + monitor

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -128,6 +128,23 @@ async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError):
 @app.exception_handler(Exception)
 async def unhandled_exception_handler(request: Request, exc: Exception):
     logger.error("Unhandled error on %s %s: %s", request.method, request.url.path, exc, exc_info=True)
+    # Counter for the Datadog "backend unhandled exception rate" monitor.
+    # Tagged with method + url-path-prefix + exception_type so a spike
+    # can be triaged without grepping logs. exception_type is the
+    # class name only (no message) — message could carry PII like
+    # uuids / emails from validation errors.
+    try:
+        from app.core.metrics import increment
+
+        path_prefix = "/".join(request.url.path.split("/", 4)[:4]) or "/"
+        increment(
+            "equip.errors.unhandled_total",
+            method=request.method,
+            path_prefix=path_prefix,
+            exception_type=type(exc).__name__,
+        )
+    except Exception:
+        pass
     return JSONResponse(
         status_code=500,
         content={"detail": "Internal server error"},

--- a/backend/tests/test_unhandled_exception_metric.py
+++ b/backend/tests/test_unhandled_exception_metric.py
@@ -1,0 +1,102 @@
+"""Tests for ``equip.errors.unhandled_total`` emission from the
+global FastAPI exception handler.
+
+The metric drives the Datadog "backend unhandled exception rate"
+monitor — current state has us reading raw Vercel logs to find
+500s, which doesn't scale.
+
+Pinned guarantees:
+
+* Fires once per unhandled exception that hits the global handler.
+* Tagged with method + path_prefix + exception_type so a spike
+  is triageable without grepping logs.
+* exception_type is the **class name only** — message content
+  could carry PII (uuids, emails from validation errors); the
+  class name is enough to bucket spikes.
+* Non-raising — a metric failure cannot leak through and turn the
+  500 into a different status code.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+if TYPE_CHECKING:
+    import pytest
+
+_test_router = APIRouter(prefix="/_metric_test", tags=["_internal"])
+
+
+# ``include_in_schema=False`` keeps these test routes callable for the
+# TestClient but invisible to OpenAPI generation, so they DO NOT bleed
+# into the production /openapi.json (and the snapshot contract test
+# stays clean).
+@_test_router.get("/raise-runtime-error", include_in_schema=False)
+def _raise_runtime_error() -> None:
+    raise RuntimeError("boom")
+
+
+@_test_router.get("/raise-key-error", include_in_schema=False)
+def _raise_key_error() -> None:
+    raise KeyError("missing")
+
+
+# Register at module import time so every test that imports this file
+# sees the test routes.
+app.include_router(_test_router)
+
+
+class TestUnhandledExceptionEmission:
+    def test_emits_counter_with_method_path_and_type_tags(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/_metric_test/raise-runtime-error")
+        assert resp.status_code == 500
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.errors.unhandled_total" in m]
+        assert events, "expected unhandled_total event"
+        assert any("method=GET" in m for m in events)
+        assert any("exception_type=RuntimeError" in m for m in events)
+        assert any("path_prefix=/_metric_test" in m or "path_prefix=/_metric_test/" in m for m in events)
+        assert any("value=1.0" in m for m in events)
+
+    def test_emits_different_exception_type_tag(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Two different exception classes raised from two different
+        routes must produce two distinct ``exception_type`` tag values
+        so the dashboard can rank "top error types"."""
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            client = TestClient(app, raise_server_exceptions=False)
+            client.get("/_metric_test/raise-runtime-error")
+            client.get("/_metric_test/raise-key-error")
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.errors.unhandled_total" in m]
+        assert any("exception_type=RuntimeError" in m for m in events)
+        assert any("exception_type=KeyError" in m for m in events)
+
+    def test_does_not_emit_on_normal_request(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """``/health`` doesn't raise — the unhandled-exception counter
+        MUST be silent. Otherwise the dashboard's error-rate widget
+        would show a false-positive baseline that drowns out real
+        spikes."""
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/health")
+        assert resp.status_code == 200
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.errors.unhandled_total" in m]
+        assert events == [], "must NOT fire on a 200 path"

--- a/docs/datadog/monitors/backend-unhandled-exception-rate.json
+++ b/docs/datadog/monitors/backend-unhandled-exception-rate.json
@@ -1,0 +1,22 @@
+{
+  "name": "[Equip] Backend unhandled exception rate spike",
+  "type": "log alert",
+  "query": "logs(\"@metric:equip.errors.unhandled_total\").index(\"*\").rollup(\"count\").last(\"10m\") > 10",
+  "message": "## Backend unhandled exception rate above 10 / 10 min\n\nThe global `unhandled_exception_handler` in `app/main.py` caught more than 10 exceptions in the last 10 minutes. Real users are hitting 500s — and they're NOT for predictable reasons (IntegrityError + SQLAlchemyError + the equip_error code paths are handled separately and do NOT increment this counter).\n\n## First-look triage\n\n1. Group `@metric:equip.errors.unhandled_total` by `exception_type` in Datadog Logs — the top class name is usually the same bug.\n2. Then group by `path_prefix` to find which route is failing. Combined: a top-2 cell like `RuntimeError × /api/v1/grades` means the regression is in the grades router.\n3. Open the most recent log line for that combo and look at the `traceback` attribute (the global handler sets `exc_info=True`).\n4. If the spike correlates with a recent deploy, `vercel rollback` and reopen the diagnosis at leisure.\n\n## Why this is distinct from the 5xx-rate monitor\n\n`backend-5xx-rate.json` triggers on ANY 5xx (including 503 from the SQLAlchemyError handler — Database temporarily unavailable). This monitor only fires on **uncategorised** exceptions — the ones we DON'T have a hand-built `@app.exception_handler` for. That's the signal that says 'a real bug just shipped', not 'Supabase is rebalancing'.\n\n@slack-equip-oncall",
+  "tags": [
+    "service:equip-backend",
+    "team:equip",
+    "env:prod"
+  ],
+  "options": {
+    "thresholds": { "critical": 10, "warning": 3 },
+    "notify_audit": false,
+    "notify_no_data": false,
+    "renotify_interval": 60,
+    "include_tags": true,
+    "evaluation_delay": 60,
+    "new_host_delay": 300
+  },
+  "priority": 1,
+  "restricted_roles": null
+}


### PR DESCRIPTION
The global FastAPI exception handler logs unhandled errors but doesn't emit a metric — we have to grep Vercel logs to find 500s, which doesn't scale.

## Backend

`unhandled_exception_handler` emits `equip.errors.unhandled_total` tagged with `method` + `path_prefix` + `exception_type` after the existing `log.error`.

| Tag | Why bounded |
|---|---|
| `exception_type` | Class name only — message could carry PII (uuids, emails). Class is enough to bucket spikes |
| `path_prefix` | First 4 url path segments (`/api/v1/grades` not `/api/v1/grades/<uuid>`). Bounded cardinality |
| `method` | GET/POST/etc. — naturally bounded |

Wrapped in try/except — metric failure cannot change the 500 into a different status code.

## Tests (3 new)

- Emits counter with method, exception_type, path_prefix, `value=1.0`
- Two distinct exception classes → two distinct `exception_type` tags (top-N ranking must work)
- `/health` (200 path) MUST NOT fire (otherwise dashboard baseline drowns spikes)

Test routes use `include_in_schema=False` so they don't bleed into `/openapi.json` — contract snapshot stays clean.

## Monitor

P1 alert when count > 10 / 10 min, warning at > 3. **Distinct from `backend-5xx-rate.json`**: that one fires on ANY 5xx (including 503 from SQLAlchemyError handler 'Supabase rebalancing'). This one fires only on **uncategorised** exceptions — the 'a real bug just shipped' signal.

## Test plan

- [x] +3 exception counter tests
- [x] Full backend suite green (1402 tests)
- [x] ruff + mypy clean
- [x] Monitor JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)