### PR TITLE
fix(api): typed response_model on the two PII-serializing endpoints

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, Header, Query, Response
+from pydantic import BaseModel
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -12,8 +13,31 @@ from app.services.translation.resolve_for_display import populate_spine_texts
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
 
+class CourseAnalyticsStudentRow(BaseModel):
+    """One enrollment row in the analytics student list. Typed so the
+    response is validated on the way out — this payload carries PII
+    (email + name), so a silent shape drift shouldn't ship unnoticed."""
+
+    enrollment_id: str
+    user_id: str
+    full_name: str
+    email: str
+    progress: int
+    enrolled_at: str | None = None
+
+
+class CourseAnalyticsResponse(BaseModel):
+    course_id: str
+    course_title: str
+    total_students: int
+    avg_progress: float
+    completion_count: int
+    enrollments: list[CourseAnalyticsStudentRow]
+
+
 @router.get(
     "/course/{course_id}",
+    response_model=CourseAnalyticsResponse,
     summary="Course-level analytics for the teacher dashboard",
     responses={
         200: {"description": "Course title + aggregate stats + paginated enrollment list"},

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -42,6 +42,7 @@ from app.schemas.cohort import (
     CohortCreate,
     CohortResponse,
     CohortStudentAdd,
+    CohortStudentRow,
     CohortUpdate,
 )
 from app.schemas.locale import normalize_locale
@@ -554,7 +555,7 @@ def detach_course(
 # ---------------------- junction: cohort x students -------------------
 
 
-@router.get("/{cohort_id}/students")
+@router.get("/{cohort_id}/students", response_model=list[CohortStudentRow])
 def list_cohort_students(
     cohort_id: UUID,
     skip: int = Query(0, ge=0, description="Pagination offset (student-level)."),

--- a/backend/app/schemas/cohort.py
+++ b/backend/app/schemas/cohort.py
@@ -135,13 +135,24 @@ class CohortStudentAdd(BaseModel):
     email: EmailStr | None = None
 
 
-class CohortStudentRow(BaseModel):
-    """One row in the per-cohort students listing — enrollment summary
-    plus the student's identity. Used by the cohort overview page."""
+class CohortStudentCourseProgress(BaseModel):
+    """Per-course enrollment summary nested inside a cohort student row."""
 
-    user_id: UUID
-    enrolled_at: datetime | None = None
+    enrollment_id: str
+    enrolled_at: str | None = None
     progress: int
-    # Per-course rows: this cohort spans N courses, so a student has N
-    # enrollments. Aggregated client-side from the per-course response.
-    per_course: dict[str, dict] = Field(default_factory=dict)
+
+
+class CohortStudentRow(BaseModel):
+    """One row in the per-cohort students listing — the student's identity
+    plus a per-course enrollment summary. Used by the cohort overview
+    page. Matches the exact shape returned by
+    ``GET /cohorts/{id}/students`` (carries PII: full_name + email, so the
+    response is validated on the way out)."""
+
+    user_id: str
+    full_name: str | None = None
+    email: str
+    # This cohort spans N courses, so a student has up to N enrollments,
+    # keyed by course_id.
+    per_course: dict[str, CohortStudentCourseProgress] = Field(default_factory=dict)


### PR DESCRIPTION
## Typed response_model on the PII endpoints (audit #13)

`GET /analytics/course/{id}` and `GET /cohorts/{id}/students` returned untyped `dict` / `list[dict]` — no output validation on payloads that carry **student email + full_name**. Added explicit Pydantic response models so a future handler change that drops, renames, or leaks a field is caught at the boundary.

- **analytics:** `CourseAnalyticsResponse` + `CourseAnalyticsStudentRow`
- **cohorts:** repurposed the **dead/mismatched** `CohortStudentRow` (it carried stale top-level `enrolled_at`/`progress`, was missing `full_name`/`email`, and was never imported anywhere) to match the real output + a nested `CohortStudentCourseProgress`; wired `response_model=list[CohortStudentRow]`.

Full backend suite **1424 passed** — the models validate the exact existing output (no field drops); ruff + mypy clean. The remaining untyped endpoints (progress chapter-id lists, enrollment teacher-complete) are typing hygiene, not defects, and carry no PII — left as optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
