### PR TITLE
chore: remove speculative dead code (translate_batch, useGrandTour return)

### DIFF
--- a/backend/app/services/translation/gemini.py
+++ b/backend/app/services/translation/gemini.py
@@ -239,13 +239,6 @@ class GeminiTranslationProvider:
 
         raise TranslationError(f"Gemini call failed after retries: {last_error!r}")
 
-    def translate_batch(self, requests: list[TranslationRequest]) -> list[TranslationResult]:
-        # The REST endpoint translates one request at a time; the batching
-        # win comes from issuing them on a shared HTTP/2 connection. The
-        # default sequential implementation is fine for the volumes we
-        # anticipate (one course publish is a few hundred chunks).
-        return [self.translate(req) for req in requests]
-
     def _build_payload(self, request: TranslationRequest) -> dict[str, Any]:
         system_prompt = build_system_prompt(
             source_locale=request.source_locale,

--- a/backend/app/services/translation/protocol.py
+++ b/backend/app/services/translation/protocol.py
@@ -105,13 +105,3 @@ class TranslationProvider(Protocol):
 
     def translate(self, request: TranslationRequest) -> TranslationResult:
         """Synchronously translate one request. Must be thread-safe."""
-
-    def translate_batch(self, requests: list[TranslationRequest]) -> list[TranslationResult]:
-        """Translate many requests.
-
-        The convention is to call ``translate()`` per request sequentially;
-        ``Protocol`` itself has no default implementation, so concrete
-        providers must implement this method (Gemini and Noop both do).
-        Providers that support native batching should override with a
-        single round-trip implementation for a meaningful speedup.
-        """

--- a/backend/app/services/translation/service.py
+++ b/backend/app/services/translation/service.py
@@ -39,9 +39,6 @@ class NoopTranslationProvider:
     def translate(self, request: TranslationRequest) -> TranslationResult:
         return TranslationResult(text=request.text, model="noop")
 
-    def translate_batch(self, requests: list[TranslationRequest]) -> list[TranslationResult]:
-        return [self.translate(req) for req in requests]
-
 
 def _api_key_value() -> str | None:
     """Return the configured Gemini API key as a plain string (or ``None``).

--- a/backend/tests/test_translation_mt_dual_write.py
+++ b/backend/tests/test_translation_mt_dual_write.py
@@ -57,9 +57,6 @@ class _RecordingProvider:
             raise TranslationError(f"forced failure for {request.text!r}")
         return TranslationResult(text=f"[{request.target_locale}]{request.text}", model="test")
 
-    def translate_batch(self, requests: list[TranslationRequest]) -> list[TranslationResult]:
-        return [self.translate(r) for r in requests]
-
 
 @pytest.fixture(autouse=True)
 def _enable_provider(monkeypatch: pytest.MonkeyPatch):

--- a/backend/tests/test_translation_orchestrator.py
+++ b/backend/tests/test_translation_orchestrator.py
@@ -57,9 +57,6 @@ class _RecordingProvider:
         # assertions can pinpoint which row a translation produced.
         return TranslationResult(text=f"[{request.target_locale}]{request.text}", model="test")
 
-    def translate_batch(self, requests: list[TranslationRequest]) -> list[TranslationResult]:
-        return [self.translate(r) for r in requests]
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/backend/tests/test_translation_per_entity_source.py
+++ b/backend/tests/test_translation_per_entity_source.py
@@ -143,9 +143,6 @@ class _RecordingProvider:
             model="recording",
         )
 
-    def translate_batch(self, requests):
-        return [self.translate(r) for r in requests]
-
 
 class TestReconcileEntityDetectsPerFieldLanguage:
     """When an entity's text is in a different language than its

--- a/frontend/src/hooks/useGrandTour.ts
+++ b/frontend/src/hooks/useGrandTour.ts
@@ -59,14 +59,6 @@ function reducedMotionPreferred(): boolean {
   }
 }
 
-interface UseGrandTourReturn {
-  /** Programmatic start — bypasses persistence and role gates. Used
-   *  for a future "Replay grand tour" trigger if we ever add one to
-   *  the welcome card. */
-  start: () => void
-  alreadySeen: boolean
-}
-
 /**
  * App-root hook that owns the cross-page grand tour.
  *
@@ -88,7 +80,7 @@ interface UseGrandTourReturn {
  * BrowserRouter). Mounting in multiple places will create multiple
  * driver instances racing each other.
  */
-export function useGrandTour(): UseGrandTourReturn {
+export function useGrandTour(): void {
   const { user } = useAuth()
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -150,20 +142,6 @@ export function useGrandTour(): UseGrandTourReturn {
     })
     driverRef.current.drive()
   }, [t, userId, navigate])
-
-  const start = useCallback(() => {
-    // Defensive: don't yank the user into a tour while the first-run
-    // Privacy/Setup screens are up. Any future "Replay grand tour"
-    // trigger that calls ``start()`` during the gate would otherwise
-    // race the modal.
-    if (getFirstRunActive()) return
-    firedRef.current = true
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current)
-      timerRef.current = null
-    }
-    buildAndDrive()
-  }, [buildAndDrive])
 
   useEffect(() => {
     if (firedRef.current) return
@@ -230,6 +208,4 @@ export function useGrandTour(): UseGrandTourReturn {
       }
     }
   }, [])
-
-  return { start, alreadySeen }
 }


### PR DESCRIPTION
Bloat/over-engineering audit (AI-authored codebase tends to accrete "just in case" machinery). Two pieces with **zero real callers**:

**Backend — `TranslationProvider.translate_batch()`**
A Protocol batch method nothing ever invoked — the orchestrator only calls `translate()` per request. The Gemini override was literally `[self.translate(r) for r in requests]` with a comment admitting the sequential default is fine. Removed the Protocol decl, Gemini + Noop overrides, and 3 test-fake impls.

**Frontend — `useGrandTour()` return**
Returned `{ start, alreadySeen }` for "a future Replay trigger if we ever add one"; `App.tsx` discards the result. Dropped the speculative `start()` callback, the return, and the interface. **Kept `alreadySeen` state** — it gates the auto-fire effect (the audit's suggestion to drop it was wrong; verified).

No behavior change. Local: backend ruff/format/mypy clean + translation tests pass; frontend tsc + eslint clean (no unused-var = trim complete).

The audit's other findings are docs accuracy (separate PR) and 3 SIMPLIFY refactors (date-picker triplication, tour-config dup) surfaced for review — not auto-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)