### PR TITLE
perf(lcp): paint public landing without blocking on auth init

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -17,9 +17,40 @@ import { setDatadogUser, clearDatadogUser } from "@/lib/datadog"
 // the canonical first-run locale UX for ALL signup paths (OAuth and
 // email alike), so the heuristic is gone.
 
+/**
+ * Synchronous "is anyone plausibly signed in?" probe used to seed the initial
+ * loading state. supabase-js persists its session under a
+ * `sb-<project-ref>-auth-token` localStorage key; if no such key holds a value,
+ * the visitor is definitely anonymous and we can render the public shell
+ * immediately instead of blocking the whole app on the async
+ * `INITIAL_SESSION` round-trip (the #1 cause of the >4s LCP on the landing).
+ * A stored session still starts `loading=true` so a logged-in user never
+ * flashes the anonymous landing before their dashboard. A localStorage that's
+ * blocked or empty → treated as anonymous (paint now). Worst case for a stale/
+ * expired stored token is the pre-existing behaviour: a brief spinner until
+ * `INITIAL_SESSION` resolves it to signed-out.
+ */
+function hasStoredSupabaseSession(): boolean {
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i)
+      if (k && k.startsWith("sb-") && k.endsWith("-auth-token")) {
+        const v = localStorage.getItem(k)
+        if (v && v !== "null") return true
+      }
+    }
+  } catch {
+    /* localStorage unavailable (private mode / blocked) → assume anonymous */
+  }
+  return false
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
+  // Seed from the synchronous storage probe: anonymous visitors (no token)
+  // skip the spinner and paint the public landing immediately; signed-in
+  // visitors wait for profile enrichment as before.
+  const [loading, setLoading] = useState(hasStoredSupabaseSession)
   const mounted = useRef(true)
   const activeUserId = useRef<string | null>(null)
   // ``inflightUserId`` deduplicates *simultaneous* enrichProfile() calls

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -112,9 +112,26 @@ describe("AuthContext", () => {
     signInWithGoogle.mockReset()
     resetPassword.mockReset()
     logout.mockReset()
+    localStorage.clear()
   })
 
-  it("starts in a loading=true, anon state until INITIAL_SESSION fires", () => {
+  it("starts loading=false + anon when no session is stored (anonymous fast paint)", () => {
+    // No `sb-*-auth-token` in localStorage → the provider seeds loading=false
+    // so the public landing paints immediately instead of blocking on the
+    // async INITIAL_SESSION round-trip (the LCP fix).
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    )
+    expect(screen.getByTestId("loading").textContent).toBe("false")
+    expect(screen.getByTestId("user").textContent).toBe("anon")
+  })
+
+  it("starts loading=true when a supabase session token IS stored", () => {
+    // A returning signed-in visitor must NOT flash the anonymous landing —
+    // a stored token seeds loading=true until INITIAL_SESSION enriches.
+    localStorage.setItem("sb-testproj-auth-token", JSON.stringify({ access_token: "tok" }))
     render(
       <AuthProvider>
         <AuthProbe />


### PR DESCRIPTION
Root cause of the **slow page load (avg LCP > 4s)** Datadog monitor. `AppRoutes` rendered a full-screen spinner while `auth.loading`, so even the static anonymous landing couldn't paint until supabase-js initialized and the async `INITIAL_SESSION` resolved.

**Fix:** seed AuthProvider's initial `loading` from a synchronous localStorage probe. No `sb-<ref>-auth-token` value → anonymous → `loading=false` → landing paints immediately. A stored token → `loading=true` (returning user never flashes the anon landing). Blocked/empty localStorage → anonymous.

Tests rewritten (anon→false, stored→true) + localStorage.clear() in beforeEach. **520 tests green**, tsc + eslint + build clean. Real LCP improvement will show on the Datadog monitor post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)