### PR TITLE
chore(db): drop unused daily_challenge_pilot_reviews table

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -337,10 +337,10 @@ jobs:
           COUNT=$(psql -tA -h localhost -p 5432 -U ci -d ci \
             -c "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE';")
           echo "public base tables after replay: $COUNT"
-          # Prod has 34 public base tables (see schema.sql). Guard against a
+          # Prod has 33 public base tables (see schema.sql). Guard against a
           # silently-truncated dump or a partial load.
-          if [ "$COUNT" -ne 34 ]; then
-            echo "::error::Expected 34 public tables after replay, got $COUNT — schema.sql may be stale or partial." >&2
+          if [ "$COUNT" -ne 33 ]; then
+            echo "::error::Expected 33 public tables after replay, got $COUNT — schema.sql may be stale or partial." >&2
             exit 1
           fi
           echo "OK: prod schema replays cleanly from supabase/schema.sql"

--- a/backend/app/models/daily_challenge.py
+++ b/backend/app/models/daily_challenge.py
@@ -34,7 +34,6 @@ from sqlalchemy import (
     Index,
     Integer,
     Text,
-    UniqueConstraint,
     func,
     text,
 )
@@ -355,42 +354,4 @@ class DailyChallengeQuestionEvent(Base):
         PgUUID(as_uuid=True), ForeignKey("profiles.id", ondelete="SET NULL")
     )
     details: Mapped[dict] = mapped_column(JSON, default=dict, server_default="{}")
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
-
-
-class DailyChallengePilotReview(Base):
-    """Stage 5 pilot answers + engagement ratings.
-
-    One row per (question, reviewer). The promotion threshold (≥80%
-    correct rate + ≥3.5/5 mean engagement, n≥5) is computed in the
-    service layer rather than persisted as a denormalised column,
-    because the threshold is an editorial knob we may tune.
-
-    Updating a review re-uses the same row — the service layer does
-    an upsert; the unique constraint enforces uniqueness.
-    """
-
-    __tablename__ = "daily_challenge_pilot_reviews"
-    __table_args__ = (
-        UniqueConstraint("question_id", "reviewer_id", name="uq_dc_pilot_reviews_pair"),
-        CheckConstraint(
-            "engagement_rating BETWEEN 1 AND 5",
-            name="dc_pilot_reviews_rating_check",
-        ),
-        Index("ix_dc_pilot_reviews_question", "question_id"),
-        Index("ix_dc_pilot_reviews_reviewer", "reviewer_id"),
-    )
-
-    id: Mapped[uuid.UUID] = mapped_column(PgUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    question_id: Mapped[uuid.UUID] = mapped_column(
-        PgUUID(as_uuid=True),
-        ForeignKey("daily_challenge_questions.id", ondelete="CASCADE"),
-    )
-    reviewer_id: Mapped[uuid.UUID] = mapped_column(
-        PgUUID(as_uuid=True),
-        ForeignKey("profiles.id", ondelete="SET NULL"),
-    )
-    answered_correctly: Mapped[bool] = mapped_column(Boolean)
-    engagement_rating: Mapped[int] = mapped_column(Integer)
-    notes: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/supabase/migrations/20260608170000_drop_dc_pilot_reviews.sql
+++ b/supabase/migrations/20260608170000_drop_dc_pilot_reviews.sql
@@ -1,0 +1,13 @@
+-- Drop the unused daily_challenge_pilot_reviews table.
+--
+-- The Daily Challenge generation pipeline reaches an
+-- "awaiting_pilot_reviewers" stage, but the human pilot-review submission
+-- half (endpoint + UI) was never built: the table has zero rows and no
+-- writer anywhere in the codebase. Removing the dead storage. If the
+-- human pilot-review gate is ever implemented, restore the table + model
+-- from git history (model: app/models/daily_challenge.py::DailyChallengePilotReview;
+-- created by 20260529230000_add_daily_challenge_editorial.sql).
+--
+-- CASCADE removes the table's FK constraints, the two indexes
+-- (ix_dc_pilot_reviews_question / _reviewer), and the RLS policy with it.
+DROP TABLE IF EXISTS public.daily_challenge_pilot_reviews CASCADE;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 2XKTDS5XRmU2AGeGBdr3ouCL2xQnTL8Lw6qQrf0bhJatveYzrTmxtUS4acfUht6
+\restrict 38WNeZxckeLZWDTy141fQPRRANl1md4zQ1MgPqINFaBepVusIObZCg3Pg5vxEKc
 
 -- Dumped from database version 17.6
 -- Dumped by pg_dump version 17.6
@@ -470,22 +470,6 @@ CREATE TABLE public.daily_challenge_options (
 
 
 --
--- Name: daily_challenge_pilot_reviews; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.daily_challenge_pilot_reviews (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    question_id uuid NOT NULL,
-    reviewer_id uuid NOT NULL,
-    answered_correctly boolean NOT NULL,
-    engagement_rating integer NOT NULL,
-    notes text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT daily_challenge_pilot_reviews_engagement_rating_check CHECK (((engagement_rating >= 1) AND (engagement_rating <= 5)))
-);
-
-
---
 -- Name: daily_challenge_question_events; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -937,22 +921,6 @@ ALTER TABLE ONLY public.daily_challenge_options
 
 
 --
--- Name: daily_challenge_pilot_reviews daily_challenge_pilot_reviews_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.daily_challenge_pilot_reviews
-    ADD CONSTRAINT daily_challenge_pilot_reviews_pkey PRIMARY KEY (id);
-
-
---
--- Name: daily_challenge_pilot_reviews daily_challenge_pilot_reviews_question_id_reviewer_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.daily_challenge_pilot_reviews
-    ADD CONSTRAINT daily_challenge_pilot_reviews_question_id_reviewer_id_key UNIQUE (question_id, reviewer_id);
-
-
---
 -- Name: daily_challenge_question_events daily_challenge_question_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1366,20 +1334,6 @@ CREATE INDEX ix_dc_attempts_user_date ON public.daily_challenge_attempts USING b
 --
 
 CREATE INDEX ix_dc_options_question ON public.daily_challenge_options USING btree (question_id, order_index);
-
-
---
--- Name: ix_dc_pilot_reviews_question; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_dc_pilot_reviews_question ON public.daily_challenge_pilot_reviews USING btree (question_id);
-
-
---
--- Name: ix_dc_pilot_reviews_reviewer; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_dc_pilot_reviews_reviewer ON public.daily_challenge_pilot_reviews USING btree (reviewer_id);
 
 
 --
@@ -1984,22 +1938,6 @@ ALTER TABLE ONLY public.daily_challenge_options
 
 
 --
--- Name: daily_challenge_pilot_reviews daily_challenge_pilot_reviews_question_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.daily_challenge_pilot_reviews
-    ADD CONSTRAINT daily_challenge_pilot_reviews_question_id_fkey FOREIGN KEY (question_id) REFERENCES public.daily_challenge_questions(id) ON DELETE CASCADE;
-
-
---
--- Name: daily_challenge_pilot_reviews daily_challenge_pilot_reviews_reviewer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.daily_challenge_pilot_reviews
-    ADD CONSTRAINT daily_challenge_pilot_reviews_reviewer_id_fkey FOREIGN KEY (reviewer_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
-
-
---
 -- Name: daily_challenge_question_events daily_challenge_question_events_actor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2534,12 +2472,6 @@ ALTER TABLE public.daily_challenge_attempts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.daily_challenge_options ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: daily_challenge_pilot_reviews; Type: ROW SECURITY; Schema: public; Owner: -
---
-
-ALTER TABLE public.daily_challenge_pilot_reviews ENABLE ROW LEVEL SECURITY;
-
---
 -- Name: daily_challenge_question_events; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -2581,15 +2513,6 @@ CREATE POLICY dc_options_select_via_question ON public.daily_challenge_options F
           WHERE ((s.question_id = q.id) AND (s.challenge_date <= ((now() AT TIME ZONE 'UTC'::text))::date))))) OR (EXISTS ( SELECT 1
            FROM public.profiles p
           WHERE ((p.id = ( SELECT auth.uid() AS uid)) AND (p.role = ANY (ARRAY['teacher'::text, 'admin'::text]))))))))));
-
-
---
--- Name: daily_challenge_pilot_reviews dc_pilot_reviews_select_editorial; Type: POLICY; Schema: public; Owner: -
---
-
-CREATE POLICY dc_pilot_reviews_select_editorial ON public.daily_challenge_pilot_reviews FOR SELECT TO authenticated USING ((EXISTS ( SELECT 1
-   FROM public.profiles p
-  WHERE ((p.id = ( SELECT auth.uid() AS uid)) AND (p.role = ANY (ARRAY['teacher'::text, 'admin'::text]))))));
 
 
 --
@@ -2933,5 +2856,5 @@ CREATE POLICY translation_jobs_no_client_access ON public.translation_jobs TO an
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 2XKTDS5XRmU2AGeGBdr3ouCL2xQnTL8Lw6qQrf0bhJatveYzrTmxtUS4acfUht6
+\unrestrict 38WNeZxckeLZWDTy141fQPRRANl1md4zQ1MgPqINFaBepVusIObZCg3Pg5vxEKc
 


### PR DESCRIPTION
The Daily Challenge pipeline logs an `awaiting_pilot_reviewers` stage, but the human pilot-review submission half (endpoint + UI) was never built: **0 rows, no writer anywhere**. De-bloat audit flagged it; confirmed drop.

- **Migration `20260608170000`** drops the table `CASCADE` (its FKs, the two `ix_dc_pilot_reviews_*` indexes, and the RLS policy go with it). **Already applied to prod via MCP** — prod verified 33 public tables, table gone.
- Removed the `DailyChallengePilotReview` model + the now-unused `UniqueConstraint` import.
- Regenerated `supabase/schema.sql` from prod (33 tables) and bumped the `schema-replay-postgres` count guard 34 → 33.

The pipeline status vocabulary (`PILOT_PASSED`, `awaiting_pilot_reviewers`) is intentionally left intact (generation state machine, not dead storage). Restore from git if the human pilot gate is ever built.

Verified: ruff/format/mypy clean, models materialize without the table, 141 daily-challenge tests pass. The schema-replay job will confirm the 33-table baseline loads from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)