### PR TITLE
fix(translation): DB-failing jobs reach failed_permanent (kill poison-loop)

### DIFF
--- a/backend/app/api/v1/internal_translation_worker.py
+++ b/backend/app/api/v1/internal_translation_worker.py
@@ -43,6 +43,7 @@ from app.services.translation.queue import (
     get_queue_status,
     mark_job_done,
     mark_job_failed,
+    record_job_failure,
 )
 
 if TYPE_CHECKING:
@@ -155,6 +156,7 @@ def _run_one_tick(db: Session) -> WorkerTickResponse:
         return WorkerTickResponse(status="idle")
 
     course_id = job.course_id
+    job_pk = job.id
     job_id = str(job.id)
     attempts = job.attempts
     course = get_course(db, course_id)
@@ -179,11 +181,15 @@ def _run_one_tick(db: Session) -> WorkerTickResponse:
     try:
         translate_course_content(db, course)
     except SQLAlchemyError as exc:
-        # Roll the session forward to a clean transaction before
-        # writing the job-status flip; otherwise the mark_job_failed
-        # commit would itself raise on the still-poisoned session.
-        db.rollback()
-        mark_job_failed(db, job, error=f"sqlalchemy: {exc}")
+        # A SQLAlchemyError poisons the transaction, so we must rollback
+        # before writing the status flip. But a plain rollback would also
+        # discard the attempts increment that claim_next_job only flushed
+        # (not committed) — leaving mark_job_failed to read the pre-claim
+        # count, never hit the cap, and re-queue a deterministically
+        # DB-failing job forever. record_job_failure rolls back AND
+        # re-stamps the post-claim ``attempts`` (captured above), so the
+        # cap check works and the job can reach failed_permanent.
+        record_job_failure(db, job_id=job_pk, attempts=attempts, error=f"sqlalchemy: {exc}")
         # Emit duration even on failure so the dashboard's p50/p95
         # tile includes the cost of failed work (the operator needs
         # to see if failures are also slow → upstream timeout).

--- a/backend/app/services/translation/queue.py
+++ b/backend/app/services/translation/queue.py
@@ -190,3 +190,41 @@ def mark_job_failed(db: Session, job: TranslationJob, *, error: str) -> Translat
     db.commit()
     db.refresh(job)
     return job
+
+
+def record_job_failure(db: Session, *, job_id: uuid.UUID, attempts: int, error: str) -> TranslationJob | None:
+    """Record a worker failure resiliently, independent of the session
+    state left by a failed ``translate_course_content`` pass.
+
+    The worker's ``except SQLAlchemyError`` path MUST ``rollback()`` to
+    clear the poisoned transaction before it can write anything. But a
+    rollback also discards the ``attempts`` increment + ``PROCESSING``
+    flip that ``claim_next_job`` only *flushed* (never committed). If we
+    then re-read ``job.attempts`` it shows the PRE-claim count, the
+    ``>= TRANSLATION_JOB_MAX_ATTEMPTS`` check never trips, and a job that
+    deterministically raises a DB error is re-claimed on every cron tick
+    forever — burning Gemini calls and never reaching
+    ``failed_permanent``. (``mark_job_failed`` is correct only when the
+    in-session increment is still live, i.e. the no-rollback paths.)
+
+    This helper sidesteps the trap: it rolls the session back to a clean
+    transaction, re-fetches the row ``FOR UPDATE``, and stamps the
+    caller-supplied ``attempts`` — captured post-claim, so it survives
+    the rollback as a plain int. Promotion then sees the correct count.
+    Returns ``None`` if the row vanished (e.g. cascade-deleted) between
+    claim and failure.
+    """
+    db.rollback()
+    job = db.execute(select(TranslationJob).where(TranslationJob.id == job_id).with_for_update()).scalars().first()
+    if job is None:
+        return None
+    job.attempts = attempts
+    job.last_error = error[:2000] if error else None
+    job.finished_at = datetime.now(UTC)
+    if attempts >= TRANSLATION_JOB_MAX_ATTEMPTS:
+        job.status = TranslationJobStatus.FAILED_PERMANENT
+    else:
+        job.status = TranslationJobStatus.FAILED
+    db.commit()
+    db.refresh(job)
+    return job

--- a/backend/tests/test_translation_worker_endpoint.py
+++ b/backend/tests/test_translation_worker_endpoint.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 
 import pytest
 from pydantic import SecretStr
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.models.course import Course
 from app.models.translation_job import (
@@ -228,3 +229,80 @@ def test_concurrent_workers_dont_claim_the_same_row(client: TestClient, db: Sess
 
     remaining = db.query(TranslationJob).filter(TranslationJob.status == TranslationJobStatus.QUEUED).count()
     assert remaining == 0
+
+
+def test_sqlalchemy_error_still_bumps_attempts(client: TestClient, db: Session, teacher, configured_worker):
+    """Regression: the ``except SQLAlchemyError`` path must persist the
+    attempts increment. It used to ``db.rollback()`` before failing,
+    which discarded the flush-only increment from ``claim_next_job`` and
+    reverted ``attempts`` to its pre-claim value — so the failure was
+    recorded with the WRONG (un-incremented) count."""
+    course = _make_course(db, teacher.id)
+    job = enqueue_course_translation(db, course.id)
+    assert job.attempts == 0
+
+    with patch(
+        "app.api.v1.internal_translation_worker.translate_course_content",
+        side_effect=SQLAlchemyError("deadlock detected"),
+    ):
+        resp = client.post(_WORKER_PATH, headers={"X-Worker-Secret": _GOOD_SECRET})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "failed"
+    assert body["attempts"] == 1
+
+    db.refresh(job)
+    assert job.status == TranslationJobStatus.FAILED
+    # The increment survives the rollback — this is the whole point.
+    assert job.attempts == 1
+    assert "sqlalchemy" in (job.last_error or "")
+
+
+def test_sqlalchemy_error_at_cap_promotes_to_failed_permanent(
+    client: TestClient, db: Session, teacher, configured_worker
+):
+    """Regression for the poison-loop: a DB-failing job at one short of
+    the attempt cap must promote to ``failed_permanent`` on the next
+    tick. Before the fix the rolled-back increment meant the cap check
+    read the stale count and re-queued the job forever (re-claimed every
+    cron tick, burning Gemini calls, never visible in failed_permanent)."""
+    course = _make_course(db, teacher.id)
+    job = enqueue_course_translation(db, course.id)
+    job.attempts = TRANSLATION_JOB_MAX_ATTEMPTS - 1
+    db.commit()
+
+    with patch(
+        "app.api.v1.internal_translation_worker.translate_course_content",
+        side_effect=SQLAlchemyError("still deadlocking"),
+    ):
+        resp = client.post(_WORKER_PATH, headers={"X-Worker-Secret": _GOOD_SECRET})
+
+    assert resp.status_code == 200
+    db.refresh(job)
+    assert job.attempts == TRANSLATION_JOB_MAX_ATTEMPTS
+    assert job.status == TranslationJobStatus.FAILED_PERMANENT
+
+
+def test_sqlalchemy_poison_job_terminates_within_cap_ticks(client: TestClient, db: Session, teacher, configured_worker):
+    """End-to-end poison-loop guard: a job that raises SQLAlchemyError on
+    EVERY tick must reach ``failed_permanent`` after exactly
+    TRANSLATION_JOB_MAX_ATTEMPTS ticks and then stop being claimable —
+    not spin forever."""
+    course = _make_course(db, teacher.id)
+    job = enqueue_course_translation(db, course.id)
+
+    with patch(
+        "app.api.v1.internal_translation_worker.translate_course_content",
+        side_effect=SQLAlchemyError("permanently broken"),
+    ):
+        for _ in range(TRANSLATION_JOB_MAX_ATTEMPTS):
+            client.post(_WORKER_PATH, headers={"X-Worker-Secret": _GOOD_SECRET})
+        # One more tick: the job is failed_permanent now, so the queue is
+        # empty and the worker reports idle (it is NOT re-claimed).
+        extra = client.post(_WORKER_PATH, headers={"X-Worker-Secret": _GOOD_SECRET}).json()
+
+    assert extra["status"] == "idle"
+    db.refresh(job)
+    assert job.attempts == TRANSLATION_JOB_MAX_ATTEMPTS
+    assert job.status == TranslationJobStatus.FAILED_PERMANENT


### PR DESCRIPTION
## TIER 1 — release blocker (from the final multi-agent audit, adversarially verified)

### Poison-loop: DB-failing translation jobs never reach `failed_permanent`
`claim_next_job()` bumps `attempts` via `db.flush()` (not commit). The worker's `except SQLAlchemyError` branch called `db.rollback()` **before** `mark_job_failed()`, discarding that increment. `mark_job_failed` then re-read the *pre-claim* count, never tripped the `>= MAX_ATTEMPTS` cap, and re-queued the job as `failed`.

Net effect: a course whose `translate_course_content` deterministically raises a DB error (CHECK/unique violation, deadlock, serialization failure during a cv write) is **re-claimed every 1-minute cron tick forever** — burning Gemini calls and never showing up in the `failed_permanent` gauge. The generic `except Exception` branch does *not* rollback, so it was correct; the two failure paths were asymmetric and the common DB-error path was broken.

### Fix
New `record_job_failure()` in `queue.py`: rolls back to a clean transaction, re-fetches the row `FOR UPDATE`, and stamps the **post-claim** `attempts` (captured as a plain int, so it survives the rollback). The `SQLAlchemyError` branch uses it. Promotion now sees the correct count.

### Tests
3 regression tests (existing ones only used `RuntimeError`, which hits the already-correct branch):
- attempts survive a `SQLAlchemyError` tick (1, not 0)
- promote to `failed_permanent` at the cap
- a poison job terminates within `MAX_ATTEMPTS` ticks and stops being claimable

Local: ruff + mypy clean; worker+queue suites 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
