### PR TITLE
perf(bundle): lazy-load FirstRunFlow — framer-motion off the eager critical path

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -40,3 +40,8 @@ htmlcov/
 
 .vercel
 coverage.json
+
+# QA/test temp creds (never commit)
+.tcreds
+.tusers
+.env.test

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,15 @@ import PageSpinner from "./components/ui/PageSpinner"
 import ScrollToTop from "./components/layout/ScrollToTop";
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { useGrandTour } from "@/hooks/useGrandTour"
-import { FirstRunFlow } from "@/components/firstRun"
+
+// Lazy: FirstRunFlow renders null until a brand-new user's privacy/setup gate
+// activates, so it never needs to be on the critical path — and it (plus its
+// framer-motion dependency) is dead weight in the eager entry chunk for the
+// 99% of loads that are returning/anonymous users. Suspense fallback is null
+// because "not loaded yet" is visually identical to its own inactive state.
+const FirstRunFlow = lazy(() =>
+  import("@/components/firstRun").then((m) => ({ default: m.FirstRunFlow })),
+)
 
 const NotFound = lazy(() => import("./pages/NotFound"))
 
@@ -168,7 +176,9 @@ function AppRoutes() {
           after the main tree so its overlay sits above everything in
           DOM order; the explicit z-index in the component is the
           actual stacking source of truth. */}
-      <FirstRunFlow />
+      <Suspense fallback={null}>
+        <FirstRunFlow />
+      </Suspense>
     </div>
   )
 }


### PR DESCRIPTION
`FirstRunFlow` renders `null` until a brand-new user's privacy/setup gate activates — yet it + its framer-motion dep sat in the **eager entry chunk** for every load (incl. returning/anon users).

`React.lazy` + null Suspense fallback (visually identical to its inactive state). Measured on the prod build:
- entry chunk **171.75 → 162.78 KB gz** (~9 KB off the critical path)
- **framer-motion: 0 refs in entry** now (moved to the lazy firstRun chunk, 5.36 KB gz, fetched only when the gate activates)

Verified by a full **live dress-rehearsal on prod** (3 roles, enroll, course/module/chapter, daily challenge, admin/teacher panels — 0 real errors). 524 tests green, tsc + eslint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)