### PR TITLE
refactor(ui): unify the three date pickers onto one calendar primitive

### DIFF
--- a/frontend/src/components/ui/CalendarPopover.tsx
+++ b/frontend/src/components/ui/CalendarPopover.tsx
@@ -1,0 +1,192 @@
+import { useMemo, useState, type ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { addMonths, buildMonthMatrix, ymdKey } from "@/lib/calendar"
+import { cn } from "@/lib/utils"
+
+/** Per-day presentation the host picker computes from its own selection. */
+export interface DayRender {
+  /** Extra classes layered onto the shared day-cell base. */
+  className?: string
+  /** Drives `aria-pressed` on the day button. */
+  selected?: boolean
+}
+
+interface CalendarPopoverProps {
+  /** Text shown inside the trigger button. */
+  triggerLabel: string
+  /** Mute the trigger text (i.e. showing a placeholder, not a value). */
+  triggerMuted: boolean
+  /** Month the grid opens on (the host derives this from its value). */
+  initialMonth: Date
+  /** Selection styling for one day cell. */
+  renderDay: (date: Date, ctx: { inCurrentMonth: boolean; isToday: boolean }) => DayRender
+  /** A day was clicked; `close()` dismisses the popover (host decides when). */
+  onPickDay: (date: Date, close: () => void) => void
+  /** Clears the value. */
+  onClear: () => void
+  clearDisabled: boolean
+  /** Optional content between the grid and the Clear footer (e.g. a time row). */
+  belowGrid?: ReactNode
+  disabled?: boolean
+  active?: boolean
+  className?: string
+  id?: string
+  "aria-label"?: string
+}
+
+/**
+ * The shared chrome for the date-input pickers: a Popover whose trigger is
+ * an editorial outline button, opening a Mon-start month grid with prev/next
+ * month nav and a Clear footer. Selection semantics (single date, datetime,
+ * range) live in the host via `renderDay` + `onPickDay`; everything visual is
+ * here so the three pickers can't drift apart again.
+ */
+export function CalendarPopover({
+  triggerLabel,
+  triggerMuted,
+  initialMonth,
+  renderDay,
+  onPickDay,
+  onClear,
+  clearDisabled,
+  belowGrid,
+  disabled,
+  active,
+  className,
+  id,
+  "aria-label": ariaLabel,
+}: CalendarPopoverProps) {
+  const { t, i18n } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [anchor, setAnchor] = useState<Date>(initialMonth)
+
+  const days = useMemo(() => buildMonthMatrix(anchor), [anchor])
+  const todayKey = ymdKey(new Date())
+  const anchorMonth = anchor.getMonth()
+
+  const weekdayHeads = [
+    t("streak.days.mon"),
+    t("streak.days.tue"),
+    t("streak.days.wed"),
+    t("streak.days.thu"),
+    t("streak.days.fri"),
+    t("streak.days.sat"),
+    t("streak.days.sun"),
+  ]
+
+  const monthLabel = anchor.toLocaleDateString(i18n.language, {
+    month: "long",
+    year: "numeric",
+  })
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          aria-label={ariaLabel}
+          className={cn(
+            "h-9 justify-start gap-2 px-3 font-normal",
+            triggerMuted && "text-ink-muted",
+            active && "border-brand/40 ring-1 ring-primary/40",
+            className,
+          )}
+        >
+          <CalendarIcon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
+          <span className="truncate text-xs sm:text-sm">{triggerLabel}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[min(20rem,calc(100vw-2rem))] max-w-sm p-0" align="start">
+        <div className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setAnchor((a) => addMonths(a, -1))}
+            aria-label={t("dateRangePicker.prevMonth")}
+          >
+            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+          <p className="text-sm font-medium capitalize text-ink">{monthLabel}</p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setAnchor((a) => addMonths(a, 1))}
+            aria-label={t("dateRangePicker.nextMonth")}
+          >
+            <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        </div>
+
+        <div className="p-2">
+          <div className="grid grid-cols-7 gap-0.5">
+            {weekdayHeads.map((d, i) => (
+              <div
+                key={i}
+                className="pb-1 text-center text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted"
+              >
+                {d}
+              </div>
+            ))}
+            {days.map((date, i) => {
+              const inCurrentMonth = date.getMonth() === anchorMonth
+              const isToday = ymdKey(date) === todayKey
+              const { className: dayClass, selected } = renderDay(date, {
+                inCurrentMonth,
+                isToday,
+              })
+              return (
+                <button
+                  type="button"
+                  key={i}
+                  onClick={() => onPickDay(date, () => setOpen(false))}
+                  className={cn(
+                    "relative flex h-8 w-full items-center justify-center rounded-sm text-xs tabular-nums",
+                    "transition-colors hover:bg-muted",
+                    inCurrentMonth ? "text-ink" : "text-ink-muted/40",
+                    dayClass,
+                  )}
+                  aria-label={date.toLocaleDateString(i18n.language, {
+                    weekday: "long",
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                  })}
+                  aria-pressed={!!selected}
+                >
+                  {date.getDate()}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {belowGrid}
+
+        <div className="flex items-center justify-end gap-2 border-t border-edge px-2 py-1.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClear}
+            disabled={clearDisabled}
+            className="h-7 text-xs text-ink-muted hover:text-ink"
+          >
+            <X className="mr-1 h-3 w-3" strokeWidth={1.75} aria-hidden />
+            {t("dateRangePicker.clear")}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -1,11 +1,7 @@
-import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, X } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { CalendarPopover } from "@/components/ui/CalendarPopover"
+import { parseYmd, startOfMonth, ymdKey } from "@/lib/calendar"
 import { cn } from "@/lib/utils"
-
-const DAYS_IN_WEEK = 7
 
 interface Props {
   /** YYYY-MM-DD string. ``""`` means "no value". */
@@ -23,60 +19,6 @@ interface Props {
   "aria-label"?: string
 }
 
-function ymdKey(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
-}
-
-function parseYmd(s: string): Date | null {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null
-  const y = Number(s.slice(0, 4))
-  const m = Number(s.slice(5, 7))
-  const d = Number(s.slice(8, 10))
-  const out = new Date(y, m - 1, d)
-  return Number.isNaN(out.getTime()) ? null : out
-}
-
-function weekdayMonStart(d: Date): number {
-  return (d.getDay() + 6) % DAYS_IN_WEEK
-}
-
-function startOfMonth(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), 1)
-}
-
-function addMonths(d: Date, n: number): Date {
-  return new Date(d.getFullYear(), d.getMonth() + n, 1)
-}
-
-interface MonthCell {
-  date: Date
-  inCurrentMonth: boolean
-  isToday: boolean
-  isSelected: boolean
-}
-
-function buildMonthGrid(anchor: Date, selected: string): MonthCell[] {
-  const year = anchor.getFullYear()
-  const month = anchor.getMonth()
-  const first = new Date(year, month, 1)
-  const offset = weekdayMonStart(first)
-  const gridStart = new Date(year, month, 1 - offset)
-  const todayKey = ymdKey(new Date())
-
-  const cells: MonthCell[] = []
-  for (let i = 0; i < 42; i++) {
-    const d = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i)
-    const key = ymdKey(d)
-    cells.push({
-      date: d,
-      inCurrentMonth: d.getMonth() === month,
-      isToday: key === todayKey,
-      isSelected: !!selected && key === selected,
-    })
-  }
-  return cells
-}
-
 function formatLong(ymd: string, locale: string): string {
   const d = parseYmd(ymd)
   if (!d) return ymd
@@ -84,10 +26,10 @@ function formatLong(ymd: string, locale: string): string {
 }
 
 /**
- * Single-date picker built on the same hand-rolled Popover + Mon-start
- * month-grid pattern as ``DateRangePicker``. Replaces native
- * ``<input type="date">`` whose look diverges across Win/Mac/Linux and
- * which read as a debug control inside an otherwise editorial layout.
+ * Single-date picker built on the shared {@link CalendarPopover} (Mon-start
+ * month grid). Replaces native ``<input type="date">`` whose look diverges
+ * across Win/Mac/Linux and which read as a debug control inside an otherwise
+ * editorial layout.
  *
  * Value contract is unchanged from the native input: ``"YYYY-MM-DD"`` ⇄
  * ``""``. Drop-in replacement for any caller that read ``e.target.value``.
@@ -103,135 +45,33 @@ export function DatePicker({
   "aria-label": ariaLabel,
 }: Props) {
   const { t, i18n } = useTranslation()
-  const [open, setOpen] = useState(false)
-  const [anchor, setAnchor] = useState<Date>(() => {
-    const v = parseYmd(value)
-    return startOfMonth(v ?? new Date())
-  })
-
-  const cells = useMemo(() => buildMonthGrid(anchor, value), [anchor, value])
-
-  const weekdayHeads = [
-    t("streak.days.mon"),
-    t("streak.days.tue"),
-    t("streak.days.wed"),
-    t("streak.days.thu"),
-    t("streak.days.fri"),
-    t("streak.days.sat"),
-    t("streak.days.sun"),
-  ]
-
-  const triggerLabel = value
-    ? formatLong(value, i18n.language)
-    : placeholder ?? t("datePicker.placeholder")
-
-  const monthLabel = anchor.toLocaleDateString(i18n.language, {
-    month: "long",
-    year: "numeric",
-  })
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          id={id}
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={disabled}
-          aria-label={ariaLabel}
-          className={cn(
-            "h-9 justify-start gap-2 px-3 font-normal",
-            !value && "text-ink-muted",
-            active && "border-brand/40 ring-1 ring-primary/40",
-            className,
-          )}
-        >
-          <CalendarIcon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
-          <span className="truncate text-xs sm:text-sm">{triggerLabel}</span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-[min(20rem,calc(100vw-2rem))] max-w-sm p-0"
-        align="start"
-      >
-        <div className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            onClick={() => setAnchor((a) => addMonths(a, -1))}
-            aria-label={t("dateRangePicker.prevMonth")}
-          >
-            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          </Button>
-          <p className="text-sm font-medium capitalize text-ink">{monthLabel}</p>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            onClick={() => setAnchor((a) => addMonths(a, 1))}
-            aria-label={t("dateRangePicker.nextMonth")}
-          >
-            <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          </Button>
-        </div>
-
-        <div className="p-2">
-          <div className="grid grid-cols-7 gap-0.5">
-            {weekdayHeads.map((d, i) => (
-              <div
-                key={i}
-                className="pb-1 text-center text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted"
-              >
-                {d}
-              </div>
-            ))}
-            {cells.map((c, i) => (
-              <button
-                type="button"
-                key={i}
-                onClick={() => {
-                  onChange(ymdKey(c.date))
-                  setOpen(false)
-                }}
-                className={cn(
-                  "relative flex h-8 w-full items-center justify-center rounded-sm text-xs tabular-nums",
-                  "transition-colors hover:bg-muted",
-                  c.inCurrentMonth ? "text-ink" : "text-ink-muted/40",
-                  c.isToday && !c.isSelected && "ring-1 ring-primary/60",
-                  c.isSelected && "bg-brand font-medium text-brand-foreground hover:bg-brand/90",
-                )}
-                aria-label={c.date.toLocaleDateString(i18n.language, {
-                  weekday: "long",
-                  day: "numeric",
-                  month: "long",
-                  year: "numeric",
-                })}
-                aria-pressed={c.isSelected}
-              >
-                {c.date.getDate()}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="flex items-center justify-end gap-2 border-t border-edge px-2 py-1.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => onChange("")}
-            disabled={!value}
-            className="h-7 text-xs text-ink-muted hover:text-ink"
-          >
-            <X className="mr-1 h-3 w-3" strokeWidth={1.75} aria-hidden />
-            {t("dateRangePicker.clear")}
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+    <CalendarPopover
+      id={id}
+      aria-label={ariaLabel}
+      active={active}
+      disabled={disabled}
+      className={className}
+      triggerLabel={value ? formatLong(value, i18n.language) : placeholder ?? t("datePicker.placeholder")}
+      triggerMuted={!value}
+      initialMonth={startOfMonth(parseYmd(value) ?? new Date())}
+      renderDay={(date, { isToday }) => {
+        const selected = !!value && ymdKey(date) === value
+        return {
+          selected,
+          className: cn(
+            isToday && !selected && "ring-1 ring-primary/60",
+            selected && "bg-brand font-medium text-brand-foreground hover:bg-brand/90",
+          ),
+        }
+      }}
+      onPickDay={(date, close) => {
+        onChange(ymdKey(date))
+        close()
+      }}
+      onClear={() => onChange("")}
+      clearDisabled={!value}
+    />
   )
 }

--- a/frontend/src/components/ui/date-range-picker.tsx
+++ b/frontend/src/components/ui/date-range-picker.tsx
@@ -1,11 +1,7 @@
-import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, X } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { CalendarPopover } from "@/components/ui/CalendarPopover"
+import { parseYmd, startOfMonth, ymdKey } from "@/lib/calendar"
 import { cn } from "@/lib/utils"
-
-const DAYS_IN_WEEK = 7
 
 export interface DateRange {
   /** YYYY-MM-DD string. ``""`` means "no lower bound". */
@@ -29,89 +25,22 @@ interface Props {
   className?: string
 }
 
-function ymdKey(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
-}
-
-function parseYmd(s: string): Date | null {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null
-  const y = Number(s.slice(0, 4))
-  const m = Number(s.slice(5, 7))
-  const d = Number(s.slice(8, 10))
-  const out = new Date(y, m - 1, d)
-  return Number.isNaN(out.getTime()) ? null : out
-}
-
-function weekdayMonStart(d: Date): number {
-  return (d.getDay() + 6) % DAYS_IN_WEEK
-}
-
-function startOfMonth(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), 1)
-}
-
-function addMonths(d: Date, n: number): Date {
-  return new Date(d.getFullYear(), d.getMonth() + n, 1)
-}
-
 function compareYmd(a: string, b: string): number {
   // ISO YYYY-MM-DD strings compare lexicographically.
   return a < b ? -1 : a > b ? 1 : 0
 }
 
-interface MonthCell {
-  date: Date
-  inCurrentMonth: boolean
-  isToday: boolean
-  isStart: boolean
-  isEnd: boolean
-  inRange: boolean
-}
-
-function buildMonthGrid(anchor: Date, from: string, to: string): MonthCell[] {
-  const year = anchor.getFullYear()
-  const month = anchor.getMonth()
-  const first = new Date(year, month, 1)
-  const offset = weekdayMonStart(first)
-  const gridStart = new Date(year, month, 1 - offset)
-  const todayKey = ymdKey(new Date())
-
-  // Normalise so ``from`` is the lower bound regardless of click order
-  // (lets the second click be either earlier or later than the first).
-  const [lo, hi] = from && to && compareYmd(from, to) > 0 ? [to, from] : [from, to]
-
-  const cells: MonthCell[] = []
-  for (let i = 0; i < 42; i++) {
-    const d = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i)
-    const key = ymdKey(d)
-    const isStart = !!lo && key === lo
-    const isEnd = !!hi && hi !== lo && key === hi
-    const inRange = !!lo && !!hi && key >= lo && key <= hi
-    cells.push({
-      date: d,
-      inCurrentMonth: d.getMonth() === month,
-      isToday: key === todayKey,
-      isStart,
-      isEnd,
-      inRange,
-    })
-  }
-  return cells
+function formatShort(ymd: string, locale: string): string {
+  const d = parseYmd(ymd)
+  if (!d) return ymd
+  return d.toLocaleDateString(locale, { day: "numeric", month: "short", year: "numeric" })
 }
 
 /**
- * Single-trigger range picker. Click once to set the lower bound,
- * click again to set the upper bound. The bounds normalise on render
- * so clicking earlier then later — or later then earlier — both
- * produce a valid range; callers receive ``{from, to}`` already
- * sorted.
- *
- * Native ``<input type=date>`` was the previous filter pattern in
- * the admin audit log; it renders differently in every browser, has
- * no range semantics, and reads as a debug control rather than part
- * of the system. This widget uses the same Mon-start week + 6-row
- * month grid the dashboard already uses, so the visual vocabulary
- * stays consistent across the app.
+ * Single-trigger range picker on the shared {@link CalendarPopover}. Click
+ * once to set the lower bound, click again to set the upper bound. The bounds
+ * normalise on render so clicking earlier then later — or later then earlier —
+ * both produce a valid range; callers receive ``{from, to}`` already sorted.
  */
 export function DateRangePicker({
   value,
@@ -122,30 +51,6 @@ export function DateRangePicker({
   className,
 }: Props) {
   const { t, i18n } = useTranslation()
-  const [open, setOpen] = useState(false)
-  // The visible month: defaults to the month of ``from`` (so the
-  // calendar opens already showing the range), then falls back to
-  // today. Stored in state so the chevron nav doesn't clobber the
-  // selection.
-  const [anchor, setAnchor] = useState<Date>(() => {
-    const fromDate = parseYmd(value.from)
-    return startOfMonth(fromDate ?? new Date())
-  })
-
-  const cells = useMemo(
-    () => buildMonthGrid(anchor, value.from, value.to),
-    [anchor, value.from, value.to],
-  )
-
-  const weekdayHeads = [
-    t("streak.days.mon"),
-    t("streak.days.tue"),
-    t("streak.days.wed"),
-    t("streak.days.thu"),
-    t("streak.days.fri"),
-    t("streak.days.sat"),
-    t("streak.days.sun"),
-  ]
 
   const triggerLabel = (() => {
     if (value.from && value.to) {
@@ -156,151 +61,59 @@ export function DateRangePicker({
     return placeholder ?? t("dateRangePicker.placeholder")
   })()
 
-  const monthLabel = anchor.toLocaleDateString(i18n.language, {
-    month: "long",
-    year: "numeric",
-  })
+  // Normalise so ``lo`` is the lower bound regardless of click order.
+  const [lo, hi] =
+    value.from && value.to && compareYmd(value.from, value.to) > 0
+      ? [value.to, value.from]
+      : [value.from, value.to]
 
-  function pick(d: Date) {
+  function pick(d: Date, close: () => void) {
     const key = ymdKey(d)
     // First click (no bounds yet) → set the lower bound.
-    // Second click (one bound) → set the other bound.
+    // Second click (one bound) → set the other bound and close.
     // Both bounds set → start a fresh range from this click.
     if (!value.from && !value.to) {
       onChange({ from: key, to: "" })
       return
     }
     if (value.from && !value.to) {
-      // Order doesn't matter — normalise on render
       onChange({ from: value.from, to: key })
-      // Close after a complete range so the admin can see the table
-      // refresh; the trigger label reflects the picked range.
-      setOpen(false)
+      close()
       return
     }
     if (!value.from && value.to) {
       onChange({ from: key, to: value.to })
-      setOpen(false)
+      close()
       return
     }
-    // Both bounds present — restart.
     onChange({ from: key, to: "" })
   }
 
-  function clear() {
-    onChange({ from: "", to: "" })
-  }
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={disabled}
-          className={cn(
-            "h-9 justify-start gap-2 px-3 font-normal",
-            !value.from && !value.to && "text-ink-muted",
-            active && "border-brand/40 ring-1 ring-primary/40",
-            className,
-          )}
-        >
-          <CalendarIcon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
-          <span className="truncate text-xs sm:text-sm">{triggerLabel}</span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-[min(20rem,calc(100vw-2rem))] max-w-sm p-0"
-        align="start"
-      >
-        {/* Header: prev / month label / next */}
-        <div className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            onClick={() => setAnchor((a) => addMonths(a, -1))}
-            aria-label={t("dateRangePicker.prevMonth")}
-          >
-            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          </Button>
-          <p className="text-sm font-medium capitalize text-ink">{monthLabel}</p>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            onClick={() => setAnchor((a) => addMonths(a, 1))}
-            aria-label={t("dateRangePicker.nextMonth")}
-          >
-            <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          </Button>
-        </div>
-
-        {/* Weekday heads + grid */}
-        <div className="p-2">
-          <div className="grid grid-cols-7 gap-0.5">
-            {weekdayHeads.map((d, i) => (
-              <div
-                key={i}
-                className="pb-1 text-center text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted"
-              >
-                {d}
-              </div>
-            ))}
-            {cells.map((c, i) => {
-              const buttonClasses = cn(
-                "relative flex h-8 w-full items-center justify-center rounded-sm text-xs tabular-nums",
-                "transition-colors hover:bg-muted",
-                c.inCurrentMonth ? "text-ink" : "text-ink-muted/40",
-                c.isToday && !c.isStart && !c.isEnd && "ring-1 ring-primary/60",
-                c.inRange && !c.isStart && !c.isEnd && "bg-brand/15 text-ink",
-                (c.isStart || c.isEnd) && "bg-brand font-medium text-brand-foreground hover:bg-brand/90",
-              )
-              return (
-                <button
-                  type="button"
-                  key={i}
-                  onClick={() => pick(c.date)}
-                  className={buttonClasses}
-                  aria-label={c.date.toLocaleDateString(i18n.language, {
-                    weekday: "long",
-                    day: "numeric",
-                    month: "long",
-                    year: "numeric",
-                  })}
-                  aria-pressed={c.isStart || c.isEnd}
-                >
-                  {c.date.getDate()}
-                </button>
-              )
-            })}
-          </div>
-        </div>
-
-        {/* Footer: Clear */}
-        <div className="flex items-center justify-end gap-2 border-t border-edge px-2 py-1.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={clear}
-            disabled={!value.from && !value.to}
-            className="h-7 text-xs text-ink-muted hover:text-ink"
-          >
-            <X className="mr-1 h-3 w-3" strokeWidth={1.75} aria-hidden />
-            {t("dateRangePicker.clear")}
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+    <CalendarPopover
+      active={active}
+      disabled={disabled}
+      className={className}
+      triggerLabel={triggerLabel}
+      triggerMuted={!value.from && !value.to}
+      initialMonth={startOfMonth(parseYmd(value.from) ?? new Date())}
+      renderDay={(date, { isToday }) => {
+        const key = ymdKey(date)
+        const isStart = !!lo && key === lo
+        const isEnd = !!hi && hi !== lo && key === hi
+        const inRange = !!lo && !!hi && key >= lo && key <= hi
+        return {
+          selected: isStart || isEnd,
+          className: cn(
+            isToday && !isStart && !isEnd && "ring-1 ring-primary/60",
+            inRange && !isStart && !isEnd && "bg-brand/15 text-ink",
+            (isStart || isEnd) && "bg-brand font-medium text-brand-foreground hover:bg-brand/90",
+          ),
+        }
+      }}
+      onPickDay={pick}
+      onClear={() => onChange({ from: "", to: "" })}
+      clearDisabled={!value.from && !value.to}
+    />
   )
-}
-
-function formatShort(ymd: string, locale: string): string {
-  const d = parseYmd(ymd)
-  if (!d) return ymd
-  return d.toLocaleDateString(locale, { day: "numeric", month: "short", year: "numeric" })
 }

--- a/frontend/src/components/ui/datetime-picker.tsx
+++ b/frontend/src/components/ui/datetime-picker.tsx
@@ -1,12 +1,8 @@
-import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, X } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { CalendarPopover } from "@/components/ui/CalendarPopover"
+import { startOfMonth, ymdKey } from "@/lib/calendar"
 import { cn } from "@/lib/utils"
-
-const DAYS_IN_WEEK = 7
 
 interface Props {
   /** ``"YYYY-MM-DDTHH:MM"`` string — identical contract to the native
@@ -22,10 +18,6 @@ interface Props {
   "aria-label"?: string
 }
 
-function ymdKey(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
-}
-
 function parseLocal(s: string): { date: Date; hh: number; mm: number } | null {
   // Tolerant parser for ``YYYY-MM-DDTHH:MM`` and ``YYYY-MM-DDTHH:MM:SS``.
   const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(s)
@@ -36,50 +28,9 @@ function parseLocal(s: string): { date: Date; hh: number; mm: number } | null {
 }
 
 function compose(date: Date, hh: number, mm: number): string {
-  const day = ymdKey(date)
   const hhs = String(hh).padStart(2, "0")
   const mms = String(mm).padStart(2, "0")
-  return `${day}T${hhs}:${mms}`
-}
-
-function weekdayMonStart(d: Date): number {
-  return (d.getDay() + 6) % DAYS_IN_WEEK
-}
-
-function startOfMonth(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), 1)
-}
-
-function addMonths(d: Date, n: number): Date {
-  return new Date(d.getFullYear(), d.getMonth() + n, 1)
-}
-
-interface MonthCell {
-  date: Date
-  inCurrentMonth: boolean
-  isToday: boolean
-  isSelected: boolean
-}
-
-function buildMonthGrid(anchor: Date, selectedYmd: string): MonthCell[] {
-  const year = anchor.getFullYear()
-  const month = anchor.getMonth()
-  const first = new Date(year, month, 1)
-  const offset = weekdayMonStart(first)
-  const gridStart = new Date(year, month, 1 - offset)
-  const todayKey = ymdKey(new Date())
-  const cells: MonthCell[] = []
-  for (let i = 0; i < 42; i++) {
-    const d = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i)
-    const key = ymdKey(d)
-    cells.push({
-      date: d,
-      inCurrentMonth: d.getMonth() === month,
-      isToday: key === todayKey,
-      isSelected: !!selectedYmd && key === selectedYmd,
-    })
-  }
-  return cells
+  return `${ymdKey(date)}T${hhs}:${mms}`
 }
 
 function formatLong(value: string, locale: string): string {
@@ -95,20 +46,18 @@ function formatLong(value: string, locale: string): string {
   return `${datePart} · ${hh}:${mm}`
 }
 
+const clampHH = (n: number) => Math.min(23, Math.max(0, Number.isFinite(n) ? Math.round(n) : 0))
+const clampMM = (n: number) => Math.min(59, Math.max(0, Number.isFinite(n) ? Math.round(n) : 0))
+
 /**
- * Date + time picker built on the same hand-rolled Popover + Mon-start
- * month-grid pattern as ``DateRangePicker``. Replaces native
- * ``<input type="datetime-local">`` whose look diverges across
- * Win/Mac/Linux (and which, on Windows, opens a chunky non-keyboard-
- * navigable popup that visually breaks the editorial layout).
+ * Date + time picker built on the shared {@link CalendarPopover} with a time
+ * row below the grid. Replaces native ``<input type="datetime-local">`` whose
+ * look diverges across Win/Mac/Linux (and which, on Windows, opens a chunky
+ * non-keyboard-navigable popup that visually breaks the editorial layout).
  *
- * Value contract is identical to the native input: ``"YYYY-MM-DDTHH:MM"``
- * ⇄ ``""``. Drop-in replacement for any caller that read
- * ``e.target.value`` from a datetime-local input.
- *
- * Time inputs use plain ``<Input type="number">`` so we don't pay for
- * a second native picker — HH (00-23) and MM (00-59) sit at the bottom
- * of the popover as two small editable cells.
+ * Value contract is identical to the native input: ``"YYYY-MM-DDTHH:MM"`` ⇄
+ * ``""``. Time inputs use plain ``<Input type="number">`` so we don't pay for
+ * a second native picker.
  */
 export function DateTimePicker({
   value,
@@ -121,147 +70,39 @@ export function DateTimePicker({
   "aria-label": ariaLabel,
 }: Props) {
   const { t, i18n } = useTranslation()
-  const [open, setOpen] = useState(false)
 
   const parsed = parseLocal(value)
   const selectedYmd = parsed ? ymdKey(parsed.date) : ""
   const hh = parsed?.hh ?? 9
   const mm = parsed?.mm ?? 0
 
-  const [anchor, setAnchor] = useState<Date>(() =>
-    startOfMonth(parsed?.date ?? new Date()),
-  )
-
-  const cells = useMemo(
-    () => buildMonthGrid(anchor, selectedYmd),
-    [anchor, selectedYmd],
-  )
-
-  const weekdayHeads = [
-    t("streak.days.mon"),
-    t("streak.days.tue"),
-    t("streak.days.wed"),
-    t("streak.days.thu"),
-    t("streak.days.fri"),
-    t("streak.days.sat"),
-    t("streak.days.sun"),
-  ]
-
-  const triggerLabel = value
-    ? formatLong(value, i18n.language)
-    : placeholder ?? t("dateTimePicker.placeholder")
-
-  const monthLabel = anchor.toLocaleDateString(i18n.language, {
-    month: "long",
-    year: "numeric",
-  })
-
-  const setDate = (d: Date) => onChange(compose(d, hh, mm))
-  const setHH = (next: number) => {
-    if (!parsed) {
-      // First time setting time — default to today's date.
-      onChange(compose(new Date(), next, mm))
-      return
-    }
-    onChange(compose(parsed.date, next, mm))
-  }
-  const setMM = (next: number) => {
-    if (!parsed) {
-      onChange(compose(new Date(), hh, next))
-      return
-    }
-    onChange(compose(parsed.date, hh, next))
-  }
-
-  const clampHH = (n: number) => Math.min(23, Math.max(0, Number.isFinite(n) ? Math.round(n) : 0))
-  const clampMM = (n: number) => Math.min(59, Math.max(0, Number.isFinite(n) ? Math.round(n) : 0))
+  const setHH = (next: number) => onChange(compose(parsed?.date ?? new Date(), next, mm))
+  const setMM = (next: number) => onChange(compose(parsed?.date ?? new Date(), hh, next))
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          id={id}
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={disabled}
-          aria-label={ariaLabel}
-          className={cn(
-            "h-9 justify-start gap-2 px-3 font-normal",
-            !value && "text-ink-muted",
-            active && "border-brand/40 ring-1 ring-primary/40",
-            className,
-          )}
-        >
-          <CalendarIcon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
-          <span className="truncate text-xs sm:text-sm">{triggerLabel}</span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-[min(20rem,calc(100vw-2rem))] max-w-sm p-0"
-        align="start"
-      >
-        <div className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            onClick={() => setAnchor((a) => addMonths(a, -1))}
-            aria-label={t("dateRangePicker.prevMonth")}
-          >
-            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          </Button>
-          <p className="text-sm font-medium capitalize text-ink">{monthLabel}</p>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            onClick={() => setAnchor((a) => addMonths(a, 1))}
-            aria-label={t("dateRangePicker.nextMonth")}
-          >
-            <ChevronRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-          </Button>
-        </div>
-
-        <div className="p-2">
-          <div className="grid grid-cols-7 gap-0.5">
-            {weekdayHeads.map((d, i) => (
-              <div
-                key={i}
-                className="pb-1 text-center text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted"
-              >
-                {d}
-              </div>
-            ))}
-            {cells.map((c, i) => (
-              <button
-                type="button"
-                key={i}
-                onClick={() => setDate(c.date)}
-                className={cn(
-                  "relative flex h-8 w-full items-center justify-center rounded-sm text-xs tabular-nums",
-                  "transition-colors hover:bg-muted",
-                  c.inCurrentMonth ? "text-ink" : "text-ink-muted/40",
-                  c.isToday && !c.isSelected && "ring-1 ring-primary/60",
-                  c.isSelected && "bg-brand font-medium text-brand-foreground hover:bg-brand/90",
-                )}
-                aria-label={c.date.toLocaleDateString(i18n.language, {
-                  weekday: "long",
-                  day: "numeric",
-                  month: "long",
-                  year: "numeric",
-                })}
-                aria-pressed={c.isSelected}
-              >
-                {c.date.getDate()}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Time row */}
+    <CalendarPopover
+      id={id}
+      aria-label={ariaLabel}
+      active={active}
+      disabled={disabled}
+      className={className}
+      triggerLabel={value ? formatLong(value, i18n.language) : placeholder ?? t("dateTimePicker.placeholder")}
+      triggerMuted={!value}
+      initialMonth={startOfMonth(parsed?.date ?? new Date())}
+      renderDay={(date, { isToday }) => {
+        const selected = !!selectedYmd && ymdKey(date) === selectedYmd
+        return {
+          selected,
+          className: cn(
+            isToday && !selected && "ring-1 ring-primary/60",
+            selected && "bg-brand font-medium text-brand-foreground hover:bg-brand/90",
+          ),
+        }
+      }}
+      onPickDay={(date) => onChange(compose(date, hh, mm))}
+      onClear={() => onChange("")}
+      clearDisabled={!value}
+      belowGrid={
         <div className="flex items-center justify-center gap-1.5 border-t border-edge px-3 py-2 text-xs">
           <Input
             type="number"
@@ -283,21 +124,7 @@ export function DateTimePicker({
             aria-label={t("dateTimePicker.minuteAria")}
           />
         </div>
-
-        <div className="flex items-center justify-end gap-2 border-t border-edge px-2 py-1.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => onChange("")}
-            disabled={!value}
-            className="h-7 text-xs text-ink-muted hover:text-ink"
-          >
-            <X className="mr-1 h-3 w-3" strokeWidth={1.75} aria-hidden />
-            {t("dateRangePicker.clear")}
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+      }
+    />
   )
 }

--- a/frontend/src/lib/calendar.ts
+++ b/frontend/src/lib/calendar.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared date math for the hand-rolled Mon-start month grid used by the
+ * three calendar pickers (`DatePicker`, `DateTimePicker`, `DateRangePicker`).
+ * These were copy-pasted byte-for-byte across all three before extraction.
+ *
+ * NOTE: this is the date-INPUT grid (Mon-start, 6 rows, no event bucketing).
+ * The dashboard's event calendar (`pages/Calendar/`) is a deliberately
+ * different Sunday-start grid — do not converge them.
+ */
+
+export const DAYS_IN_WEEK = 7
+
+/** Local `YYYY-MM-DD` key (no timezone shift — uses the date's own Y/M/D). */
+export function ymdKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}
+
+/** Parse a strict `YYYY-MM-DD` string to a local Date, or `null`. */
+export function parseYmd(s: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null
+  const y = Number(s.slice(0, 4))
+  const m = Number(s.slice(5, 7))
+  const d = Number(s.slice(8, 10))
+  const out = new Date(y, m - 1, d)
+  return Number.isNaN(out.getTime()) ? null : out
+}
+
+/** Day of week with Monday = 0 … Sunday = 6. */
+export function weekdayMonStart(d: Date): number {
+  return (d.getDay() + 6) % DAYS_IN_WEEK
+}
+
+export function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1)
+}
+
+export function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1)
+}
+
+/**
+ * The 42 dates (6 weeks) of the Mon-start grid containing `anchor`'s month,
+ * including the leading/trailing days from adjacent months. Selection state
+ * is left to the caller — the grid itself is selection-agnostic.
+ */
+export function buildMonthMatrix(anchor: Date): Date[] {
+  const year = anchor.getFullYear()
+  const month = anchor.getMonth()
+  const offset = weekdayMonStart(new Date(year, month, 1))
+  const gridStart = new Date(year, month, 1 - offset)
+  return Array.from(
+    { length: 42 },
+    (_, i) => new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i),
+  )
+}


### PR DESCRIPTION
The de-bloat audit's one real **AI copy-paste** finding: `DatePicker` / `DateTimePicker` / `DateRangePicker` each hand-rolled a byte-identical Mon-start month-grid core (date helpers, 42-cell builder, Popover trigger, month-nav, weekday heads, day-cell loop, Clear footer).

**Extracted**
- `lib/calendar.ts` — shared pure date helpers + `buildMonthMatrix()`.
- `components/ui/CalendarPopover.tsx` — shared chrome. Selection stays in each host via `renderDay()` (per-day className + selected) and `onPickDay(date, close)`; `DateTimePicker` passes its time row via the `belowGrid` slot.

The three are now thin wrappers differing only in value contract + selection styling. **Net −273 lines** (636 del / 363 ins). No behavior or public-API change — exact same props and string value contracts (`YYYY-MM-DD`, `YYYY-MM-DDTHH:MM`, `{from,to}`).

**Not folded in:** `pages/Calendar/MonthGrid.tsx` is a deliberately different Sunday-start event grid — untouched.

Verified locally: tsc, eslint, build (chunks within budget), full vitest **524/524**, date-range-picker test **4/4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)