### PR TITLE
perf(dashboard): drop module/chapter tree from /users/me/courses payload

### DIFF
--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -10,13 +10,13 @@ from app.api.dependencies import get_current_user, require_admin
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.models.user import User
-from app.schemas.course import CourseSummary, EnrollmentSummaryResponse
+from app.schemas.course import CourseDashboardSummary, EnrollmentSummaryResponse
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.schemas.user import PreferredLocaleUpdate, UserResponse
 from app.services.audit_service import log_action
 from app.services.course_service import get_user_courses
 from app.services.translation.resolve_for_display import (
-    build_localized_course_summaries,
+    build_localized_course_dashboard_summaries,
     populate_spine_texts,
     should_apply_course_translation_overlay,
 )
@@ -54,7 +54,10 @@ def get_my_courses(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[EnrollmentSummaryResponse]:
-    # Dashboard view: slim payload (chapter body content stripped).
+    # Dashboard view: slim payload — only course scalars (no module/chapter
+    # tree). ``get_user_courses`` loads courses WITHOUT the tree, so all text
+    # hydration here is course-only (``hydrate_modules=False``) to avoid an
+    # N+1 lazy-load over modules the dashboard never renders.
     response.headers["Vary"] = "Accept-Language"
     display_locale: LocaleCode = normalize_locale(accept_language)
     rows = get_user_courses(db, current_user.id, skip=skip, limit=limit)
@@ -63,15 +66,16 @@ def get_my_courses(
     courses = [e.course for e in rows if e.course is not None]
     if not courses:
         return [EnrollmentSummaryResponse.model_validate(e, from_attributes=True) for e in rows]
-    # Pre-hydrate at the source locale for the owner / admin path. The
-    # student / non-owner path uses a localized summary; per-course
-    # overlay choice depends on the caller's role.
-    populate_spine_texts(db, courses)
+    # Pre-hydrate course title/description at the source locale (baseline used
+    # by the owner / admin non-overlay path). The student / non-owner path
+    # overwrites with a display-locale summary below; overlay choice is
+    # per-course and depends on the caller's role.
+    populate_spine_texts(db, courses, hydrate_modules=False)
     localized = {
         c.id: s
         for c, s in zip(
             courses,
-            build_localized_course_summaries(db, courses, display_locale),
+            build_localized_course_dashboard_summaries(db, courses, display_locale),
             strict=True,
         )
     }
@@ -84,7 +88,7 @@ def get_my_courses(
         summary = (
             localized[c.id]
             if should_apply_course_translation_overlay(course=c, current_user=current_user)
-            else CourseSummary.model_validate(c, from_attributes=True)
+            else CourseDashboardSummary.model_validate(c, from_attributes=True)
         )
         base = EnrollmentSummaryResponse.model_validate(e, from_attributes=True)
         out.append(base.model_copy(update={"course": summary}))

--- a/backend/app/schemas/course.py
+++ b/backend/app/schemas/course.py
@@ -176,8 +176,32 @@ class EnrollmentResponse(BaseModel):
     course: CourseResponse | None = None
 
 
+class CourseDashboardSummary(CourseBase):
+    """Course shape for the student-dashboard list (``/users/me/courses``).
+
+    Deliberately omits ``modules`` (and therefore the chapter level): the
+    dashboard renders only the course title + the enrollment's progress, and
+    no ``getMyCourses`` consumer reads ``course.modules``. Keeping this shape
+    free of the module/chapter relationship lets the loader skip the tree
+    entirely — no eager full-tree fetch, no per-module lazy-load on serialise.
+    See ``course_service.get_user_courses``.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    status: str = "draft"
+    access_mode: Literal["public", "institute"] = "public"
+    created_by: UUID | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+    deleted_at: datetime | None = None
+    enrollment_start: datetime | None = None
+    enrollment_end: datetime | None = None
+
+
 class EnrollmentSummaryResponse(BaseModel):
-    """Enrollment for list views — embeds the slim CourseSummary."""
+    """Enrollment for the dashboard list — embeds the slim CourseDashboardSummary."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -187,7 +211,7 @@ class EnrollmentSummaryResponse(BaseModel):
     cohort_id: UUID | None = None
     enrolled_at: datetime
     progress: int
-    course: CourseSummary | None = None
+    course: CourseDashboardSummary | None = None
 
 
 class CourseTranslationResponse(BaseModel):

--- a/backend/app/services/course_service/_enrollment.py
+++ b/backend/app/services/course_service/_enrollment.py
@@ -15,8 +15,6 @@ from app.models.chapter_progress import ChapterProgress
 from app.models.course import Chapter, Course, Module
 from app.models.enrollment import Enrollment
 
-from ._queries import _COURSE_TREE
-
 if TYPE_CHECKING:
     from uuid import UUID
 
@@ -88,10 +86,19 @@ def get_user_courses(
     skip: int = 0,
     limit: int | None = None,
 ) -> list[Enrollment]:
+    # Dashboard list view: load the enrollment + its course SCALARS only — no
+    # module/chapter tree. ``/users/me/courses`` is the highest-traffic screen
+    # and serialises ``EnrollmentSummaryResponse`` whose embedded
+    # ``CourseDashboardSummary`` carries only id/title/progress-relevant scalar
+    # fields (no ``modules``). The old loader eager-loaded the full
+    # ``_COURSE_TREE`` (240+ chapters on a fat course) only for Pydantic to
+    # discard them; a modules-only loader would instead lazy-load chapters
+    # per module during serialisation (N+1). Dropping the tree entirely means
+    # the slim schema never touches the relationship, so neither happens.
     query = (
         db.query(Enrollment)
         .join(Course, Course.id == Enrollment.course_id)
-        .options(joinedload(Enrollment.course).options(*_COURSE_TREE))
+        .options(joinedload(Enrollment.course))
         .filter(Enrollment.user_id == user_id, Course.deleted_at.is_(None))
         .order_by(Enrollment.enrolled_at.desc())
     )

--- a/backend/app/services/translation/resolve_for_display.py
+++ b/backend/app/services/translation/resolve_for_display.py
@@ -31,7 +31,13 @@ from app.schemas.announcement import AnnouncementResponse
 from app.schemas.assignment import AssignmentResponse
 from app.schemas.calendar import CourseEventResponse
 from app.schemas.chapter_block import BlockResponse
-from app.schemas.course import ChapterResponse, CourseResponse, CourseSummary, ModuleResponse
+from app.schemas.course import (
+    ChapterResponse,
+    CourseDashboardSummary,
+    CourseResponse,
+    CourseSummary,
+    ModuleResponse,
+)
 from app.schemas.locale import LocaleCode, normalize_locale
 from app.schemas.quiz import QuizResponse, QuizStudentResponse
 from app.services.content_versions import (
@@ -134,11 +140,49 @@ def build_localized_course_summaries(
     return out
 
 
+def build_localized_course_dashboard_summaries(
+    db: Session,
+    courses: list[Course],
+    display_locale: LocaleCode,
+) -> list[CourseDashboardSummary]:
+    """Like :func:`build_localized_course_summaries` but emits the slim
+    ``CourseDashboardSummary`` (no ``modules``) for ``/users/me/courses``.
+
+    Resolves only the course-level title + description against
+    ``content_versions``; never touches the module/chapter relationship, so
+    serialising the result triggers no lazy-load on a tree-less course.
+    """
+    if not courses:
+        return []
+    by_src: dict[str, list[str]] = {}
+    for c in courses:
+        by_src.setdefault(normalize_locale(c.source_locale), []).append(c.id)
+    texts: dict[tuple[str, str], str | None] = {}
+    for src_locale, ids in by_src.items():
+        texts.update(
+            fetch_cv_entity_texts_with_fallback(
+                db,
+                entity_type="course",
+                entity_ids=ids,
+                fields=["title", "description"],
+                display_locale=display_locale,
+                source_locale=src_locale,
+            )
+        )
+    out: list[CourseDashboardSummary] = []
+    for c in courses:
+        c.title = texts.get((c.id, "title")) or ""
+        c.description = texts.get((c.id, "description"))
+        out.append(CourseDashboardSummary.model_validate(c, from_attributes=True))
+    return out
+
+
 def populate_spine_texts(
     db: Session,
     courses: list[Course],
     *,
     display_locale: LocaleCode | None = None,
+    hydrate_modules: bool = True,
 ) -> None:
     """Phase 5g: ``courses.title|description`` and ``modules.title|description``
     columns dropped. Hydrate each course (and every loaded module/chapter
@@ -197,7 +241,12 @@ def populate_spine_texts(
     # ── modules (every module attached to every course, grouped by the
     # parent course's source_locale so one bulk cv query covers each tier).
     # ``c.modules`` triggers SA's lazy-load if the relationship hasn't been
-    # eager-fetched yet; the readiness service relies on that. ──
+    # eager-fetched yet; the readiness service relies on that. The dashboard
+    # list (``/users/me/courses``) loads courses with NO module tree and only
+    # needs course-level text, so it passes ``hydrate_modules=False`` to skip
+    # this block and avoid an N+1 lazy-load over modules it never serialises. ──
+    if not hydrate_modules:
+        return
     modules_by_src: dict[str, list[Module]] = {}
     for c in courses:
         mods = list(c.modules)

--- a/backend/tests/test_users_reviews_misc.py
+++ b/backend/tests/test_users_reviews_misc.py
@@ -191,6 +191,29 @@ class TestGetMyCourses:
         resp = anon_client.get("/api/v1/users/me/courses")
         assert resp.status_code in (401, 403)
 
+    def test_dashboard_payload_omits_module_tree(self, student_client: TestClient, db: Session):
+        """The dashboard list view must NOT carry the module/chapter tree.
+
+        ``/users/me/courses`` is the highest-traffic screen; it serialises
+        only the course scalars + the enrollment's progress, and no
+        ``getMyCourses`` consumer reads ``course.modules``. This locks the
+        slim ``CourseDashboardSummary`` shape (no ``modules`` field) + the
+        tree-less loader so a future change can't silently reintroduce the
+        per-enrolled-course full-tree over-fetch (240+ chapters on a fat
+        course) discovered in the fat-course audit.
+        """
+        _seed_course(db)
+        _seed_module(db)
+        _seed_chapter(db)
+        _seed_enrollment(db, user_id=STUDENT_ID)
+        resp = student_client.get("/api/v1/users/me/courses")
+        assert resp.status_code == 200
+        data = resp.json()
+        row = next(e for e in data if e["course_id"] == "course-1")
+        assert row["course"]["title"] == "Test Course"
+        # The module (and therefore chapter) tree is absent from the payload.
+        assert "modules" not in row["course"]
+
 
 # ===================================================================
 # USERS — self-account deletion has been removed. Only admins can hard


### PR DESCRIPTION
perf(dashboard): drop module/chapter tree from /users/me/courses payload

The student dashboard (`/users/me/courses`) is the highest-traffic screen,
yet `get_user_courses` eager-loaded the full course tree (`_COURSE_TREE`) —
every module and every chapter (240+ on a fat course) — only for Pydantic
to discard them. A modules-only loader would be no better: serialising
`ModuleSummary.chapters` would lazy-load chapters per module (N+1).

Fix: the dashboard needs only course scalars + the enrollment's progress,
and no `getMyCourses` consumer reads `course.modules`. So:

- `get_user_courses` drops the tree loader entirely — `joinedload` the
  course scalars only.
- New `CourseDashboardSummary` (no `modules` field), embedded in
  `EnrollmentSummaryResponse` (a dashboard-only schema). The slim shape
  never touches the module/chapter relationship, so neither eager nor
  lazy tree loads happen.
- New `build_localized_course_dashboard_summaries` — course-level title/
  description cv resolution that never reads modules.
- `populate_spine_texts` gains `hydrate_modules=True` (default unchanged);
  the dashboard passes `False` to skip the module hydration block (which
  would otherwise lazy-load modules off a tree-less course).

Regression test `test_dashboard_payload_omits_module_tree` locks the slim
shape so the over-fetch (found in the fat-course scale audit) can't return.
No migration; no model change. Frontend untouched (no consumer reads the
enrolled-course module tree).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
