### PR TITLE
feat: soft-delete users (resolves audit #1, Vadym chose recoverable)

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -40,6 +40,15 @@ def get_current_user(
     user = db.query(User).filter(User.id == user_id).first()
     if user is None:
         raise _unauthorized("User not found")
+    if user.deactivated_at is not None:
+        # Soft-deleted account: the auth token may still be valid, but the
+        # account is deactivated — block every authenticated surface until an
+        # admin restores it.
+        raise equip_error(
+            ErrorCode.AUTH_FORBIDDEN,
+            status_code=status.HTTP_403_FORBIDDEN,
+            message="This account has been deactivated",
+        )
     return user
 
 
@@ -55,7 +64,12 @@ def get_optional_user(
     user_id: str | None = payload.get("sub")
     if user_id is None:
         return None
-    return db.query(User).filter(User.id == user_id).first()
+    user = db.query(User).filter(User.id == user_id).first()
+    # A deactivated account is treated as anonymous on optional-auth routes
+    # (public surfaces stay reachable; nothing authenticated is granted).
+    if user is not None and user.deactivated_at is not None:
+        return None
+    return user
 
 
 def require_teacher(

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, Query, Request, Response, status
@@ -9,16 +9,6 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_current_user, require_admin
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
-from app.models.assignment import AssignmentSubmission
-from app.models.audit_log import AuditLog
-from app.models.certificate import Certificate
-from app.models.chapter_progress import ChapterProgress
-from app.models.course import Course
-from app.models.enrollment import Enrollment
-from app.models.notification import Notification
-from app.models.quiz import QuizAnswer, QuizAttempt
-from app.models.review import CourseReview
-from app.models.student_grade import StudentGrade
 from app.models.user import User
 from app.schemas.course import CourseSummary, EnrollmentSummaryResponse
 from app.schemas.locale import LocaleCode, normalize_locale
@@ -141,46 +131,6 @@ def update_my_preferences(
     return current_user
 
 
-def _purge_user(db: Session, uid: UUID) -> None:
-    """Delete every row that belongs to ``uid`` and then the ``User`` itself.
-
-    Shared by the admin-delete-user path. We walk the FKs manually instead of
-    relying on ``ON DELETE CASCADE`` because several tables intentionally keep
-    history (``courses.created_by``, ``audit_logs.user_id``) — those get
-    nulled out rather than removed. Runs inside the caller's transaction so a
-    partial failure rolls back cleanly.
-    """
-    db.query(ChapterProgress).filter(ChapterProgress.user_id == uid).delete(synchronize_session=False)
-    db.query(Notification).filter(Notification.user_id == uid).delete(synchronize_session=False)
-
-    # Delete every QuizAnswer whose parent QuizAttempt belongs to this user,
-    # then the QuizAttempts themselves. The answer delete is a single SQL
-    # round-trip (subquery against QuizAttempt) instead of pulling all
-    # attempt IDs into Python first — same result, one fewer query and no
-    # memory overhead proportional to attempt count.
-    db.query(QuizAnswer).filter(
-        QuizAnswer.attempt_id.in_(db.query(QuizAttempt.id).filter(QuizAttempt.user_id == uid))
-    ).delete(synchronize_session=False)
-    db.query(QuizAttempt).filter(QuizAttempt.user_id == uid).delete(synchronize_session=False)
-
-    db.query(AssignmentSubmission).filter(AssignmentSubmission.student_id == uid).delete(synchronize_session=False)
-    db.query(StudentGrade).filter(StudentGrade.student_id == uid).delete(synchronize_session=False)
-    db.query(Enrollment).filter(Enrollment.user_id == uid).delete(synchronize_session=False)
-    db.query(CourseReview).filter(CourseReview.user_id == uid).delete(synchronize_session=False)
-    db.query(Certificate).filter(Certificate.user_id == uid).delete(synchronize_session=False)
-
-    db.query(Course).filter(Course.created_by == uid).update(
-        {Course.created_by: None},
-        synchronize_session=False,
-    )
-    db.query(AuditLog).filter(AuditLog.user_id == uid).update(
-        {AuditLog.user_id: None},
-        synchronize_session=False,
-    )
-
-    db.query(User).filter(User.id == uid).delete(synchronize_session=False)
-
-
 class AdminUserRow(BaseModel):
     id: str
     email: str
@@ -188,6 +138,9 @@ class AdminUserRow(BaseModel):
     role: str
     avatar_url: str | None
     created_at: datetime | None
+    # Non-null when the account is soft-deleted; the admin panel surfaces this
+    # so a deactivated user can be told apart and restored.
+    deactivated_at: datetime | None
 
 
 @router.get("/admin/users", response_model=list[AdminUserRow])
@@ -206,6 +159,7 @@ def list_all_users(
             role=u.role,
             avatar_url=u.avatar_url,
             created_at=u.created_at,
+            deactivated_at=u.deactivated_at,
         )
         for u in users
     ]
@@ -322,13 +276,17 @@ def admin_delete_user(
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> Response:
-    """Hard-delete another user and all their owned rows.
+    """Soft-delete (deactivate) another user.
+
+    Sets ``deactivated_at`` and blocks the account's login, but PRESERVES every
+    owned row (courses, grades, certificates) so the account can be restored
+    via ``POST /admin/users/{id}/restore``. This is deliberately reversible —
+    it avoids the old half-state where data was hard-deleted while the auth
+    identity lingered and resurrected an empty profile on next login.
 
     An admin cannot delete themselves via this route — that would leave the
-    platform without an admin in the worst case. Self-deletion is disabled by
-    design: users cannot delete their own accounts from the UI. If the last
-    admin truly wants to leave, a direct SQL operation through Supabase is the
-    right escape hatch.
+    platform without an admin in the worst case. If the last admin truly wants
+    to leave, a direct SQL operation through Supabase is the right escape hatch.
     """
     uid = _parse_user_uuid(user_id)
     if uid == admin.id:
@@ -348,22 +306,25 @@ def admin_delete_user(
             context={"resource_type": "user", "resource_id": str(uid)},
         )
 
-    log_action(
-        db,
-        admin.id,
-        "delete",
-        "user",
-        str(uid),
-        details={"email": target.email, "role": target.role},
-        request=request,
-    )
+    if target.deactivated_at is not None:
+        # Already deactivated — idempotent success.
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     try:
-        _purge_user(db, uid)
+        log_action(
+            db,
+            admin.id,
+            "delete",
+            "user",
+            str(uid),
+            details={"email": target.email, "role": target.role, "mode": "soft_delete"},
+            request=request,
+        )
+        target.deactivated_at = datetime.now(UTC)
         db.commit()
     except Exception as exc:
         db.rollback()
-        logger.exception("Admin-initiated deletion failed for user %s", uid)
+        logger.exception("Admin-initiated deactivation failed for user %s", uid)
         raise equip_error(
             ErrorCode.VALIDATION_FAILED,
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -371,4 +332,46 @@ def admin_delete_user(
             context={"resource_type": "user", "user_id": str(uid)},
         ) from exc
 
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/admin/users/{user_id}/restore", status_code=status.HTTP_204_NO_CONTENT)
+def admin_restore_user(
+    user_id: str,
+    request: Request,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> Response:
+    """Reactivate a soft-deleted account (clears ``deactivated_at``).
+
+    The user's data was preserved on deactivation, so restoring re-enables
+    login and returns the account exactly as it was.
+    """
+    uid = _parse_user_uuid(user_id)
+
+    target = db.query(User).filter(User.id == uid).first()
+    if not target:
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="User not found",
+            context={"resource_type": "user", "resource_id": str(uid)},
+        )
+
+    if target.deactivated_at is None:
+        # Already active — idempotent success.
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    log_action(
+        db,
+        admin.id,
+        "restore",
+        "user",
+        str(uid),
+        details={"email": target.email, "role": target.role},
+        request=request,
+    )
+
+    target.deactivated_at = None
+    db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -42,6 +42,12 @@ class User(Base):
     created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), onupdate=func.now())
     avatar_url: Mapped[str | None] = mapped_column()
+    # Soft-delete marker. The admin "delete user" action sets this instead of
+    # purging data: every owned row is preserved and the login is blocked
+    # (see ``get_current_user``) until an admin restores the account (clears
+    # this back to NULL). Avoids the old half-state where data was hard-deleted
+    # but the auth identity lingered and resurrected an empty profile.
+    deactivated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     enrollments: Mapped[list["Enrollment"]] = relationship(back_populates="user", cascade="all, delete-orphan")
 

--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -2368,6 +2368,21 @@
     "body": false
   },
   {
+    "method": "POST",
+    "path": "/api/v1/users/admin/users/{user_id}/restore",
+    "params": [
+      [
+        "user_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "204",
+      "422"
+    ],
+    "body": false
+  },
+  {
     "method": "PUT",
     "path": "/api/v1/users/admin/users/{user_id}/role",
     "params": [

--- a/backend/tests/test_admin_bulk_trash_and_csv.py
+++ b/backend/tests/test_admin_bulk_trash_and_csv.py
@@ -214,13 +214,33 @@ class TestBulkUpdateRoles:
 
 
 class TestAdminDeleteUser:
-    def test_admin_can_hard_delete_student(self, admin_client: TestClient, db: Session):
+    def test_admin_delete_soft_deletes_and_preserves_data(self, admin_client: TestClient, db: Session):
         student = _make_other_student(db)
         student_id = student.id
         resp = admin_client.delete(f"{USERS_PREFIX}/admin/users/{student_id}")
         assert resp.status_code == 204
         db.expire_all()
-        assert db.query(User).filter(User.id == student_id).first() is None
+        # The row is NOT purged — it is deactivated, so the account can be restored.
+        row = db.query(User).filter(User.id == student_id).first()
+        assert row is not None
+        assert row.deactivated_at is not None
+
+    def test_admin_restore_reactivates(self, admin_client: TestClient, db: Session):
+        student = _make_other_student(db)
+        student_id = student.id
+        admin_client.delete(f"{USERS_PREFIX}/admin/users/{student_id}")
+        resp = admin_client.post(f"{USERS_PREFIX}/admin/users/{student_id}/restore")
+        assert resp.status_code == 204
+        db.expire_all()
+        row = db.query(User).filter(User.id == student_id).first()
+        assert row is not None
+        assert row.deactivated_at is None
+
+    def test_double_delete_is_idempotent(self, admin_client: TestClient, db: Session):
+        student = _make_other_student(db)
+        student_id = student.id
+        assert admin_client.delete(f"{USERS_PREFIX}/admin/users/{student_id}").status_code == 204
+        assert admin_client.delete(f"{USERS_PREFIX}/admin/users/{student_id}").status_code == 204
 
     def test_admin_cannot_delete_self(self, admin_client: TestClient, db: Session):
         resp = admin_client.delete(f"{USERS_PREFIX}/admin/users/{ADMIN_ID}")

--- a/backend/tests/test_api_dependencies.py
+++ b/backend/tests/test_api_dependencies.py
@@ -158,6 +158,24 @@ class TestGetCurrentUser:
         out = deps.get_current_user(credentials=_bearer(), db=db)
         assert out.id == teacher.id
 
+    def test_deactivated_user_returns_403(
+        self,
+        db: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A soft-deleted (deactivated) account is blocked even with a still
+        valid token — the auth identity lingers, but access is revoked."""
+        from datetime import UTC, datetime
+
+        teacher = _seed_teacher(db)
+        teacher.deactivated_at = datetime.now(UTC)
+        db.commit()
+        monkeypatch.setattr(deps, "decode_access_token", lambda _t: {"sub": teacher.id})
+        with pytest.raises(HTTPException) as exc:
+            deps.get_current_user(credentials=_bearer(), db=db)
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+        assert exc.value.detail["code"] == "auth.forbidden"
+
 
 # ---------------------------------------------------------------------------
 # get_optional_user — the don't-raise sibling
@@ -206,6 +224,21 @@ class TestGetOptionalUser:
         out = deps.get_optional_user(credentials=_bearer(), db=db)
         assert out is not None
         assert out.id == teacher.id
+
+    def test_deactivated_user_returns_none(
+        self,
+        db: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A deactivated account is treated as anonymous on optional-auth
+        routes — public surfaces stay reachable, nothing authenticated leaks."""
+        from datetime import UTC, datetime
+
+        teacher = _seed_teacher(db)
+        teacher.deactivated_at = datetime.now(UTC)
+        db.commit()
+        monkeypatch.setattr(deps, "decode_access_token", lambda _t: {"sub": teacher.id})
+        assert deps.get_optional_user(credentials=_bearer(), db=db) is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_users_announcements_error_paths.py
+++ b/backend/tests/test_users_announcements_error_paths.py
@@ -69,15 +69,15 @@ class TestAdminDeleteUserErrorPath:
         student,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When ``_purge_user`` raises (FK cascade trouble,
-        constraint hit, etc.) the route catches it, rolls back, and
+        """When the soft-delete write fails (DB trouble during the
+        deactivation commit) the route catches it, rolls back, and
         surfaces a clean 500 — never a raw 503 or stack trace."""
         from app.api.v1 import users as route_mod
 
-        def fake_purge(*_a: object, **_k: object) -> None:
-            raise RuntimeError("cascade fanout exploded")
+        def boom(*_a: object, **_k: object) -> None:
+            raise RuntimeError("audit write exploded")
 
-        monkeypatch.setattr(route_mod, "_purge_user", fake_purge)
+        monkeypatch.setattr(route_mod, "log_action", boom)
         r = admin_client.delete(f"/api/v1/users/admin/users/{student.id}")
         assert r.status_code == 500
         body = r.json()["detail"]

--- a/supabase/migrations/20260608190000_add_profiles_deactivated_at.sql
+++ b/supabase/migrations/20260608190000_add_profiles_deactivated_at.sql
@@ -1,0 +1,8 @@
+-- Soft-delete support for user accounts.
+--
+-- The admin "delete user" action now DEACTIVATES rather than purges: it sets
+-- profiles.deactivated_at and the backend blocks that account's login, but all
+-- owned data (courses, grades, certificates) is preserved so the account can
+-- be restored. This replaces the old behaviour where data was hard-deleted but
+-- the auth.users identity lingered and resurrected an empty profile on re-login.
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS deactivated_at timestamptz;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict tyLrXpaYjAbthHaMXm2WKgaGW0nGUUromjYU6ew8mYakVhNvrQA7MTZSdg7f1FS
+\restrict 8K1aodcsXaRqlCvPFJCkovMfXshyZJJjwUbdnQbmysPMVEotwqaOmQQxv9o5Wlq
 
 -- Dumped from database version 17.6
 -- Dumped by pg_dump version 17.6
@@ -603,6 +603,7 @@ CREATE TABLE public.profiles (
     avatar_url text,
     preferred_locale character varying(8) DEFAULT 'ru'::character varying NOT NULL,
     calendar_ical_min_iat bigint,
+    deactivated_at timestamp with time zone,
     CONSTRAINT chk_profiles_role CHECK ((role = ANY (ARRAY['admin'::text, 'teacher'::text, 'student'::text]))),
     CONSTRAINT profiles_preferred_locale_check CHECK (((preferred_locale)::text = ANY (ARRAY[('ru'::character varying)::text, ('en'::character varying)::text])))
 )
@@ -2856,5 +2857,5 @@ CREATE POLICY translation_jobs_no_client_access ON public.translation_jobs TO an
 -- PostgreSQL database dump complete
 --
 
-\unrestrict tyLrXpaYjAbthHaMXm2WKgaGW0nGUUromjYU6ew8mYakVhNvrQA7MTZSdg7f1FS
+\unrestrict 8K1aodcsXaRqlCvPFJCkovMfXshyZJJjwUbdnQbmysPMVEotwqaOmQQxv9o5Wlq
 


### PR DESCRIPTION
Resolves audit **#1**. Vadym chose **soft-delete (recoverable)** over hard-delete.

The old admin "delete user" hard-deleted all the user's data but LEFT the `auth.users` identity → a re-login resurrected an empty profile with the default role (data gone, identity lingering, GDPR-leaky). Now deletion is a **reversible deactivation**:

- `profiles.deactivated_at` (migration `20260608190000`, applied to prod; `schema.sql` regenerated, 33 tables) + `User.deactivated_at`.
- `admin_delete_user` sets `deactivated_at` and **preserves every owned row** (courses, grades, certificates). Idempotent; self-delete still blocked.
- New `admin_restore_user` (`POST /admin/users/{id}/restore`) clears it.
- `get_current_user` now **403s** a deactivated account (`auth.forbidden`) even with a valid token; `get_optional_user` treats it as anonymous.
- `AdminUserRow` exposes `deactivated_at`; removed the now-dead `_purge_user` walker + imports.

**Tests:** soft-delete preserves row + sets flag, restore clears it, double-delete idempotent, deactivated user 403'd / anonymous, error path still clean-500s. OpenAPI snapshot updated. The new `rls-policy-postgres` + `schema-replay` jobs validate the new column.

Follow-up (noted): the admin-UI restore **button** — the delete button already soft-deletes correctly; restore is API-available today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)