### PR TITLE
fix(security): stop shipping source maps to prod + guard file_url href

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build && node scripts/check-bundle-size.mjs && node scripts/upload-sourcemaps.mjs",
+    "build": "tsc && vite build && node scripts/check-bundle-size.mjs && node scripts/upload-sourcemaps.mjs && node scripts/delete-sourcemaps.mjs",
     "bundle:check": "node scripts/check-bundle-size.mjs",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "i18n:check": "node scripts/i18n-check.mjs",

--- a/frontend/scripts/delete-sourcemaps.mjs
+++ b/frontend/scripts/delete-sourcemaps.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Delete Vite source maps after they've been uploaded to Datadog, so the
+// `.map` files (full original TS source) are NEVER served publicly from
+// Vercel. `vite.config.ts` uses `sourcemap: 'hidden'` (no sourceMappingURL
+// trailer), but the files are still fetchable by URL at
+// `https://equipbible.com/assets/<chunk>.js.map` unless removed.
+// Datadog already has its copy (see upload-sourcemaps.mjs), so deleting them
+// here costs nothing and closes the source-disclosure hole.
+
+import { existsSync, readdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+const dir = 'dist/assets'
+if (!existsSync(dir)) {
+  console.log('[sourcemaps] dist/assets not found, nothing to delete')
+  process.exit(0)
+}
+
+const maps = readdirSync(dir).filter((f) => f.endsWith('.map'))
+for (const f of maps) rmSync(join(dir, f), { force: true })
+console.log(`[sourcemaps] deleted ${maps.length} .map file(s) from ${dir} (not shipped to Vercel)`)

--- a/frontend/src/components/assignment/editor/SubmissionGrader.tsx
+++ b/frontend/src/components/assignment/editor/SubmissionGrader.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge"
 import { FileText, Loader2, MessageSquare, Save, Star, User } from "lucide-react"
 import { coursesService } from "@/services/courses"
 import { toast } from "@/lib/toast"
+import { isHttpUrl } from "@/lib/url"
 import type { AssignmentSubmission } from "@/types"
 
 interface Props {
@@ -79,7 +80,7 @@ export function SubmissionGrader({ submission, maxScore, onUpdate }: Props) {
           </div>
         )}
 
-        {submission.file_url && (
+        {submission.file_url && isHttpUrl(submission.file_url) && (
           <a
             href={submission.file_url}
             target="_blank"

--- a/frontend/src/lib/url.ts
+++ b/frontend/src/lib/url.ts
@@ -1,0 +1,19 @@
+/**
+ * True only for fully-qualified http(s) URLs. Used to gate user-supplied
+ * URLs before they land in an `<a href>` — React does NOT block dangerous
+ * schemes like `javascript:` in href, so a stored `javascript:…` value would
+ * execute in the viewer's session on click.
+ *
+ * Defence-in-depth: the backend already rejects non-`https://` submission
+ * URLs (`schemas/assignment.py::_enforce_https_scheme`); this keeps the
+ * render side safe even if an upstream check ever regresses.
+ */
+export function isHttpUrl(url: string | null | undefined): boolean {
+  if (!url) return false
+  try {
+    const parsed = new URL(url, window.location.origin)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Pre-prod security audit (frontend).

## Fixes
- **Source maps (medium):** `vite build` emitted 114 `.map` files (full TS source) into `dist/assets`. `sourcemap:'hidden'` removes the trailer but the files were still fetchable at `equipbible.com/assets/<chunk>.js.map`. New `scripts/delete-sourcemaps.mjs` runs **after** the Datadog upload, so Datadog keeps its copy (symbolication intact) and nothing ships to Vercel. Verified: 114 deleted, 0 left. No secret in the maps (grepped) — disclosure only.
- **file_url href (defence-in-depth):** `SubmissionGrader` rendered student `file_url` into `<a href>`; React doesn't block `javascript:`. Backend **already** rejects non-https on submit (`_enforce_https_scheme`), so this is belt-and-suspenders: new `lib/url.ts` `isHttpUrl()` gates the link.

Build + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)