### PR TITLE
fix(design): emit the v2 token bridge — restore card fills + borders app-wide

### DIFF
--- a/frontend/src/components/assignment/AssignmentPanel.tsx
+++ b/frontend/src/components/assignment/AssignmentPanel.tsx
@@ -164,7 +164,7 @@ function SingleAssignment({ assignment, initialSubmission, onSubmitted }: { assi
   )
 
   return (
-    <div className="rounded-lg bg-card">
+    <div className="rounded-lg border border-edge dark:border-transparent bg-card">
       <div className="border-b border-edge px-5 py-5">
         <p className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
           <FileText className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />

--- a/frontend/src/components/dashboard/TodayCard.tsx
+++ b/frontend/src/components/dashboard/TodayCard.tsx
@@ -80,7 +80,7 @@ export function TodayCard() {
   return (
     <section
       aria-labelledby="today-card-heading"
-      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md bg-card transition-[border-color] duration-300 hover:border-brand/25"
+      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-edge dark:border-transparent bg-card transition-[border-color] duration-300 hover:border-brand/25"
     >
       <header className="flex items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <div className="flex min-w-0 items-center gap-2.5">

--- a/frontend/src/components/home/VerseOfTheDayCard.tsx
+++ b/frontend/src/components/home/VerseOfTheDayCard.tsx
@@ -54,7 +54,7 @@ export function VerseOfTheDayCard() {
   return (
     <section
       aria-labelledby="verse-of-the-day-heading"
-      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md bg-card transition-[border-color] duration-300 hover:border-brand/25"
+      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-edge dark:border-transparent bg-card transition-[border-color] duration-300 hover:border-brand/25"
     >
       {/* Compact header to match MiniCalendar / MyCoursesSection rhythm on
           the dashboard side rail. Icon dropped from a framed 10×10 box to

--- a/frontend/src/components/quiz/QuizTaker.tsx
+++ b/frontend/src/components/quiz/QuizTaker.tsx
@@ -144,7 +144,7 @@ export default function QuizTaker({ chapterId, quizId, onSubmitted }: QuizTakerP
     : 0
 
   return (
-    <div className="mt-6 rounded-lg bg-card">
+    <div className="mt-6 rounded-lg border border-edge dark:border-transparent bg-card">
       <QuizHeader
         quiz={quiz}
         questionCount={sortedQuestions.length}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,19 +1,26 @@
+/*
+ * Visual overhaul v2 — Wave 2 bridge. Defines the v2 semantic token
+ * names (--color-edge, --color-ink, --color-surface-elevated, …) backed
+ * by the v1 HSL palette, so v2-vocabulary classes (border-edge,
+ * text-ink, bg-surface-elevated) resolve.
+ *
+ * MUST come FIRST: per the CSS spec, `@import` after any other rule
+ * (including `@tailwind base`) is invalid and silently dropped by the
+ * bundler — which is exactly what happened from Wave 2 (#660) until
+ * 2026-06-06. With the import below the `@tailwind` directives, the
+ * entire bridge was absent from the build: every `--color-*` token
+ * was undefined, so all v2-vocabulary surfaces fell back (cards lost
+ * their `bg-surface-elevated` fill → transparent; `border-edge` →
+ * currentColor → dark outlines). Custom properties resolve lazily at
+ * use time, so importing the bridge before the v1 `:root` block is
+ * fine — `--color-edge: var(--border)` still picks up `--border`.
+ * See ADR-0011.
+ */
+@import "./styles/tokens-bridge.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/*
- * Visual overhaul v2 — Wave 2 bridge. Defines the v2 semantic token
- * names backed by the v1 HSL palette, so components can opt into the
- * new vocabulary today and the rest of the migration is invisible.
- * Imported AFTER the v1 ``@layer base`` block (below) so v1 vars
- * are declared by the time the bridge resolves them.
- *
- * Until Wave 3 starts swapping component code, this import is a
- * no-op at the rendered-pixel level — every bridge token resolves to
- * the same v1 color. See ADR-0011.
- */
-@import "./styles/tokens-bridge.css";
 
 /*
  * Theme: warm editorial paper (light) + zinc-depth dark (2025–2026 practice).

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -368,7 +368,7 @@ function CohortsTable({ items }: { items: Cohort[] }) {
           <Link
             key={c.id}
             to={`/admin/cohorts/${c.id}`}
-            className="block rounded-md bg-card p-3 transition-colors hover:border-brand/30 hover:bg-muted/40"
+            className="block rounded-md border border-edge dark:border-transparent bg-card p-3 transition-colors hover:border-brand/30 hover:bg-muted/40"
           >
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0 flex-1">

--- a/frontend/src/pages/Admin/dailyChallenge/DailyChallengeReviewDetailPage.tsx
+++ b/frontend/src/pages/Admin/dailyChallenge/DailyChallengeReviewDetailPage.tsx
@@ -221,7 +221,7 @@ interface FieldEditorProps {
 
 function FieldEditor({ label, field, cells, optionId, saving, onSave }: FieldEditorProps) {
   return (
-    <div className="rounded-md bg-card p-4">
+    <div className="rounded-md border border-edge dark:border-transparent bg-card p-4">
       <div className="mb-3 text-xs font-medium uppercase tracking-[0.14em] text-ink-muted">{label}</div>
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
         <LocaleCellEditor

--- a/frontend/src/pages/Admin/dailyChallenge/DailyChallengeReviewPage.tsx
+++ b/frontend/src/pages/Admin/dailyChallenge/DailyChallengeReviewPage.tsx
@@ -97,7 +97,7 @@ export default function DailyChallengeReviewPage() {
         }
       />
 
-      <section className="mt-6 rounded-md bg-card">
+      <section className="mt-6 rounded-md border border-edge dark:border-transparent bg-card">
         <header className="flex flex-wrap items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">

--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -183,7 +183,7 @@ function FileBlockLink({
       type="button"
       onClick={handleClick}
       disabled={opening}
-      className="group flex w-full items-center gap-3 rounded-md bg-card px-4 py-3 text-left transition-colors hover:border-brand/40 hover:bg-muted/40 disabled:opacity-60"
+      className="group flex w-full items-center gap-3 rounded-md border border-edge dark:border-transparent bg-card px-4 py-3 text-left transition-colors hover:border-brand/40 hover:bg-muted/40 disabled:opacity-60"
       aria-label={t("chapter.downloadFileAria", { name: label })}
     >
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">

--- a/frontend/src/pages/DailyChallengeArchive/DailyChallengeArchivePage.tsx
+++ b/frontend/src/pages/DailyChallengeArchive/DailyChallengeArchivePage.tsx
@@ -104,7 +104,7 @@ export default function DailyChallengeArchivePage() {
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,360px)]">
         <section
           aria-labelledby="dc-archive-grid-heading"
-          className="rounded-md bg-card"
+          className="rounded-md border border-edge dark:border-transparent bg-card"
         >
           <header className="flex items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
             <div className="flex items-center gap-2.5">
@@ -388,7 +388,7 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
 
   if (!challengeDate) {
     return (
-      <section className="rounded-md bg-card p-6 text-center">
+      <section className="rounded-md border border-edge dark:border-transparent bg-card p-6 text-center">
         <EmptyState
           variant="compact"
           title={t("dailyChallenge.archive.detail.pickDate")}
@@ -401,7 +401,7 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
   return (
     <section
       aria-labelledby="dc-archive-detail-heading"
-      className="rounded-md bg-card"
+      className="rounded-md border border-edge dark:border-transparent bg-card"
     >
       <header className="flex items-center gap-2.5 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <Button

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -83,7 +83,7 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
   const shell = (body: React.ReactNode, centered = false) => (
     <section
       data-tour="my-courses"
-      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md bg-card transition-[border-color] duration-300 hover:border-brand/25"
+      className="animate-fade-in flex h-full flex-col overflow-hidden rounded-md border border-edge dark:border-transparent bg-card transition-[border-color] duration-300 hover:border-brand/25"
     >
       <header className="flex items-center justify-between gap-3 border-b border-edge bg-gradient-accent-subtle px-4 py-3 sm:px-5 sm:py-4">
         <div className="flex min-w-0 items-center gap-2.5">

--- a/frontend/src/pages/Teacher/editor/CourseReadinessCard.tsx
+++ b/frontend/src/pages/Teacher/editor/CourseReadinessCard.tsx
@@ -61,7 +61,7 @@ export function CourseReadinessCard({ report, loading, onFix }: Props) {
   if (loading) {
     return (
       <section
-        className="mb-6 overflow-hidden rounded-md bg-card"
+        className="mb-6 overflow-hidden rounded-md border border-edge dark:border-transparent bg-card"
         aria-busy="true"
       >
         <div className="flex items-center gap-4 px-5 py-4">


### PR DESCRIPTION
## ROOT CAUSE — this is the real fix for the whole "white panels / ugly HTML-markup" saga

`@import "./styles/tokens-bridge.css"` was placed **after** the `@tailwind` directives in `frontend/src/index.css`. Per the CSS spec, an `@import` that follows any other rule is **invalid and silently dropped** by the bundler.

So from the visual overhaul Wave 2 (#660, 2026-06-02) onward, the bridge layer was **completely absent** from the production CSS. Every `--color-*` token was undefined → all v2-vocabulary surfaces fell back to invalid values:

| class | intended | actual (broken) |
|---|---|---|
| `bg-surface-elevated` | `--card` fill | invalid → **transparent** (cards had no fill) |
| `border-edge` | `--border` hairline | invalid → **currentColor** → dark outline |
| `text-ink` | `--foreground` | invalid → inherited |

Transparent cards + dark outlines = the "ugly HTML markup" look. It affected **every** surface migrated in Waves 3–16 (base `<Card>`, dashboards, editors, admin, quiz/forms, course pages…). `.surface-card` escaped only because it uses v1 classes (`bg-card` / `border-border`) that map straight to `--card` / `--border` — which is why my earlier landing fixes (#739/#740) appeared to work there but nothing else changed.

## Fix

Move the bridge `@import` to the top of `index.css`, before `@tailwind`. CSS custom properties resolve lazily at use time, so `--color-edge: var(--border)` still picks up the v1 palette declared lower in the file.

**Verified** against the built CSS and computed styles, both themes:
- light → card bg `#fdfdfc` (`--card` 99% L), border `#dddae2` (`--border` 87% L)
- dark → card bg `#1d1d20` (`--card` 12% L), border `#2e2e33` (`--border` 19% L)

## Plus: restore stripped feature-surface borders

#699 stripped `border border-edge` off ~40 hand-rolled `bg-card` surfaces. Re-applied the theme-specific border (`border border-edge dark:border-transparent`) to the ~12 top-level near-white panels among them (DailyChallenge pages, TodayCard, VerseOfTheDayCard, AssignmentPanel, QuizTaker, dashboard tiles, ChapterView rows, CourseReadinessCard) so they're bordered in light (no white panel) and grid-free in dark.

## Checks
- 168 style tests green (ADR-0011 sentinel + per-wave snapshots)
- eslint `--max-warnings 0` clean, `tsc` + build clean

Will re-verify on live prod (real catalog data) in both themes after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
