### PR TITLE
fix(api): validate course image_url scheme; admin 404s use equip_error envelope

### DIFF
--- a/backend/app/api/v1/admin_translations.py
+++ b/backend/app/api/v1/admin_translations.py
@@ -20,7 +20,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import UUID  # noqa: TC003 — used by Pydantic schema at runtime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session  # noqa: TC002 — used by FastAPI Depends at
 
 from app.api.dependencies import require_admin
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.models.content_version import ContentVersion
 from app.models.translation_job import TranslationJob, TranslationJobStatus
 from app.services.audit_service import log_action
@@ -106,9 +107,11 @@ def reset_by_ids(
         db.rollback()
         raise
     if affected == 0:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="No failed_permanent rows matched the supplied ids.",
+            message="No failed_permanent rows matched the supplied ids.",
+            context={"resource_type": "content_version"},
         )
     log_action(
         db,
@@ -163,9 +166,11 @@ def reset_by_entity(
         db.rollback()
         raise
     if affected == 0:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="No failed_permanent row matched the selector.",
+            message="No failed_permanent row matched the selector.",
+            context={"resource_type": "content_version"},
         )
     log_action(
         db,

--- a/backend/app/schemas/_media_url.py
+++ b/backend/app/schemas/_media_url.py
@@ -1,0 +1,36 @@
+"""Shared validator for user-supplied media URLs (course covers, etc.).
+
+A stored media URL is later rendered into an ``<img src>`` / CSS
+background on the client. React escapes attribute values, so this is
+defence-in-depth rather than the only line — but keeping
+``javascript:`` / ``data:`` / ``vbscript:`` and bare ``http://`` out of
+the database means a future non-React consumer (an email, an OG-image
+renderer, a server-side template) can't be tricked by a value that was
+never validated at write time.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+
+def validate_safe_media_url(value: str | None) -> str | None:
+    """Accept only ``None``/empty, a same-origin relative path, or a
+    fully-qualified ``https://`` URL. Reject every other scheme.
+
+    Every legitimate storage origin in this stack is HTTPS (Supabase
+    public buckets) and the in-app image proxy uses same-origin ``/img/``
+    paths, so this allows both real shapes while blocking dangerous
+    schemes and mixed-content ``http://``.
+    """
+    if value is None or not value.strip():
+        return None
+    candidate = value.strip()
+    # Same-origin relative path (e.g. the ``/img/`` proxy convention).
+    # Reject protocol-relative ``//host`` which is NOT same-origin.
+    if candidate.startswith("/") and not candidate.startswith("//"):
+        return candidate
+    parsed = urlparse(candidate)
+    if parsed.scheme.lower() != "https" or not parsed.netloc:
+        raise ValueError("must be an https:// URL or a same-origin path")
+    return candidate

--- a/backend/app/schemas/course.py
+++ b/backend/app/schemas/course.py
@@ -2,7 +2,9 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.schemas._media_url import validate_safe_media_url
 
 # Mirrors the ``chapters_chapter_type_check`` CHECK in Postgres. ``video`` /
 # ``audio`` / ``mixed`` / ``content`` were collapsed into block-based
@@ -98,7 +100,13 @@ class CourseBase(BaseModel):
 
 
 class CourseCreate(CourseBase):
-    pass
+    # Validate the inherited image_url on INPUT only (CourseResponse also
+    # inherits CourseBase but defines no validator, so reads of any
+    # legacy value are never rejected).
+    @field_validator("image_url")
+    @classmethod
+    def _validate_image_url(cls, value: str | None) -> str | None:
+        return validate_safe_media_url(value)
 
 
 class CourseUpdate(BaseModel):
@@ -112,6 +120,11 @@ class CourseUpdate(BaseModel):
     access_mode: Literal["public", "institute"] | None = None
     enrollment_start: datetime | None = None
     enrollment_end: datetime | None = None
+
+    @field_validator("image_url")
+    @classmethod
+    def _validate_image_url(cls, value: str | None) -> str | None:
+        return validate_safe_media_url(value)
 
 
 class CourseResponse(CourseBase):

--- a/backend/tests/test_admin_translations_error_paths.py
+++ b/backend/tests/test_admin_translations_error_paths.py
@@ -91,4 +91,7 @@ class TestResetByIdsNotFound:
             json={"ids": ["00000000-0000-0000-0000-000000000000"]},
         )
         assert r.status_code == 404
-        assert "failed_permanent" in r.json()["detail"]
+        # equip_error envelope: detail is {code, message, context}.
+        detail = r.json()["detail"]
+        assert detail["code"] == "resource.not_found"
+        assert "failed_permanent" in detail["message"]

--- a/backend/tests/test_media_url_validation.py
+++ b/backend/tests/test_media_url_validation.py
@@ -1,0 +1,66 @@
+"""Course cover ``image_url`` must reject dangerous URL schemes on input.
+
+The value is stored and later rendered into an ``<img src>`` / CSS
+background. React escapes attributes, but keeping ``javascript:`` /
+``data:`` / bare ``http://`` out of the DB is defence-in-depth for any
+future non-React consumer. The validator allows real shapes: a
+fully-qualified ``https://`` URL (Supabase storage) or a same-origin
+``/img/`` proxy path.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas._media_url import validate_safe_media_url
+from app.schemas.course import CourseCreate, CourseUpdate
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://abc.supabase.co/storage/v1/object/public/covers/c.jpg",
+        "/img/covers/c.jpg",
+        None,
+        "",
+        "   ",
+    ],
+)
+def test_validator_accepts_safe_values(value: str | None) -> None:
+    # No exception; empty/whitespace normalise to None.
+    result = validate_safe_media_url(value)
+    if value and value.strip():
+        assert result == value.strip()
+    else:
+        assert result is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "vbscript:msgbox(1)",
+        "http://insecure.example.com/x.jpg",  # bare http rejected
+        "//evil.example.com/x.jpg",  # protocol-relative is NOT same-origin
+    ],
+)
+def test_validator_rejects_dangerous_or_insecure_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        validate_safe_media_url(value)
+
+
+def test_course_create_rejects_javascript_url() -> None:
+    with pytest.raises(ValidationError):
+        CourseCreate(title="X", image_url="javascript:alert(1)")
+
+
+def test_course_update_rejects_javascript_url() -> None:
+    with pytest.raises(ValidationError):
+        CourseUpdate(image_url="javascript:alert(1)")
+
+
+def test_course_create_accepts_https_cover() -> None:
+    c = CourseCreate(title="X", image_url="https://abc.supabase.co/covers/c.jpg")
+    assert c.image_url == "https://abc.supabase.co/covers/c.jpg"


### PR DESCRIPTION
## API hardening (audit #11, #12)

### #11 (low) — course `image_url` accepted any scheme
Stored and rendered into an `<img src>`/CSS background. New shared `validate_safe_media_url` rejects `javascript:`/`data:`/`vbscript:` and bare `http://`, allowing only `https://` URLs or same-origin `/img/` paths. Applied to `CourseCreate` + `CourseUpdate` (input only — `CourseResponse` keeps reading any legacy value, so no read breakage). `avatar_url` was checked: it is response-only (populated from OAuth/storage, no free-form input path), so no validator needed there.

### #12 (low) — admin 404s bypassed the error envelope
`reset-by-ids` / `reset-by-entity` raised bare `HTTPException` on the 0-rows-matched 404, returning `{detail: "string"}` instead of the `equip_error`/`ErrorCode` `{code, message, context}` envelope the rest of the API uses. Both now return `RESOURCE_NOT_FOUND`.

Tests: validator accept/reject matrix + CourseCreate/Update rejection; updated the admin 404 test to assert the envelope. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
