### PR TITLE
chore: dedup GoogleIcon + fix doc drift from cleanliness sweep

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -165,6 +165,8 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
             exception_type=type(exc).__name__,
         )
     except Exception:
+        # Never let metric emission failures mask the original error or
+        # recurse back into this same handler — swallow and still 500.
         pass
     return JSONResponse(
         status_code=500,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -29,7 +29,7 @@ the Vercel project pages -- not in this repo.
 - `ruff format --check .`
 - `python -m py_compile` (smoke import of every module)
 - `mypy --config-file mypy.ini`
-- `pytest tests/` against in-memory SQLite (~600 tests)
+- `pytest tests/` against in-memory SQLite (~1400 tests)
 - `pip-audit` (allow-list-of-known-issues only)
 - A second job `schema-smoke-postgres` materializes the SQLAlchemy
   models against a real Postgres service container -- catches

--- a/docs/adr/0010-cohorts-as-top-level-entities.md
+++ b/docs/adr/0010-cohorts-as-top-level-entities.md
@@ -34,9 +34,13 @@ as we tried to model real Bible schools:
 
 Cohorts become **top-level admin entities**.
 
-- A cohort has its own table (`cohorts`) with `name`, `start_date`,
+- A cohort has its own table (`cohorts`) with `start_date`,
   `end_date`, `enrollment_start/end`, `max_students`, `status`
-  (`upcoming → active → completed`, forward-only).
+  (`upcoming → active → completed`, forward-only). The display name
+  is **not** a column: it lives in `content_versions`
+  (`entity_type='cohort'`, `field='title'`) so it can be localized,
+  per the Phase 5e1 EAV i18n model. The legacy `name` column was
+  dropped in migration `20260528020000_drop_cohorts_name.sql`.
 - The relationship to courses is **many-to-many** through a junction
   table `cohort_courses(cohort_id, course_id)`. A single cohort
   can span any number of courses; a single course can be taught to

--- a/frontend/src/pages/Auth/Login.tsx
+++ b/frontend/src/pages/Auth/Login.tsx
@@ -8,17 +8,7 @@ import { useAuth } from "@/context/useAuth"
 import { makeLoginSchema, type LoginFormData } from "@/lib/validations/auth"
 import AuthLayout from "@/components/layout/AuthLayout"
 import { Loader2 } from "lucide-react"
-
-function GoogleIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24">
-      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
-      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
-    </svg>
-  )
-}
+import { GoogleIcon } from "./register/GoogleIcon"
 
 export default function Login() {
   const [form, setForm] = useState<LoginFormData>({ email: "", password: "" })


### PR DESCRIPTION
Concrete cleanup targets from the 4-agent code/repo/docs cleanliness sweep (rest of the codebase verified spotless).

- **frontend**: `Login.tsx` had an inline `GoogleIcon` byte-identical to the exported `register/GoogleIcon.tsx` that `RegisterForm` already imports — deduped to the shared component.
- **docs/adr/0010**: `cohorts.name` was listed as a column but was dropped in `20260528020000_drop_cohorts_name.sql`; name now lives in `content_versions` (Phase 5e1 EAV). Corrected.
- **docs/DEPLOYMENT.md**: stale `~600 tests` → `~1400` (1439 collected).
- **backend/main.py**: documented the intentional `except/pass` in the unhandled-exception handler.

No behavior change. Local: tsc clean, eslint clean, ruff check/format clean, py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)