### PR TITLE
fix(observability): post-commit metric, transport-outage emit, dead-tile sentinel

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -105,14 +105,15 @@ def teacher_complete_chapter(
     progress.completed_by = teacher.id
     progress.completion_type = "teacher"
     sync_enrollment_progress(db, student_id, course_id)
-    increment(
-        "equip.engagement.chapter_completed_total",
-        chapter_id=str(chapter_id),
-        course_id=str(course_id),
-        completion_type="teacher",
-    )
+    # Emit only AFTER a successful commit that actually flipped the row.
+    # Emitting before commit double-counted: on the concurrent-completion
+    # race below the loser rolls back but would already have fired the
+    # metric, and the winner fires it too — two increments for one real
+    # completion, contradicting the documented idempotency.
+    committed_flip = False
     try:
         db.commit()
+        committed_flip = True
     except IntegrityError:
         # Concurrent (teacher_complete + student-side autocomplete, or
         # two co-teachers clicking together) just committed a row for
@@ -132,9 +133,9 @@ def teacher_complete_chapter(
         )
         if not winner:
             raise
-        # If the winner is already complete just acknowledge it. If
-        # not (it raced but lost on a different field), reapply this
-        # teacher's intent — they explicitly asked for completion.
+        # If the winner is already complete just acknowledge it (no emit —
+        # the request that flipped it already counted). If not, reapply
+        # this teacher's intent — they explicitly asked for completion.
         if not winner.completed:
             winner.completed = True
             winner.completed_at = datetime.now(UTC)
@@ -142,6 +143,14 @@ def teacher_complete_chapter(
             winner.completion_type = "teacher"
             sync_enrollment_progress(db, student_id, course_id)
             db.commit()
+            committed_flip = True
+    if committed_flip:
+        increment(
+            "equip.engagement.chapter_completed_total",
+            chapter_id=str(chapter_id),
+            course_id=str(course_id),
+            completion_type="teacher",
+        )
     return {
         "message": "Chapter marked as complete by teacher",
         "chapter_id": chapter_id,

--- a/backend/app/services/verse_of_the_day.py
+++ b/backend/app/services/verse_of_the_day.py
@@ -455,8 +455,28 @@ def _fetch_passage(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
     transient outage, not a content gap).
     """
     url = f"{YOUVERSION_API_BASE}/bibles/{bible_id}/passages/{ref}"
-    with httpx.Client(timeout=8.0) as client:
-        response = client.get(url, headers={"X-YVP-App-Key": api_key})
+    try:
+        with httpx.Client(timeout=8.0) as client:
+            response = client.get(url, headers={"X-YVP-App-Key": api_key})
+    except httpx.HTTPError:
+        # Transport-level failure (timeout, connection refused, DNS) — the
+        # call never produced a status. This is precisely the outage the
+        # API-budget dashboard most needs to see, yet the per-call metric
+        # below only fired once we had a response. Emit a fatal data point
+        # (status_code=0 = "no response") before re-raising so an outage
+        # registers. Metric failure must never mask the original error.
+        try:
+            from app.core.metrics import increment
+
+            increment(
+                "equip.youversion.api_calls_total",
+                bible_id=str(bible_id),
+                outcome="fatal",
+                status_code="0",
+            )
+        except Exception:
+            pass
+        raise
     # Emit per-call API metric BEFORE the status branches so the dashboard
     # sees every call, not just the 200s. Tagged with bible_id (which
     # locale) + outcome (which budget bucket: 200 = ok, 404 = not_in_bible

--- a/backend/tests/test_metric_readme_sentinel.py
+++ b/backend/tests/test_metric_readme_sentinel.py
@@ -30,6 +30,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 APP_DIR = REPO_ROOT / "backend" / "app"
 README = REPO_ROOT / "docs" / "datadog" / "README.md"
+DASHBOARDS_DIR = REPO_ROOT / "docs" / "datadog"
 
 # Captures the first argument to metrics helpers (``emit("equip.X")``
 # / ``increment("equip.X")`` / ``gauge("equip.X")`` / ``timing("equip.X")``).
@@ -105,3 +106,46 @@ def test_collect_emitted_metrics_finds_known_emitters() -> None:
     # These are known to ship today (post-#701 / #702 / #707).
     assert "equip.activity.requests_total" in emitted
     assert "equip.errors.unhandled_total" in emitted
+
+
+# A metric name in a Datadog query is followed by ``{tags}`` so the bare
+# name harvests cleanly, but strip the query helpers Datadog can append
+# after the closing brace just in case one is written inline.
+_DASHBOARD_METRIC_RE = re.compile(r"equip\.[a-zA-Z0-9_.]+")
+_QUERY_SUFFIXES = (".as_count", ".as_rate", ".rollup", ".fill", ".weight")
+
+
+def _collect_dashboard_metrics() -> set[str]:
+    """Harvest every ``equip.*`` metric name referenced in the dashboard
+    JSON specs under ``docs/datadog/``."""
+    found: set[str] = set()
+    for path in DASHBOARDS_DIR.glob("*.json"):
+        text = path.read_text(encoding="utf-8")
+        for raw in _DASHBOARD_METRIC_RE.findall(text):
+            name = raw.rstrip(".")
+            for suffix in _QUERY_SUFFIXES:
+                if name.endswith(suffix):
+                    name = name[: -len(suffix)]
+            found.add(name)
+    return found
+
+
+def test_every_dashboard_metric_is_emitted_or_documented() -> None:
+    """Reverse of the emitter sentinel: every ``equip.*`` metric a
+    dashboard JSON queries must be EITHER emitted from ``app/`` OR
+    documented in the README (a live stanza, a "Still TODO" bullet, or an
+    ``equip.<group>.*`` wildcard). Catches DEAD TILES — widgets that
+    render a perpetual "no data" because nobody emits the metric — which
+    the original one-directional sentinel missed."""
+    dashboard = _collect_dashboard_metrics()
+    assert dashboard, "expected to find equip.* metrics in docs/datadog/*.json"
+
+    emitted = _collect_emitted_metrics()
+    doc = _readme_text()
+    orphans = sorted(m for m in dashboard if m not in emitted and not _readme_mentions(m, doc))
+    assert not orphans, (
+        "These metrics are queried by a Datadog dashboard but are neither "
+        "emitted from app/ nor documented in docs/datadog/README.md "
+        "(dead tiles). Wire an emitter, or add a 'Still TODO' bullet / an "
+        "``equip.<group>.*`` wildcard:\n  - " + "\n  - ".join(orphans)
+    )

--- a/backend/tests/test_verse_of_the_day_internals.py
+++ b/backend/tests/test_verse_of_the_day_internals.py
@@ -187,6 +187,24 @@ class TestFetchPassage:
         with pytest.raises(svc.VerseOfTheDayUnavailable):
             svc._fetch_passage("KEY", 3034, "JHN.3.16")
 
+    def test_transport_error_emits_fatal_metric(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A transport-level failure (connect error / timeout) yields no
+        HTTP status, so the per-call metric — which fired only after a
+        response — never registered the outage operators most need to
+        see. It must now emit a fatal data point (status_code=0) before
+        the error propagates."""
+        import logging
+
+        _install_client(monkeypatch, httpx.ConnectError("connection refused"))
+        with caplog.at_level(logging.INFO, logger="equip.metric"), pytest.raises(httpx.HTTPError):
+            svc._fetch_passage("KEY", 3034, "JHN.3.16")
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        calls = [m for m in msgs if "equip.youversion.api_calls_total" in m]
+        assert calls, "a transport failure must still emit api_calls_total"
+        assert any("outcome=fatal" in m and "status_code=0" in m for m in calls)
+
 
 class TestStripHtml:
     """The collapse-to-prose helper — pure regex, easy unit-test."""

--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -108,12 +108,26 @@ Drop-off rate is computed in the dashboard query as:
 
 over the chosen window — no separate emitter required.
 
-Still TODO (panels render "no data" gracefully):
+Still TODO (panels render "no data" gracefully). These metric names are
+referenced by dashboard widgets but **not emitted yet** — the
+`test_every_dashboard_metric_is_emitted_or_documented` sentinel requires
+every dashboard metric to be either emitted or listed here, so a dead
+tile can't sneak in silently:
 
-* `equip.questions.*` — course Q&A surface when it lands.
+* `equip.questions.*` — course Q&A surface when it lands
+  (covers `questions.open` + `questions.response_time.p50`).
 * `equip.completion.chapter_avg_pct` — per-chapter aggregate.
 * `equip.engagement.first_dropoff.p50` — needs session-window
   computation; deferred until session_id tagging lands.
+* `equip.activity.daily_active_users` — needs a distinct-user rollup
+  (the request-logging middleware emits `requests_total`, not DAU).
+* `equip.enrollments.count` — point-in-time enrollment gauge; today we
+  only emit `enrollments.created_total` (a counter).
+* `equip.courses.active_7d` — rolling 7-day active-course gauge; no
+  emitter yet.
+* `equip.grading.pending` — pending-grade depth gauge; today we emit
+  `grading.graded_total` + `grading.time_to_grade.p50` on grade, not a
+  pending-queue gauge.
 
 ## See also
 


### PR DESCRIPTION
## Observability gaps (audit #5, #6, #7)

### #6 (low) — chapter-completion metric double-counted on the race path
`teacher_complete_chapter` fired `equip.engagement.chapter_completed_total` **before** `db.commit()`. On the concurrent-completion `IntegrityError` path the loser rolls back but had already emitted, and the winner emits too → two increments for one real completion. Moved the emit to **after** a successful commit, guarded by a `committed_flip` flag so it fires only when this request actually flipped the row (mirrors the assignment-submit path).

### #7 (low) — youversion metric never fired on transport outages
`_fetch_passage` emitted `equip.youversion.api_calls_total` only after a response object existed, so a transport-level failure (timeout / connection refused / DNS) — the outage operators most need on the API-budget dashboard — produced no data point. Now emits `outcome=fatal status_code=0` before re-raising `httpx.HTTPError`.

### #5 (medium) — dead dashboard tiles
Dashboards queried `equip.activity.daily_active_users`, `courses.active_7d`, `enrollments.count`, `grading.pending` — none emitted, so the widgets render perpetual "no data". The original sentinel only checked emitted→documented, never the reverse. Added `test_every_dashboard_metric_is_emitted_or_documented`: every `equip.*` metric in `docs/datadog/*.json` must be emitted or listed in the README. Documented the four as Still-TODO with honest notes on what each would need.

Local: ruff + mypy clean; 106 targeted tests + the sentinels pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
