### PR TITLE
fix(design): kill white card outlines — soft-shadow .surface-card surface

### DIFF
--- a/frontend/src/components/announcements/AnnouncementPager.tsx
+++ b/frontend/src/components/announcements/AnnouncementPager.tsx
@@ -81,7 +81,7 @@ export function AnnouncementPager({ announcements, onDelete }: AnnouncementPager
       aria-label={t("teacherEditor.modals.announcements.title")}
       onKeyDown={onKeyDown}
       tabIndex={-1}
-      className="flex overflow-hidden rounded-lg border bg-card"
+      className="surface-card flex overflow-hidden rounded-lg"
     >
       <div className="flex min-w-0 flex-1 items-start gap-3 p-3 sm:p-4">
         <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-info" strokeWidth={1.75} aria-hidden />

--- a/frontend/src/components/dashboard/DailyChallengeCard.tsx
+++ b/frontend/src/components/dashboard/DailyChallengeCard.tsx
@@ -228,7 +228,7 @@ export function DailyChallengeCard() {
   return (
     <section
       aria-labelledby="dc-card-heading"
-      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md bg-card transition-[border-color] duration-300 hover:border-brand/25"
+      className="surface-card animate-fade-in flex h-full flex-col overflow-hidden rounded-md"
     >
       <header className="flex items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <div className="flex min-w-0 items-center gap-2.5">

--- a/frontend/src/components/quiz/QuizSubmissionsReview.tsx
+++ b/frontend/src/components/quiz/QuizSubmissionsReview.tsx
@@ -161,7 +161,7 @@ export default function QuizSubmissionsReview({ quizId }: Props) {
         return (
           <div
             key={item.answer_id}
-            className="rounded-md border bg-card p-4 space-y-3"
+            className="surface-card rounded-md p-4 space-y-3"
           >
             <div className="flex flex-wrap items-start justify-between gap-2">
               <div className="min-w-0 flex-1">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -213,6 +213,20 @@
   }
 }
 
+@layer components {
+  /* Canonical elevated card/panel surface. Single source of truth so we
+   * never reintroduce the "white обводка" — a light --border hairline
+   * around a near-white bg-card on the warm 97%L page read as a white
+   * outline (Vadym rejected it repeatedly). Instead we separate by a soft
+   * SHADOW in light mode (no outline line at all), and fall back to the
+   * subtle etched --border in dark mode where a shadow is invisible.
+   * Replaces the hand-rolled ``border bg-card`` panel pattern. Keep
+   * ``rounded-*`` / padding on the element; this only owns surface + edge. */
+  .surface-card {
+    @apply bg-card shadow-sm dark:border dark:border-edge dark:shadow-none;
+  }
+}
+
 @layer utilities {
   /* Suppress the visible scrollbar on horizontally-scrolling
    * surfaces that already have a clear affordance (e.g. the

--- a/frontend/src/pages/Dashboard/PublicLanding.tsx
+++ b/frontend/src/pages/Dashboard/PublicLanding.tsx
@@ -110,7 +110,7 @@ export function PublicLanding() {
       {/* ── How it works ────────────────────────────────────────── */}
       <section
         aria-labelledby="landing-how-heading"
-        className="mt-20 rounded-lg border bg-muted/30 px-6 py-10 sm:mt-28 sm:px-10 sm:py-12"
+        className="mt-20 rounded-lg bg-muted/40 px-6 py-10 sm:mt-28 sm:px-10 sm:py-12"
       >
         <h2
           id="landing-how-heading"
@@ -198,7 +198,7 @@ interface FeatureCardProps {
 
 function FeatureCard({ icon, title, body }: FeatureCardProps) {
   return (
-    <div className="flex flex-col rounded-lg border bg-card p-5">
+    <div className="surface-card flex flex-col rounded-lg p-5">
       <span className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-brand/10 text-brand">
         {icon}
       </span>
@@ -236,7 +236,7 @@ function QuickLink({ to, icon, title, body }: QuickLinkProps) {
     <li>
       <Link
         to={to}
-        className="group flex items-start gap-3 rounded-md border bg-card p-4 transition-colors hover:border-brand/40 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
+        className="group surface-card flex items-start gap-3 rounded-md p-4 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
       >
         <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted text-ink-muted transition-colors group-hover:bg-brand/10 group-hover:text-brand">
           {icon}


### PR DESCRIPTION
## Kill the white card outlines (real root cause)

Three rounds of tuning the `--border` lightness failed because a single token can never be both invisible-on-a-near-white-card AND visible-on-a-background-divider. The "белая обводка везде" was hand-rolled card panels with a bare `border` (the light `--border` hairline) around `bg-card` on the warm 97%L page — that hairline reads as a white outline. Verified by screenshotting live prod.

## Fix — per-surface, not per-token
New `.surface-card` utility (single source of truth in `src/index.css`):
- **light mode:** soft `shadow-sm` — clean elevation, *no outline line at all*
- **dark mode:** etched `border-edge` (shadows are invisible on dark, so a hairline below the card lightness separates without a bright stripe)

Screenshot-verified in **both** themes on the landing.

## Scope
Converted the visible offenders: `PublicLanding` feature + link cards + the muted "how it works" section, `AnnouncementPager`, `DailyChallengeCard`, `QuizSubmissionsReview`. A 12-file audit (1 agent/file) left the other 9 untouched — they already use the borderless `<Card>` primitive or carry intentional borders (dashed add-affordance, colored/semantic status, partial-side dividers, form controls).

tsc + eslint + build + vitest (518) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
