### PR TITLE
fix: exclude deactivated students from grades + progress; make fat-seed work on Postgres

### DIFF
--- a/backend/app/services/grade_calculator.py
+++ b/backend/app/services/grade_calculator.py
@@ -191,7 +191,10 @@ def calculate_all_student_grades(db: Session, course: Course):
     enrollments = (
         db.query(Enrollment.user_id, User.full_name, User.email)
         .join(User, User.id == Enrollment.user_id)
-        .filter(Enrollment.course_id == course.id)
+        # Exclude deactivated (soft-deleted) students so the gradebook,
+        # class average, and CSV match the analytics roster — they must not
+        # count ghosts (mirrors analytics.py + cohort_capacity.py).
+        .filter(Enrollment.course_id == course.id, User.deactivated_at.is_(None))
         .all()
     )
     if not enrollments:

--- a/backend/app/services/student_progress_service.py
+++ b/backend/app/services/student_progress_service.py
@@ -299,7 +299,10 @@ def build_course_student_progress(db: Session, course: Course, course_id: str) -
     enrollments = (
         db.query(Enrollment, User)
         .join(User, Enrollment.user_id == User.id)
-        .filter(Enrollment.course_id == course_id)
+        # Exclude deactivated (soft-deleted) students so the teacher progress
+        # board + total_students match the analytics roster (mirrors
+        # analytics.py / cohort_capacity.py).
+        .filter(Enrollment.course_id == course_id, User.deactivated_at.is_(None))
         .all()
     )
 

--- a/backend/scripts/seed_fat_test_course.py
+++ b/backend/scripts/seed_fat_test_course.py
@@ -48,6 +48,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 from app.core.database import _get_engine
@@ -329,13 +330,31 @@ def _ordered_chapter_ids(db: Session, *, course_id: str) -> list[str]:
     return [r[0] for r in rows]
 
 
+def _ensure_auth_user(db: Session, *, user_id: uuid.UUID, email: str) -> None:
+    """``profiles.id`` FKs to ``auth.users(id)`` — on real Postgres a profile
+    row can't exist without its auth row, so seed that first. SQLite test DBs
+    have no ``auth`` schema, so skip there (the FK isn't materialised). These
+    are ``@seed.invalid`` identities with no password — a staging/dev tool,
+    never for prod auth. ``ON CONFLICT DO NOTHING`` keeps it idempotent.
+    """
+    if db.bind is None or db.bind.dialect.name != "postgresql":
+        return
+    db.execute(
+        text("INSERT INTO auth.users (id, email) VALUES (:id, :email) ON CONFLICT (id) DO NOTHING"),
+        {"id": str(user_id), "email": email},
+    )
+    db.flush()
+
+
 def _ensure_student(db: Session, *, course_id: str, index: int) -> User:
     student_id = _student_id(course_id, index)
     student = db.query(User).filter(User.id == student_id).first()
     if student is None:
+        email = _student_email(course_id, index)
+        _ensure_auth_user(db, user_id=student_id, email=email)
         student = User(
             id=student_id,
-            email=_student_email(course_id, index),
+            email=email,
             full_name=f"Seed Student {index + 1}",
             role=UserRole.STUDENT.value,
         )
@@ -386,18 +405,22 @@ def seed_students(
         db.flush()
         enrolled += 1
 
-        # Mark the first ``done`` chapters complete for this student.
-        for chapter_id in chapter_ids[:done]:
-            exists = (
-                db.query(ChapterProgress)
-                .filter(
+        # Mark the first ``done`` chapters complete for this student. Fetch
+        # the student's already-recorded chapters in ONE query, then bulk-add
+        # the missing ones — the previous per-chapter existence check was
+        # O(students * chapters) round-trips (minutes of latency at pilot
+        # scale against a remote DB).
+        target = chapter_ids[:done]
+        if target:
+            existing = {
+                cid
+                for (cid,) in db.query(ChapterProgress.chapter_id).filter(
                     ChapterProgress.user_id == student.id,
-                    ChapterProgress.chapter_id == chapter_id,
+                    ChapterProgress.chapter_id.in_(target),
                 )
-                .first()
-            )
-            if exists is None:
-                db.add(
+            }
+            db.add_all(
+                [
                     ChapterProgress(
                         id=uuid.uuid4(),
                         user_id=student.id,
@@ -406,7 +429,10 @@ def seed_students(
                         completed_at=datetime.now(UTC),
                         completion_type="self",
                     )
-                )
+                    for chapter_id in target
+                    if chapter_id not in existing
+                ]
+            )
         if (i + 1) % 20 == 0:
             db.commit()
             logger.info("Committed through student %s", i + 1)
@@ -534,6 +560,13 @@ def purge(db: Session, *, course_id: str) -> dict:
 
     if student_ids:
         db.query(User).filter(User.id.in_(student_ids)).delete(synchronize_session=False)
+        # Profiles FK to auth.users — drop the seeded auth rows too so purge
+        # leaves nothing behind (postgres only; SQLite has no auth schema).
+        if db.bind is not None and db.bind.dialect.name == "postgresql":
+            db.execute(
+                text("DELETE FROM auth.users WHERE id = ANY(:ids)"),
+                {"ids": [str(sid) for sid in student_ids]},
+            )
 
     db.commit()
     return {

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -810,6 +810,28 @@ class TestGradeSummary:
         assert r.json()["students"] == []
         assert r.json()["class_average"] == 0.0
 
+    def test_deactivated_student_excluded(self, client: TestClient, db: Session):
+        # A soft-deleted student keeps their enrollment but must NOT appear in
+        # the gradebook summary or drag the class average — matches the
+        # analytics roster (the recently-fixed deactivated-exclusion rule).
+        _seed_enrolled_course(db, progress=50)  # live STUDENT_ID
+        ghost_id = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+        db.add(
+            User(
+                id=ghost_id,
+                email="ghost@example.com",
+                full_name="Ghost",
+                role=UserRole.STUDENT.value,
+                deactivated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        db.add(Enrollment(id="enroll-ghost", user_id=ghost_id, course_id="course-1", progress=0))
+        db.commit()
+
+        body = client.get("/api/v1/grades/course/course-1/summary").json()
+        ids = {s["student_id"] for s in body["students"]}
+        assert ids == {str(STUDENT_ID)}  # ghost excluded
+
     def test_not_owner(self, client: TestClient, db: Session):
         _seed_foreign_course(db)
         r = client.get("/api/v1/grades/course/other-course/summary")
@@ -1099,6 +1121,27 @@ class TestCourseStudentProgress:
         assert ch_infos[ch_asg_id]["assignment_result"]["status"] == "submitted"
         assert ch_infos[ch_read_id]["quiz_result"] is None
         assert ch_infos[ch_read_id]["assignment_result"] is None
+
+    def test_deactivated_student_excluded(self, client: TestClient, db: Session):
+        # A soft-deleted student must not appear on the teacher progress board
+        # nor inflate total_students (mirrors analytics + grades).
+        course_id, *_ = _seed_teacher_progress_dashboard(db)
+        ghost_id = uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+        db.add(
+            User(
+                id=ghost_id,
+                email="ghost-prog@example.com",
+                full_name="Ghost",
+                role=UserRole.STUDENT.value,
+                deactivated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        db.add(Enrollment(id=f"enroll-ghost-{course_id}", user_id=ghost_id, course_id=course_id, progress=0))
+        db.commit()
+
+        body = client.get(f"/api/v1/progress/course/{course_id}/students").json()
+        assert body["total_students"] == 1
+        assert {s["id"] for s in body["students"]} == {str(STUDENT_ID)}
 
     def test_empty_enrollments(self, client: TestClient, db: Session):
         _seed_course(db, course_id="course-empty-stu")


### PR DESCRIPTION
Findings from the pilot-scale fat-course test (240 chapters; attempted 250 students) + a 4-agent scale audit.

**1. HIGH (correctness)** — deactivated students still counted in grades (`calculate_all_student_grades` → /summary, CSV, class_average) + teacher progress board (`build_course_student_progress` → total_students). analytics.py/cohort_capacity.py were fixed earlier; these two were missed. Added `User.deactivated_at.is_(None)` to both; 2 new tests.

**2. Tooling bug** — fat-seed student seeding broke on real Postgres (`profiles.id`→`auth.users` FK; SQLite tests masked it). Now seeds minimal auth.users(id,email) first (postgres-only, @seed.invalid); purge removes them.

**3. Perf** — fat-seed did O(students×chapters) existence SELECTs; batched to one/student.

Full backend suite **1468 green**; ruff/mypy clean. Fat course seeded to prod (structure only), measured, fully purged — prod clean (12 courses, 0 remnants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)