### PR TITLE
refactor(errors): auth 401/403 use the equip_error typed envelope (arch M1)

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -5,6 +5,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
+from app.core.errors import ErrorCode, equip_error
 from app.core.security import decode_access_token
 from app.models.course import Chapter, Course, CourseStatus, Module
 from app.models.enrollment import Enrollment
@@ -22,23 +23,26 @@ def get_current_user(
 ) -> User:
     payload = decode_access_token(credentials.credentials)
     if payload is None:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_REQUIRED,
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate credentials",
+            message="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
         )
     user_id: str | None = payload.get("sub")
     if user_id is None:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_REQUIRED,
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate credentials",
+            message="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
         )
     user = db.query(User).filter(User.id == user_id).first()
     if user is None:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_REQUIRED,
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User not found",
+            message="User not found",
             headers={"WWW-Authenticate": "Bearer"},
         )
     return user
@@ -63,9 +67,10 @@ def require_teacher(
     current_user: User = Depends(get_current_user),
 ) -> User:
     if current_user.role not in (UserRole.TEACHER.value, UserRole.ADMIN.value):
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only teachers can perform this action",
+            message="Only teachers can perform this action",
         )
     return current_user
 
@@ -74,9 +79,10 @@ def require_admin(
     current_user: User = Depends(get_current_user),
 ) -> User:
     if current_user.role != UserRole.ADMIN.value:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin access required",
+            message="Admin access required",
         )
     return current_user
 
@@ -137,9 +143,10 @@ def verify_course_owner(
         return course
     if allow_admin and _resolve_admin_flag(db, teacher):
         return course
-    raise HTTPException(
+    raise equip_error(
+        ErrorCode.AUTH_FORBIDDEN,
         status_code=status.HTTP_403_FORBIDDEN,
-        detail="You do not own this course",
+        message="You do not own this course",
     )
 
 
@@ -175,9 +182,10 @@ def verify_chapter_access(db: Session, chapter_id: str, user: User) -> Chapter:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chapter not found")
     enrolled = db.query(Enrollment).filter(Enrollment.user_id == user.id, Enrollment.course_id == course.id).first()
     if not enrolled:
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You must be enrolled in this course",
+            message="You must be enrolled in this course",
         )
     return chapter
 
@@ -192,9 +200,10 @@ def verify_chapter_owner(db: Session, chapter_id: str, teacher: User | str) -> t
     if str(course.created_by) == str(teacher_id):
         return chapter, str(course.id)
     if not _resolve_admin_flag(db, teacher):
-        raise HTTPException(
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not own this course",
+            message="You do not own this course",
         )
     return chapter, str(course.id)
 

--- a/backend/tests/test_api_dependencies.py
+++ b/backend/tests/test_api_dependencies.py
@@ -144,7 +144,9 @@ class TestGetCurrentUser:
         with pytest.raises(HTTPException) as exc:
             deps.get_current_user(credentials=_bearer(), db=db)
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert "User not found" in exc.value.detail
+        # equip_error envelope: detail is now the typed dict, not a bare string.
+        assert exc.value.detail["code"] == "auth.required"
+        assert exc.value.detail["message"] == "User not found"
 
     def test_returns_user_on_happy_path(
         self,
@@ -230,7 +232,8 @@ class TestRequireTeacher:
         with pytest.raises(HTTPException) as exc:
             deps.require_teacher(current_user=student)
         assert exc.value.status_code == status.HTTP_403_FORBIDDEN
-        assert "teachers" in exc.value.detail.lower()
+        assert exc.value.detail["code"] == "auth.forbidden"
+        assert "teachers" in exc.value.detail["message"].lower()
 
 
 class TestRequireAdmin:
@@ -247,7 +250,8 @@ class TestRequireAdmin:
         with pytest.raises(HTTPException) as exc:
             deps.require_admin(current_user=teacher)
         assert exc.value.status_code == status.HTTP_403_FORBIDDEN
-        assert "admin" in exc.value.detail.lower()
+        assert exc.value.detail["code"] == "auth.forbidden"
+        assert "admin" in exc.value.detail["message"].lower()
 
     def test_student_is_403(self) -> None:
         student = User(id=STUDENT_ID, email="s", full_name="s", role=UserRole.STUDENT.value)


### PR DESCRIPTION
Architecture audit **M1**: the most common error class (401/403 from the auth dependencies) still returned legacy `{"detail": "..."}` — the thing `core/errors.py` exists to replace. `AUTH_REQUIRED`/`AUTH_FORBIDDEN` were defined but never raised.

Converts every auth raise in `api/dependencies.py` to `equip_error(...)` (401s keep `WWW-Authenticate: Bearer`). 404 resource raises left as-is (separate concern). Frontend `getErrorDetail` already handles both shapes → non-breaking.

Updated 3 dependency-test assertions to read the typed envelope. **1433 backend tests green**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)