### PR TITLE
fix(design): theme-specific card border — none in dark (kill the grid)

### DIFF
--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -8,21 +8,23 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      // 2026-06-06: resting border RESTORED (Vadym: "a couple days ago
-      // there were no white lines, everything was normal"). Removing the
-      // border (#696) left a near-white surface-elevated (99% L) fill
-      // floating on the warm 97% L page — that read as "white panels", the
-      // exact thing being complained about. The bordered card (the state
-      // through #662) is the look that read as normal: a clear --edge (87% L)
-      // hairline frames the card instead of letting the fill float.
+      // 2026-06-06: resting border is THEME-SPECIFIC (border in light,
+      // transparent in dark) — the two themes fail oppositely:
+      //   LIGHT — a borderless near-white surface-elevated (99% L) fill on
+      //           the warm 97% L page floats as a "white panel" (#696's bug).
+      //           Needs the --edge (87% L) hairline to read as a card.
+      //   DARK  — a 19% L border around a 12% L card on the 9% L page outlines
+      //           every card into an ugly "HTML-table grid". Dark separates by
+      //           elevation (the lighter fill), not by a line → border-transparent.
       //
       // `transition-[border-color,background-color]` keeps the hover
       // border-tint handoff smooth (call sites use `hover:border-primary/40`).
+      // Those hover/selected/dnd opt-ins set their own border color and so
+      // still show in dark, which is intended (a deliberate frame, not a grid).
       //
       // ADR-0011 Wave 3 — v2 semantic vocabulary (`border-edge
-      // bg-surface-elevated text-ink`), bridged to --border/--card today;
-      // flips to OKLCH in Wave 9 with no code change.
-      "rounded-md border border-edge bg-surface-elevated text-ink shadow-none transition-[border-color,background-color] duration-200 ease-editorial",
+      // bg-surface-elevated text-ink`), bridged to --border/--card today.
+      "rounded-md border border-edge bg-surface-elevated text-ink shadow-none transition-[border-color,background-color] duration-200 ease-editorial dark:border-transparent",
       className
     )}
     {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -211,13 +211,17 @@
 
 @layer components {
   /* Canonical card/panel surface. Single source of truth. 2026-06-06:
-   * restored the resting border (Vadym — flat/borderless cards made the
-   * near-white bg-card fill read as floating "white panels" on the warm
-   * page; the pre-overhaul bordered card is the look that read as normal).
-   * bg-card + a clear --border (87% L) hairline = a defined card, not a
-   * white block. Keep ``rounded-*`` / padding on the element. */
+   * the border is THEME-SPECIFIC, because the two themes fail oppositely:
+   *   LIGHT — a near-white bg-card (99% L) on the warm 97% L page with NO
+   *           border floats as a "white panel". It NEEDS the 87% L hairline
+   *           to read as a defined card.
+   *   DARK  — a 19% L border around a 12% L card on the 9% L page outlines
+   *           every card = an ugly "HTML-table grid". Dark separates by
+   *           elevation (the lighter card fill), NOT by a line, so the
+   *           border is transparent there.
+   * Keep ``rounded-*`` / padding on the element. */
   .surface-card {
-    @apply rounded-md border border-border bg-card;
+    @apply rounded-md border border-border bg-card dark:border-transparent;
   }
 }
 


### PR DESCRIPTION
## Problem

#739 fixed light-mode "white panels" by restoring the card border — but in **dark mode** that border (19% L) around a 12% L card on the 9% L page outlines every card into an ugly "HTML-table grid" (Vadym: "прям такая как HTML-разметка, не красиво").

## Root cause

The two themes fail in opposite directions:
- **Light** — a borderless near-white (99% L) card on the warm 97% L page floats as a "white panel". Needs a border.
- **Dark** — dark UIs separate surfaces by **elevation** (lighter fill), not by lines. A border just adds grid noise.

A single border rule can't satisfy both.

## Fix

`.surface-card` and base `<Card>` keep their light-mode border but add `dark:border-transparent`. Dark cards now separate by the 12%→9% L elevation step alone — exactly the clean flat look that read as normal in dark before #739.

Hover / selected / dnd opt-ins set their own border color and still render in dark (a deliberate frame, not a grid).

## Verification

Screenshot-verified **both themes** on a prod-config build: light shows clean gray-bordered cards (no white panels); dark shows borderless elevation cards (no grid). Will re-verify both themes on live prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
