### PR TITLE
chore: finish de-bloat cleanup (dead code + real duplication)

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -15,6 +15,16 @@ security = HTTPBearer()
 optional_security = HTTPBearer(auto_error=False)
 
 
+def _unauthorized(message: str) -> HTTPException:
+    """Build the standard 401 envelope (same shape for every auth failure)."""
+    return equip_error(
+        ErrorCode.AUTH_REQUIRED,
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        message=message,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
 # Sync so FastAPI runs it in the threadpool: keeps the event loop free while
 # decode_access_token (possible Supabase HTTP call) and the User SELECT block.
 def get_current_user(
@@ -23,28 +33,13 @@ def get_current_user(
 ) -> User:
     payload = decode_access_token(credentials.credentials)
     if payload is None:
-        raise equip_error(
-            ErrorCode.AUTH_REQUIRED,
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            message="Could not validate credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        raise _unauthorized("Could not validate credentials")
     user_id: str | None = payload.get("sub")
     if user_id is None:
-        raise equip_error(
-            ErrorCode.AUTH_REQUIRED,
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            message="Could not validate credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        raise _unauthorized("Could not validate credentials")
     user = db.query(User).filter(User.id == user_id).first()
     if user is None:
-        raise equip_error(
-            ErrorCode.AUTH_REQUIRED,
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            message="User not found",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        raise _unauthorized("User not found")
     return user
 
 

--- a/backend/app/services/translation/registry.py
+++ b/backend/app/services/translation/registry.py
@@ -141,18 +141,8 @@ def _resolve_course_via_chapter(db: Session, entity: Any) -> Course | None:
 
 
 def _resolve_course_via_quiz_chapter(db: Session, entity: Any) -> Course | None:
-    """Quiz -> chapter -> module -> course."""
-    chapter_id = getattr(entity, "chapter_id", None)
-    if not chapter_id:
-        return None
-    row = (
-        db.query(Course)
-        .join(Module, Module.course_id == Course.id)
-        .join(Chapter, Chapter.module_id == Module.id)
-        .filter(Chapter.id == chapter_id)
-        .first()
-    )
-    return row
+    """Quiz -> chapter -> module -> course (same chapter_id walk as a block)."""
+    return _resolve_course_via_chapter(db, entity)
 
 
 def _resolve_course_via_question(db: Session, entity: Any) -> Course | None:

--- a/frontend/src/lib/__tests__/errorCode.test.ts
+++ b/frontend/src/lib/__tests__/errorCode.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it } from "vitest"
 
-import { getErrorCode, getErrorContext } from "../errorCode"
+import { getErrorCode } from "../errorCode"
 
 function fakeAxiosError(body: unknown, status = 400): unknown {
   // Shape mirrors what `axios.isAxiosError` accepts. The
@@ -45,30 +45,5 @@ describe("getErrorCode", () => {
     expect(getErrorCode(new Error("boom"))).toBeNull()
     expect(getErrorCode("plain string")).toBeNull()
     expect(getErrorCode(null)).toBeNull()
-  })
-})
-
-describe("getErrorContext", () => {
-  it("returns the context dict when present", () => {
-    const err = fakeAxiosError({
-      detail: {
-        code: "quiz.attempts_exhausted",
-        message: "Out of attempts",
-        context: { remaining: 0, cap: 3 },
-      },
-    })
-    expect(getErrorContext(err)).toEqual({ remaining: 0, cap: 3 })
-  })
-
-  it("returns an empty object when context is missing", () => {
-    const err = fakeAxiosError({
-      detail: { code: "auth.required", message: "Sign in" },
-    })
-    expect(getErrorContext(err)).toEqual({})
-  })
-
-  it("returns an empty object for the legacy string detail", () => {
-    const err = fakeAxiosError({ detail: "Course not found" })
-    expect(getErrorContext(err)).toEqual({})
   })
 })

--- a/frontend/src/lib/errorCode.ts
+++ b/frontend/src/lib/errorCode.ts
@@ -82,15 +82,3 @@ export function getErrorCode(err: unknown): ErrorCode | null {
   const detail: unknown = err.response?.data?.detail
   return isStructuredErrorDetail(detail) ? detail.code : null
 }
-
-/**
- * Return the `context` dict from a structured error, or an empty
- * object when the error is legacy / unstructured. Useful for codes
- * that include machine-readable parameters (e.g. retries left,
- * conflicting resource id).
- */
-export function getErrorContext(err: unknown): Record<string, unknown> {
-  if (!isAxiosError(err)) return {}
-  const detail: unknown = err.response?.data?.detail
-  return isStructuredErrorDetail(detail) ? detail.context ?? {} : {}
-}

--- a/frontend/src/lib/grandTour.ts
+++ b/frontend/src/lib/grandTour.ts
@@ -1,7 +1,7 @@
 import { driver, type Config, type Driver, type DriveStep } from "driver.js"
 import "driver.js/dist/driver.css"
 import "@/styles/editorial-tour.css"
-import { sanitizeHtml } from "@/lib/sanitize"
+import { EDITORIAL_TOUR_BASE, sanitizePopover } from "@/lib/tour"
 
 /**
  * A grand-tour step is a regular driver.js step plus an optional
@@ -110,15 +110,7 @@ export function createGrandTour({
   // future user-interpolated tour copy could otherwise XSS.
   const baseSteps: DriveStep[] = steps.map((s) => ({
     element: s.element,
-    popover: s.popover
-      ? {
-          ...s.popover,
-          title: s.popover.title ? sanitizeHtml(s.popover.title) : s.popover.title,
-          description: s.popover.description
-            ? sanitizeHtml(s.popover.description)
-            : s.popover.description,
-        }
-      : s.popover,
+    popover: sanitizePopover(s.popover),
   }))
 
   // Pre-position on the first step's route so the very first
@@ -197,15 +189,9 @@ export function createGrandTour({
   }
 
   const config: Config = {
+    ...EDITORIAL_TOUR_BASE,
     steps: baseSteps,
     animate: !reducedMotion,
-    smoothScroll: true,
-    allowClose: true,
-    disableActiveInteraction: true,
-    overlayColor: "hsl(265 28% 13%)",
-    overlayOpacity: 0.55,
-    stagePadding: 6,
-    stageRadius: 8,
     showProgress: steps.length > 1,
     progressText: labels.progress,
     nextBtnText: labels.next,

--- a/frontend/src/lib/tour.ts
+++ b/frontend/src/lib/tour.ts
@@ -26,22 +26,43 @@ export type TourStep = DriveStep
  * ``<em>`` keeps those tags while ``<script>``, ``<img onerror>``,
  * ``href="javascript:..."`` etc. are stripped.
  */
-function sanitiseStepTextInPlace(steps: readonly TourStep[]): TourStep[] {
-  return steps.map((step) => {
-    if (!step.popover) return step
-    const { popover, ...rest } = step
-    return {
-      ...rest,
-      popover: {
-        ...popover,
-        title: popover.title ? sanitizeHtml(popover.title) : popover.title,
-        description: popover.description
-          ? sanitizeHtml(popover.description)
-          : popover.description,
-      },
-    }
-  })
+/**
+ * Sanitise a driver.js popover's ``title`` + ``description`` (both rendered
+ * via ``innerHTML``) so a future user-interpolated tour string can't XSS.
+ * Shared by the per-page tour and the cross-route grand tour.
+ */
+export function sanitizePopover(popover: DriveStep["popover"]): DriveStep["popover"] {
+  if (!popover) return popover
+  return {
+    ...popover,
+    title: popover.title ? sanitizeHtml(popover.title) : popover.title,
+    description: popover.description ? sanitizeHtml(popover.description) : popover.description,
+  }
 }
+
+function sanitiseStepTextInPlace(steps: readonly TourStep[]): TourStep[] {
+  return steps.map((step) =>
+    step.popover ? { ...step, popover: sanitizePopover(step.popover) } : step,
+  )
+}
+
+/**
+ * Visual + interaction constants shared by both editorial tours, so the
+ * overlay tint, stage geometry, and popover class can't drift between the
+ * per-page tour and the grand tour. ``disableActiveInteraction`` keeps the
+ * spotlit element from acting as a click-trap (without it the catalog-search
+ * step would eat keystrokes and reposition the spotlight on every char).
+ */
+export const EDITORIAL_TOUR_BASE = {
+  smoothScroll: true,
+  allowClose: true,
+  disableActiveInteraction: true,
+  overlayColor: "hsl(265 28% 13%)",
+  overlayOpacity: 0.55,
+  stagePadding: 6,
+  stageRadius: 8,
+  popoverClass: "editorial-tour-popover",
+} satisfies Partial<Config>
 
 interface CreateTourOpts {
   steps: readonly TourStep[]
@@ -112,22 +133,12 @@ export function createEditorialTour({
   const animate = !reducedMotionPreferred()
 
   const config: Config = {
+    ...EDITORIAL_TOUR_BASE,
     steps: sanitiseStepTextInPlace(steps) as DriveStep[],
     // Both the SVG stage morph and the popover fade are gated on this
     // single flag — driver.js doesn't expose them separately, and the
     // CSS media query catches the popover fade as a defense in depth.
     animate,
-    smoothScroll: true,
-    allowClose: true,
-    // The spotlit element should READ as the subject of the popover,
-    // not be a click-trap that scrolls the page underneath while the
-    // user is reading. Without this, the catalog-search step would
-    // accept keystrokes and reposition the spotlight on every char.
-    disableActiveInteraction: true,
-    overlayColor: "hsl(265 28% 13%)",
-    overlayOpacity: 0.55,
-    stagePadding: 6,
-    stageRadius: 8,
     showProgress: steps.length > 1,
     progressText: labels.progress,
     nextBtnText: labels.next,


### PR DESCRIPTION
The remaining bloat/over-engineering audit items, all genuine dead-code / copy-paste removals. **No behavior change.**

- **frontend `lib/errorCode.ts`**: delete `getErrorContext()` (exported, only its own test called it). Dropped its 3 test cases.
- **frontend `lib/tour.ts` + `grandTour.ts`**: the two tour factories duplicated the driver.js visual config (overlay tint, stage geometry, popover class) and the popover-sanitise loop. Extracted `EDITORIAL_TOUR_BASE` + shared `sanitizePopover()`; both spread/call them. Divergent navigation hooks untouched. One source of truth so the overlay styling can't drift.
- **backend `api/dependencies.py`**: same 401 envelope built 3× in `get_current_user` → local `_unauthorized(message)` helper.
- **backend `services/translation/registry.py`**: `_resolve_course_via_quiz_chapter` had a byte-identical body to `_resolve_course_via_chapter` → delegates.

Verified locally: backend ruff/format/mypy clean + 219 auth/translation tests; frontend tsc/eslint/build clean + full vitest (521).

🤖 Generated with [Claude Code](https://claude.com/claude-code)