### PR TITLE
fix(design): kill remaining stripes — --border invisible (light) / etched (dark)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -44,11 +44,15 @@
     --warning-foreground: 265 28% 13%;
     --info: 215 75% 42%;
     --info-foreground: 0 0% 98%;
-    /* 2026-06-03 UX call (Vadym): --border softened from 87% L to
-     * 94% L so directional dividers + remaining edge lines fade to
-     * a hint instead of an HTML-table grid. --input stays sharp at
-     * 87% L because field affordance IS the border. */
-    --border: 265 8% 94%;
+    /* 2026-06-03 second UX iteration (Vadym): the soft 94%L hint
+     * still read as "endless white stripes" — especially in dark
+     * mode where ANY value lighter than the card surface is visible.
+     * Match --border to --card (light) / a touch DARKER than --card
+     * (dark) so dividers either vanish (light) or read as a subtle
+     * etched line (dark). --input stays sharp at 87% L / 19% L
+     * because the field affordance IS the border — must remain
+     * visible. */
+    --border: 40 35% 99%;
     --input: 265 12% 87%;
     --ring: 262 56% 38%;
     --radius: 0.5rem;
@@ -97,11 +101,13 @@
     --warning-foreground: 240 12% 10%;
     --info: 215 72% 58%;
     --info-foreground: 240 12% 10%;
-    /* Dark-mode counterpart of the light-mode softening: --border
-     * drops from 19% L to 13% L so it's nearly bg-card (12% L),
-     * dividers fade to a hint. --input stays at 19% L so form
-     * fields keep a visible boundary. */
-    --border: 240 5% 13%;
+    /* Dark mode: --border drops BELOW --card (12% L) to 10% L. A
+     * border slightly DARKER than the card surface reads as an
+     * "etched" hairline (depth cue) rather than a brighter "stripe"
+     * (highlight). Bright stripes on dark surfaces are the
+     * specific complaint we're solving here. --input stays at 19% L
+     * so form fields keep visible boundary. */
+    --border: 240 8% 10%;
     --input: 240 5% 19%;
     --ring: 262 58% 72%;
 


### PR DESCRIPTION
**Second UX iteration on the token softening (#700).** The 94% L 'hint' border still read as endless white stripes — especially in dark mode where anything lighter than the card surface (12% L) shows as a highlight stripe across every directional divider, panel separator, and section underline.

## Strategy: stop softening, start matching

| Token | Before | After | Effect |
|---|---|---|---|
| `--border` light | `265 8% 94%` | `40 35% 99%` (= `--card`) | Invisible |
| `--border` dark | `240 5% 13%` | `240 8% 10%` (DARKER than `--card` 12%) | Etched depth cue, NOT highlight stripe |
| `--input` light | `265 12% 87%` | (unchanged) | Field affordance stays |
| `--input` dark | `240 5% 19%` | (unchanged) | Field affordance stays |

## Why DARKER than card in dark mode

A hairline slightly **darker** than the surface reads as **depth** (an 'indented' edge); a hairline slightly **lighter** reads as a **bright stripe**. The specific complaint was bright stripes in dark mode, not the presence of separators per se.

## What doesn't break

- Floating overlays (Popover / Dialog / DropdownMenu / Sheet) still separate via `bg-surface-elevated` + `shadow-md` — the border becoming invisible/etched doesn't break their definition.
- Form inputs (`--input`, 87% / 19% L) stay sharp — losing a field boundary would be a real a11y regression.

Single CSS token tweak, no component code touched.

## Test plan

- [x] 518 frontend tests green
- [x] eslint + tsc clean
- [ ] Eyeball review in both light + dark (Vadym)

🤖 Generated with [Claude Code](https://claude.com/claude-code)