### PR TITLE
test(storage): pin course-materials path convention (first segment = course id)

### DIFF
--- a/frontend/src/services/__tests__/storage.test.ts
+++ b/frontend/src/services/__tests__/storage.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// The `course-materials` bucket's RLS policy (`course_materials_enrolled_read`)
+// authorises a download by matching the object's FIRST path segment against
+// the caller's enrolment / course ownership. So every upload into that bucket
+// MUST be keyed `{courseId}/...` or enrolled students get a 400 when signing
+// the file. These tests pin that invariant — a regression here was the exact
+// bug that hid a chapter PDF from a real pilot student (block files were once
+// stored under `{chapterId}/...`, which matches no course).
+//
+// `vi.hoisted` so the upload spy exists before the hoisted `vi.mock` factory
+// runs; the mock only needs the storage surface the upload helpers touch.
+const { uploadMock } = vi.hoisted(() => ({ uploadMock: vi.fn() }))
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    storage: {
+      from: vi.fn(() => ({ upload: uploadMock })),
+    },
+  },
+}))
+
+import { storageService } from "@/services/storage"
+
+const COURSE_ID = "1f3c4803-d229-464b-ad8e-848a0355e71f"
+const CHAPTER_ID = "e7a8cfa0-e93a-4dfb-9648-ad6605a9ca2e"
+
+function makeFile(name = "Lecture Notes.pdf"): File {
+  return new File(["pdf-bytes"], name, { type: "application/pdf" })
+}
+
+describe("storageService course-materials path convention", () => {
+  beforeEach(() => {
+    uploadMock.mockReset()
+    uploadMock.mockResolvedValue({ error: null })
+  })
+
+  it("uploadBlockFile keys the object under {courseId}/{chapterId}/", async () => {
+    const { bucket, path } = await storageService.uploadBlockFile(COURSE_ID, CHAPTER_ID, makeFile())
+
+    expect(bucket).toBe("course-materials")
+    // RLS-critical: first segment is the course id, second the chapter id.
+    expect(path.startsWith(`${COURSE_ID}/${CHAPTER_ID}/`)).toBe(true)
+    expect(path.split("/")[0]).toBe(COURSE_ID)
+    // The path the helper returns is exactly what it asked storage to store.
+    expect(uploadMock).toHaveBeenCalledWith(path, expect.any(File))
+  })
+
+  it("uploadCourseMaterial keys the object under {courseId}/", async () => {
+    await storageService.uploadCourseMaterial(COURSE_ID, makeFile())
+
+    const storedPath = uploadMock.mock.calls[0]?.[0] as string
+    expect(storedPath.split("/")[0]).toBe(COURSE_ID)
+  })
+
+  it("sanitises spaces/special chars in the file name segment", async () => {
+    const { path } = await storageService.uploadBlockFile(COURSE_ID, CHAPTER_ID, makeFile('a b/c:d?.pdf'))
+    const nameSegment = path.split("/").slice(2).join("/")
+    expect(nameSegment).not.toMatch(/[ /\\:*?"<>|]/)
+    expect(nameSegment.endsWith(".pdf")).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes the gap that let the chapter-PDF bug ship. There was no test asserting that `course-materials` uploads are keyed `{courseId}/...` — the exact shape the bucket's RLS policy needs to authorise an enrolled student's download. `uploadBlockFile` had regressed to `{chapterId}/...` and nothing caught it (prior audits ran as admin, who bypasses the policy; only a real pilot student surfaced the 400).

Adds `storage.test.ts`:
- `uploadBlockFile` keys under `{courseId}/{chapterId}/`
- `uploadCourseMaterial` keys under `{courseId}/`
- file-name segment is sanitised

Note: storage-level RLS isn't replayable in CI (schema baseline is public-only; `storage.objects` + policies are Supabase-managed, not in `supabase/schema.sql`). The policy is correct — what needed pinning is the client obeying the key shape, done here deterministically with no Postgres dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)