### PR TITLE
fix(storage): chapter-block files under course-id folder so students can open them

### DIFF
--- a/frontend/src/components/editor/ChapterBlockEditor.tsx
+++ b/frontend/src/components/editor/ChapterBlockEditor.tsx
@@ -11,6 +11,7 @@ import { AddBlockMenu, BlockRow, type BlockType } from "./blocks"
 import { BLOCK_TYPE_LABEL_KEYS } from "./blocks/types"
 
 interface Props {
+  courseId: string
   chapterId: string
 }
 
@@ -20,7 +21,7 @@ interface Props {
  * state for reordering, and delegates each row (and every type of
  * per-block editor) to `./blocks/`.
  */
-export default function ChapterBlockEditor({ chapterId }: Props) {
+export default function ChapterBlockEditor({ courseId, chapterId }: Props) {
   const confirm = useConfirm()
   const { t } = useTranslation()
   const [blocks, setBlocks] = useState<ChapterBlock[]>([])
@@ -180,6 +181,7 @@ export default function ChapterBlockEditor({ chapterId }: Props) {
           <BlockRow
             key={block.id}
             block={block}
+            courseId={courseId}
             chapterId={chapterId}
             index={idx}
             expanded={expandedId === block.id}

--- a/frontend/src/components/editor/blocks/BlockRow.tsx
+++ b/frontend/src/components/editor/blocks/BlockRow.tsx
@@ -12,6 +12,7 @@ import { FileBlockEditor } from "./FileBlockEditor"
 
 interface Props {
   block: ChapterBlock
+  courseId: string
   chapterId: string
   index: number
   expanded: boolean
@@ -31,6 +32,7 @@ interface Props {
  */
 export function BlockRow({
   block,
+  courseId,
   chapterId,
   index,
   expanded,
@@ -114,6 +116,7 @@ export function BlockRow({
           {block.block_type === "file" && (
             <FileBlockEditor
               block={block}
+              courseId={courseId}
               chapterId={chapterId}
               onUpdated={onBlockUpdated}
             />

--- a/frontend/src/components/editor/blocks/FileBlockEditor.tsx
+++ b/frontend/src/components/editor/blocks/FileBlockEditor.tsx
@@ -11,6 +11,7 @@ import type { ChapterBlock } from "@/types"
 
 interface Props {
   block: ChapterBlock
+  courseId: string
   chapterId: string
   onUpdated: (updated: ChapterBlock) => void
 }
@@ -20,7 +21,7 @@ interface Props {
  * single file. Owns its own "uploading" state so sibling blocks aren't
  * affected by this block's upload.
  */
-export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
+export function FileBlockEditor({ block, courseId, chapterId, onUpdated }: Props) {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
@@ -29,7 +30,7 @@ export function FileBlockEditor({ block, chapterId, onUpdated }: Props) {
   const upload = async (file: File) => {
     setUploading(true)
     try {
-      const { bucket, path, name } = await storageService.uploadBlockFile(chapterId, file)
+      const { bucket, path, name } = await storageService.uploadBlockFile(courseId, chapterId, file)
       const updated = await coursesService.updateBlock(block.id, {
         file_bucket: bucket,
         file_path: path,

--- a/frontend/src/pages/Teacher/ChapterEditor.tsx
+++ b/frontend/src/pages/Teacher/ChapterEditor.tsx
@@ -210,6 +210,10 @@ export default function ChapterEditor() {
     void guardedNavigate(to)
   }
 
+  // Route always supplies these, but useParams types them optional. Narrow
+  // once here so children (e.g. ChapterBlockEditor) get a concrete courseId.
+  if (!courseId || !moduleId || !chapterId) return null
+
   if (loading) {
     return (
       <div className="container mx-auto px-4 py-8 max-w-4xl">
@@ -362,7 +366,7 @@ export default function ChapterEditor() {
       <Card data-tour="chapter-editor-blocks" className="mb-6">
         <CardContent className="space-y-4 p-5">
           {chapterType === "reading" && (
-            <ChapterBlockEditor chapterId={chapter.id} />
+            <ChapterBlockEditor courseId={courseId} chapterId={chapter.id} />
           )}
 
           {(chapterType === "quiz" || chapterType === "exam") && (

--- a/frontend/src/services/storage.ts
+++ b/frontend/src/services/storage.ts
@@ -161,10 +161,15 @@ export const storageService = {
    * is ever stored in the database, so rotating the Supabase JWT secret
    * doesn't invalidate anything.
    */
-  async uploadBlockFile(chapterId: string, file: File): Promise<UploadedBlockFile> {
+  async uploadBlockFile(courseId: string, chapterId: string, file: File): Promise<UploadedBlockFile> {
     const timestamp = Date.now()
     const safeName = sanitizeFileName(file.name)
-    const path = `${chapterId}/${timestamp}-${safeName}`
+    // First path segment MUST be the course id: the `course-materials`
+    // bucket's RLS policy (`course_materials_enrolled_read`) authorises a
+    // download by matching `foldername[1]` against the caller's enrolment /
+    // course ownership. A chapter-id-first path (the old shape) matches no
+    // course, so enrolled students got a 400 when signing the file.
+    const path = `${courseId}/${chapterId}/${timestamp}-${safeName}`
 
     const { error } = await supabase.storage
       .from(COURSE_MATERIALS_BUCKET)


### PR DESCRIPTION
## Found via Сергей's session
A real pilot user (registered + finished a course this morning) hit a **400 on a chapter PDF**. RUM showed 0 JS errors, 0 backend errors — the only real failure was a Supabase storage `sign` 400.

## Root cause
The `course-materials` RLS policy `course_materials_enrolled_read` authorises a download by matching the object's **first path segment** against the caller's enrolment / course ownership. But `uploadBlockFile` stored attachments under `{chapterId}/...` — a chapter id matches no course, so **every enrolled student got 400 "Object not found"** when signing a block file. (Course-level materials were unaffected; they already use `{courseId}/...`.)

## Fix
- Block files now upload to `{courseId}/{chapterId}/{ts}-{name}` — first segment is the course id the policy checks.
- `courseId` threaded ChapterEditor → ChapterBlockEditor → BlockRow → FileBlockEditor (mirrors existing `chapterId`).
- The one existing affected object (Acts `sources.pdf`, seeded under an `acts-course/` slug) was relocated to the correct path in prod and its block updated; **verified an enrolled student's RLS now resolves it** (count=1 acting as that user).

Verified: tsc + eslint clean, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)