### PR TITLE
fix(db): tighten quiz_questions.points CHECK to match API contract (ge=1,le=100)

### DIFF
--- a/backend/tests/test_quiz_points_contract.py
+++ b/backend/tests/test_quiz_points_contract.py
@@ -1,0 +1,30 @@
+"""Locks the quiz_questions.points range contract (part of the 4-way mirror).
+
+``schemas.quiz.QuizQuestionCreate.points`` is ``Field(ge=1, le=100)``; migration
+``20260607120000_quiz_points_range_check`` tightened the DB CHECK to match
+(``points BETWEEN 1 AND 100``) after the earlier constraint only enforced
+``>= 0`` with no upper bound. This pins the schema side so the Postgres ⇄
+Pydantic mirror can't silently drift again.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.quiz import QuizQuestionCreate
+
+
+def _make(points: int) -> QuizQuestionCreate:
+    return QuizQuestionCreate(question_text="Q", points=points)
+
+
+def test_points_accepts_inclusive_bounds() -> None:
+    assert _make(1).points == 1
+    assert _make(100).points == 100
+
+
+@pytest.mark.parametrize("bad", [0, -1, 101, 1000])
+def test_points_rejects_out_of_range(bad: int) -> None:
+    with pytest.raises(ValidationError):
+        _make(bad)

--- a/supabase/migrations/20260607120000_quiz_points_range_check.sql
+++ b/supabase/migrations/20260607120000_quiz_points_range_check.sql
@@ -1,0 +1,12 @@
+-- Tighten quiz_questions.points CHECK to match the API contract.
+--
+-- schemas/quiz.py QuizQuestionBase.points = Field(1, ge=1, le=100), but the DB
+-- constraint (20260522004659) only enforced `points >= 0` with no upper bound
+-- and a comment that wrongly claimed it mirrored `ge=0`. A direct / admin write
+-- could persist 0 or > 100, violating the 4-way enum/range mirror. Verified
+-- prod has 0 rows outside [1, 100] before tightening (min=1, max=20 over 86 rows).
+ALTER TABLE public.quiz_questions DROP CONSTRAINT IF EXISTS quiz_questions_points_nonneg;
+ALTER TABLE public.quiz_questions
+  ADD CONSTRAINT quiz_questions_points_range CHECK (points >= 1 AND points <= 100);
+COMMENT ON CONSTRAINT quiz_questions_points_range ON public.quiz_questions IS
+  'Mirrors app.schemas.quiz.QuizQuestionBase.points Field(ge=1, le=100).';


### PR DESCRIPTION
The **only real defect** from the final world-class audit (8 parallel agents + adversarial verify; all else was false-positive / already-accepted / deliberate gradual migration / test-coverage polish).

DB CHECK (mig 20260522004659) enforced only `points >= 0` (no upper bound) with a comment wrongly claiming it mirrored `ge=0` — but `QuizQuestionCreate.points` is `Field(ge=1, le=100)`. Direct/admin write could persist 0 or >100.

Mig 20260607120000 → `CHECK (points BETWEEN 1 AND 100)` + correct comment. Prod verified 0 rows outside [1,100] before tightening; **applied to prod via MCP**. New Pydantic contract test pins the schema side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)