### PR TITLE
fix(security): harden Supabase token fallback (audience + expiry) + cap grade

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -27,10 +27,28 @@ def _cache_get(token: str) -> dict | None:
     return payload
 
 
+def _token_exp_epoch(token: str) -> float | None:
+    """Best-effort read of a JWT's ``exp`` (seconds since epoch) WITHOUT
+    verifying the signature. Used only to upper-bound the fallback cache TTL
+    so a token can never be served from cache past its own expiry."""
+    try:
+        claims = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return None
+    exp = claims.get("exp")
+    return float(exp) if isinstance(exp, (int, float)) else None
+
+
 def _cache_put(token: str, payload: dict) -> None:
     if len(_supabase_cache) >= _SUPABASE_CACHE_MAX_ENTRIES:
         _supabase_cache.pop(next(iter(_supabase_cache)), None)
-    _supabase_cache[token] = (time.monotonic() + _SUPABASE_CACHE_TTL_SECONDS, payload)
+    # TTL is the lesser of the fixed window and the token's own remaining
+    # lifetime — a token that expires in 5s must not stay valid for 60s.
+    ttl = _SUPABASE_CACHE_TTL_SECONDS
+    exp_epoch = _token_exp_epoch(token)
+    if exp_epoch is not None:
+        ttl = max(0.0, min(ttl, exp_epoch - time.time()))
+    _supabase_cache[token] = (time.monotonic() + ttl, payload)
 
 
 def _validate_via_supabase(token: str) -> dict | None:
@@ -64,11 +82,18 @@ def _validate_via_supabase(token: str) -> dict | None:
     if resp.status_code != 200:
         return None
     data = resp.json()
+    # Validate the audience from the REAL response rather than defaulting it.
+    # The local-secret path enforces audience="authenticated"; this fallback
+    # must not be weaker, or a token minted for a different audience under the
+    # same project would be accepted as a normal user.
+    if data.get("aud") != "authenticated":
+        logger.warning("Supabase token rejected: aud != authenticated")
+        return None
     payload = {
         "sub": data.get("id"),
         "email": data.get("email"),
-        "aud": data.get("aud", "authenticated"),
-        "role": data.get("role", "authenticated"),
+        "aud": data.get("aud"),
+        "role": data.get("role"),
     }
     _cache_put(token, payload)
     return payload

--- a/backend/app/schemas/assignment.py
+++ b/backend/app/schemas/assignment.py
@@ -78,7 +78,10 @@ class SubmissionResponse(BaseModel):
 
 
 class GradeSubmissionRequest(BaseModel):
-    grade: int = Field(..., ge=0)
+    # ``le`` mirrors ``max_score`` (≤10000) as a schema-level sanity ceiling.
+    # The route still rejects ``grade > the assignment's own max_score``; this
+    # just stops an absurd value being accepted by the schema alone.
+    grade: int = Field(..., ge=0, le=10000)
     feedback: str | None = Field(None, max_length=5000)
     # Must stay a subset of the DB CHECK on ``assignment_submissions.status``
     # (``submitted|graded|returned``). ``pending`` used to be accepted here

--- a/backend/tests/test_core_security.py
+++ b/backend/tests/test_core_security.py
@@ -79,6 +79,23 @@ class TestCacheRoundTrip:
         _clear_cache()
         assert core_security._cache_get("never-put") is None
 
+    def test_ttl_clamped_to_token_expiry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A token that expires in 5s must not stay cached for the full 60s
+        window. The cache TTL is ``min(60, token_exp - now)``.
+        """
+        _clear_cache()
+        monkeypatch.setattr(core_security.time, "time", lambda: 1000.0)
+        clock = {"mono": 0.0}
+        monkeypatch.setattr(core_security.time, "monotonic", lambda: clock["mono"])
+        # Token expires 5s after "now" (1000 -> 1005).
+        monkeypatch.setattr(core_security, "_token_exp_epoch", lambda _t: 1005.0)
+
+        core_security._cache_put("tok-short", {"sub": "u"})
+        clock["mono"] = 4.0  # within the token's 5s remaining life
+        assert core_security._cache_get("tok-short") == {"sub": "u"}
+        clock["mono"] = 6.0  # past token exp, but well under the 60s fixed TTL
+        assert core_security._cache_get("tok-short") is None
+
     def test_eviction_when_cache_is_full(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When the cache hits ``_SUPABASE_CACHE_MAX_ENTRIES`` the next
         ``_cache_put`` drops the oldest entry (insertion-order FIFO via
@@ -200,6 +217,39 @@ class TestSupabaseFallback:
         monkeypatch.setattr(core_security.httpx, "get", fake_get)
         core_security._validate_via_supabase("tok")
         assert captured["headers"]["apikey"] == ""
+
+    def test_wrong_audience_rejected_and_not_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A 200 from ``/auth/v1/user`` whose ``aud`` is NOT "authenticated"
+        must be rejected — the fallback path must be no weaker than the
+        local-secret path, which pins audience="authenticated".
+        """
+        _clear_cache()
+        monkeypatch.setattr(core_security.settings, "SUPABASE_URL", "https://proj.supabase.co")
+        monkeypatch.setattr(core_security.settings, "SUPABASE_SERVICE_ROLE_KEY", "sk-test")
+        monkeypatch.setattr(
+            core_security.httpx,
+            "get",
+            lambda *_a, **_k: _FakeHttpxResponse(
+                status_code=200,
+                json_body={"id": "u", "email": "e", "aud": "anon", "role": "anon"},
+            ),
+        )
+        assert core_security._validate_via_supabase("tok-wrongaud") is None
+        assert "tok-wrongaud" not in core_security._supabase_cache
+
+    def test_missing_audience_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_cache()
+        monkeypatch.setattr(core_security.settings, "SUPABASE_URL", "https://proj.supabase.co")
+        monkeypatch.setattr(core_security.settings, "SUPABASE_SERVICE_ROLE_KEY", "sk-test")
+        monkeypatch.setattr(
+            core_security.httpx,
+            "get",
+            lambda *_a, **_k: _FakeHttpxResponse(
+                status_code=200,
+                json_body={"id": "u", "email": "e", "role": "authenticated"},
+            ),
+        )
+        assert core_security._validate_via_supabase("tok-noaud") is None
 
 
 class TestDecodeAccessToken:


### PR DESCRIPTION
Pre-prod security audit fixes on the Supabase-token fallback path (`core/security.py`).

## Fixes
- **Audience (medium):** `_validate_via_supabase` defaulted `aud`/`role` to `authenticated` instead of validating the real value — the fallback was weaker than the local-secret path (which pins `audience=authenticated`). Now rejects when `aud != authenticated`.
- **Cache expiry (medium):** the 60s fallback cache ignored the token's `exp` → a token expiring in 5s stayed valid ~60s. TTL is now `min(60, exp-now)`.
- **Grade bound (low):** `GradeSubmissionRequest.grade` gets `le=10000` mirroring `max_score` (route already caps at the assignment's own max_score).

## Tests
Added: wrong/missing `aud` rejected + not cached; cache TTL clamped to token expiry. Green: 18 security + 39 auth/deps + grading; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)