### PR TITLE
fix(metrics): emit chapter_completed_total post-commit on the quiz paths

### DIFF
--- a/backend/app/api/v1/quizzes/attempts.py
+++ b/backend/app/api/v1/quizzes/attempts.py
@@ -14,6 +14,7 @@ from app.api.dependencies import (
 )
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
+from app.core.metrics import increment
 from app.models.enrollment import Enrollment
 from app.models.quiz import Quiz, QuizAttempt, QuizQuestion
 from app.models.user import User
@@ -138,13 +139,25 @@ def submit_quiz(
     attempt.passed = max_score > 0 and percentage >= quiz.passing_score
     attempt.completed_at = datetime.now(UTC)
 
+    newly_completed_chapter = False
     if attempt.passed:
-        quiz_service.upsert_passed_chapter_progress(db, current_user.id, str(quiz.chapter_id), course_id=course_id)
+        newly_completed_chapter = quiz_service.upsert_passed_chapter_progress(db, current_user.id, str(quiz.chapter_id))
         sync_enrollment_progress(db, current_user.id, course_id)
 
     db.commit()
     db.refresh(attempt)
     assert attempt.started_at is not None
+
+    # Emit the completion metric only AFTER the commit succeeds (and only when
+    # this submit actually flipped the chapter) — emitting pre-commit
+    # double-counts if the transaction rolls back.
+    if newly_completed_chapter:
+        increment(
+            "equip.engagement.chapter_completed_total",
+            chapter_id=str(quiz.chapter_id),
+            course_id=course_id,
+            completion_type="quiz",
+        )
 
     return QuizAttemptResponse(
         id=attempt.id,

--- a/backend/app/api/v1/quizzes/grading.py
+++ b/backend/app/api/v1/quizzes/grading.py
@@ -227,9 +227,20 @@ def grade_answer(
     was_pending = answer.graded_at is None
     answer.graded_at = datetime.now(UTC)
 
-    quiz_service.recompute_attempt_grade(db, attempt, quiz)
+    newly_completed_course_id = quiz_service.recompute_attempt_grade(db, attempt, quiz)
     db.commit()
     db.refresh(answer)
+
+    # Emit the chapter-completion metric only AFTER commit, and only when this
+    # re-grade actually flipped the chapter to complete (fail→pass) — pre-commit
+    # emission double-counts on a rollback.
+    if newly_completed_course_id is not None:
+        increment(
+            "equip.engagement.chapter_completed_total",
+            chapter_id=str(quiz.chapter_id),
+            course_id=newly_completed_course_id,
+            completion_type="quiz",
+        )
 
     # ``equip.grading.*`` metrics feed the Teacher Load dashboard.
     # Only counts the first time this answer transitioned out of the

--- a/backend/app/services/quiz_service.py
+++ b/backend/app/services/quiz_service.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException, status
 from sqlalchemy.exc import IntegrityError
 
-from app.core.metrics import increment
 from app.models.chapter_progress import ChapterProgress
 from app.models.quiz import (
     Quiz,
@@ -226,8 +225,14 @@ def persist_answers(
     return total_score, answer_results
 
 
-def upsert_passed_chapter_progress(db: Session, user_id: UUID, chapter_id: str, *, course_id: str) -> None:
+def upsert_passed_chapter_progress(db: Session, user_id: UUID, chapter_id: str) -> bool:
     """Mark the chapter as ``quiz``-completed for the student (idempotent).
+
+    Returns ``True`` iff THIS call flipped the chapter to completed, so the
+    caller can emit ``equip.engagement.chapter_completed_total`` AFTER its
+    own ``db.commit()``. Emitting in here (pre-commit) double-counted: on
+    the concurrent-completion rollback path the counter fired even though
+    the row write was rolled back.
 
     Race-safe: a concurrent teacher-mark-complete or assignment-submit
     for the same ``(user, chapter)`` may also be inserting a progress
@@ -265,21 +270,21 @@ def upsert_passed_chapter_progress(db: Session, user_id: UUID, chapter_id: str, 
         cp.completed = True
         cp.completed_at = datetime.now(UTC)
         cp.completion_type = "quiz"
-        increment(
-            "equip.engagement.chapter_completed_total",
-            chapter_id=str(chapter_id),
-            course_id=str(course_id),
-            completion_type="quiz",
-        )
+        return True
+    return False
 
 
-def recompute_attempt_grade(db: Session, attempt: QuizAttempt, quiz: Quiz) -> None:
+def recompute_attempt_grade(db: Session, attempt: QuizAttempt, quiz: Quiz) -> str | None:
     """Re-aggregate ``score`` / ``passed`` from the persisted answer rows.
 
     Called after every manual grade update so the attempt stays in sync
     without the teacher having to touch a "recompute" button. If
     ``passed`` flipped ``False`` → ``True`` the chapter is marked done
     and the enrollment progress is re-synced.
+
+    Returns the ``course_id`` iff this re-grade newly completed the chapter
+    (so the caller emits ``chapter_completed_total`` AFTER commit), else
+    ``None``.
     """
     rows = db.query(QuizAnswer).filter(QuizAnswer.attempt_id == attempt.id).all()
     attempt.score = sum(int(r.points_earned or 0) for r in rows)
@@ -293,13 +298,14 @@ def recompute_attempt_grade(db: Session, attempt: QuizAttempt, quiz: Quiz) -> No
     attempt.passed = max_score > 0 and percentage >= quiz.passing_score
 
     if attempt.passed == was_passed:
-        return
+        return None
 
     course_id = resolve_chapter_course_id(db, quiz.chapter_id)
     if attempt.passed:
         # fail → pass: mark the chapter done and sync progress up.
-        upsert_passed_chapter_progress(db, attempt.user_id, str(quiz.chapter_id), course_id=course_id)
+        newly_completed = upsert_passed_chapter_progress(db, attempt.user_id, str(quiz.chapter_id))
         sync_enrollment_progress(db, attempt.user_id, course_id)
+        return course_id if newly_completed else None
     else:
         # pass → fail (teacher lowered a manual grade below passing). The
         # inverse used to be missing: the chapter stayed quiz-completed and
@@ -310,6 +316,8 @@ def recompute_attempt_grade(db: Session, attempt: QuizAttempt, quiz: Quiz) -> No
         # passing attempt for this chapter survives, then re-sync down.
         _undo_quiz_chapter_completion(db, attempt.user_id, quiz.chapter_id, exclude_attempt_id=attempt.id)
         sync_enrollment_progress(db, attempt.user_id, course_id)
+    # pass→fail un-completes; nothing newly completed, so no metric to emit.
+    return None
 
 
 def _undo_quiz_chapter_completion(db: Session, user_id: UUID, chapter_id: str, *, exclude_attempt_id: UUID) -> None:

--- a/backend/tests/test_engagement_metrics.py
+++ b/backend/tests/test_engagement_metrics.py
@@ -75,9 +75,12 @@ def _seed_basic_course(db: Session, course_id: str = "eng-test") -> str:
 
 
 class TestQuizEngagementEmission:
-    """``upsert_passed_chapter_progress`` is the auto-from-quiz path."""
+    """``upsert_passed_chapter_progress`` is the auto-from-quiz path. It now
+    RETURNS whether it flipped completion (the route handlers emit the metric
+    post-commit); the helper itself no longer emits, so a rolled-back
+    transaction can't double-count."""
 
-    def test_emits_on_first_quiz_completion(
+    def test_returns_true_and_does_not_self_emit_on_first_completion(
         self,
         db: Session,
         caplog: pytest.LogCaptureFixture,
@@ -85,40 +88,24 @@ class TestQuizEngagementEmission:
         _seed_users(db)
         chapter_id = _seed_basic_course(db, "eng-q1")
         with caplog.at_level(logging.INFO, logger="equip.metric"):
-            quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id, course_id="eng-q1")
+            flipped = quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id)
             db.commit()
+        assert flipped is True
+        # The helper must NOT emit — emission is the caller's job, post-commit.
         msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
-        completed = [m for m in msgs if "equip.engagement.chapter_completed_total" in m]
-        assert completed, "expected chapter_completed_total to fire"
-        assert any("completion_type=quiz" in m for m in completed)
-        assert any(f"chapter_id={chapter_id}" in m for m in completed)
-        # course_id must be present so per-course drop-off widgets work
-        # (the quiz path used to drop it, unlike the other two paths).
-        assert any("course_id=eng-q1" in m for m in completed)
-        assert any("value=1.0" in m for m in completed)
+        assert [m for m in msgs if "equip.engagement.chapter_completed_total" in m] == []
 
-    def test_does_not_emit_when_already_complete(
+    def test_returns_false_on_already_complete(
         self,
         db: Session,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A second call after the chapter is already ``completed=True``
-        is a no-op and MUST NOT double-count toward drop-off math."""
+        """A second call after the chapter is already ``completed=True`` is a
+        no-op and returns False, so the caller won't double-count."""
         _seed_users(db)
         chapter_id = _seed_basic_course(db, "eng-q2")
-        # First pass to set up the completed row
-        quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id, course_id="eng-q2")
+        assert quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id) is True
         db.commit()
-        # Clear out whatever the setup pass emitted; the assertion
-        # below is about what fires on the SECOND call.
-        caplog.clear()
-
-        with caplog.at_level(logging.INFO, logger="equip.metric"):
-            quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id, course_id="eng-q2")
-            db.commit()
-        msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
-        completed = [m for m in msgs if "equip.engagement.chapter_completed_total" in m]
-        assert completed == [], "must NOT re-emit on no-op re-completion"
+        assert quiz_service.upsert_passed_chapter_progress(db, STUDENT_ID, chapter_id) is False
 
 
 class TestTeacherCompleteEngagementEmission:

--- a/backend/tests/test_quizzes_and_blocks.py
+++ b/backend/tests/test_quizzes_and_blocks.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for Quiz and Block endpoints."""
 
+import logging
 import uuid
 
 from fastapi.testclient import TestClient
@@ -1501,6 +1502,23 @@ def test_grade_essay_answer_recomputes_passed(client: TestClient, student, db: S
     graded_list = client.get(f"/api/v1/quizzes/{quiz.id}/pending-answers?include_graded=true").json()
     assert len(graded_list) == 1
     assert graded_list[0]["points_earned"] == 18
+
+
+def test_grade_up_to_passing_emits_chapter_completed_post_commit(client: TestClient, student, db: Session, caplog):
+    """Grading an essay up to passing flips the chapter to complete — the
+    chapter_completed_total metric must fire (now from the grading route,
+    AFTER commit, not pre-commit inside the service helper)."""
+    _seed_course_with_enrollment(db)
+    quiz, _essay, _attempt, essay_answer = _seed_submitted_essay_attempt(db)
+
+    with caplog.at_level(logging.INFO, logger="equip.metric"):
+        resp = client.patch(f"/api/v1/quizzes/answers/{essay_answer.id}", json={"points_earned": 18})
+    assert resp.status_code == 200
+
+    msgs = [r.getMessage() for r in caplog.records if r.name == "equip.metric"]
+    completed = [m for m in msgs if "equip.engagement.chapter_completed_total" in m]
+    assert completed, "grading up to passing must emit chapter_completed_total"
+    assert any("completion_type=quiz" in m and f"chapter_id={quiz.chapter_id}" in m for m in completed)
 
 
 def test_regrade_below_passing_uncompletes_chapter(client: TestClient, student, db: Session):


### PR DESCRIPTION
The quiz-submit and grade-up paths emitted `equip.engagement.chapter_completed_total` from inside `upsert_passed_chapter_progress` — **pre-commit**. A rolled-back transaction (e.g. the concurrent-completion `IntegrityError` path) over-counted, inconsistent with the post-commit hardening already on the teacher-mark + assignment-submit paths.

`upsert_passed_chapter_progress` now **returns** whether it flipped completion (no longer emits / needs course_id); `recompute_attempt_grade` returns the `course_id` when a re-grade newly completes the chapter. The two route handlers (`attempts.submit`, `grading.grade_answer`) emit **after** their commit, only on a real flip.

Unit tests assert the new return contract; a route-level test confirms grading up to passing still emits post-commit. Full backend suite **1426 passed**; ruff + mypy clean. From the full-systems verification (the last remaining metric-timing item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)