### PR TITLE
feat(observability): equip.daily_challenge.attempt_total counter

### DIFF
--- a/backend/app/api/v1/daily_challenge.py
+++ b/backend/app/api/v1/daily_challenge.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session  # noqa: TC002 — FastAPI Depends runtime us
 from app.api.dependencies import get_current_user
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
+from app.core.metrics import increment
 from app.models.daily_challenge import DailyChallengeAttempt
 from app.models.user import User  # noqa: TC001 — FastAPI Depends runtime use
 from app.schemas.daily_challenge import (
@@ -207,6 +208,23 @@ def submit_attempt(
     # set — we wrote it in this same transaction. Fall back to the
     # caller's submitted id rather than risking a Pydantic None.
     selected_id = outcome.attempt.selected_option_id or data.selected_option_id
+
+    # ``equip.daily_challenge.attempt_total`` — counts unique attempts
+    # only (``is_new_attempt=True``). The idempotent re-submit path
+    # still returns 201 to the client but does NOT increment, so the
+    # dashboard's "attempts per day" tile matches the actual student
+    # count even if a student clicks twice. Tagged with
+    # ``is_correct={true,false}`` so the dashboard can derive a
+    # correct-rate without a second metric.
+    if outcome.is_new_attempt:
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            increment(
+                "equip.daily_challenge.attempt_total",
+                challenge_date=outcome.schedule.challenge_date.isoformat(),
+                is_correct=str(outcome.attempt.is_correct).lower(),
+            )
 
     return DailyChallengeAttemptResponse(
         id=outcome.attempt.id,

--- a/backend/tests/test_daily_challenge_metric.py
+++ b/backend/tests/test_daily_challenge_metric.py
@@ -48,8 +48,16 @@ def _seed_dc_today(db: Session) -> tuple[DailyChallengeQuestion, uuid.UUID, uuid
     q = _seed_question_with_options(db, author_id=author.id)
     _schedule_for_today(db, q, scheduled_by=author.id)
     db.refresh(q)
-    correct = next(o.id for o in db.query(DailyChallengeOption).filter(DailyChallengeOption.question_id == q.id).all() if o.is_correct)
-    wrong = next(o.id for o in db.query(DailyChallengeOption).filter(DailyChallengeOption.question_id == q.id).all() if not o.is_correct)
+    correct = next(
+        o.id
+        for o in db.query(DailyChallengeOption).filter(DailyChallengeOption.question_id == q.id).all()
+        if o.is_correct
+    )
+    wrong = next(
+        o.id
+        for o in db.query(DailyChallengeOption).filter(DailyChallengeOption.question_id == q.id).all()
+        if not o.is_correct
+    )
     return q, correct, wrong
 
 

--- a/backend/tests/test_daily_challenge_metric.py
+++ b/backend/tests/test_daily_challenge_metric.py
@@ -1,0 +1,120 @@
+"""Tests for ``equip.daily_challenge.attempt_total`` emission from
+``submit_attempt``.
+
+The metric drives the Course Engagement dashboard's daily-challenge
+participation tile. Pinned guarantees:
+
+* Fires once per *new* attempt (``is_new_attempt=True``).
+* Idempotent re-submits (same user, same day) return 201 but do
+  NOT increment — otherwise a double-click would inflate the
+  "unique participants" denominator and skew correct-rate math.
+* Tagged with ``challenge_date`` (so the dashboard can plot by day)
+  and ``is_correct`` (so correct-rate is derivable from a single
+  metric, no second counter needed).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+from app.models.daily_challenge import DailyChallengeOption
+from app.models.user import User, UserRole
+
+# Reuse the proven seed helpers from the existing DC test file. They
+# build a question + 4 options + content_versions text rows the way
+# the editorial pipeline will when it lands; matching that shape
+# means this test exercises the real submit path, not a synthetic one.
+from .test_daily_challenge_service import _schedule_for_today, _seed_question_with_options
+
+if TYPE_CHECKING:
+    import pytest
+    from sqlalchemy.orm import Session
+
+    from app.models.daily_challenge import DailyChallengeQuestion
+
+
+def _seed_dc_today(db: Session) -> tuple[DailyChallengeQuestion, uuid.UUID, uuid.UUID]:
+    """Returns (question, correct_option_id, wrong_option_id)."""
+    author = User(
+        id=uuid.uuid4(),
+        email=f"a-{uuid.uuid4().hex[:8]}@e.com",
+        full_name="A",
+        role=UserRole.TEACHER.value,
+    )
+    db.add(author)
+    db.commit()
+    q = _seed_question_with_options(db, author_id=author.id)
+    _schedule_for_today(db, q, scheduled_by=author.id)
+    db.refresh(q)
+    correct = next(o.id for o in db.query(DailyChallengeOption).filter(DailyChallengeOption.question_id == q.id).all() if o.is_correct)
+    wrong = next(o.id for o in db.query(DailyChallengeOption).filter(DailyChallengeOption.question_id == q.id).all() if not o.is_correct)
+    return q, correct, wrong
+
+
+class TestAttemptMetric:
+    def test_correct_attempt_emits_with_is_correct_true(
+        self,
+        db: Session,
+        student_client,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _, correct_id, _ = _seed_dc_today(db)
+
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            resp = student_client.post(
+                "/api/v1/daily-challenge/today/attempt",
+                json={"selected_option_id": str(correct_id)},
+            )
+        assert resp.status_code == 201, resp.text
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.daily_challenge.attempt_total" in m]
+        assert events, "expected attempt_total event"
+        assert any("is_correct=true" in m for m in events)
+        assert any("value=1.0" in m for m in events)
+
+    def test_incorrect_attempt_emits_with_is_correct_false(
+        self,
+        db: Session,
+        student_client,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _, _, wrong_id = _seed_dc_today(db)
+
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            resp = student_client.post(
+                "/api/v1/daily-challenge/today/attempt",
+                json={"selected_option_id": str(wrong_id)},
+            )
+        assert resp.status_code == 201
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.daily_challenge.attempt_total" in m]
+        assert events
+        assert any("is_correct=false" in m for m in events)
+
+    def test_idempotent_resubmit_does_not_re_emit(
+        self,
+        db: Session,
+        student_client,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Same user, same option, second POST — returns 201 (same
+        attempt) but MUST NOT re-fire the counter."""
+        _, correct_id, _ = _seed_dc_today(db)
+
+        student_client.post(
+            "/api/v1/daily-challenge/today/attempt",
+            json={"selected_option_id": str(correct_id)},
+        )
+        caplog.clear()
+
+        with caplog.at_level(logging.INFO, logger="equip.metric"):
+            resp = student_client.post(
+                "/api/v1/daily-challenge/today/attempt",
+                json={"selected_option_id": str(correct_id)},
+            )
+        assert resp.status_code == 201
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        events = [m for m in msgs if "equip.daily_challenge.attempt_total" in m]
+        assert events == [], "idempotent re-submit must NOT re-emit"

--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -65,8 +65,9 @@ Live emission today (sites tagged with the route file that wires them):
   `path_prefix` (first 4 url segments), and `exception_type` (class
   name, never the message — message could carry PII). Drives the
   P1 `backend-unhandled-exception-rate` monitor.
-* **`equip.translation.queue_depth`** + **`queue_processing`** +
-  **`queue_failed_permanent`** — `app/api/v1/
+* **`equip.translation.queue_depth`** +
+  **`equip.translation.queue_processing`** +
+  **`equip.translation.queue_failed_permanent`** — `app/api/v1/
   internal_translation_worker.py::_emit_queue_gauges` fires three
   per-status gauges on every cron tick. Drives the Course
   Engagement dashboard's *Translation queue health* group and the
@@ -79,6 +80,12 @@ Live emission today (sites tagged with the route file that wires them):
   `tokens_*_total` use the token count as the metric VALUE so
   `sum:` over the window equals cumulative token spend → multiply
   by Gemini's $/million rate to get $-burn.
+* **`equip.daily_challenge.attempt_total`** — `app/api/v1/
+  daily_challenge.py::submit_attempt` fires per **new** attempt
+  (`is_new_attempt=True`); idempotent re-submits return 201 but
+  do NOT increment. Tagged with `challenge_date` + `is_correct`
+  so the dashboard can chart attempts-per-day and derive a correct-
+  rate without a second metric.
 
 Drop-off rate is computed in the dashboard query as:
 


### PR DESCRIPTION
Daily Challenge is the **highest-frequency student touchpoint** (one attempt per day per user); zero metric visibility today means we can't tell if engagement is dropping or flat.

## Backend

`equip.daily_challenge.attempt_total` fires on every NEW (`is_new_attempt=True`) submit. Idempotent re-submits return 201 to the client but do **not** increment — the dashboard's 'unique participants' math depends on this.

| Tag | Why |
|---|---|
| `challenge_date` | Day-over-day chart |
| `is_correct` | Correct-rate derivable from one metric (no second counter) |

Wrapped in `contextlib.suppress(Exception)` — metric failure must never block an attempt write.

## Tests (3 new)

- Correct attempt → counter fires with `is_correct=true`
- Wrong attempt → counter fires with `is_correct=false`
- Idempotent re-submit → 201 but counter MUST NOT re-fire

Reuses `_seed_question_with_options` + `_schedule_for_today` helpers from `test_daily_challenge_service.py` so the test exercises the same content_versions shape the editorial pipeline ships in prod.

## README

New stanza added; `metric-readme-sentinel` (#709) enforces.

## Test plan

- [x] +3 DC metric tests
- [x] Full backend suite green (1405 tests)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)