### PR TITLE
fix: deepest-audit wave 2 — dc-events CHECK bug, deactivated logout, observability

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -43,9 +43,9 @@ def get_current_user(
     if user.deactivated_at is not None:
         # Soft-deleted account: the auth token may still be valid, but the
         # account is deactivated — block every authenticated surface until an
-        # admin restores it.
+        # admin restores it. A dedicated code lets the client sign out cleanly.
         raise equip_error(
-            ErrorCode.AUTH_FORBIDDEN,
+            ErrorCode.ACCOUNT_DEACTIVATED,
             status_code=status.HTTP_403_FORBIDDEN,
             message="This account has been deactivated",
         )

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -67,6 +67,12 @@ class ErrorCode(enum.StrEnum):
     AUTH_FORBIDDEN = "auth.forbidden"
     """Caller is authenticated but lacks the required role / ownership."""
 
+    ACCOUNT_DEACTIVATED = "account.deactivated"
+    """The account was soft-deleted (deactivated) by an admin. The token may
+    still be valid, but every authenticated surface is blocked until restored.
+    Distinct from AUTH_FORBIDDEN so the client can sign the user out cleanly
+    rather than showing a generic permission error."""
+
     # ── Generic resource lookups ────────────────────────────────────────
     RESOURCE_NOT_FOUND = "resource.not_found"
     """A specific entity was not located. ``context.resource_type`` +

--- a/backend/tests/test_api_dependencies.py
+++ b/backend/tests/test_api_dependencies.py
@@ -174,7 +174,7 @@ class TestGetCurrentUser:
         with pytest.raises(HTTPException) as exc:
             deps.get_current_user(credentials=_bearer(), db=db)
         assert exc.value.status_code == status.HTTP_403_FORBIDDEN
-        assert exc.value.detail["code"] == "auth.forbidden"
+        assert exc.value.detail["code"] == "account.deactivated"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -50,6 +50,7 @@ def test_enum_values_are_stable_strings():
     expected = {
         "auth.required",
         "auth.forbidden",
+        "account.deactivated",
         "resource.not_found",
         "course.not_published",
         "course.already_enrolled",

--- a/docs/datadog/monitors/backend-error-log-spike.json
+++ b/docs/datadog/monitors/backend-error-log-spike.json
@@ -1,0 +1,26 @@
+{
+  "name": "equip backend: error log spike",
+  "type": "log alert",
+  "query": "logs(\"service:equip-backend env:production status:(error OR critical)\").index(\"*\").rollup(\"count\").last(\"10m\") >= 10",
+  "message": "5+ backend error logs in 10 minutes. Check https://app.us5.datadoghq.com/logs?query=service%3Aequip-backend%20env%3Aproduction%20status%3A%28error%20OR%20critical%29\n\nNotify: @arvavitcorp@gmail.com",
+  "tags": [
+    "env:production",
+    "project:equip",
+    "managed_by:claude"
+  ],
+  "priority": 2,
+  "options": {
+    "evaluation_delay": 60,
+    "thresholds": {
+      "warning": 6.0,
+      "critical": 10.0
+    },
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "notify_audit": false,
+    "new_host_delay": 300,
+    "include_tags": true,
+    "groupby_simple_monitor": false,
+    "silenced": {}
+  }
+}

--- a/docs/datadog/monitors/daily-challenge-schedule-dry.json
+++ b/docs/datadog/monitors/daily-challenge-schedule-dry.json
@@ -1,0 +1,20 @@
+{
+  "name": "[Equip] Daily Challenge schedule ran dry (serving fallback)",
+  "type": "log alert",
+  "query": "logs(\"service:equip-backend `\"auto-filled schedule`\"\").index(\"*\").rollup(\"count\").last(\"1d\") >= 1",
+  "message": "The Daily Challenge editorial schedule ran out and the live path is auto-filling from the published pool (recycled questions). Seed fresh questions. @arvavitcorp@gmail.com",
+  "tags": [],
+  "priority": 4,
+  "options": {
+    "renotify_interval": 0,
+    "thresholds": {
+      "critical": 1.0
+    },
+    "notify_no_data": false,
+    "notify_audit": false,
+    "new_host_delay": 300,
+    "include_tags": true,
+    "groupby_simple_monitor": false,
+    "silenced": {}
+  }
+}

--- a/docs/datadog/monitors/send-email-failures.json
+++ b/docs/datadog/monitors/send-email-failures.json
@@ -1,0 +1,20 @@
+{
+  "name": "[Equip] send-email failures (silent email outage)",
+  "type": "log alert",
+  "query": "logs(\"service:send-email status:error\").index(\"*\").rollup(\"count\").last(\"15m\") >= 3",
+  "message": "The send-email edge function is logging delivery/function errors. Supabase Auth sees 200 (non-blocking design) but users are NOT receiving signup/reset emails. Check Resend + the function. @arvavitcorp@gmail.com",
+  "tags": [],
+  "priority": 2,
+  "options": {
+    "renotify_interval": 0,
+    "notify_no_data": false,
+    "thresholds": {
+      "critical": 3.0
+    },
+    "notify_audit": false,
+    "new_host_delay": 300,
+    "include_tags": true,
+    "groupby_simple_monitor": false,
+    "silenced": {}
+  }
+}

--- a/docs/datadog/monitors/translation-jobs-stuck-processing.json
+++ b/docs/datadog/monitors/translation-jobs-stuck-processing.json
@@ -1,0 +1,19 @@
+{
+  "name": "[Equip] Translation jobs stuck in processing",
+  "type": "metric alert",
+  "query": "avg(last_30m):avg:equip.translation.queue_processing{env:production} > 3",
+  "message": "Translation jobs are piling up in 'processing' (workers dying mid-run). The 15-min reaper re-claims them but a sustained backlog means repeated worker failures. @arvavitcorp@gmail.com",
+  "tags": [],
+  "priority": 3,
+  "options": {
+    "renotify_interval": 0,
+    "notify_no_data": false,
+    "thresholds": {
+      "critical": 3.0
+    },
+    "notify_audit": false,
+    "new_host_delay": 300,
+    "include_tags": true,
+    "silenced": {}
+  }
+}

--- a/frontend/src/lib/errorCode.ts
+++ b/frontend/src/lib/errorCode.ts
@@ -34,6 +34,7 @@ export type ErrorCode =
   // auth / permissions
   | "auth.required"
   | "auth.forbidden"
+  | "account.deactivated"
   // generic resource lookups
   | "resource.not_found"
   // course lifecycle

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -94,6 +94,16 @@ function refreshAccessTokenOnce(): Promise<string | null> {
 api.interceptors.response.use(
   (response) => response,
   async (error: unknown) => {
+    // A soft-deleted account returns 403 ``account.deactivated`` on every
+    // authenticated call. Eject the user cleanly to the auth screens instead
+    // of leaving them on a wall of generic permission errors.
+    if (isAxiosError(error) && error.response?.status === 403) {
+      const code = (error.response.data as { detail?: { code?: string } } | undefined)?.detail?.code
+      if (code === "account.deactivated") {
+        await supabase.auth.signOut()
+        return Promise.reject(error)
+      }
+    }
     if (!isAxiosError(error) || error.response?.status !== 401) {
       return Promise.reject(error)
     }

--- a/supabase/ci/rls_assertions.sql
+++ b/supabase/ci/rls_assertions.sql
@@ -11,6 +11,9 @@
 
 INSERT INTO auth.users (id, email) VALUES (:'student', 'student@test.local');
 INSERT INTO public.profiles (id, email, role) VALUES (:'student', 'student@test.local', 'student');
+-- A second, unrelated user to prove cross-tenant reads are blocked.
+INSERT INTO auth.users (id, email) VALUES ('22222222-2222-2222-2222-222222222222', 'other@test.local');
+INSERT INTO public.profiles (id, email, role) VALUES ('22222222-2222-2222-2222-222222222222', 'other@test.local', 'student');
 
 -- Become the logged-in student. The GUC is set at session level (as superuser)
 -- so it survives SET ROLE; auth.uid() reads it.
@@ -115,6 +118,27 @@ BEGIN
   RAISE EXCEPTION 'SECURITY HOLE: authenticated can UPDATE quiz_answers (tamper a submitted answer)';
 EXCEPTION
   WHEN insufficient_privilege THEN RAISE NOTICE 'OK: quiz_answers UPDATE denied';
+END $$;
+
+-- 8) cross-tenant SELECT: the profiles_select_self policy must hide another
+--    user's row entirely (RLS filters rather than errors, so assert 0 rows).
+DO $$
+DECLARE visible int;
+BEGIN
+  SELECT count(*) INTO visible
+  FROM public.profiles
+  WHERE id = '22222222-2222-2222-2222-222222222222';
+  IF visible <> 0 THEN
+    RAISE EXCEPTION 'SECURITY HOLE: authenticated can read another user''s profile row (% visible)', visible;
+  END IF;
+  -- And the own row IS visible (proves the policy isn't just hiding everything).
+  SELECT count(*) INTO visible
+  FROM public.profiles
+  WHERE id = '11111111-1111-1111-1111-111111111111';
+  IF visible <> 1 THEN
+    RAISE EXCEPTION 'HARNESS BROKEN: own profile row not visible (% rows)', visible;
+  END IF;
+  RAISE NOTICE 'OK: profiles SELECT is self-only (cross-tenant read blocked)';
 END $$;
 
 RESET ROLE;

--- a/supabase/migrations/20260608220000_drop_redundant_dc_events_check.sql
+++ b/supabase/migrations/20260608220000_drop_redundant_dc_events_check.sql
@@ -1,0 +1,12 @@
+-- Drop the redundant, STALE event_type CHECK on daily_challenge_question_events.
+--
+-- The table carries two overlapping CHECKs: the older
+-- ``daily_challenge_question_events_event_type_check`` (12 values, missing
+-- ``bilingual_edit``) and the newer ``dc_q_events_type_check`` (13 values,
+-- the superset the SQLAlchemy model declares). Both must pass, so the narrower
+-- one silently REJECTS a ``bilingual_edit`` event — which the bilingual-review
+-- code (services/daily_challenge/admin.py) actually writes. On prod this fails
+-- the INSERT; SQLite tests miss it because the model only declares the 13-value
+-- constraint. Drop the stale one so prod matches the model (4-way mirror).
+ALTER TABLE public.daily_challenge_question_events
+    DROP CONSTRAINT IF EXISTS daily_challenge_question_events_event_type_check;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 8K1aodcsXaRqlCvPFJCkovMfXshyZJJjwUbdnQbmysPMVEotwqaOmQQxv9o5Wlq
+\restrict NzQrkPhq8NcxjTJ3V2khfl29SehTJwAIqRrUN8QGaMEp7yJi4VhZ79HkVTez3Gz
 
 -- Dumped from database version 17.6
 -- Dumped by pg_dump version 17.6
@@ -481,7 +481,6 @@ CREATE TABLE public.daily_challenge_question_events (
     actor_id uuid,
     details jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT daily_challenge_question_events_event_type_check CHECK ((event_type = ANY (ARRAY['status_change'::text, 'rejected'::text, 'published'::text, 'scheduled'::text, 'unscheduled'::text, 'ai_generated'::text, 'ai_critique'::text, 'ai_synthesis'::text, 'scripture_validated'::text, 'doctrinally_reviewed'::text, 'bilingually_reviewed'::text, 'pilot_summary'::text]))),
     CONSTRAINT dc_q_events_type_check CHECK ((event_type = ANY (ARRAY['status_change'::text, 'rejected'::text, 'published'::text, 'scheduled'::text, 'unscheduled'::text, 'ai_generated'::text, 'ai_critique'::text, 'ai_synthesis'::text, 'scripture_validated'::text, 'doctrinally_reviewed'::text, 'bilingually_reviewed'::text, 'pilot_summary'::text, 'bilingual_edit'::text])))
 );
 
@@ -2857,5 +2856,5 @@ CREATE POLICY translation_jobs_no_client_access ON public.translation_jobs TO an
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 8K1aodcsXaRqlCvPFJCkovMfXshyZJJjwUbdnQbmysPMVEotwqaOmQQxv9o5Wlq
+\unrestrict NzQrkPhq8NcxjTJ3V2khfl29SehTJwAIqRrUN8QGaMEp7yJi4VhZ79HkVTez3Gz
 


### PR DESCRIPTION
More real findings from the deepest multi-agent audit.

## CORRECTNESS — a stale CHECK silently blocked a written event_type on prod
`daily_challenge_question_events` carried TWO overlapping event_type CHECKs: `dc_q_events_type_check` (13 values, what the model declares) + a stale 12-value leftover missing `bilingual_edit`. Both must pass → the bilingual-review code (`admin.py` writes `event_type='bilingual_edit'`) **failed its INSERT on prod**, invisible to SQLite tests. Migration `20260608220000` drops the stale constraint (applied to prod; schema.sql regen).

## UX — deactivated account logs out cleanly
The soft-delete 403 used generic `AUTH_FORBIDDEN`, so a deactivated user mid-session saw generic errors + could re-login to a dead shell. New `ErrorCode.ACCOUNT_DEACTIVATED`; `api.ts` interceptor signs out on a 403 with that code. Frontend union + enum/dep tests updated.

## SECURITY (CI) — cross-tenant SELECT assertion
`rls_assertions.sql`: as authenticated, another user's profiles row must be invisible (0 rows) while the own row stays visible. Closes the writes-covered-reads-untested gap.

## OBSERVABILITY — committed live monitors + 2 new ones
Committed the API-made monitors that weren't in git (error-log-spike retuned, daily-challenge-schedule-dry) + created/committed **send-email-failures** (silent email outage — Auth sees 200, users get nothing) and **translation-jobs-stuck-processing** (reaper backlog). Correct `status:`/metric queries.

Verified: ruff/format/mypy, error/deps tests, frontend tsc/eslint/build/vitest. The rls-policy + schema-replay CI jobs validate the new assertion + the dropped CHECK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)