### PR TITLE
chore(security): close code-scanning alerts + harden supply-chain

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,14 +20,20 @@ name: Dependabot auto-merge
 
 on: pull_request_target
 
+# Least-privilege at the top level — critical here because pull_request_target
+# runs with access to repo secrets even for fork PRs, so a broad default token
+# is a real supply-chain risk (OpenSSF Scorecard flags it HIGH). The write
+# scopes the auto-merge actually needs are granted ONLY on the job below.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write # enable auto-merge / merge the PR
+      pull-requests: write # approve + set auto-merge on the PR
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -31,9 +31,9 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
           node-version: 22.18.0
           cache: npm
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: playwright-report
           path: frontend/playwright-report/
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: playwright-traces
           path: frontend/test-results/

--- a/frontend/src/lib/__tests__/images.test.ts
+++ b/frontend/src/lib/__tests__/images.test.ts
@@ -49,6 +49,13 @@ describe("toProxyImage", () => {
     )
   })
 
+  it("rejects dangerous URL schemes (defence-in-depth)", async () => {
+    const { toProxyImage: fn } = await freshImages()
+    expect(fn("javascript:alert(1)")).toBeUndefined()
+    expect(fn("data:text/html,<script>alert(1)</script>")).toBeUndefined()
+    expect(fn("vbscript:msgbox(1)")).toBeUndefined()
+  })
+
   it("returns original URL when Supabase URL is not configured", async () => {
     vi.stubEnv("VITE_SUPABASE_URL", "")
     const { toProxyImage: fn } = await freshImages()

--- a/frontend/src/lib/images.ts
+++ b/frontend/src/lib/images.ts
@@ -34,6 +34,11 @@ export function toProxyImage(url: string | null | undefined): string | undefined
   if (url.startsWith("/img/")) return url
   try {
     const parsed = new URL(url, window.location.origin)
+    // Defence-in-depth: only ever emit an http(s) URL into an <img src> /
+    // CSS background. React already escapes JSX attributes, but rejecting
+    // javascript:/data:/vbscript: here keeps dangerous schemes out of the
+    // DOM entirely (and out of the HTML-rewrite path below).
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined
     const supabaseHost = getSupabaseHost()
     if (!supabaseHost || parsed.host !== supabaseHost) return url
     if (!parsed.pathname.startsWith(STORAGE_PUBLIC_PREFIX)) return url


### PR DESCRIPTION
Closing the GitHub Code Scanning alerts before advertising to a large audience:

- **Scorecard PinnedDependencies ×6** — pinned the 4 `@v4` actions in `frontend-e2e.yml` to commit SHAs (reused the repo's existing pins). Dependabot already tracks the `github-actions` ecosystem so pins stay current.
- **Scorecard TokenPermissions HIGH** (`dependabot-auto-merge.yml`) — it runs on `pull_request_target` (secret access even for fork PRs), so top-level `write` was a real supply-chain risk. Top-level → `contents: read`; write scopes moved to the job.
- **CodeQL `js/xss-through-dom` HIGH** (`SetupStep.tsx`) — the `<img src>` flows from `toProxyImage`; React escapes JSX attrs (not exploitable) but added a defence-in-depth scheme guard: `toProxyImage` now returns `undefined` for any non-http(s) URL (`javascript:`/`data:`/`vbscript:`), with a test.

The remaining Scorecard items (BranchProtection / CodeReview / Fuzzing / SAST / CII-badge) are repo-policy opinions inherent to a solo maintainer, not code issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)