### PR TITLE
fix(e2e): placeholder Supabase env so the SPA mounts (real cause of red E2E)

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -54,9 +54,15 @@ jobs:
         # (missing tree-shake-safe markers, env wiring) the same way
         # a real prod deploy would.
         env:
-          # Smoke tests don't need real backend env vars; the public
-          # routes degrade gracefully when ``VITE_API_URL`` is unset.
+          # Smoke tests don't hit a real backend, BUT the build must still
+          # be given Supabase vars: src/lib/supabase.ts THROWS at module
+          # load if VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY are unset,
+          # which blanks the whole SPA (React never mounts) and fails every
+          # public-flow spec with "element not found". These are throwaway
+          # placeholders — the public routes never call Supabase.
           VITE_API_URL: http://localhost:8000
+          VITE_SUPABASE_URL: https://example.supabase.co
+          VITE_SUPABASE_ANON_KEY: e2e-placeholder-anon-key-not-real
         run: |
           npm run build
           npx vite preview --host 127.0.0.1 --port 5173 &

--- a/frontend/src/components/layout/AuthLayout.tsx
+++ b/frontend/src/components/layout/AuthLayout.tsx
@@ -49,7 +49,7 @@ export default function AuthLayout({ children, heading, subheading }: AuthLayout
             </div>
           </div>
 
-          <p className="font-sans text-xs text-[hsl(var(--auth-panel-text)/0.38)]">
+          <p className="font-sans text-xs text-[hsl(var(--auth-panel-text-muted))]">
             {t("auth.marketingPanelFooter", { year, appName: t("common.appName") })}
           </p>
         </div>


### PR DESCRIPTION
## The REAL reason Frontend E2E was red on every commit

My earlier #727 (hydration waits) treated the wrong symptom. The actual cause:

The e2e build step set only `VITE_API_URL`, but `src/lib/supabase.ts` **throws at module load** when `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` are missing. So the production bundle threw on bootstrap → React never mounted → `#root` stayed empty → every public-flow assertion failed with "element not found". It never reproduced locally because a dev `.env` supplies those vars (my blind spot — I did not test under the CI env condition).

## Proof
- Moved `.env` aside + built (CI condition): `rootHtmlLen=0`, pageerror `"VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY must be set"`
- Added throwaway placeholders + built: `rootHtmlLen=18325`, 3 login links, 0 errors; `4/4` public specs pass

The public smoke routes never call Supabase, so placeholders are safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
