### PR TITLE
fix(infra): serverless pooler guard + connect_timeout; correct the log-drain doc

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from collections.abc import Generator
+from urllib.parse import urlparse
 
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -42,6 +43,26 @@ def _get_engine() -> Engine:
         separator = "&" if "?" in db_url else "?"
         db_url = f"{db_url}{separator}sslmode=require"
 
+    # Serverless DB-shape guard. NullPool (below) opens ONE connection per warm
+    # instance, so on Vercel/Lambda prod MUST point at Supabase's transaction
+    # pooler (:6543), not the direct Postgres endpoint (:5432). A direct
+    # connection caps at ~15-60 backends and exhausts almost immediately under a
+    # launch spike. Nothing else enforces this documented invariant
+    # (.env.example / DEPLOYMENT.md), so warn loudly at boot rather than discover
+    # it during an incident.
+    if IS_SERVERLESS:
+        try:
+            _port = urlparse(db_url).port
+        except ValueError:
+            _port = None
+        if _port == 5432:
+            logger.warning(
+                "DATABASE_URL targets port 5432 (DIRECT Postgres) under serverless. "
+                "With NullPool this opens one backend per warm instance and will "
+                "exhaust connections under load — use the Supabase TRANSACTION "
+                "POOLER (:6543) instead."
+            )
+
     try:
         try:
             import psycopg2 as _psycopg2
@@ -55,7 +76,10 @@ def _get_engine() -> Engine:
 
         pool_kwargs: dict = {
             "connect_args": {
-                "connect_timeout": 10,
+                # 5s (was 10) so a saturated pooler sheds load fast under a
+                # spike instead of queueing each request for 10s. A healthy
+                # pooler connect is sub-second; this only bites when saturated.
+                "connect_timeout": 5,
                 "options": "-c statement_timeout=30000",
             },
             "pool_pre_ping": True,

--- a/backend/tests/test_core_database.py
+++ b/backend/tests/test_core_database.py
@@ -127,3 +127,43 @@ class TestGetDbErrorHandling:
             next(gen)  # exhaust → enters finally
         fake_session.close.assert_called_once()
         fake_session.rollback.assert_not_called()
+
+
+class TestServerlessPoolerGuard:
+    def test_warns_on_direct_5432_url_under_serverless(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """On serverless, a direct :5432 DATABASE_URL would exhaust
+        connections under load (NullPool). _get_engine must WARN so the
+        misconfiguration surfaces at boot, not during an incident."""
+        import logging
+
+        monkeypatch.setattr(core_db, "_engine", None)
+        monkeypatch.setattr(core_db, "_SessionLocal", None)
+        monkeypatch.setattr(core_db, "IS_SERVERLESS", True)
+        monkeypatch.setattr(
+            core_db.settings, "DATABASE_URL", "postgresql://u:p@db.abc.supabase.co:5432/postgres", raising=False
+        )
+        with caplog.at_level(logging.WARNING):
+            core_db._get_engine()
+        monkeypatch.setattr(core_db, "_engine", None)  # don't cache the throwaway engine
+        assert any("5432" in r.getMessage() and "POOLER" in r.getMessage() for r in caplog.records)
+
+    def test_quiet_on_transaction_pooler_6543(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        monkeypatch.setattr(core_db, "_engine", None)
+        monkeypatch.setattr(core_db, "_SessionLocal", None)
+        monkeypatch.setattr(core_db, "IS_SERVERLESS", True)
+        monkeypatch.setattr(
+            core_db.settings,
+            "DATABASE_URL",
+            "postgresql://u:p@aws-0-us.pooler.supabase.com:6543/postgres",
+            raising=False,
+        )
+        with caplog.at_level(logging.WARNING):
+            core_db._get_engine()
+        monkeypatch.setattr(core_db, "_engine", None)
+        assert not any("POOLER" in r.getMessage() for r in caplog.records)

--- a/docs/datadog/monitors/README.md
+++ b/docs/datadog/monitors/README.md
@@ -65,15 +65,23 @@ never codified; the fix is to remove/retune them in the Datadog UI:
 - For BOTH (and every monitor here): turn **off** re-notification on Warn
   and Recovered — one email on Trigger is enough.
 
-### Redundant + failing Vercel log drain
+### Failing Vercel log drain — FIX it, do NOT just delete it
 
 The Vercel → Datadog **log drain** is failing ~80% (hourly "Drain failures
-on Equip" emails) AND is redundant: the app already ships WARNING+ logs to
-Datadog in-app via `DatadogHTTPHandler` (`backend/app/core/logging.py`).
-**Remove the drain** in Vercel → Settings → Log Drains. Single log path =
-the in-app handler; INFO stays in Vercel's own log viewer. Also turn off
-deploy-failure emails (Vercel → Account → Notifications) — preview/prod
-deploy failures are already visible in CI.
+on Equip" emails). It is tempting to call it redundant because the app ships
+logs to Datadog in-app via `DatadogHTTPHandler` — **but that handler is
+WARNING+ only** (`logging.py`), while every `equip.*` metric is emitted as an
+**INFO** log line (`app/core/metrics.py`). INFO reaches Datadog ONLY through
+this drain. **So deleting the drain silently kills the entire metric +
+dashboard layer** (engagement, translation-queue health, the
+`translation-queue-backlog` monitor) — only the WARNING+ pages survive.
+
+Correct fix order: **first** give `equip.metric` a second transport (a
+dedicated low-level HTTP path in the handler, or POST to the Datadog metrics
+API), verify metrics still flow, **then** the drain can be fixed or removed.
+Until then, repair the drain (it's the only metric pipeline) — do not delete
+it. (Deploy-failure emails are separate and safe to turn off: Vercel →
+Account → Notifications.)
 
 ## Open follow-ups
 


### PR DESCRIPTION
From the holistic architecture review (pre-large-audience launch):

- **DB connection guard.** NullPool on serverless opens one Postgres conn per warm instance, so prod MUST use the Supabase **transaction pooler (:6543)**, not the direct **:5432** endpoint (caps ~15-60 backends → exhausts under spike). Nothing enforced that documented invariant — added a boot-time WARNING if `DATABASE_URL` targets :5432 under serverless. Lowered `connect_timeout` 10s→5s so a saturated pooler sheds load fast instead of queueing. Tests for warn + quiet paths.
- **Corrected a dangerous doc (mine).** The monitors README said to DELETE the failing Vercel→Datadog log drain as "redundant". It is NOT — the in-app `DatadogHTTPHandler` ships WARNING+ only, while every `equip.*` metric is an INFO log line reaching Datadog ONLY via the drain. Deleting it would silently kill all metrics + dashboards + the translation-backlog monitor. Doc now: give `equip.metric` a 2nd transport FIRST, then touch the drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)