### PR TITLE
fix(obs): gemini transport-outage metric + cap Datadog log POST at 0.5s

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -76,7 +76,13 @@ class DatadogHTTPHandler(logging.Handler):
                 method="POST",
             )
             setattr(record, self._REENTRY_GUARD_ATTR, True)
-            urllib.request.urlopen(req, timeout=2)
+            # 0.5s cap: this POST runs inline on the request thread for every
+            # WARNING+ record, so under an error burst a slow Datadog intake
+            # could stack-block requests. A tight timeout bounds that; losing
+            # a log line on a slow intake is preferable to adding latency to
+            # a user request. (A background QueueListener would drop logs on
+            # Vercel serverless — the function freezes before it drains.)
+            urllib.request.urlopen(req, timeout=0.5)
         except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
             # Best effort. Losing a log record is preferable to crashing the request.
             pass

--- a/backend/app/services/translation/gemini.py
+++ b/backend/app/services/translation/gemini.py
@@ -154,6 +154,18 @@ class GeminiTranslationProvider:
             except httpx.HTTPError as exc:
                 last_error = exc
                 logger.warning("Gemini transport error attempt=%s err=%s", attempt, exc)
+                # A transport-level failure (timeout/connect/DNS) produces no
+                # HTTP status, so without this the per-call metric never fires
+                # on a full Gemini network outage — the failure mode the cost/
+                # budget dashboard most needs to see (same gap the youversion
+                # fix closed). status_code=0 = "no response".
+                with contextlib.suppress(Exception):
+                    increment(
+                        "equip.gemini.calls_total",
+                        model=self._model,
+                        outcome="transport",
+                        status_code="0",
+                    )
             else:
                 if response.status_code == 200:
                     result = self._parse_response(response.json())

--- a/backend/tests/test_gemini_metric_emission.py
+++ b/backend/tests/test_gemini_metric_emission.py
@@ -178,3 +178,31 @@ class TestFatalMetrics:
         calls = [m for m in msgs if "equip.gemini.calls_total" in m]
         assert calls
         assert any("outcome=fatal" in m and "status_code=400" in m for m in calls)
+
+    def test_transport_error_emits_transport_outcome(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A network-level failure (timeout/connect/DNS) yields no HTTP
+        status. Without an emit on this branch a full Gemini outage is
+        invisible on the cost/budget dashboard — so it must fire
+        outcome=transport status_code=0 (per failed attempt)."""
+        client = MagicMock(spec=httpx.Client)
+        client.post.side_effect = httpx.ConnectError("name resolution failed")
+        provider = _make_provider(client)
+        with (
+            caplog.at_level(logging.INFO, logger="equip.metric"),
+            contextlib.suppress(Exception),
+        ):
+            provider.translate(
+                TranslationRequest(
+                    text="Hello",
+                    source_locale="en",
+                    target_locale="ru",
+                    content_kind="text",
+                )
+            )
+        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+        calls = [m for m in msgs if "equip.gemini.calls_total" in m]
+        assert calls
+        assert any("outcome=transport" in m and "status_code=0" in m for m in calls)

--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -82,7 +82,9 @@ Live emission today (sites tagged with the route file that wires them):
   + **`equip.gemini.tokens_output_total`** —
   `app/services/translation/gemini.py::translate` emits per Gemini
   API call. Tagged with `model` (so a future flash → pro migration
-  keeps cost curves separable) and `outcome={success,retry,fatal}`.
+  keeps cost curves separable) and `outcome={success,retry,fatal,transport}`
+  (`transport` + `status_code=0` = a network-level failure with no HTTP
+  response, so a full Gemini outage still registers).
   `tokens_*_total` use the token count as the metric VALUE so
   `sum:` over the window equals cumulative token spend → multiply
   by Gemini's $/million rate to get $-burn.


### PR DESCRIPTION
Two launch-readiness findings (full-systems verification):

1. **Gemini transport outage invisible** — `gemini.py` `except httpx.HTTPError` logged but never emitted `equip.gemini.calls_total`, so a full Gemini *network* outage (all retries fail, no HTTP status) never showed on the cost/budget dashboard — same bug class the youversion fix closed. Now emits `outcome=transport status_code=0` (+ documented in datadog README, + test).
2. **Datadog log POST blocked the request thread** — `DatadogHTTPHandler` did a synchronous 2s `urlopen` per WARNING+ record inline; an error burst under ad traffic could stack-block requests. Timeout 2s→0.5s. (Background `QueueListener` deliberately NOT used — it drops logs on Vercel serverless.)

Local: ruff + mypy clean; gemini + sentinel tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)