### PR TITLE
fix(design): flat cards — drop the soft shadow, separate by fill alone

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -214,16 +214,16 @@
 }
 
 @layer components {
-  /* Canonical elevated card/panel surface. Single source of truth so we
-   * never reintroduce the "white обводка" — a light --border hairline
-   * around a near-white bg-card on the warm 97%L page read as a white
-   * outline (Vadym rejected it repeatedly). Instead we separate by a soft
-   * SHADOW in light mode (no outline line at all), and fall back to the
-   * subtle etched --border in dark mode where a shadow is invisible.
-   * Replaces the hand-rolled ``border bg-card`` panel pattern. Keep
-   * ``rounded-*`` / padding on the element; this only owns surface + edge. */
+  /* Canonical card/panel surface. Single source of truth so we never
+   * reintroduce the "белая обводка": a light --border hairline around a
+   * near-white bg-card on the warm 97%L page read as a white outline, and
+   * a soft shadow read as an equally-unwanted frame. The design language
+   * (and Vadym's preference) is FLAT — separate by the bg-card fill +
+   * spacing alone, exactly like the base <Card>. No border, no shadow.
+   * Replaces the hand-rolled ``border bg-card`` panel pattern; keep
+   * ``rounded-*`` / padding on the element. */
   .surface-card {
-    @apply bg-card shadow-sm dark:border dark:border-edge dark:shadow-none;
+    @apply bg-card;
   }
 }
 


### PR DESCRIPTION
Drop the soft shadow from `.surface-card` too — it still read as a frame ("явная и яркая обводка"). The app design language is flat (the base `<Card>` has no border and no shadow), so card panels now separate by the `bg-card` fill + spacing alone. No border, no shadow, both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
