### PR TITLE
fix(enrollment): allow multi-cohort retake (scope existence to user+course+cohort)

### DIFF
--- a/backend/app/services/course_service/_enrollment.py
+++ b/backend/app/services/course_service/_enrollment.py
@@ -35,9 +35,7 @@ def enroll_user_in_course(
     # get a NEW row, which is the intended multi-cohort-retake behaviour. A
     # plain (user, course) check would wrongly return the old row and silently
     # block the retake the index was designed to permit.
-    cohort_match = (
-        Enrollment.cohort_id.is_(None) if cohort_id is None else Enrollment.cohort_id == cohort_id
-    )
+    cohort_match = Enrollment.cohort_id.is_(None) if cohort_id is None else Enrollment.cohort_id == cohort_id
     existing = (
         db.query(Enrollment)
         .filter(Enrollment.user_id == user_id, Enrollment.course_id == course_id, cohort_match)

--- a/backend/app/services/course_service/_enrollment.py
+++ b/backend/app/services/course_service/_enrollment.py
@@ -29,7 +29,20 @@ def enroll_user_in_course(
     course_id: str,
     cohort_id: str | None = None,
 ) -> Enrollment:
-    existing = db.query(Enrollment).filter(Enrollment.user_id == user_id, Enrollment.course_id == course_id).first()
+    # Existence is scoped to (user, course, cohort) — matching the DB unique
+    # index `(user_id, course_id, COALESCE(cohort_id, sentinel))`. A student
+    # who took the course solo (or in cohort A) may re-enrol via cohort B and
+    # get a NEW row, which is the intended multi-cohort-retake behaviour. A
+    # plain (user, course) check would wrongly return the old row and silently
+    # block the retake the index was designed to permit.
+    cohort_match = (
+        Enrollment.cohort_id.is_(None) if cohort_id is None else Enrollment.cohort_id == cohort_id
+    )
+    existing = (
+        db.query(Enrollment)
+        .filter(Enrollment.user_id == user_id, Enrollment.course_id == course_id, cohort_match)
+        .first()
+    )
     if existing:
         return existing
 
@@ -44,10 +57,14 @@ def enroll_user_in_course(
     try:
         db.commit()
     except IntegrityError:
-        # A concurrent POST for the same (user, course) just committed.
+        # A concurrent POST for the same (user, course, cohort) just committed.
         # Return the winner row instead of propagating the 500.
         db.rollback()
-        existing = db.query(Enrollment).filter(Enrollment.user_id == user_id, Enrollment.course_id == course_id).first()
+        existing = (
+            db.query(Enrollment)
+            .filter(Enrollment.user_id == user_id, Enrollment.course_id == course_id, cohort_match)
+            .first()
+        )
         if existing:
             return existing
         raise

--- a/backend/tests/test_enrollment_metrics.py
+++ b/backend/tests/test_enrollment_metrics.py
@@ -10,8 +10,11 @@ and MUST NOT fire when the existing-row early return path is taken
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING
 
+from app.models.cohort import Cohort, CohortCourse
+from app.models.enrollment import Enrollment
 from app.models.user import User, UserRole
 from app.services.course_service import enroll_user_in_course
 
@@ -118,3 +121,77 @@ class TestEnrollmentMetricEmission:
         assert events
         for m in events:
             assert "cohort_id=" not in m, f"unexpected cohort_id attribute in: {m}"
+
+
+class TestMultiCohortRetake:
+    """Existence is scoped to (user, course, cohort) — a student may retake a
+    course in a different cohort and get a NEW enrollment row, matching the DB
+    unique index `(user_id, course_id, COALESCE(cohort_id, sentinel))`. The
+    previous (user, course)-only check wrongly returned the old row and blocked
+    the retake the index was designed to allow.
+    """
+
+    def test_retake_in_different_cohort_creates_new_row(self, db: Session) -> None:
+        _seed_users(db)
+        course = make_course_with_text(
+            db,
+            course_id="enr-retake",
+            title="Retake",
+            status="published",
+            created_by=TEACHER_ID,
+        )
+        db.commit()
+
+        # Solo enrollment (no cohort).
+        solo = enroll_user_in_course(db, STUDENT_ID, course.id)
+
+        # A cohort that includes this course.
+        cohort = Cohort(
+            start_date=datetime(2020, 1, 1),
+            end_date=datetime(2030, 1, 1),
+            status="active",
+        )
+        db.add(cohort)
+        db.commit()
+        db.refresh(cohort)
+        db.add(CohortCourse(cohort_id=cohort.id, course_id=course.id))
+        db.commit()
+
+        # Retake via the cohort → a NEW row, not the solo one.
+        via_cohort = enroll_user_in_course(db, STUDENT_ID, course.id, cohort_id=cohort.id)
+        assert via_cohort.id != solo.id
+        assert via_cohort.cohort_id == cohort.id
+
+        # Same cohort again → idempotent: returns the existing cohort row.
+        again = enroll_user_in_course(db, STUDENT_ID, course.id, cohort_id=cohort.id)
+        assert again.id == via_cohort.id
+
+        # Net: exactly two rows for (user, course) — solo + cohort.
+        rows = (
+            db.query(Enrollment)
+            .filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == course.id)
+            .count()
+        )
+        assert rows == 2
+
+    def test_solo_reenroll_still_idempotent(self, db: Session) -> None:
+        """The None-cohort path must still early-return the existing solo row
+        (cohort_id IS NULL match), not create a duplicate."""
+        _seed_users(db)
+        course = make_course_with_text(
+            db,
+            course_id="enr-solo-idem",
+            title="Solo",
+            status="published",
+            created_by=TEACHER_ID,
+        )
+        db.commit()
+        first = enroll_user_in_course(db, STUDENT_ID, course.id)
+        again = enroll_user_in_course(db, STUDENT_ID, course.id)
+        assert again.id == first.id
+        rows = (
+            db.query(Enrollment)
+            .filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == course.id)
+            .count()
+        )
+        assert rows == 1

--- a/backend/tests/test_enrollment_metrics.py
+++ b/backend/tests/test_enrollment_metrics.py
@@ -167,11 +167,7 @@ class TestMultiCohortRetake:
         assert again.id == via_cohort.id
 
         # Net: exactly two rows for (user, course) — solo + cohort.
-        rows = (
-            db.query(Enrollment)
-            .filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == course.id)
-            .count()
-        )
+        rows = db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == course.id).count()
         assert rows == 2
 
     def test_solo_reenroll_still_idempotent(self, db: Session) -> None:
@@ -189,9 +185,5 @@ class TestMultiCohortRetake:
         first = enroll_user_in_course(db, STUDENT_ID, course.id)
         again = enroll_user_in_course(db, STUDENT_ID, course.id)
         assert again.id == first.id
-        rows = (
-            db.query(Enrollment)
-            .filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == course.id)
-            .count()
-        )
+        rows = db.query(Enrollment).filter(Enrollment.user_id == STUDENT_ID, Enrollment.course_id == course.id).count()
         assert rows == 1


### PR DESCRIPTION
Architecture audit: the enroll service contradicted its own schema. The unique index `(user_id, course_id, COALESCE(cohort_id, sentinel))` is designed for multi-cohort retake, but `enroll_user_in_course` checked existence by (user, course) only → a student enrolled solo/in cohort A who enrolled via cohort B got the OLD row and the retake was silently blocked.

Vadym confirmed multi-cohort retake **is** intended. Existence query + IntegrityError re-query now include the cohort (IS NULL match for the solo case, so solo re-enroll stays idempotent).

Tests: retake creates a 2nd row; same-cohort re-enroll idempotent; solo re-enroll idempotent. 27 green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)