### PR TITLE
fix(dashboard): Daily Challenge question + options fit one viewport, no scroll

### DIFF
--- a/frontend/src/components/dashboard/DailyChallengeCard.tsx
+++ b/frontend/src/components/dashboard/DailyChallengeCard.tsx
@@ -54,7 +54,7 @@ function OptionButton({ option, reveal, disabled, onClick }: OptionButtonProps) 
       disabled={disabled}
       aria-pressed={isSelected}
       className={cn(
-        "group flex w-full items-center gap-2.5 rounded-md border px-3 py-2 text-left text-xs transition-colors",
+        "group flex w-full items-center gap-2.5 rounded-md border px-3 py-1.5 text-left text-xs transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
         reveal === null && "border-edge bg-surface hover:border-brand/30 hover:bg-muted/30",
         showAsCorrect && "border-success/40 bg-success/10 text-ink",
@@ -259,7 +259,7 @@ export function DailyChallengeCard() {
         </div>
       </header>
 
-      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-3 sm:px-5 sm:py-4">
+      <div className="min-h-0 flex-1 space-y-2.5 overflow-y-auto px-4 py-3 sm:px-5 sm:py-4">
         {loading ? (
           <div className="space-y-2">
             <Skeleton className="h-4 w-3/4" />

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -252,8 +252,10 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
  *
  * **Layout (lg+).** Two columns:
  * - Left (wider): My Courses with internal scroll.
- * - Right (narrow): Verse + Today + Streak in equal vertical thirds
- *   so the right rail stays inside the viewport.
+ * - Right (narrow): Verse + Today + Daily Challenge in a 4-row grid —
+ *   Verse and Today take one row each, Daily Challenge spans two so its
+ *   question + options fit without an internal scrollbar. The whole rail
+ *   stays inside the viewport.
  *
  * **Mobile (< lg).** Single column stack in importance order: My
  * Courses → Verse → Today → Streak.
@@ -278,19 +280,21 @@ export default function DashboardPage() {
     <div className="container mx-auto h-full px-4 py-4 sm:py-6 lg:h-[calc(100dvh-3rem-3rem)]">
       <div className="grid h-full grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:gap-5">
         <MyCoursesSection onTourStart={startTour} />
-        {/* Right rail: equal-thirds on lg+ via grid-rows-3. Each card
-            gets the same vertical share so Verse + Today + Streak all
-            fit one viewport without one starving another. ``min-h-0``
-            on the inner grid items lets each card's internal overflow
-            kick in rather than expanding the row. */}
-        <div className="flex flex-col gap-4 lg:grid lg:grid-rows-3 lg:gap-5 lg:overflow-hidden">
+        {/* Right rail on lg+ via grid-rows-4. Verse + Today take one row
+            each; Daily Challenge spans two (``row-span-2``) because its
+            question + four options need more height than a light card, so
+            it fits one viewport without an internal scrollbar — and the
+            page itself never scrolls. ``min-h-0`` on the inner grid items
+            lets each card's own overflow kick in rather than expanding
+            the row. */}
+        <div className="flex flex-col gap-4 lg:grid lg:grid-rows-4 lg:gap-5 lg:overflow-hidden">
           <div data-tour="verse-of-day" className="lg:min-h-0 lg:overflow-hidden">
             <VerseOfTheDayCard />
           </div>
           <div data-tour="today" className="lg:min-h-0 lg:overflow-hidden">
             <TodayCard />
           </div>
-          <div data-tour="daily-challenge" className="lg:min-h-0 lg:overflow-hidden">
+          <div data-tour="daily-challenge" className="lg:row-span-2 lg:min-h-0 lg:overflow-hidden">
             <DailyChallengeCard />
           </div>
         </div>


### PR DESCRIPTION
## Problem
On the dashboard the right rail split its height into three equal thirds (`grid-rows-3`). Daily Challenge — question + four options + header — is the heaviest of the three cards, so it overflowed its third and grew an **internal scrollbar**, while Verse-of-the-Day and Today sat half-empty.

## Fix
- Right rail is now a **4-row grid**; Daily Challenge **spans 2 rows** (`lg:row-span-2`), Verse + Today keep one each. The card gets twice the height, so the question + all four options are visible with no scroll.
- Light compaction so it still fits on shorter laptops: option-button padding `py-2 → py-1.5`, card body gap `space-y-3 → space-y-2.5`.
- The dashboard stays a single, non-scrolling viewport — no page scroll, no new chrome.

No answer options removed (4 kept). Card retains its `overflow-y-auto` only as a last-resort safety for a pathologically long question.

Verified: eslint + tsc clean, `DailyChallengeCard` tests pass (6), `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
