### PR TITLE
feat(observability): equip.youversion.api_calls_total — VOD API budget visibility

### DIFF
--- a/backend/app/services/verse_of_the_day.py
+++ b/backend/app/services/verse_of_the_day.py
@@ -457,6 +457,25 @@ def _fetch_passage(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
     url = f"{YOUVERSION_API_BASE}/bibles/{bible_id}/passages/{ref}"
     with httpx.Client(timeout=8.0) as client:
         response = client.get(url, headers={"X-YVP-App-Key": api_key})
+    # Emit per-call API metric BEFORE the status branches so the dashboard
+    # sees every call, not just the 200s. Tagged with bible_id (which
+    # locale) + outcome (which budget bucket: 200 = ok, 404 = not_in_bible
+    # which we walk past in the caller, 5xx = outage). Wrapped in
+    # try/except so a metric failure cannot break VOD rendering.
+    try:
+        from app.core.metrics import increment
+
+        outcome = (
+            "success" if response.status_code == 200 else ("not_in_bible" if response.status_code == 404 else "fatal")
+        )
+        increment(
+            "equip.youversion.api_calls_total",
+            bible_id=str(bible_id),
+            outcome=outcome,
+            status_code=str(response.status_code),
+        )
+    except Exception:
+        pass
     if response.status_code == 404:
         raise VerseNotInBible(f"YouVersion has no {ref} for bible {bible_id}")
     if response.status_code != 200:

--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -92,6 +92,13 @@ Live emission today (sites tagged with the route file that wires them):
   do NOT increment. Tagged with `challenge_date` + `is_correct`
   so the dashboard can chart attempts-per-day and derive a correct-
   rate without a second metric.
+* **`equip.youversion.api_calls_total`** —
+  `app/services/verse_of_the_day.py::_fetch_passage` fires per
+  YouVersion REST call. Tagged with `bible_id` (which locale's
+  bible), `outcome={success,not_in_bible,fatal}`, and `status_code`.
+  Lets the dashboard track API budget burn separately from app-side
+  errors (`not_in_bible` is the version-difference walk-forward
+  case, not a real failure).
 
 Drop-off rate is computed in the dashboard query as:
 


### PR DESCRIPTION
YouVersion API has a per-app quota (free tier is rate-limited at the Bible API key level). Zero metric today means we can't tell if VOD is healthy, walking forward through Psalm versification differences (common 404), or actually outage-ing.

## What

`equip.youversion.api_calls_total` fires per fetch BEFORE the status branches so the dashboard sees every call, not just 200s.

| Tag | Why |
|---|---|
| `bible_id` | Splits NRT vs BSB call counts (which locale's bible) |
| `outcome` | `success` (200) / `not_in_bible` (404 — Psalm versification walk-forward, **NORMAL**) / `fatal` (5xx — real outage) |
| `status_code` | Raw HTTP status for triage |

## Why the success/not_in_bible split

The dashboard reading `sum:equip.youversion.api_calls_total{outcome:fatal}` should be the alert signal. Folding 404s into 'errors' would create constant noise from the Psalm versification path that's **already designed** to walk past it.

Wrapped in try/except — metric failure must NEVER block VOD rendering.

## README

Updated with the new stanza; `metric-readme-sentinel` (#709) enforces.

## Test plan

- [x] Full backend suite green (1402 tests)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)