### PR TITLE
feat(observability): Gemini cost metrics — calls + tokens per outcome

### DIFF
--- a/backend/app/services/translation/gemini.py
+++ b/backend/app/services/translation/gemini.py
@@ -11,6 +11,7 @@ set. See ``app.services.translation.service.get_translation_provider``.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
 from typing import TYPE_CHECKING, Any
@@ -20,6 +21,7 @@ import httpx
 if TYPE_CHECKING:
     from types import TracebackType
 
+from app.core.metrics import emit, increment
 from app.services.bible.substitution import post_substitute, pre_substitute
 from app.services.translation.prompt import build_system_prompt, build_user_prompt
 from app.services.translation.protocol import (
@@ -155,6 +157,30 @@ class GeminiTranslationProvider:
             else:
                 if response.status_code == 200:
                     result = self._parse_response(response.json())
+                    # Emit Gemini cost metrics on every successful 200.
+                    # Tagged with model so a future model migration
+                    # (e.g. flash → pro) keeps the curves separable.
+                    # Wrapped in try/except — metric failure must NEVER
+                    # break the translation pipeline.
+                    try:
+                        increment("equip.gemini.calls_total", model=self._model, outcome="success")
+                        # ``emit`` lets us pass the token count as the metric
+                        # value directly — Datadog ``sum:`` over this gives
+                        # the cumulative token spend.
+                        if result.input_tokens:
+                            emit(
+                                "equip.gemini.tokens_input_total",
+                                float(result.input_tokens),
+                                model=self._model,
+                            )
+                        if result.output_tokens:
+                            emit(
+                                "equip.gemini.tokens_output_total",
+                                float(result.output_tokens),
+                                model=self._model,
+                            )
+                    except Exception:
+                        pass
                     if bible_subs:
                         # Restore Bible quote markers with the canonical
                         # target-locale text. Falls back to source if the
@@ -174,7 +200,21 @@ class GeminiTranslationProvider:
                         attempt,
                         response.text[:200],
                     )
+                    with contextlib.suppress(Exception):
+                        increment(
+                            "equip.gemini.calls_total",
+                            model=self._model,
+                            outcome="retry",
+                            status_code=str(response.status_code),
+                        )
                 else:
+                    with contextlib.suppress(Exception):
+                        increment(
+                            "equip.gemini.calls_total",
+                            model=self._model,
+                            outcome="fatal",
+                            status_code=str(response.status_code),
+                        )
                     raise TranslationError(f"Gemini returned {response.status_code}: {response.text[:200]}")
 
             if attempt < self._max_retries:

--- a/backend/tests/test_gemini_metric_emission.py
+++ b/backend/tests/test_gemini_metric_emission.py
@@ -1,0 +1,178 @@
+"""Tests for ``equip.gemini.*`` emission from
+``GeminiTranslationProvider.translate``.
+
+Cost visibility is the whole point: ``calls_total`` is what tells us
+if we're hammering Gemini, ``tokens_input_total`` / ``tokens_output_total``
+fold into Gemini's $/M-token rate to give us $-burn over the
+window.
+
+Pinned guarantees:
+
+* One ``calls_total`` increment per network call (success, retry, fatal).
+* Token counts emitted via ``emit`` (not ``increment``) so the metric
+  value carries the token count itself — Datadog ``sum:`` over the
+  window gives cumulative spend.
+* Tags include ``model`` so a future flash → pro migration keeps
+  cost curves separable.
+* Outcome is ``success`` / ``retry`` / ``fatal`` — the dashboard
+  should be able to flag a rising retry-rate before it becomes a
+  fatal-rate.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import httpx
+
+from app.services.translation.gemini import GeminiTranslationProvider
+from app.services.translation.protocol import TranslationRequest
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _make_provider(client: httpx.Client) -> GeminiTranslationProvider:
+    return GeminiTranslationProvider(
+        api_key="k",
+        model="gemini-flash-latest",
+        timeout_seconds=1.0,
+        max_output_tokens=256,
+        client=client,
+    )
+
+
+def _gemini_success_response(input_tokens: int = 100, output_tokens: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json={
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [{"text": "Translated"}],
+                    },
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": input_tokens,
+                "candidatesTokenCount": output_tokens,
+            },
+        },
+    )
+
+
+class TestSuccessMetrics:
+    def test_emits_calls_total_with_model_tag(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        client = MagicMock(spec=httpx.Client)
+        client.post.return_value = _gemini_success_response()
+        provider = _make_provider(client)
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            provider.translate(
+                TranslationRequest(
+                    text="Hello",
+                    source_locale="en",
+                    target_locale="ru",
+                    content_kind="text",
+                )
+            )
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        calls = [m for m in msgs if "equip.gemini.calls_total" in m]
+        assert calls, "expected calls_total event"
+        assert any("model=gemini-flash-latest" in m for m in calls)
+        assert any("outcome=success" in m for m in calls)
+        assert any("value=1.0" in m for m in calls)
+
+    def test_token_counts_emitted_as_metric_value(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        client = MagicMock(spec=httpx.Client)
+        client.post.return_value = _gemini_success_response(input_tokens=42, output_tokens=137)
+        provider = _make_provider(client)
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            provider.translate(
+                TranslationRequest(
+                    text="Hello",
+                    source_locale="en",
+                    target_locale="ru",
+                    content_kind="text",
+                )
+            )
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        # Token counts ARE the metric value (not 1.0). sum: over the
+        # window = cumulative token spend.
+        in_events = [m for m in msgs if "equip.gemini.tokens_input_total" in m]
+        out_events = [m for m in msgs if "equip.gemini.tokens_output_total" in m]
+        assert in_events
+        assert out_events
+        assert any("value=42.0" in m for m in in_events)
+        assert any("value=137.0" in m for m in out_events)
+
+    def test_zero_token_count_does_not_emit(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """If Gemini omits usageMetadata (rare but possible), token
+        counts default to 0 — no emit. The cumulative-sum metric
+        would otherwise see meaningless 0-valued rows."""
+        client = MagicMock(spec=httpx.Client)
+        client.post.return_value = httpx.Response(
+            status_code=200,
+            json={
+                "candidates": [{"content": {"parts": [{"text": "Translated"}]}}],
+                # No usageMetadata field at all.
+            },
+        )
+        provider = _make_provider(client)
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            provider.translate(
+                TranslationRequest(
+                    text="Hello",
+                    source_locale="en",
+                    target_locale="ru",
+                    content_kind="text",
+                )
+            )
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        # calls_total still fires; tokens_*_total skipped.
+        assert any("equip.gemini.calls_total" in m for m in msgs)
+        assert not any("equip.gemini.tokens_input_total" in m for m in msgs)
+        assert not any("equip.gemini.tokens_output_total" in m for m in msgs)
+
+
+class TestFatalMetrics:
+    def test_4xx_emits_fatal_outcome(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """400/401/403 are non-retryable — fired as ``outcome=fatal``
+        immediately before raising. Dashboard distinction matters:
+        a rising fatal-rate is "credentials / config broken NOW",
+        rising retry-rate is "Gemini is rate-limiting us"."""
+        client = MagicMock(spec=httpx.Client)
+        client.post.return_value = httpx.Response(
+            status_code=400,
+            text="Bad request",
+        )
+        provider = _make_provider(client)
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            try:
+                provider.translate(
+                    TranslationRequest(
+                        text="Hello",
+                        source_locale="en",
+                        target_locale="ru",
+                        content_kind="text",
+                    )
+                )
+            except Exception:
+                pass  # expected — non-retryable status raises
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        calls = [m for m in msgs if "equip.gemini.calls_total" in m]
+        assert calls
+        assert any("outcome=fatal" in m and "status_code=400" in m for m in calls)

--- a/backend/tests/test_gemini_metric_emission.py
+++ b/backend/tests/test_gemini_metric_emission.py
@@ -21,6 +21,7 @@ Pinned guarantees:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
@@ -160,18 +161,19 @@ class TestFatalMetrics:
             text="Bad request",
         )
         provider = _make_provider(client)
-        with caplog.at_level(logging.INFO, logger="equip.metric"):
-            try:
-                provider.translate(
-                    TranslationRequest(
-                        text="Hello",
-                        source_locale="en",
-                        target_locale="ru",
-                        content_kind="text",
-                    )
+        # non-retryable status raises — expected, we only assert on metrics
+        with (
+            caplog.at_level(logging.INFO, logger="equip.metric"),
+            contextlib.suppress(Exception),
+        ):
+            provider.translate(
+                TranslationRequest(
+                    text="Hello",
+                    source_locale="en",
+                    target_locale="ru",
+                    content_kind="text",
                 )
-            except Exception:
-                pass  # expected — non-retryable status raises
+            )
         msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
         calls = [m for m in msgs if "equip.gemini.calls_total" in m]
         assert calls

--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -64,6 +64,14 @@ Live emission today (sites tagged with the route file that wires them):
   per-status gauges on every cron tick. Drives the Course
   Engagement dashboard's *Translation queue health* group and the
   `translation-queue-backlog` monitor.
+* **`equip.gemini.calls_total`** + **`equip.gemini.tokens_input_total`**
+  + **`equip.gemini.tokens_output_total`** —
+  `app/services/translation/gemini.py::translate` emits per Gemini
+  API call. Tagged with `model` (so a future flash → pro migration
+  keeps cost curves separable) and `outcome={success,retry,fatal}`.
+  `tokens_*_total` use the token count as the metric VALUE so
+  `sum:` over the window equals cumulative token spend → multiply
+  by Gemini's $/million rate to get $-burn.
 
 Drop-off rate is computed in the dashboard query as:
 


### PR DESCRIPTION
The translation pipeline burns Gemini API tokens with **zero visibility today**. One bad day with a stuck retry loop + free-tier rotation could rack up an unexpected bill before anyone notices. This wires three log-based metrics so cost burn shows up on the dashboard.

## What

| Metric | Type | Tags | Note |
|---|---|---|---|
| `equip.gemini.calls_total` | counter | `model`, `outcome={success,retry,fatal}`, `status_code` (on non-200) | Lets dashboard distinguish retry-rate (rate-limited) from fatal-rate (broken creds) |
| `equip.gemini.tokens_input_total` | sum-by-value | `model` | Value IS the token count → `sum:` = cumulative spend |
| `equip.gemini.tokens_output_total` | sum-by-value | `model` | Same — `× $/M-token rate` = $-burn |

All emissions wrapped in `contextlib.suppress(Exception)` — metric failure must NEVER break the translation pipeline.

## Tests (4 new)

- `calls_total` fires with `model=...` + `outcome=success` tag
- Token counts emitted as metric value (not 1.0) → sum-over-window semantics work
- Zero `usageMetadata` response does NOT emit tokens (would inject meaningless 0 rows)
- 4xx emits `outcome=fatal` with `status_code` tag before raising

## README

New stanza added; `metric-readme-sentinel` (#709) enforces.

## Test plan

- [x] +4 Gemini metric tests
- [x] Full backend suite green (1406 tests)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)