### PR TITLE
fix(dashboard): distribute right rail by need so no card scrolls

### DIFF
--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -252,10 +252,11 @@ function MyCoursesSection({ onTourStart }: MyCoursesSectionProps) {
  *
  * **Layout (lg+).** Two columns:
  * - Left (wider): My Courses with internal scroll.
- * - Right (narrow): Verse + Today + Daily Challenge in a 4-row grid —
- *   Verse and Today take one row each, Daily Challenge spans two so its
- *   question + options fit without an internal scrollbar. The whole rail
- *   stays inside the viewport.
+ * - Right (narrow): Verse + Today + Daily Challenge distributed by need
+ *   (``[auto auto minmax(0,1fr)]``) — the two light cards take exactly
+ *   their content height so they never scroll, and Daily Challenge takes
+ *   the remainder so its question + options fit. The whole rail stays
+ *   inside the viewport and nothing scrolls.
  *
  * **Mobile (< lg).** Single column stack in importance order: My
  * Courses → Verse → Today → Streak.
@@ -280,21 +281,22 @@ export default function DashboardPage() {
     <div className="container mx-auto h-full px-4 py-4 sm:py-6 lg:h-[calc(100dvh-3rem-3rem)]">
       <div className="grid h-full grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:gap-5">
         <MyCoursesSection onTourStart={startTour} />
-        {/* Right rail on lg+ via grid-rows-4. Verse + Today take one row
-            each; Daily Challenge spans two (``row-span-2``) because its
-            question + four options need more height than a light card, so
-            it fits one viewport without an internal scrollbar — and the
-            page itself never scrolls. ``min-h-0`` on the inner grid items
-            lets each card's own overflow kick in rather than expanding
-            the row. */}
-        <div className="flex flex-col gap-4 lg:grid lg:grid-rows-4 lg:gap-5 lg:overflow-hidden">
+        {/* Right rail on lg+ as ``[auto auto minmax(0,1fr)]``. Verse and
+            Today are light, bounded cards (a single verse; at most three
+            events) so they take exactly their content height (``auto``)
+            and never grow an internal scrollbar. Daily Challenge — the
+            tallest, interactive card — takes the remaining space
+            (``minmax(0,1fr)``), so its question + four options sit in one
+            viewport. Nothing on the dashboard scrolls; the rail just
+            distributes by need instead of forcing equal slots. */}
+        <div className="flex flex-col gap-4 lg:grid lg:grid-rows-[auto_auto_minmax(0,1fr)] lg:gap-5 lg:overflow-hidden">
           <div data-tour="verse-of-day" className="lg:min-h-0 lg:overflow-hidden">
             <VerseOfTheDayCard />
           </div>
           <div data-tour="today" className="lg:min-h-0 lg:overflow-hidden">
             <TodayCard />
           </div>
-          <div data-tour="daily-challenge" className="lg:row-span-2 lg:min-h-0 lg:overflow-hidden">
+          <div data-tour="daily-challenge" className="lg:min-h-0 lg:overflow-hidden">
             <DailyChallengeCard />
           </div>
         </div>


### PR DESCRIPTION
## Problem
PR #778 gave Daily Challenge two of four equal rows. That shrank Verse-of-the-Day and Today into quarter-height slots, so **those two** started scrolling instead. Equal rows are simply the wrong model here.

## Fix
The three right-rail cards have very different natural heights:
- **Verse** — a single verse (short, bounded)
- **Today** — capped at 3 events (short, bounded)
- **Daily Challenge** — question + four options (the tall one)

So distribute by need: `lg:grid-rows-[auto_auto_minmax(0,1fr)]`. Verse and Today take exactly their content height → they're shown in full and never scroll. Daily Challenge takes the remainder → its question + options fit. The rail stays one viewport; nothing on the dashboard scrolls.

Verified: eslint + tsc clean, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
