### PR TITLE
fix(cohort): unify capacity gate + fix already-seated student wrongly blocked (H3)

### DIFF
--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -47,6 +47,7 @@ from app.schemas.cohort import (
 )
 from app.schemas.locale import normalize_locale
 from app.services.audit_service import log_action
+from app.services.cohort_capacity import assert_cohort_has_capacity
 from app.services.content_versions import record_human_version
 from app.services.language_detection import detect_locale
 from app.services.translation.pipeline_hooks import reconcile_entity_if_course_published
@@ -110,15 +111,6 @@ def _fetch_cohort_names(db: Session, cohort_ids: list[UUID]) -> dict[str, str]:
 def _course_ids_for_cohort(db: Session, cohort_id: UUID) -> list[str]:
     """Return course_ids attached to the cohort via the junction."""
     return [row[0] for row in db.query(CohortCourse.course_id).filter(CohortCourse.cohort_id == cohort_id).all()]
-
-
-def _student_count(db: Session, cohort_id: UUID) -> int:
-    """Distinct users enrolled in this cohort. A cohort student typically
-    has N enrollment rows (one per attached course), so we COUNT DISTINCT
-    rather than count enrollment rows."""
-    return (
-        db.query(func.count(func.distinct(Enrollment.user_id))).filter(Enrollment.cohort_id == cohort_id).scalar() or 0
-    )
 
 
 def _serialize_many(db: Session, cohorts: list[Cohort]) -> list[CohortResponse]:
@@ -691,20 +683,11 @@ def add_student(
         )
     }
 
-    if cohort.max_students:
-        current_count = _student_count(db, cohort.id)
-        if not already_enrolled_courses and current_count >= cohort.max_students:
-            raise equip_error(
-                ErrorCode.VALIDATION_FAILED,
-                status_code=status.HTTP_403_FORBIDDEN,
-                message="Cohort has reached maximum capacity",
-                context={
-                    "resource_type": "cohort",
-                    "resource_id": str(cohort_id),
-                    "max_students": cohort.max_students,
-                    "current_count": current_count,
-                },
-            )
+    # Capacity gate — shared with the student self-enroll path (one helper so
+    # the already-seated exemption + error code can't drift again). The helper
+    # does its own "already in cohort?" check, so it's equivalent to the prior
+    # ``not already_enrolled_courses`` guard.
+    assert_cohort_has_capacity(db, cohort, user.id)
 
     course_ids = _course_ids_for_cohort(db, cohort.id)
     missing_course_ids = [cid for cid in course_ids if cid not in already_enrolled_courses]

--- a/backend/app/api/v1/courses/enrollment.py
+++ b/backend/app/api/v1/courses/enrollment.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime
 
 from fastapi import Depends, Request, status
 from pydantic import BaseModel
-from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_current_user
@@ -16,6 +15,7 @@ from app.models.enrollment import Enrollment
 from app.models.user import User
 from app.schemas.course import EnrollmentResponse
 from app.services.audit_service import log_action
+from app.services.cohort_capacity import assert_cohort_has_capacity
 from app.services.course_service import enroll_user_in_course
 from app.services.translation.resolve_for_display import populate_spine_texts
 
@@ -53,7 +53,7 @@ def get_enrollment_status(
     }
 
 
-def _enforce_cohort_gates(db: Session, course_id: str, cohort_id: str, now: datetime) -> None:
+def _enforce_cohort_gates(db: Session, course_id: str, cohort_id: str, user_id: str, now: datetime) -> None:
     """Validate that the student can enroll into the requested cohort.
 
     Returns nothing on success; raises the appropriate HTTPException on
@@ -111,25 +111,10 @@ def _enforce_cohort_gates(db: Session, course_id: str, cohort_id: str, now: date
                 "enrollment_end": cohort.enrollment_end.isoformat(),
             },
         )
-    if cohort.max_students:
-        current_count = (
-            db.query(sa_func.count(sa_func.distinct(Enrollment.user_id)))
-            .filter(Enrollment.cohort_id == cohort.id)
-            .scalar()
-            or 0
-        )
-        if current_count >= cohort.max_students:
-            raise equip_error(
-                ErrorCode.COURSE_ENROLMENT_CLOSED,
-                status_code=status.HTTP_403_FORBIDDEN,
-                message="Cohort has reached maximum capacity",
-                context={
-                    "resource_type": "cohort",
-                    "cohort_id": cohort_id,
-                    "max_students": cohort.max_students,
-                    "current_count": current_count,
-                },
-            )
+    # Capacity gate — shared with the admin add-student path so the
+    # already-seated exemption + error code stay identical. Runs under the
+    # with_for_update() lock taken above.
+    assert_cohort_has_capacity(db, cohort, user_id)
 
 
 @router.post("/{course_id}/enroll", response_model=EnrollmentResponse)
@@ -174,7 +159,7 @@ def enroll_course(
         # Cohort-route self-enrollment works for either access mode —
         # joining the cohort is the director's intent regardless of
         # whether the course is institute or public.
-        _enforce_cohort_gates(db, course_id, body.cohort_id, now)
+        _enforce_cohort_gates(db, course_id, body.cohort_id, str(current_user.id), now)
         cohort_id = body.cohort_id
     else:
         # Solo (no-cohort) enrollment. Institute courses block this path

--- a/backend/app/services/cohort_capacity.py
+++ b/backend/app/services/cohort_capacity.py
@@ -1,0 +1,72 @@
+"""Single source of truth for the cohort seat-capacity gate.
+
+Both enrollment paths must enforce ``max_students`` identically:
+
+* student self-enroll — ``api/v1/courses/enrollment.py::_enforce_cohort_gates``
+* admin add-student   — ``api/v1/cohorts.py::add_student``
+
+The rule: a user who ALREADY holds a seat in the cohort is exempt (a second
+course in the SAME cohort never consumes a new seat — that's the whole point
+of the multi-cohort design), everyone else counts toward the cap.
+
+Before this helper the two paths inlined the check differently and DIVERGED:
+the admin path exempted already-seated users, the self-enroll path did not —
+so a student already in a full cohort was wrongly 403'd when self-enrolling
+into a SECOND course of that same cohort. They also raised different
+``ErrorCode``s for the identical "cohort full" condition. One helper, one
+behaviour, one code.
+
+Note: the *status* gate (cohort must be "active" for self-enroll, but an admin
+may add to an "upcoming" cohort) is deliberately NOT unified — that divergence
+is intentional and stays at each call site.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import status
+from sqlalchemy import func
+
+from app.core.errors import ErrorCode, equip_error
+from app.models.enrollment import Enrollment
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.orm import Session
+
+    from app.models.cohort import Cohort
+
+
+def assert_cohort_has_capacity(db: Session, cohort: Cohort, user_id: str | UUID) -> None:
+    """Raise ``COURSE_ENROLMENT_CLOSED`` (403) if seating ``user_id`` would push
+    the cohort past ``max_students``. No-op when ``max_students`` is unset or the
+    user already holds a seat in this cohort.
+
+    Call under the same ``with_for_update()`` lock on the cohort row that the
+    write path uses, so the count + insert are atomic against concurrent adds.
+    """
+    if not cohort.max_students:
+        return
+    already_seated = (
+        db.query(Enrollment.id).filter(Enrollment.cohort_id == cohort.id, Enrollment.user_id == user_id).first()
+        is not None
+    )
+    if already_seated:
+        return
+    current_count = (
+        db.query(func.count(func.distinct(Enrollment.user_id))).filter(Enrollment.cohort_id == cohort.id).scalar() or 0
+    )
+    if current_count >= cohort.max_students:
+        raise equip_error(
+            ErrorCode.COURSE_ENROLMENT_CLOSED,
+            status_code=status.HTTP_403_FORBIDDEN,
+            message="Cohort has reached maximum capacity",
+            context={
+                "resource_type": "cohort",
+                "cohort_id": str(cohort.id),
+                "max_students": cohort.max_students,
+                "current_count": current_count,
+            },
+        )

--- a/backend/tests/test_cohort_enrollment_gates.py
+++ b/backend/tests/test_cohort_enrollment_gates.py
@@ -172,7 +172,7 @@ def _seed_enrollment(db: Session, *, user_id, course_id: str, cohort_id) -> None
 
 
 # ===========================================================================
-# UNIT TESTS — _enforce_cohort_gates(db, course_id, cohort_id, now)
+# UNIT TESTS — _enforce_cohort_gates(db, course_id, cohort_id, user_id, now)
 # ===========================================================================
 #
 # Tests here drive the gate function directly so we can pass an explicit
@@ -186,7 +186,7 @@ class TestCohortGateCohortLookup:
     def test_nonexistent_cohort_id_raises_404(self, db: Session, teacher):
         _seed_public_course(db)
         with pytest.raises(HTTPException) as exc:
-            _enforce_cohort_gates(db, "test-course-1", str(uuid.uuid4()), NOW_NAIVE)
+            _enforce_cohort_gates(db, "test-course-1", str(uuid.uuid4()), STUDENT_ID, NOW_NAIVE)
         assert exc.value.status_code == 404
         assert exc.value.detail["message"] == "Cohort not found"
 
@@ -195,7 +195,7 @@ class TestCohortGateCohortLookup:
         _seed_public_course(db, course_id="course-b")
         cohort = _seed_cohort(db, course_id="course-a")
         with pytest.raises(HTTPException) as exc:
-            _enforce_cohort_gates(db, "course-b", str(cohort.id), NOW_NAIVE)
+            _enforce_cohort_gates(db, "course-b", str(cohort.id), STUDENT_ID, NOW_NAIVE)
         assert exc.value.status_code == 404
         assert exc.value.detail["message"] == "Cohort does not include this course"
 
@@ -205,7 +205,7 @@ class TestCohortGateStatus:
         _seed_public_course(db)
         cohort = _seed_cohort(db, status="upcoming")
         with pytest.raises(HTTPException) as exc:
-            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), NOW_NAIVE)
+            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), STUDENT_ID, NOW_NAIVE)
         assert exc.value.status_code == 403
         assert exc.value.detail["message"] == "Cohort is not active"
 
@@ -213,7 +213,7 @@ class TestCohortGateStatus:
         _seed_public_course(db)
         cohort = _seed_cohort(db, status="completed")
         with pytest.raises(HTTPException) as exc:
-            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), NOW_NAIVE)
+            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), STUDENT_ID, NOW_NAIVE)
         assert exc.value.status_code == 403
         assert exc.value.detail["message"] == "Cohort is not active"
 
@@ -223,7 +223,7 @@ class TestCohortGateWindow:
         _seed_public_course(db)
         cohort = _seed_cohort(db, enrollment_start=NEAR_FUTURE_NAIVE)
         with pytest.raises(HTTPException) as exc:
-            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), NOW_NAIVE)
+            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), STUDENT_ID, NOW_NAIVE)
         assert exc.value.status_code == 403
         assert "not started yet" in exc.value.detail["message"].lower()
 
@@ -231,7 +231,7 @@ class TestCohortGateWindow:
         _seed_public_course(db)
         cohort = _seed_cohort(db, enrollment_end=RECENT_PAST_NAIVE)
         with pytest.raises(HTTPException) as exc:
-            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), NOW_NAIVE)
+            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), STUDENT_ID, NOW_NAIVE)
         assert exc.value.status_code == 403
         assert "ended" in exc.value.detail["message"].lower()
 
@@ -239,12 +239,12 @@ class TestCohortGateWindow:
         _seed_public_course(db)
         cohort = _seed_cohort(db, enrollment_start=PAST_NAIVE, enrollment_end=FAR_FUTURE_NAIVE)
         # No exception = pass.
-        _enforce_cohort_gates(db, "test-course-1", str(cohort.id), NOW_NAIVE)
+        _enforce_cohort_gates(db, "test-course-1", str(cohort.id), STUDENT_ID, NOW_NAIVE)
 
     def test_null_window_means_unlimited(self, db: Session, teacher):
         _seed_public_course(db)
         cohort = _seed_cohort(db)
-        _enforce_cohort_gates(db, "test-course-1", str(cohort.id), NOW_NAIVE)
+        _enforce_cohort_gates(db, "test-course-1", str(cohort.id), STUDENT_ID, NOW_NAIVE)
 
 
 class TestCohortGateCapacity:
@@ -253,7 +253,7 @@ class TestCohortGateCapacity:
         cohort = _seed_cohort(db, max_students=1)
         _seed_enrollment(db, user_id=TEACHER_ID, course_id="test-course-1", cohort_id=cohort.id)
         with pytest.raises(HTTPException) as exc:
-            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), NOW_NAIVE)
+            _enforce_cohort_gates(db, "test-course-1", str(cohort.id), STUDENT_ID, NOW_NAIVE)
         assert exc.value.status_code == 403
         assert "capacity" in exc.value.detail["message"].lower()
 
@@ -271,13 +271,30 @@ class TestCohortGateCapacity:
         _seed_enrollment(db, user_id=TEACHER_ID, course_id="course-b", cohort_id=cohort.id)
 
         # 1 distinct user against cap of 2 → seat available.
-        _enforce_cohort_gates(db, "course-a", str(cohort.id), NOW_NAIVE)
+        _enforce_cohort_gates(db, "course-a", str(cohort.id), STUDENT_ID, NOW_NAIVE)
 
     def test_unlimited_capacity_when_max_students_null(self, db: Session, teacher, student):
         _seed_public_course(db)
         cohort = _seed_cohort(db, max_students=None)
         _seed_enrollment(db, user_id=TEACHER_ID, course_id="test-course-1", cohort_id=cohort.id)
-        _enforce_cohort_gates(db, "test-course-1", str(cohort.id), NOW_NAIVE)
+        _enforce_cohort_gates(db, "test-course-1", str(cohort.id), STUDENT_ID, NOW_NAIVE)
+
+    def test_already_seated_user_exempt_from_capacity(self, db: Session, teacher, student):
+        """A student already holding a seat in a FULL cohort can self-enroll
+        into a SECOND course of that same cohort — they don't consume a new
+        seat. Regression: the self-enroll path previously lacked the
+        already-seated exemption that the admin add-student path had, so it
+        wrongly 403'd this case. Now both share assert_cohort_has_capacity.
+        """
+        _seed_public_course(db, course_id="course-a")
+        _seed_public_course(db, course_id="course-b")
+        cohort = _seed_cohort(db, course_id="course-a", max_students=1)
+        db.add(CohortCourse(cohort_id=cohort.id, course_id="course-b"))
+        db.commit()
+        # The student takes the single seat via course-a.
+        _seed_enrollment(db, user_id=STUDENT_ID, course_id="course-a", cohort_id=cohort.id)
+        # Cohort is full (1/1), but the SAME student joining course-b must pass.
+        _enforce_cohort_gates(db, "course-b", str(cohort.id), STUDENT_ID, NOW_NAIVE)
 
 
 # ===========================================================================


### PR DESCRIPTION
Architecture audit **H3** + the bug it hid. `max_students` was checked twice and diverged: the admin path exempted already-seated users (a 2nd course of the same cohort = no new seat) and raised `VALIDATION_FAILED`; the student self-enroll path had **no exemption** and raised `COURSE_ENROLMENT_CLOSED`.

**Bug:** a student already in a FULL cohort (course A) self-enrolling into course B of that cohort was wrongly 403'd — the multi-cohort design says it must pass.

**Fix:** one helper `app/services/cohort_capacity.py::assert_cohort_has_capacity` used by both paths (exemption + single error code). The intentional *status*-gate divergence (self-enroll needs active; admin may add to upcoming) stays. Removed dead `_student_count`. `_enforce_cohort_gates` gained `user_id`.

New regression test (already-seated exempt). **1434 tests green**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)