### PR TITLE
chore(daily-challenge): full-year passage manifest (210 curated passages)

### DIFF
--- a/backend/scripts/build_full_dc_manifest.py
+++ b/backend/scripts/build_full_dc_manifest.py
@@ -1,0 +1,286 @@
+"""Build the full-year Daily Challenge passage manifest.
+
+Emits `scripts/data/daily_challenge_seed_passages_full.json` — ~220 curated
+passages spread across the canon and balanced over the three question
+categories, enough to schedule one unique passage per day from 2026-06-17
+through the end of 2026 (with buffer for editorial-gate rejections).
+
+Selection rules (so the generator has the best shot at a clean,
+unambiguous question):
+  - narrative_recall  -> narrative chapters ("what happened")
+  - passage_exegesis  -> teaching passages ("what it means")
+  - cross_reference   -> passages with a well-known OT<->NT or
+                         prophecy/fulfilment link
+Chapter-level refs (no verse range) are used wherever a whole-chapter
+context is natural; that also avoids emitting an invalid verse range.
+
+Run:  python -m scripts.build_full_dc_manifest
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+N, E, C = "narrative_recall", "passage_exegesis", "cross_reference"
+
+# (book, chapter, category) or (book, chapter, verse_from, verse_to, category)
+_RAW: list[tuple] = [
+    # ---- Genesis / Pentateuch (narrative + foundational) ----
+    ("Genesis", 1, E),
+    ("Genesis", 2, N),
+    ("Genesis", 3, N),
+    ("Genesis", 6, N),
+    ("Genesis", 7, N),
+    ("Genesis", 9, C),
+    ("Genesis", 12, C),
+    ("Genesis", 15, C),
+    ("Genesis", 22, C),
+    ("Genesis", 28, N),
+    ("Genesis", 37, N),
+    ("Genesis", 39, N),
+    ("Genesis", 41, N),
+    ("Genesis", 45, N),
+    ("Genesis", 50, E),
+    ("Exodus", 3, N),
+    ("Exodus", 12, C),
+    ("Exodus", 14, N),
+    ("Exodus", 16, N),
+    ("Exodus", 20, E),
+    ("Exodus", 32, N),
+    ("Exodus", 34, E),
+    ("Leviticus", 16, C),
+    ("Leviticus", 19, E),
+    ("Leviticus", 23, E),
+    ("Numbers", 13, N),
+    ("Numbers", 14, N),
+    ("Numbers", 21, C),
+    ("Deuteronomy", 6, E),
+    ("Deuteronomy", 8, E),
+    ("Deuteronomy", 30, E),
+    ("Deuteronomy", 34, N),
+    # ---- History ----
+    ("Joshua", 1, E),
+    ("Joshua", 6, N),
+    ("Joshua", 24, N),
+    ("Judges", 6, N),
+    ("Judges", 7, N),
+    ("Judges", 16, N),
+    ("Ruth", 1, N),
+    ("Ruth", 4, C),
+    ("1 Samuel", 3, N),
+    ("1 Samuel", 16, N),
+    ("1 Samuel", 17, N),
+    ("2 Samuel", 7, C),
+    ("2 Samuel", 11, N),
+    ("2 Samuel", 12, N),
+    ("1 Kings", 3, N),
+    ("1 Kings", 18, N),
+    ("1 Kings", 19, N),
+    ("2 Kings", 5, N),
+    ("2 Kings", 2, N),
+    ("Nehemiah", 8, N),
+    ("Esther", 4, N),
+    ("Esther", 7, N),
+    # ---- Wisdom / Psalms (exegesis-heavy) ----
+    ("Job", 1, N),
+    ("Job", 38, E),
+    ("Job", 42, N),
+    ("Psalms", 1, E),
+    ("Psalms", 8, E),
+    ("Psalms", 19, E),
+    ("Psalms", 22, C),
+    ("Psalms", 23, E),
+    ("Psalms", 51, E),
+    ("Psalms", 91, E),
+    ("Psalms", 103, E),
+    ("Psalms", 110, C),
+    ("Psalms", 119, 1, 16, E),
+    ("Psalms", 121, E),
+    ("Psalms", 139, E),
+    ("Proverbs", 3, E),
+    ("Proverbs", 31, E),
+    ("Ecclesiastes", 3, E),
+    ("Ecclesiastes", 12, E),
+    ("Song of Solomon", 2, E),
+    # ---- Prophets (cross-reference heavy) ----
+    ("Isaiah", 6, N),
+    ("Isaiah", 7, C),
+    ("Isaiah", 9, C),
+    ("Isaiah", 40, E),
+    ("Isaiah", 53, C),
+    ("Isaiah", 55, E),
+    ("Isaiah", 61, C),
+    ("Jeremiah", 1, N),
+    ("Jeremiah", 29, E),
+    ("Jeremiah", 31, C),
+    ("Ezekiel", 36, C),
+    ("Ezekiel", 37, C),
+    ("Daniel", 2, N),
+    ("Daniel", 3, N),
+    ("Daniel", 6, N),
+    ("Daniel", 9, C),
+    ("Hosea", 11, C),
+    ("Joel", 2, C),
+    ("Amos", 5, E),
+    ("Jonah", 1, N),
+    ("Jonah", 2, N),
+    ("Jonah", 3, N),
+    ("Micah", 5, C),
+    ("Micah", 6, E),
+    ("Habakkuk", 2, C),
+    ("Zechariah", 9, C),
+    ("Malachi", 3, C),
+    # ---- Matthew ----
+    ("Matthew", 1, C),
+    ("Matthew", 2, C),
+    ("Matthew", 3, N),
+    ("Matthew", 4, N),
+    ("Matthew", 5, E),
+    ("Matthew", 6, E),
+    ("Matthew", 7, E),
+    ("Matthew", 13, E),
+    ("Matthew", 16, N),
+    ("Matthew", 17, N),
+    ("Matthew", 18, E),
+    ("Matthew", 22, E),
+    ("Matthew", 24, E),
+    ("Matthew", 26, N),
+    ("Matthew", 27, N),
+    ("Matthew", 28, N),
+    # ---- Mark ----
+    ("Mark", 1, N),
+    ("Mark", 2, N),
+    ("Mark", 4, E),
+    ("Mark", 5, N),
+    ("Mark", 8, N),
+    ("Mark", 10, E),
+    ("Mark", 12, E),
+    ("Mark", 15, N),
+    ("Mark", 16, N),
+    # ---- Luke ----
+    ("Luke", 1, N),
+    ("Luke", 2, N),
+    ("Luke", 4, N),
+    ("Luke", 10, E),
+    ("Luke", 15, E),
+    ("Luke", 18, E),
+    ("Luke", 19, N),
+    ("Luke", 22, N),
+    ("Luke", 23, N),
+    ("Luke", 24, N),
+    # ---- John ----
+    ("John", 1, C),
+    ("John", 3, E),
+    ("John", 4, N),
+    ("John", 6, E),
+    ("John", 8, E),
+    ("John", 10, E),
+    ("John", 11, N),
+    ("John", 13, N),
+    ("John", 14, E),
+    ("John", 15, E),
+    ("John", 17, E),
+    ("John", 19, N),
+    ("John", 20, N),
+    ("John", 21, N),
+    # ---- Acts ----
+    ("Acts", 1, N),
+    ("Acts", 2, C),
+    ("Acts", 3, N),
+    ("Acts", 4, N),
+    ("Acts", 7, N),
+    ("Acts", 8, N),
+    ("Acts", 9, N),
+    ("Acts", 10, N),
+    ("Acts", 12, N),
+    ("Acts", 16, N),
+    ("Acts", 17, N),
+    ("Acts", 20, E),
+    ("Acts", 27, N),
+    # ---- Romans ----
+    ("Romans", 1, E),
+    ("Romans", 3, E),
+    ("Romans", 5, E),
+    ("Romans", 6, E),
+    ("Romans", 8, E),
+    ("Romans", 10, C),
+    ("Romans", 12, E),
+    # ---- Corinthians ----
+    ("1 Corinthians", 1, E),
+    ("1 Corinthians", 12, E),
+    ("1 Corinthians", 13, E),
+    ("1 Corinthians", 15, E),
+    ("2 Corinthians", 5, E),
+    ("2 Corinthians", 12, N),
+    # ---- Paul's letters ----
+    ("Galatians", 2, E),
+    ("Galatians", 5, E),
+    ("Ephesians", 1, E),
+    ("Ephesians", 2, E),
+    ("Ephesians", 4, E),
+    ("Ephesians", 6, E),
+    ("Philippians", 2, E),
+    ("Philippians", 4, E),
+    ("Colossians", 1, E),
+    ("Colossians", 3, E),
+    ("1 Thessalonians", 4, E),
+    ("2 Thessalonians", 2, E),
+    ("1 Timothy", 3, E),
+    ("2 Timothy", 3, E),
+    ("Titus", 2, E),
+    ("Philemon", 1, N),
+    # ---- General epistles ----
+    ("Hebrews", 1, C),
+    ("Hebrews", 4, E),
+    ("Hebrews", 11, E),
+    ("Hebrews", 12, E),
+    ("James", 1, E),
+    ("James", 2, E),
+    ("1 Peter", 1, E),
+    ("1 Peter", 2, C),
+    ("2 Peter", 1, E),
+    ("1 John", 1, E),
+    ("1 John", 3, E),
+    ("1 John", 4, E),
+    ("Jude", 1, E),
+    # ---- Revelation ----
+    ("Revelation", 1, N),
+    ("Revelation", 3, E),
+    ("Revelation", 5, C),
+    ("Revelation", 21, C),
+    ("Revelation", 22, C),
+]
+
+
+def _entry(t: tuple) -> dict:
+    if len(t) == 3:
+        book, chapter, category = t
+        return {"book": book, "chapter": chapter, "category": category}
+    book, chapter, vf, vt, category = t
+    return {"book": book, "chapter": chapter, "verse_from": vf, "verse_to": vt, "category": category}
+
+
+def main() -> None:
+    passages = [_entry(t) for t in _RAW]
+    # Guard against accidental duplicates (same book+chapter+verse window).
+    seen = set()
+    dupes = []
+    for p in passages:
+        key = (p["book"], p["chapter"], p.get("verse_from"), p.get("verse_to"))
+        if key in seen:
+            dupes.append(key)
+        seen.add(key)
+    counts = {N: 0, E: 0, C: 0}
+    for p in passages:
+        counts[p["category"]] += 1
+    out = Path(__file__).parent / "data" / "daily_challenge_seed_passages_full.json"
+    out.write_text(json.dumps({"passages": passages}, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"wrote {len(passages)} passages -> {out}")
+    print(f"categories: {counts}")
+    if dupes:
+        print(f"WARNING duplicates: {dupes}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/data/daily_challenge_seed_passages_full.json
+++ b/backend/scripts/data/daily_challenge_seed_passages_full.json
@@ -1,0 +1,1056 @@
+{
+  "passages": [
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 7,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 9,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 15,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 28,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 37,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 39,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 41,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 45,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Exodus",
+      "chapter": 16,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Exodus",
+      "chapter": 32,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Exodus",
+      "chapter": 34,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Leviticus",
+      "chapter": 16,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Leviticus",
+      "chapter": 19,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Leviticus",
+      "chapter": 23,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Numbers",
+      "chapter": 13,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Numbers",
+      "chapter": 14,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Numbers",
+      "chapter": 21,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 8,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 30,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 34,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Joshua",
+      "chapter": 6,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Joshua",
+      "chapter": 24,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Judges",
+      "chapter": 6,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Judges",
+      "chapter": 7,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Judges",
+      "chapter": 16,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Ruth",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Ruth",
+      "chapter": 4,
+      "category": "cross_reference"
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 3,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "category": "cross_reference"
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 11,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 12,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "1 Kings",
+      "chapter": 3,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "1 Kings",
+      "chapter": 18,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "1 Kings",
+      "chapter": 19,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "2 Kings",
+      "chapter": 5,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "2 Kings",
+      "chapter": 2,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Nehemiah",
+      "chapter": 8,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Esther",
+      "chapter": 4,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Esther",
+      "chapter": 7,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Job",
+      "chapter": 38,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Job",
+      "chapter": 42,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 8,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 22,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 23,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 110,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 119,
+      "verse_from": 1,
+      "verse_to": 16,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 121,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 31,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Ecclesiastes",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Ecclesiastes",
+      "chapter": 12,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Song of Solomon",
+      "chapter": 2,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 7,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 9,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 40,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 55,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 61,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 29,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 31,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Ezekiel",
+      "chapter": 36,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Ezekiel",
+      "chapter": 37,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Daniel",
+      "chapter": 2,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Daniel",
+      "chapter": 6,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Daniel",
+      "chapter": 9,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Hosea",
+      "chapter": 11,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Joel",
+      "chapter": 2,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Amos",
+      "chapter": 5,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Jonah",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Jonah",
+      "chapter": 3,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Micah",
+      "chapter": 5,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Micah",
+      "chapter": 6,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Habakkuk",
+      "chapter": 2,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Zechariah",
+      "chapter": 9,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Malachi",
+      "chapter": 3,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 3,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 17,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 18,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 22,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 24,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 26,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Mark",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Mark",
+      "chapter": 2,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Mark",
+      "chapter": 4,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Mark",
+      "chapter": 5,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Mark",
+      "chapter": 8,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Mark",
+      "chapter": 10,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Mark",
+      "chapter": 12,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Mark",
+      "chapter": 15,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Mark",
+      "chapter": 16,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Luke",
+      "chapter": 4,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "category": "cross_reference"
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Acts",
+      "chapter": 3,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 4,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 7,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 8,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 10,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 17,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Acts",
+      "chapter": 20,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Acts",
+      "chapter": 27,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "2 Thessalonians",
+      "chapter": 2,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Philemon",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "category": "cross_reference"
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 John",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Jude",
+      "chapter": 1,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "category": "narrative_recall"
+    },
+    {
+      "book": "Revelation",
+      "chapter": 3,
+      "category": "passage_exegesis"
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "category": "cross_reference"
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "category": "cross_reference"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a **210-passage manifest** + its builder so the Daily Challenge bank can be filled through end-of-2026 (one unique passage/day from 2026-06-17, buffer for gate rejections). Whole-canon spread, balanced categories (narrative 85 / exegesis 90 / cross-ref 35).

**Why not already filled:** the Gemini project is on the **free tier** — the key 429s (`exceeded your current quota… check your plan and billing`) after ~1 passage, so the bulk run can't finish. Enable billing (~$1 for all 210 at ~$0.005/passage), then:
```
python -m scripts.bootstrap_daily_challenge_bank --created-by <admin-uuid>   --manifest scripts/data/daily_challenge_seed_passages_full.json   --max-passages 210 --max-survivors 1 --start-date 2026-06-17
```

A 1-passage live smoke (Genesis 1) verified the pipeline end-to-end: clean bilingual Q, correct answer, 0 gate rejections, published + scheduled for 2026-06-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)