### PR TITLE
test(frontend): cover isHttpUrl + drop dead preferences mock

### DIFF
--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -31,14 +31,6 @@ vi.mock("@/lib/supabase", () => ({
   },
 }))
 
-// New dependency of ``AuthContext`` for post-OAuth locale reconciliation.
-// Tests in this file never exercise that path, so just stub the call.
-vi.mock("@/services/preferences", () => ({
-  preferencesService: {
-    setPreferredLocale: vi.fn().mockResolvedValue({}),
-  },
-}))
-
 const login = vi.fn()
 const register = vi.fn()
 const signInWithGoogle = vi.fn()

--- a/frontend/src/lib/__tests__/url.test.ts
+++ b/frontend/src/lib/__tests__/url.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest"
+import { isHttpUrl } from "../url"
+
+describe("isHttpUrl", () => {
+  it("rejects empty / nullish input", () => {
+    expect(isHttpUrl(null)).toBe(false)
+    expect(isHttpUrl(undefined)).toBe(false)
+    expect(isHttpUrl("")).toBe(false)
+  })
+
+  it("rejects dangerous schemes that React would execute in an href", () => {
+    expect(isHttpUrl("javascript:alert(1)")).toBe(false)
+    // Scheme matching is case-insensitive in the browser, so this must fail too.
+    expect(isHttpUrl("JavaScript:alert(1)")).toBe(false)
+    expect(isHttpUrl("  javascript:alert(1)")).toBe(false)
+    expect(isHttpUrl("data:text/html,<script>alert(1)</script>")).toBe(false)
+    expect(isHttpUrl("vbscript:msgbox(1)")).toBe(false)
+    expect(isHttpUrl("file:///etc/passwd")).toBe(false)
+    expect(isHttpUrl("blob:https://x/y")).toBe(false)
+  })
+
+  it("accepts fully-qualified http(s) URLs", () => {
+    expect(isHttpUrl("https://example.com/file.pdf")).toBe(true)
+    expect(isHttpUrl("http://example.com")).toBe(true)
+  })
+
+  it("accepts a relative path (resolves against the safe page origin, not a script scheme)", () => {
+    // window.location.origin in jsdom is http://localhost → http(s). Note a
+    // base is always supplied, so a non-scheme string resolves as a relative
+    // path (safe http origin) rather than failing — only explicit dangerous
+    // schemes above are rejected.
+    expect(isHttpUrl("/some/path")).toBe(true)
+  })
+})


### PR DESCRIPTION
Two LOW cleanups from the final adversarial verification (no bugs found):
- New `src/lib/__tests__/url.test.ts` — locks the `isHttpUrl` file_url XSS guard (rejects `javascript:`/`data:`/`vbscript:`/`file:`/`blob:`, accepts http(s)+relative).
- Removed dead `vi.mock("@/services/preferences")` in AuthContext.test.tsx (no longer imported).

524 frontend tests green, eslint + tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)