### PR TITLE
fix: maximum-audit wave 1 — security + correctness + drift + test gaps

### DIFF
--- a/backend/app/api/v1/grades.py
+++ b/backend/app/api/v1/grades.py
@@ -36,6 +36,20 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/grades", tags=["grades"])
 
+# Spreadsheet apps (Excel / Google Sheets / LibreOffice) treat a cell that
+# begins with =, +, -, @, or a leading tab/CR as a FORMULA. Student names and
+# emails come from OAuth/profile data the user controls, so a name like
+# ``=HYPERLINK("http://evil","click")`` would execute on open. Prefix any such
+# cell with a single quote so it renders as literal text (CSV formula-injection
+# guard).
+_CSV_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _csv_safe(value: object) -> object:
+    if isinstance(value, str) and value and value[0] in _CSV_FORMULA_TRIGGERS:
+        return "'" + value
+    return value
+
 
 @router.get("/course/{course_id}/config", response_model=GradingConfigResponse)
 def get_grading_config(
@@ -199,8 +213,8 @@ def export_grades_csv(
         b = r["breakdown"]
         writer.writerow(
             [
-                r["student_name"] or "",
-                r["student_email"],
+                _csv_safe(r["student_name"] or ""),
+                _csv_safe(r["student_email"]),
                 b.quiz_avg,
                 b.quiz_weighted,
                 b.assignment_avg,

--- a/backend/app/core/http.py
+++ b/backend/app/core/http.py
@@ -31,11 +31,13 @@ def get_client_ip(request: Request, fallback: str | None = None) -> str | None:
 
     On Vercel (and any other configured reverse-proxy deploy)
     ``request.client.host`` is the proxy worker's IP, not the user's
-    real IP. ``X-Forwarded-For`` is set by the proxy to ``<client>,
-    <proxy>, <proxy>...`` (left-to-right), so the left-most entry is
-    the original client; everything after is proxy chain.
+    real IP. We prefer ``x-vercel-forwarded-for``: Vercel sets it to the
+    single, authoritative client IP and rewrites it on every request, so
+    a client CANNOT spoof it. The standard ``x-forwarded-for`` is only a
+    fallback — a client can PREPEND entries to it, so taking its left-most
+    value would let an attacker farm a fresh rate-limit bucket per request.
 
-    Outside that trusted-proxy environment we ignore both forwarded
+    Outside that trusted-proxy environment we ignore the forwarded
     headers and use ``request.client.host`` directly — otherwise any
     client can spoof their IP per request and defeat per-IP throttling.
     Returns ``fallback`` when we truly cannot determine the IP (for the
@@ -43,6 +45,16 @@ def get_client_ip(request: Request, fallback: str | None = None) -> str | None:
     so the DB column stays NULL).
     """
     if _TRUSTED_PROXY:
+        # Authoritative, un-spoofable on Vercel — set by the platform.
+        vercel_ip = request.headers.get("x-vercel-forwarded-for")
+        if vercel_ip:
+            ip = vercel_ip.split(",")[0].strip()
+            if ip:
+                return ip
+
+        # Generic reverse-proxy fallback (Cloudflare/nginx/Caddy via
+        # TRUST_FORWARDED_HEADERS). Left-most = original client when the
+        # proxy is the one writing this header.
         forwarded = request.headers.get("x-forwarded-for")
         if forwarded:
             ip = forwarded.split(",")[0].strip()

--- a/backend/app/core/sanitize.py
+++ b/backend/app/core/sanitize.py
@@ -79,7 +79,12 @@ _ALLOWED_TAGS = frozenset(
 )
 
 _ALLOWED_ATTRIBUTES: dict[str, list[str]] = {
-    "a": ["href", "title", "target", "rel"],
+    # No ``target``: a stored link must never open a new browsing context,
+    # so there is no ``window.opener`` for the opened page to abuse
+    # (reverse tabnabbing). The frontend renderer strips ``target`` too;
+    # dropping it here keeps both layers consistent. Intentional new-tab
+    # links are built in app code with an explicit rel="noopener noreferrer".
+    "a": ["href", "title"],
     "img": ["src", "alt", "title", "width", "height", "loading"],
     "iframe": [
         "src",

--- a/backend/app/models/chapter_progress.py
+++ b/backend/app/models/chapter_progress.py
@@ -31,7 +31,7 @@ class ChapterProgress(Base):
     completed: Mapped[bool] = mapped_column(default=False)
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     completed_by: Mapped[uuid.UUID | None] = mapped_column()
-    completion_type: Mapped[str] = mapped_column(String(10), default="self")
+    completion_type: Mapped[str] = mapped_column(String(20), default="self")
     created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/app/services/translation/queue.py
+++ b/backend/app/services/translation/queue.py
@@ -27,10 +27,10 @@ state across requests.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 
 from app.models.translation_job import (
     TRANSLATION_JOB_MAX_ATTEMPTS,
@@ -45,6 +45,13 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# A worker that claimed a job but never reported back — Vercel function
+# timeout/OOM mid-run — leaves the row stuck in ``processing`` forever:
+# never re-claimed, never failed, and it blocks re-enqueue of that course.
+# A single serverless invocation is capped well under this window, so any
+# job still ``processing`` past it is certainly dead and safe to re-claim.
+_PROCESSING_STALE_AFTER = timedelta(minutes=15)
 
 
 def enqueue_course_translation(
@@ -104,7 +111,9 @@ def claim_next_job(db: Session) -> TranslationJob | None:
     ``SELECT ... FOR UPDATE SKIP LOCKED`` predicate makes Postgres
     skip any row already row-locked by another transaction.
     ``failed`` jobs are eligible for re-claim so a transient Gemini
-    outage doesn't leak a job into oblivion.
+    outage doesn't leak a job into oblivion. Jobs stuck in ``processing``
+    past ``_PROCESSING_STALE_AFTER`` (a worker that died mid-run) are also
+    re-claimed so they recover instead of blocking the course forever.
 
     Returns ``None`` when no claimable job exists; the worker endpoint
     then 204s and the cron re-fires on the next tick.
@@ -115,10 +124,19 @@ def claim_next_job(db: Session) -> TranslationJob | None:
     flip in the same transaction so the row visibility window is
     minimised.
     """
+    stale_before = datetime.now(UTC) - _PROCESSING_STALE_AFTER
     job = (
         db.execute(
             select(TranslationJob)
-            .where(TranslationJob.status.in_([TranslationJobStatus.QUEUED, TranslationJobStatus.FAILED]))
+            .where(
+                or_(
+                    TranslationJob.status.in_([TranslationJobStatus.QUEUED, TranslationJobStatus.FAILED]),
+                    and_(
+                        TranslationJob.status == TranslationJobStatus.PROCESSING,
+                        TranslationJob.started_at < stale_before,
+                    ),
+                )
+            )
             .order_by(TranslationJob.enqueued_at)
             .limit(1)
             .with_for_update(skip_locked=True)

--- a/backend/tests/test_grades_csv_injection.py
+++ b/backend/tests/test_grades_csv_injection.py
@@ -1,0 +1,17 @@
+"""Guards the CSV formula-injection neutralizer on the grade export."""
+
+from app.api.v1.grades import _csv_safe
+
+
+def test_csv_safe_prefixes_formula_leading_chars() -> None:
+    for trigger in ("=", "+", "-", "@", "\t", "\r"):
+        payload = f'{trigger}HYPERLINK("http://evil","x")'
+        assert _csv_safe(payload) == "'" + payload
+
+
+def test_csv_safe_passes_plain_values_through() -> None:
+    assert _csv_safe("Vadym Arnaut") == "Vadym Arnaut"
+    assert _csv_safe("") == ""
+    assert _csv_safe("a=b+c") == "a=b+c"  # trigger char not in leading position
+    assert _csv_safe(42) == 42
+    assert _csv_safe(None) is None

--- a/backend/tests/test_sanitize.py
+++ b/backend/tests/test_sanitize.py
@@ -38,6 +38,13 @@ class TestBaseAllowlist:
         # bleach drops the href attribute when its protocol isn't allowlisted.
         assert "javascript:" not in cleaned
 
+    def test_anchor_target_is_stripped(self):
+        # No ``target`` survives sanitisation: a stored link can't open a
+        # new browsing context, so it can't reverse-tabnab via window.opener.
+        cleaned = sanitize_string('<a href="/x" target="_blank">click</a>')
+        assert "target" not in cleaned
+        assert 'href="/x"' in cleaned
+
 
 class TestTableAllowlist:
     """The TipTap Table extension emits ``<table>`` + ``<thead>`` /

--- a/frontend/src/components/ui/__tests__/date-picker.test.tsx
+++ b/frontend/src/components/ui/__tests__/date-picker.test.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { I18nextProvider } from "react-i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import i18n from "@/i18n/config"
+import { DatePicker } from "../date-picker"
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}
+
+function dayCell(text: string) {
+  return screen.getAllByRole("button").find((b) => b.textContent === text)
+}
+
+describe("DatePicker", () => {
+  it("renders the placeholder when no value is set", () => {
+    render(<DatePicker value="" onChange={() => {}} />, { wrapper: Wrapper })
+    expect(screen.getByText(/pick a date|выберите дату/i)).toBeInTheDocument()
+  })
+
+  it("emits YYYY-MM-DD for the picked day", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<DatePicker value="2026-05-10" onChange={onChange} />, { wrapper: Wrapper })
+    await user.click(screen.getByRole("button"))
+    const day20 = await waitFor(() => {
+      const el = dayCell("20")
+      expect(el).toBeDefined()
+      return el!
+    })
+    await user.click(day20)
+    expect(onChange).toHaveBeenCalledWith("2026-05-20")
+  })
+
+  it("marks the current value's day with aria-pressed", async () => {
+    const user = userEvent.setup()
+    render(<DatePicker value="2026-05-10" onChange={() => {}} />, { wrapper: Wrapper })
+    await user.click(screen.getByRole("button"))
+    const day10 = await waitFor(() => {
+      const el = dayCell("10")
+      expect(el).toBeDefined()
+      return el!
+    })
+    expect(day10).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("navigates to the previous month and picks from it", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<DatePicker value="2026-05-10" onChange={onChange} />, { wrapper: Wrapper })
+    await user.click(screen.getByRole("button"))
+    await user.click(await screen.findByRole("button", { name: /previous month|предыдущий месяц/i }))
+    const day15 = await waitFor(() => {
+      const el = dayCell("15")
+      expect(el).toBeDefined()
+      return el!
+    })
+    await user.click(day15)
+    expect(onChange).toHaveBeenCalledWith("2026-04-15")
+  })
+
+  it("clear emits an empty string", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<DatePicker value="2026-05-10" onChange={onChange} />, { wrapper: Wrapper })
+    await user.click(screen.getByRole("button"))
+    await user.click(await screen.findByRole("button", { name: /^(clear|очистить)$/i }))
+    expect(onChange).toHaveBeenCalledWith("")
+  })
+})

--- a/frontend/src/lib/__tests__/calendar.test.ts
+++ b/frontend/src/lib/__tests__/calendar.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  addMonths,
+  buildMonthMatrix,
+  parseYmd,
+  startOfMonth,
+  weekdayMonStart,
+  ymdKey,
+} from "../calendar"
+
+describe("ymdKey", () => {
+  it("formats local Y-M-D with zero padding (no UTC drift)", () => {
+    expect(ymdKey(new Date(2026, 0, 5))).toBe("2026-01-05") // month is 0-indexed
+    expect(ymdKey(new Date(2026, 11, 31))).toBe("2026-12-31")
+  })
+
+  it("uses local date parts even just after midnight", () => {
+    expect(ymdKey(new Date(2026, 2, 1, 0, 30))).toBe("2026-03-01")
+  })
+})
+
+describe("parseYmd", () => {
+  it("parses a strict YYYY-MM-DD into local Y/M/D", () => {
+    const d = parseYmd("2026-02-28")
+    expect(d).not.toBeNull()
+    expect([d!.getFullYear(), d!.getMonth(), d!.getDate()]).toEqual([2026, 1, 28])
+  })
+
+  it("round-trips with ymdKey", () => {
+    expect(ymdKey(parseYmd("2026-07-04")!)).toBe("2026-07-04")
+  })
+
+  it("rejects malformed input", () => {
+    for (const bad of ["", "2026-2-4", "2026/02/04", "26-02-04", "garbage", "2026-02-4"]) {
+      expect(parseYmd(bad)).toBeNull()
+    }
+  })
+})
+
+describe("weekdayMonStart", () => {
+  it("maps Monday to 0 and Sunday to 6", () => {
+    expect(weekdayMonStart(new Date(2024, 0, 1))).toBe(0) // 2024-01-01 was a Monday
+    expect(weekdayMonStart(new Date(2024, 0, 7))).toBe(6) // the following Sunday
+  })
+})
+
+describe("startOfMonth", () => {
+  it("collapses to day 1 of the same month", () => {
+    expect(ymdKey(startOfMonth(new Date(2026, 5, 23)))).toBe("2026-06-01")
+  })
+})
+
+describe("addMonths", () => {
+  it("moves to the first of the target month without day overflow", () => {
+    expect(ymdKey(addMonths(new Date(2026, 0, 31), 1))).toBe("2026-02-01") // Jan 31 + 1m, no Mar bleed
+    expect(ymdKey(addMonths(new Date(2026, 0, 15), -1))).toBe("2025-12-01") // crosses year backwards
+    expect(ymdKey(addMonths(new Date(2026, 11, 10), 1))).toBe("2027-01-01") // crosses year forwards
+  })
+})
+
+describe("buildMonthMatrix", () => {
+  const grid = buildMonthMatrix(new Date(2026, 1, 15)) // February 2026
+
+  it("returns exactly 42 cells (6 weeks)", () => {
+    expect(grid).toHaveLength(42)
+  })
+
+  it("starts on a Monday and runs as consecutive days", () => {
+    expect(weekdayMonStart(grid[0]!)).toBe(0)
+    for (let i = 1; i < grid.length; i++) {
+      const deltaDays = Math.round((grid[i]!.getTime() - grid[i - 1]!.getTime()) / 86_400_000)
+      expect(deltaDays).toBe(1) // round() absorbs 23h/25h DST transitions
+    }
+  })
+
+  it("contains every day of the anchor month", () => {
+    const keys = new Set(grid.map(ymdKey))
+    for (let day = 1; day <= 28; day++) {
+      expect(keys.has(`2026-02-${String(day).padStart(2, "0")}`)).toBe(true)
+    }
+  })
+
+  it("includes leading/trailing days from adjacent months", () => {
+    const months = new Set(grid.map((d) => d.getMonth()))
+    expect(months.size).toBeGreaterThan(1)
+  })
+
+  it("places the 1st of the anchor month at its Mon-start offset", () => {
+    const first = new Date(2026, 2, 1) // 1 March 2026
+    const march = buildMonthMatrix(first)
+    expect(march).toHaveLength(42)
+    expect(weekdayMonStart(march[0]!)).toBe(0)
+    expect(ymdKey(march[weekdayMonStart(first)]!)).toBe("2026-03-01")
+  })
+})

--- a/frontend/src/lib/__tests__/sanitize.test.ts
+++ b/frontend/src/lib/__tests__/sanitize.test.ts
@@ -110,4 +110,14 @@ describe("sanitizeHtml", () => {
     expect(output).toContain("<summary>q</summary>")
     expect(output).toContain('data-callout="toggle"')
   })
+
+  it("strips target from anchors so a new-tab link can't reverse-tabnab", () => {
+    // The renderer deliberately drops ``target`` entirely — a sanitized
+    // chapter link never opens a new browsing context, so there is no
+    // window.opener for the opened page to abuse. (The only intentional
+    // new-tab links are built in app code with rel="noopener noreferrer".)
+    const output = sanitizeHtml('<a href="https://example.com" target="_blank">x</a>')
+    expect(output).toContain('href="https://example.com"')
+    expect(output).not.toContain("target")
+  })
 })

--- a/supabase/migrations/20260608180000_narrow_profiles_role_check.sql
+++ b/supabase/migrations/20260608180000_narrow_profiles_role_check.sql
@@ -1,0 +1,15 @@
+-- Narrow the profiles.role CHECK to the three roles the app actually uses.
+--
+-- 'pending_teacher' was removed functionally by
+-- 20260531120000_remove_pending_teacher_role_handle_new_user.sql (every row
+-- downgraded to 'student', the signup trigger rewritten), but the CHECK
+-- constraint was never narrowed — so prod still permitted a value that
+-- neither UserRole (backend/app/models/user.py) nor the frontend UserRole
+-- accepts. This makes the DB exactly match code.
+--
+-- Verified before applying: 0 rows with role='pending_teacher', 0 RLS
+-- policies reference the value.
+ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS chk_profiles_role;
+ALTER TABLE public.profiles
+    ADD CONSTRAINT chk_profiles_role
+    CHECK (role = ANY (ARRAY['admin'::text, 'teacher'::text, 'student'::text]));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 38WNeZxckeLZWDTy141fQPRRANl1md4zQ1MgPqINFaBepVusIObZCg3Pg5vxEKc
+\restrict tyLrXpaYjAbthHaMXm2WKgaGW0nGUUromjYU6ew8mYakVhNvrQA7MTZSdg7f1FS
 
 -- Dumped from database version 17.6
 -- Dumped by pg_dump version 17.6
@@ -603,7 +603,7 @@ CREATE TABLE public.profiles (
     avatar_url text,
     preferred_locale character varying(8) DEFAULT 'ru'::character varying NOT NULL,
     calendar_ical_min_iat bigint,
-    CONSTRAINT chk_profiles_role CHECK ((role = ANY (ARRAY['admin'::text, 'teacher'::text, 'pending_teacher'::text, 'student'::text]))),
+    CONSTRAINT chk_profiles_role CHECK ((role = ANY (ARRAY['admin'::text, 'teacher'::text, 'student'::text]))),
     CONSTRAINT profiles_preferred_locale_check CHECK (((preferred_locale)::text = ANY (ARRAY[('ru'::character varying)::text, ('en'::character varying)::text])))
 )
 WITH (autovacuum_vacuum_threshold='25', autovacuum_analyze_threshold='25');
@@ -2856,5 +2856,5 @@ CREATE POLICY translation_jobs_no_client_access ON public.translation_jobs TO an
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 38WNeZxckeLZWDTy141fQPRRANl1md4zQ1MgPqINFaBepVusIObZCg3Pg5vxEKc
+\unrestrict tyLrXpaYjAbthHaMXm2WKgaGW0nGUUromjYU6ew8mYakVhNvrQA7MTZSdg7f1FS
 


### PR DESCRIPTION
Safe, self-contained findings from the exhaustive multi-agent audit. Each verified against prod/code before fixing. No behavior change for legitimate users.

**Security**
- `core/http.py`: rate-limit client IP prefers `x-vercel-forwarded-for` (authoritative, un-spoofable) over left-most `x-forwarded-for` (a client can prepend it to farm fresh buckets).
- `api/v1/grades.py`: CSV grade export neutralizes **formula injection** — a name/email starting with `= + - @`/tab/CR is prefixed with `'` so Excel/Sheets treat it as text, not a live `=HYPERLINK`.
- `core/sanitize.py`: drop `target`/`rel` from the `<a>` allowlist — a stored link can't open a new context (no `window.opener` to reverse-tabnab); frontend already strips `target`, now both layers agree.

**Reliability**
- `translation/queue.py`: `claim_next_job` re-claims jobs stuck in `processing` >15 min (worker died mid-run) so a killed function no longer blocks the course forever.

**Schema drift (4-way mirror)**
- Migration `20260608180000` narrows `profiles.role` CHECK to admin/teacher/student (`pending_teacher` removed in code + data by `20260531120000` but the CHECK still allowed it). Applied to prod (0 rows / 0 policies referenced it); `schema.sql` regenerated.
- `chapter_progress.completion_type` `String(10)`→`String(20)` to match prod.

**Test gaps**
- New `calendar.test.ts` (the unified picker's month math had zero coverage) + `date-picker.test.tsx` (pick/aria-pressed/nav/clear) + CSV-injection unit test + anchor-target-stripped sanitize test.

Verified: backend ruff/format/mypy + **1442 pytest**; frontend tsc/eslint/build + **vitest 540**; schema-replay confirms the 33-table baseline still loads.

Deferred for discussion (per Vadym): auth.users hard-delete on user purge, real-role RLS CI job, send-email source-to-repo + fail-closed, daily-challenge runway seeding + monitors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)