### PR TITLE
fix(quizzes): re-grade down un-completes chapter; best-quiz by %; course_id metric tag

### DIFF
--- a/backend/app/api/v1/quizzes/attempts.py
+++ b/backend/app/api/v1/quizzes/attempts.py
@@ -139,7 +139,7 @@ def submit_quiz(
     attempt.completed_at = datetime.now(UTC)
 
     if attempt.passed:
-        quiz_service.upsert_passed_chapter_progress(db, current_user.id, str(quiz.chapter_id))
+        quiz_service.upsert_passed_chapter_progress(db, current_user.id, str(quiz.chapter_id), course_id=course_id)
         sync_enrollment_progress(db, current_user.id, course_id)
 
     db.commit()

--- a/backend/app/services/quiz_service.py
+++ b/backend/app/services/quiz_service.py
@@ -226,7 +226,7 @@ def persist_answers(
     return total_score, answer_results
 
 
-def upsert_passed_chapter_progress(db: Session, user_id: UUID, chapter_id: str) -> None:
+def upsert_passed_chapter_progress(db: Session, user_id: UUID, chapter_id: str, *, course_id: str) -> None:
     """Mark the chapter as ``quiz``-completed for the student (idempotent).
 
     Race-safe: a concurrent teacher-mark-complete or assignment-submit
@@ -268,6 +268,7 @@ def upsert_passed_chapter_progress(db: Session, user_id: UUID, chapter_id: str) 
         increment(
             "equip.engagement.chapter_completed_total",
             chapter_id=str(chapter_id),
+            course_id=str(course_id),
             completion_type="quiz",
         )
 
@@ -291,7 +292,52 @@ def recompute_attempt_grade(db: Session, attempt: QuizAttempt, quiz: Quiz) -> No
     percentage = (attempt.score / max_score * 100) if max_score > 0 else 0
     attempt.passed = max_score > 0 and percentage >= quiz.passing_score
 
-    if attempt.passed and not was_passed:
-        upsert_passed_chapter_progress(db, attempt.user_id, str(quiz.chapter_id))
-        course_id = resolve_chapter_course_id(db, quiz.chapter_id)
+    if attempt.passed == was_passed:
+        return
+
+    course_id = resolve_chapter_course_id(db, quiz.chapter_id)
+    if attempt.passed:
+        # fail → pass: mark the chapter done and sync progress up.
+        upsert_passed_chapter_progress(db, attempt.user_id, str(quiz.chapter_id), course_id=course_id)
         sync_enrollment_progress(db, attempt.user_id, course_id)
+    else:
+        # pass → fail (teacher lowered a manual grade below passing). The
+        # inverse used to be missing: the chapter stayed quiz-completed and
+        # enrollment.progress stayed inflated, so certificate eligibility
+        # was based on a grade the student no longer holds. Un-complete the
+        # chapter ONLY when (a) it was completed via the quiz path (don't
+        # clobber a teacher-mark / assignment completion) and (b) no OTHER
+        # passing attempt for this chapter survives, then re-sync down.
+        _undo_quiz_chapter_completion(db, attempt.user_id, quiz.chapter_id, exclude_attempt_id=attempt.id)
+        sync_enrollment_progress(db, attempt.user_id, course_id)
+
+
+def _undo_quiz_chapter_completion(db: Session, user_id: UUID, chapter_id: str, *, exclude_attempt_id: UUID) -> None:
+    """Clear a quiz-sourced chapter completion when the student no longer
+    has any passing attempt for that chapter. No-op if the chapter was
+    completed by a different path or another passing attempt remains."""
+    other_pass = (
+        db.query(QuizAttempt.id)
+        .join(Quiz, QuizAttempt.quiz_id == Quiz.id)
+        .filter(
+            Quiz.chapter_id == chapter_id,
+            QuizAttempt.user_id == user_id,
+            QuizAttempt.passed.is_(True),
+            QuizAttempt.id != exclude_attempt_id,
+        )
+        .first()
+    )
+    if other_pass is not None:
+        return
+
+    cp = (
+        db.query(ChapterProgress)
+        .filter(
+            ChapterProgress.user_id == user_id,
+            ChapterProgress.chapter_id == str(chapter_id),
+        )
+        .first()
+    )
+    if cp is not None and cp.completed and cp.completion_type == "quiz":
+        cp.completed = False
+        cp.completed_at = None

--- a/backend/app/services/student_progress_service.py
+++ b/backend/app/services/student_progress_service.py
@@ -107,24 +107,42 @@ def _aggregate_quiz_results(
         for q in qs:
             quiz_to_chapter[q.id] = ch_id
 
-    passed_any = func.max(case((QuizAttempt.passed.is_(True), 1), else_=0)).label("passed_any")
-    quiz_aggs = (
+    # The "best" attempt per (user, quiz) must come from a SINGLE row:
+    # independent MAX(score) + MAX(max_score) aggregates could combine a
+    # high score from one attempt with a high max_score from another and
+    # report a percentage that never happened (e.g. 8/10 + 5/20 -> "8/20").
+    # Rank attempts by PERCENTAGE (coalescing a 0 max_score to -1 so it
+    # sorts last, dialect-safe) and take rn=1; the per-group aggregates
+    # (passed_any / attempts / last_completed) ride along as window funcs
+    # so it's still one query. Window functions work on both Postgres and
+    # the SQLite test backend.
+    partition = (QuizAttempt.user_id, QuizAttempt.quiz_id)
+    pct_order = func.coalesce(QuizAttempt.score * 1.0 / func.nullif(QuizAttempt.max_score, 0), -1.0)
+    ranked = (
         db.query(
             QuizAttempt.user_id.label("user_id"),
             QuizAttempt.quiz_id.label("quiz_id"),
-            func.max(QuizAttempt.score).label("best_score"),
-            func.max(QuizAttempt.max_score).label("best_max_score"),
-            passed_any,
-            func.count().label("attempts"),
-            func.max(QuizAttempt.completed_at).label("last_completed"),
+            QuizAttempt.score.label("score"),
+            QuizAttempt.max_score.label("max_score"),
+            func.row_number()
+            .over(partition_by=partition, order_by=(pct_order.desc(), QuizAttempt.completed_at.desc()))
+            .label("rn"),
+            func.count().over(partition_by=partition).label("attempts"),
+            func.max(case((QuizAttempt.passed.is_(True), 1), else_=0)).over(partition_by=partition).label("passed_any"),
+            func.max(QuizAttempt.completed_at).over(partition_by=partition).label("last_completed"),
         )
         .filter(
             QuizAttempt.quiz_id.in_(all_quiz_ids),
             QuizAttempt.completed_at.isnot(None),
         )
-        .group_by(QuizAttempt.user_id, QuizAttempt.quiz_id)
-        .all()
+        .subquery()
     )
+    quiz_aggs = db.query(ranked).filter(ranked.c.rn == 1).all()
+
+    def _pct(entry: dict[str, Any]) -> float:
+        mx = entry["max_score"]
+        return entry["score"] / mx if mx else 0.0
+
     for row in quiz_aggs:
         uid = str(row.user_id)
         resolved_ch_id = quiz_to_chapter.get(row.quiz_id)
@@ -132,16 +150,17 @@ def _aggregate_quiz_results(
             continue
         ch_key = (uid, str(resolved_ch_id))
         attempts_by_user_chapter[ch_key] = attempts_by_user_chapter.get(ch_key, 0) + int(row.attempts or 0)
-        score = int(row.best_score or 0)
         entry = {
             "chapter_id": str(resolved_ch_id),
             "quiz_id": str(row.quiz_id),
-            "score": score,
-            "max_score": int(row.best_max_score or 0),
+            "score": int(row.score or 0),
+            "max_score": int(row.max_score or 0),
             "passed": bool(row.passed_any),
         }
         prev = best_by_user_chapter.get(ch_key)
-        if prev is None or score > prev["score"]:
+        # A chapter may hold several quizzes; the representative is the
+        # quiz the student did best on by PERCENTAGE, not raw points.
+        if prev is None or _pct(entry) > _pct(prev):
             best_by_user_chapter[ch_key] = entry
         if row.last_completed and (uid not in latest_quiz_by_user or row.last_completed > latest_quiz_by_user[uid]):
             latest_quiz_by_user[uid] = row.last_completed

--- a/backend/tests/test_engagement_metrics.py
+++ b/backend/tests/test_engagement_metrics.py
@@ -85,13 +85,16 @@ class TestQuizEngagementEmission:
         _seed_users(db)
         chapter_id = _seed_basic_course(db, "eng-q1")
         with caplog.at_level(logging.INFO, logger="equip.metric"):
-            quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id)
+            quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id, course_id="eng-q1")
             db.commit()
         msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
         completed = [m for m in msgs if "equip.engagement.chapter_completed_total" in m]
         assert completed, "expected chapter_completed_total to fire"
         assert any("completion_type=quiz" in m for m in completed)
         assert any(f"chapter_id={chapter_id}" in m for m in completed)
+        # course_id must be present so per-course drop-off widgets work
+        # (the quiz path used to drop it, unlike the other two paths).
+        assert any("course_id=eng-q1" in m for m in completed)
         assert any("value=1.0" in m for m in completed)
 
     def test_does_not_emit_when_already_complete(
@@ -104,14 +107,14 @@ class TestQuizEngagementEmission:
         _seed_users(db)
         chapter_id = _seed_basic_course(db, "eng-q2")
         # First pass to set up the completed row
-        quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id)
+        quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id, course_id="eng-q2")
         db.commit()
         # Clear out whatever the setup pass emitted; the assertion
         # below is about what fires on the SECOND call.
         caplog.clear()
 
         with caplog.at_level(logging.INFO, logger="equip.metric"):
-            quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id)
+            quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id, course_id="eng-q2")
             db.commit()
         msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
         completed = [m for m in msgs if "equip.engagement.chapter_completed_total" in m]

--- a/backend/tests/test_quizzes_and_blocks.py
+++ b/backend/tests/test_quizzes_and_blocks.py
@@ -1503,6 +1503,47 @@ def test_grade_essay_answer_recomputes_passed(client: TestClient, student, db: S
     assert graded_list[0]["points_earned"] == 18
 
 
+def test_regrade_below_passing_uncompletes_chapter(client: TestClient, student, db: Session):
+    """Regression: lowering a manual grade so the attempt drops below the
+    passing score must un-complete the quiz-sourced chapter and re-sync
+    enrollment progress. Previously only the fail->pass direction synced,
+    so a downgrade left the chapter completed and certificate eligibility
+    inflated on a grade the student no longer holds."""
+    from app.models.chapter_progress import ChapterProgress
+
+    _seed_course_with_enrollment(db)
+    quiz, _essay, attempt, essay_answer = _seed_submitted_essay_attempt(db)
+
+    # Grade high → attempt passes → chapter auto-completes via the quiz path.
+    up = client.patch(f"/api/v1/quizzes/answers/{essay_answer.id}", json={"points_earned": 18})
+    assert up.status_code == 200
+    db.expire_all()
+    cp = (
+        db.query(ChapterProgress)
+        .filter(ChapterProgress.user_id == STUDENT_ID, ChapterProgress.chapter_id == quiz.chapter_id)
+        .first()
+    )
+    assert cp is not None and cp.completed is True
+    assert cp.completion_type == "quiz"
+
+    # Re-grade the same essay down → 1 (mcq) + 2 = 3/21 ≈ 14% < 70 → fails.
+    down = client.patch(f"/api/v1/quizzes/answers/{essay_answer.id}", json={"points_earned": 2})
+    assert down.status_code == 200
+    attempts_resp = client.get(f"/api/v1/quizzes/{quiz.id}/attempts").json()
+    attempt_view = next(a for a in attempts_resp if a["id"] == str(attempt.id))
+    assert attempt_view["passed"] is False
+
+    db.expire_all()
+    cp = (
+        db.query(ChapterProgress)
+        .filter(ChapterProgress.user_id == STUDENT_ID, ChapterProgress.chapter_id == quiz.chapter_id)
+        .first()
+    )
+    assert cp is not None
+    assert cp.completed is False, "chapter must un-complete when the attempt drops below passing"
+    assert cp.completed_at is None
+
+
 def test_grade_answer_acquires_for_update_lock_on_attempt(client: TestClient, student, db: Session, monkeypatch):
     """The PATCH handler must take a ``FOR UPDATE`` row lock on the
     attempt before recomputing the aggregate score.


### PR DESCRIPTION
## Quiz / grading correctness + metrics (audit #2, #3, #4)

### #2 (medium) — re-grading below passing left the chapter completed
`recompute_attempt_grade` only handled `fail → pass`. A teacher lowering a manual (essay/short-answer) grade so the attempt drops below passing left the chapter quiz-completed and `enrollment.progress` inflated — certificate eligibility then rested on a grade the student no longer holds. Added the inverse: `pass → fail` un-completes the chapter (only when it was quiz-sourced **and** no other passing attempt for that chapter survives — never clobbers a teacher-mark/assignment completion) and re-syncs enrollment progress down.

### #3 (low) — best-quiz rollup mixed MAX() from different attempts
Independent `MAX(score)` + `MAX(max_score)` could combine a high score from one attempt with a high max_score from another → a percentage that never happened. And the per-chapter representative was chosen by raw score, not percentage. Now a `row_number()` window ranks attempts by percentage and takes the single best row (per-group `passed_any`/`attempts`/`last_completed` ride along as window aggregates — one query, works on Postgres + SQLite).

### #4 (medium) — quiz completion dropped the `course_id` metric tag
`equip.engagement.chapter_completed_total` was emitted without `course_id` on the quiz path (the other two completion paths tag it), corrupting per-course drop-off/completion widgets. Threaded `course_id` through `upsert_passed_chapter_progress`.

### Tests
- regrade-down un-completes the chapter (would fail without #2)
- `course_id` present in the quiz completion metric
- full backend suite **1404 passed**; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
