### PR TITLE
feat(admin): restore-user UI for the soft-delete flow

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1915,7 +1915,10 @@
       "emptyNoUsers": "No users found",
       "showing": "Showing {{shown}} of {{total}} users",
       "missingName": "—",
-      "changeRoleAria": "Change role for {{name}}"
+      "changeRoleAria": "Change role for {{name}}",
+      "deactivatedBadge": "Deactivated",
+      "restoreTooltip": "Restore user",
+      "restoreAriaPrefix": "Restore {{name}}"
     },
     "pendingCerts": {
       "title": "Certificate Approvals",
@@ -1950,7 +1953,10 @@
         "deleteUserFailed": "Failed to delete user",
         "cannotDeleteSelf": "You can't delete your own account from here.",
         "bulkUpdated": "Updated {{count}} user(s) to {{role}}",
-        "bulkUpdateFailed": "Bulk update failed"
+        "bulkUpdateFailed": "Bulk update failed",
+        "userDeactivated": "User deactivated",
+        "userRestored": "User restored",
+        "restoreUserFailed": "Failed to restore user"
       },
       "confirm": {
         "deleteUserTitle": "Delete {{name}}?",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1536,7 +1536,10 @@
       "emptyNoUsers": "Пользователи не найдены",
       "showing": "Показано {{shown}} из {{total}} пользователей",
       "missingName": "—",
-      "changeRoleAria": "Изменить роль для {{name}}"
+      "changeRoleAria": "Изменить роль для {{name}}",
+      "deactivatedBadge": "Деактивирован",
+      "restoreTooltip": "Восстановить пользователя",
+      "restoreAriaPrefix": "Восстановить {{name}}"
     },
     "pendingCerts": {
       "title": "Сертификаты на финальное одобрение",
@@ -1571,7 +1574,10 @@
         "deleteUserFailed": "Не удалось удалить пользователя",
         "cannotDeleteSelf": "Вы не можете удалить свой собственный аккаунт отсюда.",
         "bulkUpdated": "Обновлено пользователей: {{count}} — роль {{role}}",
-        "bulkUpdateFailed": "Массовое обновление не удалось"
+        "bulkUpdateFailed": "Массовое обновление не удалось",
+        "userDeactivated": "Пользователь деактивирован",
+        "userRestored": "Пользователь восстановлен",
+        "restoreUserFailed": "Не удалось восстановить пользователя"
       },
       "confirm": {
         "deleteUserTitle": "Удалить {{name}}?",

--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -143,6 +143,7 @@ export default function AdminDashboard() {
             onToggleSelect={overview.toggleSelect}
             onRoleChange={overview.handleRoleChange}
             onDeleteUser={overview.handleDeleteUser}
+            onRestoreUser={overview.handleRestoreUser}
           />
         </div>
       )}

--- a/frontend/src/pages/Admin/VirtualAdminUsers.tsx
+++ b/frontend/src/pages/Admin/VirtualAdminUsers.tsx
@@ -1,6 +1,7 @@
 import { List, type RowComponentProps } from "react-window"
 import { useTranslation } from "react-i18next"
-import { Trash2 } from "lucide-react"
+import { RotateCcw, Trash2 } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { RoleSelector } from "@/components/admin/RoleSelector"
@@ -16,6 +17,7 @@ interface ProfileRow {
   role: UserRole
   created_at: string
   avatar_url: string | null
+  deactivated_at: string | null
 }
 
 interface VirtualAdminUsersProps {
@@ -26,6 +28,7 @@ interface VirtualAdminUsersProps {
   onToggleSelect: (id: string) => void
   onRoleChange: (userId: string, role: UserRole) => void
   onDeleteUser: (user: ProfileRow) => void
+  onRestoreUser: (user: ProfileRow) => void
 }
 
 type RowProps = Omit<VirtualAdminUsersProps, "users"> & { users: ProfileRow[] }
@@ -42,11 +45,13 @@ function UserRow({
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
+  onRestoreUser,
 }: RowComponentProps<RowProps>) {
   const { t } = useTranslation()
   const u = users[index]
   if (!u) return null
   const selected = selectedIds.has(u.id)
+  const deactivated = u.deactivated_at !== null
   const displayName = displayNameOf(u.full_name, u.email)
   return (
     <div
@@ -71,9 +76,17 @@ function UserRow({
           size="sm"
           alt={t("admin.users.avatarAltPrefix", { name: displayName })}
         />
-        <span className="truncate font-medium" title={u.full_name ?? undefined}>
+        <span
+          className={`truncate font-medium ${deactivated ? "text-ink-muted line-through" : ""}`}
+          title={u.full_name ?? undefined}
+        >
           {u.full_name?.trim() || t("admin.users.missingName")}
         </span>
+        {deactivated && (
+          <Badge variant="muted" className="shrink-0">
+            {t("admin.users.deactivatedBadge")}
+          </Badge>
+        )}
       </div>
       <div role="cell" className="truncate px-3 text-ink-muted" title={u.email}>
         {u.email}
@@ -90,17 +103,31 @@ function UserRow({
         {formatDate(u.created_at)}
       </div>
       <div role="cell" className="flex items-center justify-center">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 w-8 p-0 text-ink-muted hover:text-destructive"
-          disabled={updatingId === u.id || u.id === currentUserId}
-          onClick={() => onDeleteUser(u)}
-          aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
-          title={u.id === currentUserId ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
-        >
-          <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-        </Button>
+        {deactivated ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-ink-muted hover:text-brand"
+            disabled={updatingId === u.id}
+            onClick={() => onRestoreUser(u)}
+            aria-label={t("admin.users.restoreAriaPrefix", { name: displayName })}
+            title={t("admin.users.restoreTooltip")}
+          >
+            <RotateCcw className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-ink-muted hover:text-destructive"
+            disabled={updatingId === u.id || u.id === currentUserId}
+            onClick={() => onDeleteUser(u)}
+            aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
+            title={u.id === currentUserId ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
+          >
+            <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        )}
       </div>
     </div>
   )
@@ -114,6 +141,7 @@ export default function VirtualAdminUsers({
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
+  onRestoreUser,
 }: VirtualAdminUsersProps) {
   const { t } = useTranslation()
   // Height budget: enough to show ~10 rows before the window scrolls. Keeps the
@@ -150,6 +178,7 @@ export default function VirtualAdminUsers({
           onToggleSelect,
           onRoleChange,
           onDeleteUser,
+          onRestoreUser,
         }}
         style={{ height, width: "100%" }}
         overscanCount={5}

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -12,7 +12,8 @@ import {
 } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
-import { Users, Search, Trash2 } from "lucide-react"
+import { Users, Search, Trash2, RotateCcw } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
 import PageSpinner from "@/components/ui/PageSpinner"
 import { EmptyState } from "@/components/patterns/EmptyState"
 import { RoleSelector } from "@/components/admin/RoleSelector"
@@ -61,6 +62,7 @@ interface Props {
   onToggleSelect: (id: string) => void
   onRoleChange: (userId: string, role: UserRole) => void
   onDeleteUser: (user: ProfileRow) => void
+  onRestoreUser: (user: ProfileRow) => void
 }
 
 /** Main users table + bulk-action bar + search input. */
@@ -87,6 +89,7 @@ export function UsersCard({
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
+  onRestoreUser,
 }: Props) {
   const { t } = useTranslation()
   const allFilteredSelected =
@@ -253,6 +256,7 @@ export function UsersCard({
                 onToggleSelect={onToggleSelect}
                 onRoleChange={onRoleChange}
                 onDeleteUser={onDeleteUser}
+                onRestoreUser={onRestoreUser}
               />
             </Suspense>
           </>
@@ -266,6 +270,7 @@ export function UsersCard({
             onToggleSelect={onToggleSelect}
             onRoleChange={onRoleChange}
             onDeleteUser={onDeleteUser}
+            onRestoreUser={onRestoreUser}
           />
         )}
         {!loading && filtered.length > 0 && (
@@ -300,6 +305,7 @@ interface UsersTableProps {
   onToggleSelect: (id: string) => void
   onRoleChange: (userId: string, role: UserRole) => void
   onDeleteUser: (user: ProfileRow) => void
+  onRestoreUser: (user: ProfileRow) => void
 }
 
 function UsersTable({
@@ -311,6 +317,7 @@ function UsersTable({
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
+  onRestoreUser,
 }: UsersTableProps) {
   const { t } = useTranslation()
   const allFilteredSelected =
@@ -348,6 +355,7 @@ function UsersTable({
               onToggleSelect={onToggleSelect}
               onRoleChange={onRoleChange}
               onDeleteUser={onDeleteUser}
+              onRestoreUser={onRestoreUser}
             />
           ))}
         </div>
@@ -413,6 +421,7 @@ function UsersTable({
                 onToggleSelect={onToggleSelect}
                 onRoleChange={onRoleChange}
                 onDeleteUser={onDeleteUser}
+                onRestoreUser={onRestoreUser}
               />
             ))}
           </tbody>
@@ -430,9 +439,11 @@ function UserCard({
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
+  onRestoreUser,
 }: UserRowProps) {
   const { t } = useTranslation()
   const displayName = displayNameOf(user.full_name, user.email)
+  const deactivated = user.deactivated_at !== null
   return (
     <div
       className={cn(
@@ -455,25 +466,42 @@ function UserCard({
           alt={t("admin.users.avatarAltPrefix", { name: displayName })}
         />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-ink">
+          <p className={cn("truncate text-sm font-medium text-ink", deactivated && "text-ink-muted line-through")}>
             {user.full_name?.trim() || t("admin.users.missingName")}
           </p>
+          {deactivated && (
+            <Badge variant="muted" className="mt-0.5">{t("admin.users.deactivatedBadge")}</Badge>
+          )}
           <p className="truncate text-xs text-ink-muted">{user.email}</p>
           <p className="mt-1 text-xs text-ink-muted">
             {formatDate(user.created_at)}
           </p>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-11 w-11 shrink-0 p-0 text-ink-muted hover:text-destructive"
-          disabled={updating || isSelf}
-          onClick={() => onDeleteUser(user)}
-          aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
-          title={isSelf ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
-        >
-          <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-        </Button>
+        {deactivated ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-11 w-11 shrink-0 p-0 text-ink-muted hover:text-brand"
+            disabled={updating}
+            onClick={() => onRestoreUser(user)}
+            aria-label={t("admin.users.restoreAriaPrefix", { name: displayName })}
+            title={t("admin.users.restoreTooltip")}
+          >
+            <RotateCcw className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-11 w-11 shrink-0 p-0 text-ink-muted hover:text-destructive"
+            disabled={updating || isSelf}
+            onClick={() => onDeleteUser(user)}
+            aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
+            title={isSelf ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
+          >
+            <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        )}
       </div>
       <div className="mt-3 pl-7">
         <RoleSelector
@@ -495,6 +523,7 @@ interface UserRowProps {
   onToggleSelect: (id: string) => void
   onRoleChange: (userId: string, role: UserRole) => void
   onDeleteUser: (user: ProfileRow) => void
+  onRestoreUser: (user: ProfileRow) => void
 }
 
 function UserRow({
@@ -505,9 +534,11 @@ function UserRow({
   onToggleSelect,
   onRoleChange,
   onDeleteUser,
+  onRestoreUser,
 }: UserRowProps) {
   const { t } = useTranslation()
   const displayName = displayNameOf(user.full_name, user.email)
+  const deactivated = user.deactivated_at !== null
   return (
     <tr
       className={cn(
@@ -531,9 +562,15 @@ function UserRow({
             size="sm"
             alt={t("admin.users.avatarAltPrefix", { name: displayName })}
           />
-          <span className="min-w-0 truncate font-medium" title={user.full_name ?? undefined}>
+          <span
+            className={cn("min-w-0 truncate font-medium", deactivated && "text-ink-muted line-through")}
+            title={user.full_name ?? undefined}
+          >
             {user.full_name?.trim() || t("admin.users.missingName")}
           </span>
+          {deactivated && (
+            <Badge variant="muted" className="shrink-0">{t("admin.users.deactivatedBadge")}</Badge>
+          )}
         </div>
       </td>
       <td className="px-5 py-3 text-ink-muted">
@@ -551,17 +588,31 @@ function UserRow({
         {formatDate(user.created_at)}
       </td>
       <td className="px-3 py-3 text-right">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 w-8 p-0 text-ink-muted hover:text-destructive"
-          disabled={updating || isSelf}
-          onClick={() => onDeleteUser(user)}
-          aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
-          title={isSelf ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
-        >
-          <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
-        </Button>
+        {deactivated ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-ink-muted hover:text-brand"
+            disabled={updating}
+            onClick={() => onRestoreUser(user)}
+            aria-label={t("admin.users.restoreAriaPrefix", { name: displayName })}
+            title={t("admin.users.restoreTooltip")}
+          >
+            <RotateCcw className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-ink-muted hover:text-destructive"
+            disabled={updating || isSelf}
+            onClick={() => onDeleteUser(user)}
+            aria-label={t("admin.users.deleteAriaPrefix", { name: displayName })}
+            title={isSelf ? t("admin.users.deleteSelfTooltip") : t("admin.users.deleteTooltip")}
+          >
+            <Trash2 className="h-4 w-4" strokeWidth={1.75} aria-hidden />
+          </Button>
+        )}
       </td>
     </tr>
   )

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -99,6 +99,9 @@ export interface ProfileRow {
   role: UserRole
   created_at: string
   avatar_url: string | null
+  // Non-null when the account is soft-deleted (deactivated). The admin table
+  // shows a badge + a Restore action instead of Delete.
+  deactivated_at: string | null
 }
 
 export interface AdminStats {

--- a/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
+++ b/frontend/src/pages/Admin/dashboard/useAdminOverview.ts
@@ -208,17 +208,40 @@ export function useAdminOverview({ currentUserId, enabled = true }: UseAdminOver
     setUpdatingId(target.id)
     try {
       await coursesService.adminDeleteUser(target.id)
-      setUsers((prev) => prev.filter((u) => u.id !== target.id))
+      // Soft-delete: the row is NOT removed — it stays visible as deactivated
+      // so an admin can restore it. Preserve all data; just flip the flag.
+      const deactivatedAt = new Date().toISOString()
+      setUsers((prev) =>
+        prev.map((u) => (u.id === target.id ? { ...u, deactivated_at: deactivatedAt } : u)),
+      )
       setSelectedIds((prev) => {
         if (!prev.has(target.id)) return prev
         const next = new Set(prev)
         next.delete(target.id)
         return next
       })
-      toast({ title: t("admin.overview.toast.userDeleted"), variant: "success" })
+      toast({ title: t("admin.overview.toast.userDeactivated"), variant: "success" })
     } catch (err) {
       toast({
         title: getErrorDetail(err, t("admin.overview.toast.deleteUserFailed")),
+        variant: "destructive",
+      })
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  const handleRestoreUser = async (target: ProfileRow) => {
+    setUpdatingId(target.id)
+    try {
+      await coursesService.restoreUser(target.id)
+      setUsers((prev) =>
+        prev.map((u) => (u.id === target.id ? { ...u, deactivated_at: null } : u)),
+      )
+      toast({ title: t("admin.overview.toast.userRestored"), variant: "success" })
+    } catch (err) {
+      toast({
+        title: getErrorDetail(err, t("admin.overview.toast.restoreUserFailed")),
         variant: "destructive",
       })
     } finally {
@@ -344,6 +367,7 @@ export function useAdminOverview({ currentUserId, enabled = true }: UseAdminOver
     setBulkRole,
     handleRoleChange,
     handleDeleteUser,
+    handleRestoreUser,
     toggleSelect,
     toggleSelectAll,
     clearSelection,

--- a/frontend/src/services/adminUsers.ts
+++ b/frontend/src/services/adminUsers.ts
@@ -30,4 +30,8 @@ export const adminUsersService = {
   async adminDeleteUser(userId: string): Promise<void> {
     await api.delete(`/users/admin/users/${userId}`)
   },
+
+  async restoreUser(userId: string): Promise<void> {
+    await api.post(`/users/admin/users/${userId}/restore`)
+  },
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -28,6 +28,10 @@ export interface User {
   preferred_locale: PreferredLocale
   created_at: string
   updated_at: string
+  // Present on the admin user-list rows; non-null when the account is
+  // soft-deleted (deactivated). Optional because the current-user profile
+  // shape doesn't always carry it.
+  deactivated_at?: string | null
 }
 
 export interface Course {


### PR DESCRIPTION
Completes the soft-delete feature (#1). The backend already deactivates + exposes `POST /admin/users/{id}/restore`; this surfaces it in the admin users panel so a deactivated account is **visible and recoverable from the UI**, not just the API.

- `adminUsers.restoreUser()` → restore endpoint.
- `ProfileRow` + `User` type gain `deactivated_at`.
- `useAdminOverview`: delete now **marks the row deactivated (keeps it visible)** instead of removing it; new `handleRestoreUser` clears the flag; new toasts.
- **Every** admin user table — `VirtualAdminUsers` (big lists) + `UsersTable`'s desktop row **and** mobile card — shows a **Deactivated badge** + strikethrough name and swaps the Trash action for a **Restore (RotateCcw)** action when deactivated.
- i18n keys (en + ru, in parity).

Verified: tsc (forced every prop through all render sites), eslint, i18n parity, build, full vitest **540**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)