### PR TITLE
perf(progress): slim teacher progress-board list + lazy per-student detail

### DIFF
--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -14,7 +14,11 @@ from app.models.course import Chapter, Module
 from app.models.enrollment import Enrollment
 from app.models.user import User
 from app.services.course_service import sync_enrollment_progress
-from app.services.student_progress_service import build_course_student_progress
+from app.services.student_progress_service import (
+    build_course_gradebook_matrix,
+    build_course_student_progress,
+    build_student_chapter_detail,
+)
 
 router = APIRouter(prefix="/progress", tags=["progress"])
 
@@ -60,6 +64,47 @@ def get_course_student_progress(
 ):
     course = verify_course_owner(db, course_id, teacher)
     return build_course_student_progress(db, course, course_id)
+
+
+@router.get("/course/{course_id}/gradebook")
+def get_course_gradebook_matrix(
+    course_id: str,
+    teacher: User = Depends(require_teacher),
+    db: Session = Depends(get_db),
+):
+    """Full students x chapters matrix for the gradebook spreadsheet.
+
+    Separate from the slim ``/students`` list because the gradebook renders
+    every student against every chapter at once, so it needs the per-chapter
+    breakdown for the whole roster.
+    """
+    course = verify_course_owner(db, course_id, teacher)
+    return build_course_gradebook_matrix(db, course, course_id)
+
+
+@router.get("/course/{course_id}/students/{student_id}/detail")
+def get_student_progress_detail(
+    course_id: str,
+    student_id: UUID,
+    teacher: User = Depends(require_teacher),
+    db: Session = Depends(get_db),
+):
+    """Per-chapter breakdown + quiz/assignment results for ONE student.
+
+    Backs the progress-board row expansion: the list endpoint returns only
+    lightweight per-student summaries, so the heavy per-chapter detail is
+    pulled lazily here when a teacher expands a row.
+    """
+    course = verify_course_owner(db, course_id, teacher)
+    enrolled = db.query(Enrollment).filter(Enrollment.user_id == student_id, Enrollment.course_id == course_id).first()
+    if not enrolled:
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Student is not enrolled in this course",
+            context={"resource_type": "enrollment", "course_id": course_id},
+        )
+    return build_student_chapter_detail(db, course, course_id, str(student_id))
 
 
 @router.put("/chapter/{chapter_id}/student/{student_id}/complete")

--- a/backend/app/services/student_progress_service.py
+++ b/backend/app/services/student_progress_service.py
@@ -83,6 +83,7 @@ def _load_chapter_quizzes_and_assignments(
 def _aggregate_quiz_results(
     db: Session,
     quiz_map: dict[str, list[Quiz]],
+    user_ids: list[str] | None = None,
 ) -> tuple[
     dict[tuple[str, str], dict[str, Any]],
     dict[tuple[str, str], int],
@@ -118,6 +119,12 @@ def _aggregate_quiz_results(
     # the SQLite test backend.
     partition = (QuizAttempt.user_id, QuizAttempt.quiz_id)
     pct_order = func.coalesce(QuizAttempt.score * 1.0 / func.nullif(QuizAttempt.max_score, 0), -1.0)
+    # ``user_ids`` scopes the aggregation to a single student (the per-student
+    # detail endpoint) or a page of students, so the window functions don't
+    # churn over the whole roster when only one row's worth is needed.
+    attempt_filters = [QuizAttempt.quiz_id.in_(all_quiz_ids), QuizAttempt.completed_at.isnot(None)]
+    if user_ids is not None:
+        attempt_filters.append(QuizAttempt.user_id.in_(user_ids))
     ranked = (
         db.query(
             QuizAttempt.user_id.label("user_id"),
@@ -131,10 +138,7 @@ def _aggregate_quiz_results(
             func.max(case((QuizAttempt.passed.is_(True), 1), else_=0)).over(partition_by=partition).label("passed_any"),
             func.max(QuizAttempt.completed_at).over(partition_by=partition).label("last_completed"),
         )
-        .filter(
-            QuizAttempt.quiz_id.in_(all_quiz_ids),
-            QuizAttempt.completed_at.isnot(None),
-        )
+        .filter(*attempt_filters)
         .subquery()
     )
     quiz_aggs = db.query(ranked).filter(ranked.c.rn == 1).all()
@@ -170,6 +174,7 @@ def _aggregate_quiz_results(
 def _aggregate_assignment_submissions(
     db: Session,
     assignment_map: dict[str, list[Assignment]],
+    user_ids: list[str] | None = None,
 ) -> tuple[
     dict[tuple[str, str], list[dict[str, Any]]],
     dict[str, Assignment],
@@ -196,13 +201,16 @@ def _aggregate_assignment_submissions(
     # Two-step query: compute MAX(submitted_at) per (student, assignment)
     # in a subquery, then pull the full row that matches. We tie-break on
     # ``id`` below for determinism when two rows share submitted_at.
+    sub_filters = [AssignmentSubmission.assignment_id.in_(all_assignment_ids)]
+    if user_ids is not None:
+        sub_filters.append(AssignmentSubmission.student_id.in_(user_ids))
     latest_ts_subq = (
         db.query(
             AssignmentSubmission.student_id.label("student_id"),
             AssignmentSubmission.assignment_id.label("assignment_id"),
             func.max(AssignmentSubmission.submitted_at).label("latest_at"),
         )
-        .filter(AssignmentSubmission.assignment_id.in_(all_assignment_ids))
+        .filter(*sub_filters)
         .group_by(AssignmentSubmission.student_id, AssignmentSubmission.assignment_id)
         .subquery()
     )
@@ -242,59 +250,205 @@ def _aggregate_assignment_submissions(
     return subs_by_user_chapter, assignment_by_id_str, latest_sub_by_user
 
 
-def _load_completed_progress(db: Session, chapter_ids: list[str]) -> dict[str, dict[str, ChapterProgress]]:
+def _load_completed_progress(
+    db: Session, chapter_ids: list[str], user_ids: list[str] | None = None
+) -> dict[str, dict[str, ChapterProgress]]:
     """Map ``user_id -> chapter_id -> ChapterProgress`` for completed rows only."""
     if not chapter_ids:
         return {}
-    rows = (
-        db.query(ChapterProgress)
-        .filter(
-            ChapterProgress.chapter_id.in_(chapter_ids),
-            ChapterProgress.completed == True,
-        )
-        .all()
-    )
+    progress_filters = [ChapterProgress.chapter_id.in_(chapter_ids), ChapterProgress.completed == True]
+    if user_ids is not None:
+        progress_filters.append(ChapterProgress.user_id.in_(user_ids))
+    rows = db.query(ChapterProgress).filter(*progress_filters).all()
     out: dict[str, dict[str, ChapterProgress]] = defaultdict(dict)
     for p in rows:
         out[str(p.user_id)][str(p.chapter_id)] = p
     return out
 
 
+def _load_assignment_titles(db: Session, course: Course, assignment_by_id_str: dict[str, Assignment]) -> dict[str, str]:
+    """Phase 5e3: ``assignments.title`` column dropped — bulk-fetch the
+    source-language title from cv. Any-locale fallback keeps the lookup
+    defensive against missing rows (prefer showing *something* over crashing).
+    """
+    if not assignment_by_id_str:
+        return {}
+    from app.services.content_versions import fetch_cv_entity_texts_with_fallback
+
+    source_locale = course.source_locale or "en"
+    cv_titles = fetch_cv_entity_texts_with_fallback(
+        db,
+        entity_type="assignment",
+        entity_ids=list(assignment_by_id_str.keys()),
+        fields=["title"],
+        display_locale=source_locale,
+        source_locale=source_locale,
+    )
+    return {aid: (cv_titles.get((aid, "title")) or "") for aid in assignment_by_id_str}
+
+
+def _build_quiz_results(
+    uid: str,
+    quiz_map: dict[str, list[Quiz]],
+    best_by_user_chapter: dict[tuple[str, str], dict[str, Any]],
+    attempts_by_user_chapter: dict[tuple[str, str], int],
+    chapter_title_map: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Per-chapter best-quiz rollup for one student."""
+    quiz_results = []
+    for ch_id in quiz_map:
+        ch_key = (uid, str(ch_id))
+        best = best_by_user_chapter.get(ch_key)
+        if best is None:
+            continue
+        quiz_results.append(
+            {
+                "chapter_title": chapter_title_map.get(str(ch_id), ""),
+                "chapter_id": str(ch_id),
+                "quiz_id": best["quiz_id"],
+                "score": best["score"],
+                "max_score": best["max_score"],
+                "passed": best["passed"],
+                "attempts_used": attempts_by_user_chapter.get(ch_key, 0),
+            }
+        )
+    return quiz_results
+
+
+def _build_assignment_results(
+    uid: str,
+    assignment_map: dict[str, list[Assignment]],
+    subs_by_user_chapter: dict[tuple[str, str], list[dict[str, Any]]],
+    assignment_title_by_id: dict[str, str],
+    chapter_title_map: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Latest-submission-per-assignment rollup for one student."""
+    assignment_results = []
+    for ch_id, assignments in assignment_map.items():
+        ch_key = (uid, str(ch_id))
+        submissions = subs_by_user_chapter.get(ch_key, [])
+        # Build assignment_id -> latest-submission dict once per chapter so the
+        # per-assignment lookup is O(1). Submissions are already filtered to
+        # the latest per assignment upstream in _aggregate_assignment_submissions.
+        sub_by_assignment: dict[str, dict[str, Any]] = {s["assignment_id"]: s for s in submissions}
+        for a in assignments:
+            latest = sub_by_assignment.get(str(a.id))
+            if latest is None:
+                continue
+            assignment_results.append(
+                {
+                    "chapter_title": chapter_title_map.get(str(ch_id), ""),
+                    "chapter_id": str(ch_id),
+                    "title": assignment_title_by_id.get(str(a.id), ""),
+                    "status": latest["status"],
+                    "grade": latest["grade"],
+                    "max_score": a.max_score or 0,
+                }
+            )
+    return assignment_results
+
+
+def _quiz_avg(quiz_results: list[dict[str, Any]]) -> int | None:
+    """Mean quiz percentage, mirroring the (now removed) frontend ``quizAvg``."""
+    if not quiz_results:
+        return None
+    total = sum((q["score"] / q["max_score"] * 100) if q["max_score"] else 0.0 for q in quiz_results)
+    return round(total / len(quiz_results))
+
+
+def _assignment_avg(assignment_results: list[dict[str, Any]]) -> int | None:
+    """Mean graded-assignment percentage, mirroring the frontend ``assignmentAvg``."""
+    graded = [a for a in assignment_results if a["grade"] is not None]
+    if not graded:
+        return None
+    total = sum((a["grade"] / a["max_score"] * 100) if a["max_score"] else 0.0 for a in graded)
+    return round(total / len(graded))
+
+
+def _overall_grade(quiz_avg: int | None, assignment_avg: int | None) -> int | None:
+    """Unweighted mean of the present averages, mirroring frontend ``overallGrade``."""
+    scores = [s for s in (quiz_avg, assignment_avg) if s is not None]
+    if not scores:
+        return None
+    return round(sum(scores) / len(scores))
+
+
+def _latest_activity_iso(enrolled_at: datetime | None, quiz_ts: datetime | None, sub_ts: datetime | None) -> str | None:
+    latest = enrolled_at
+    for ts in (quiz_ts, sub_ts):
+        if ts and (latest is None or ts > latest):
+            latest = ts
+    return latest.isoformat() if latest else None
+
+
+def _build_chapter_infos(
+    uid: str,
+    chapters: list[Chapter],
+    user_progress: dict[str, ChapterProgress],
+    best_by_user_chapter: dict[tuple[str, str], dict[str, Any]],
+    subs_by_user_chapter: dict[tuple[str, str], list[dict[str, Any]]],
+    assignment_by_id_str: dict[str, Assignment],
+) -> list[dict[str, Any]]:
+    """Per-chapter completion + embedded quiz/assignment result for one student.
+
+    Shared by the row-expand detail (progress board) and the full gradebook
+    matrix, which both need the per-chapter view for a student.
+    """
+    chapter_infos = []
+    for ch in chapters:
+        cp = user_progress.get(str(ch.id))
+        ch_key = (uid, str(ch.id))
+        best = best_by_user_chapter.get(ch_key)
+        quiz_data = None
+        if best is not None:
+            quiz_data = {"score": best["score"], "max_score": best["max_score"], "passed": best["passed"]}
+        ch_subs = subs_by_user_chapter.get(ch_key, [])
+        asgn_data = None
+        if ch_subs:
+            latest_sub = max(ch_subs, key=lambda s: s["submitted_at"] or datetime.min)
+            asgn = assignment_by_id_str.get(latest_sub["assignment_id"])
+            max_score = asgn.max_score if asgn is not None else 100
+            asgn_data = {"status": latest_sub["status"], "grade": latest_sub["grade"], "max_score": max_score}
+        chapter_infos.append(
+            {
+                "id": str(ch.id),
+                "title": ch.title,
+                "module_id": str(ch.module_id),
+                "chapter_type": ch.chapter_type or "reading",
+                "requires_completion": bool(ch.requires_completion),
+                "completed": cp is not None,
+                "completed_by": cp.completion_type if cp else None,
+                "quiz_result": quiz_data,
+                "assignment_result": asgn_data,
+            }
+        )
+    return chapter_infos
+
+
 def build_course_student_progress(db: Session, course: Course, course_id: str) -> dict[str, Any]:
-    """Return the full teacher-dashboard progress payload for a course."""
+    """Teacher progress-board LIST payload: one lightweight summary row per
+    enrolled student — scalars plus server-computed quiz/assignment/overall
+    averages. The heavy per-chapter breakdown (``chapters``) and the full
+    quiz/assignment result arrays are NOT included here; they're fetched
+    per-student on row expand via :func:`build_student_chapter_detail`.
+
+    This keeps the list response O(students) instead of O(students x chapters):
+    a 250-student x 240-chapter course used to emit ~60k chapter objects in one
+    response. The averages still need the per-student result rollups, but those
+    arrays are computed and discarded rather than serialised.
+    """
     populate_spine_texts(db, [course])
     chapters, module_map, chapter_title_map = _load_course_structure(db, course_id)
     chapter_ids = [c.id for c in chapters]
     gradable_chapter_ids = [c.id for c in chapters if c.chapter_type in GRADABLE_CHAPTER_TYPES]
 
     quiz_map, assignment_map = _load_chapter_quizzes_and_assignments(db, chapter_ids)
-
     best_by_user_chapter, attempts_by_user_chapter, latest_quiz_by_user = _aggregate_quiz_results(db, quiz_map)
-
     subs_by_user_chapter, assignment_by_id_str, latest_sub_by_user = _aggregate_assignment_submissions(
         db, assignment_map
     )
-
-    # Phase 5e3: assignments.title column dropped — bulk-fetch the
-    # source-language title from cv for the dashboard rendering below.
-    # Any-locale fallback keeps the lookup defensive against missing
-    # rows (the dashboard prefers showing *something* over crashing).
-    assignment_title_by_id: dict[str, str] = {}
-    if assignment_by_id_str:
-        from app.services.content_versions import fetch_cv_entity_texts_with_fallback
-
-        source_locale = course.source_locale or "en"
-        cv_titles = fetch_cv_entity_texts_with_fallback(
-            db,
-            entity_type="assignment",
-            entity_ids=list(assignment_by_id_str.keys()),
-            fields=["title"],
-            display_locale=source_locale,
-            source_locale=source_locale,
-        )
-        assignment_title_by_id = {aid: (cv_titles.get((aid, "title")) or "") for aid in assignment_by_id_str}
-
-    progress_by_user = _load_completed_progress(db, chapter_ids)
+    assignment_title_by_id = _load_assignment_titles(db, course, assignment_by_id_str)
+    progress_by_user = _load_completed_progress(db, gradable_chapter_ids)
 
     enrollments = (
         db.query(Enrollment, User)
@@ -309,93 +463,16 @@ def build_course_student_progress(db: Session, course: Course, course_id: str) -
     student_progress = []
     for enrollment, user in enrollments:
         uid = str(user.id)
-
-        quiz_results = []
-        for ch_id in quiz_map:
-            ch_key = (uid, str(ch_id))
-            best = best_by_user_chapter.get(ch_key)
-            if best is None:
-                continue
-            quiz_results.append(
-                {
-                    "chapter_title": chapter_title_map.get(str(ch_id), ""),
-                    "chapter_id": str(ch_id),
-                    "quiz_id": best["quiz_id"],
-                    "score": best["score"],
-                    "max_score": best["max_score"],
-                    "passed": best["passed"],
-                    "attempts_used": attempts_by_user_chapter.get(ch_key, 0),
-                }
-            )
-
-        assignment_results = []
-        for ch_id, assignments in assignment_map.items():
-            ch_key = (uid, str(ch_id))
-            submissions = subs_by_user_chapter.get(ch_key, [])
-            # Build assignment_id -> latest-submission dict once per chapter
-            # so the per-assignment lookup is O(1) instead of an O(M) list
-            # comprehension. Submissions are already filtered to the latest
-            # per assignment upstream in _aggregate_assignment_submissions.
-            sub_by_assignment: dict[str, dict[str, Any]] = {s["assignment_id"]: s for s in submissions}
-            for a in assignments:
-                latest = sub_by_assignment.get(str(a.id))
-                if latest is None:
-                    continue
-                assignment_results.append(
-                    {
-                        "chapter_title": chapter_title_map.get(str(ch_id), ""),
-                        "chapter_id": str(ch_id),
-                        "title": assignment_title_by_id.get(str(a.id), ""),
-                        "status": latest["status"],
-                        "grade": latest["grade"],
-                        "max_score": a.max_score or 0,
-                    }
-                )
-
+        quiz_results = _build_quiz_results(
+            uid, quiz_map, best_by_user_chapter, attempts_by_user_chapter, chapter_title_map
+        )
+        assignment_results = _build_assignment_results(
+            uid, assignment_map, subs_by_user_chapter, assignment_title_by_id, chapter_title_map
+        )
         user_progress = progress_by_user.get(uid, {})
         chapters_completed = sum(1 for cid in gradable_chapter_ids if cid in user_progress)
-
-        chapter_infos = []
-        for ch in chapters:
-            cp = user_progress.get(str(ch.id))
-            ch_key = (uid, str(ch.id))
-            best = best_by_user_chapter.get(ch_key)
-            quiz_data = None
-            if best is not None:
-                quiz_data = {
-                    "score": best["score"],
-                    "max_score": best["max_score"],
-                    "passed": best["passed"],
-                }
-            ch_subs = subs_by_user_chapter.get(ch_key, [])
-            asgn_data = None
-            if ch_subs:
-                latest_sub = max(ch_subs, key=lambda s: s["submitted_at"] or datetime.min)
-                asgn = assignment_by_id_str.get(latest_sub["assignment_id"])
-                max_score = asgn.max_score if asgn is not None else 100
-                asgn_data = {
-                    "status": latest_sub["status"],
-                    "grade": latest_sub["grade"],
-                    "max_score": max_score,
-                }
-            chapter_infos.append(
-                {
-                    "id": str(ch.id),
-                    "title": ch.title,
-                    "module_id": str(ch.module_id),
-                    "chapter_type": ch.chapter_type or "reading",
-                    "requires_completion": bool(ch.requires_completion),
-                    "completed": cp is not None,
-                    "completed_by": cp.completion_type if cp else None,
-                    "quiz_result": quiz_data,
-                    "assignment_result": asgn_data,
-                }
-            )
-
-        latest_activity = enrollment.enrolled_at
-        for ts in (latest_quiz_by_user.get(uid), latest_sub_by_user.get(uid)):
-            if ts and (latest_activity is None or ts > latest_activity):
-                latest_activity = ts
+        quiz_avg = _quiz_avg(quiz_results)
+        assignment_avg = _assignment_avg(assignment_results)
 
         student_progress.append(
             {
@@ -406,10 +483,12 @@ def build_course_student_progress(db: Session, course: Course, course_id: str) -
                 "progress": enrollment.progress,
                 "chapters_completed": chapters_completed,
                 "total_chapters": len(gradable_chapter_ids),
-                "quiz_results": quiz_results,
-                "assignment_results": assignment_results,
-                "last_activity": latest_activity.isoformat() if latest_activity else None,
-                "chapters": chapter_infos,
+                "quiz_avg": quiz_avg,
+                "assignment_avg": assignment_avg,
+                "overall_grade": _overall_grade(quiz_avg, assignment_avg),
+                "last_activity": _latest_activity_iso(
+                    enrollment.enrolled_at, latest_quiz_by_user.get(uid), latest_sub_by_user.get(uid)
+                ),
             }
         )
 
@@ -420,4 +499,100 @@ def build_course_student_progress(db: Session, course: Course, course_id: str) -
         "total_students": len(enrollments),
         "modules": list(module_map.values()),
         "students": student_progress,
+    }
+
+
+def build_student_chapter_detail(db: Session, course: Course, course_id: str, student_id: str) -> dict[str, Any]:
+    """Per-student detail for the progress-board row expansion: the full
+    per-chapter breakdown plus the quiz/assignment result arrays for ONE
+    student. Every aggregation is scoped to ``student_id`` so this stays cheap
+    regardless of roster size.
+    """
+    populate_spine_texts(db, [course])
+    chapters, _module_map, chapter_title_map = _load_course_structure(db, course_id)
+    chapter_ids = [c.id for c in chapters]
+
+    quiz_map, assignment_map = _load_chapter_quizzes_and_assignments(db, chapter_ids)
+    best_by_user_chapter, attempts_by_user_chapter, _latest_quiz = _aggregate_quiz_results(
+        db, quiz_map, user_ids=[student_id]
+    )
+    subs_by_user_chapter, assignment_by_id_str, _latest_sub = _aggregate_assignment_submissions(
+        db, assignment_map, user_ids=[student_id]
+    )
+    assignment_title_by_id = _load_assignment_titles(db, course, assignment_by_id_str)
+    progress_by_user = _load_completed_progress(db, chapter_ids, user_ids=[student_id])
+    user_progress = progress_by_user.get(student_id, {})
+
+    quiz_results = _build_quiz_results(
+        student_id, quiz_map, best_by_user_chapter, attempts_by_user_chapter, chapter_title_map
+    )
+    assignment_results = _build_assignment_results(
+        student_id, assignment_map, subs_by_user_chapter, assignment_title_by_id, chapter_title_map
+    )
+
+    chapter_infos = _build_chapter_infos(
+        student_id, chapters, user_progress, best_by_user_chapter, subs_by_user_chapter, assignment_by_id_str
+    )
+
+    return {
+        "student_id": student_id,
+        "chapters": chapter_infos,
+        "quiz_results": quiz_results,
+        "assignment_results": assignment_results,
+    }
+
+
+def build_course_gradebook_matrix(db: Session, course: Course, course_id: str) -> dict[str, Any]:
+    """Full students x chapters matrix for the teacher GRADEBOOK.
+
+    Unlike the progress-board list (which is a per-student summary), the
+    gradebook renders an always-visible spreadsheet of every student against
+    every chapter, so it genuinely needs the per-chapter breakdown for the
+    whole roster. The top-level quiz/assignment result arrays the board's
+    detail carries are omitted — the gradebook reads only the per-chapter
+    ``quiz_result`` / ``assignment_result`` embedded in each chapter cell.
+    """
+    populate_spine_texts(db, [course])
+    chapters, module_map, _chapter_title_map = _load_course_structure(db, course_id)
+    chapter_ids = [c.id for c in chapters]
+    gradable_chapter_ids = [c.id for c in chapters if c.chapter_type in GRADABLE_CHAPTER_TYPES]
+
+    quiz_map, assignment_map = _load_chapter_quizzes_and_assignments(db, chapter_ids)
+    best_by_user_chapter, _attempts, _latest_quiz = _aggregate_quiz_results(db, quiz_map)
+    subs_by_user_chapter, assignment_by_id_str, _latest_sub = _aggregate_assignment_submissions(db, assignment_map)
+    progress_by_user = _load_completed_progress(db, gradable_chapter_ids)
+
+    enrollments = (
+        db.query(Enrollment, User)
+        .join(User, Enrollment.user_id == User.id)
+        # Mirror the board/analytics roster: deactivated students are excluded.
+        .filter(Enrollment.course_id == course_id, User.deactivated_at.is_(None))
+        .all()
+    )
+
+    students = []
+    for enrollment, user in enrollments:
+        uid = str(user.id)
+        user_progress = progress_by_user.get(uid, {})
+        students.append(
+            {
+                "id": uid,
+                "full_name": user.full_name or user.email,
+                "email": user.email,
+                "progress": enrollment.progress,
+                "chapters_completed": sum(1 for cid in gradable_chapter_ids if cid in user_progress),
+                "total_chapters": len(gradable_chapter_ids),
+                "chapters": _build_chapter_infos(
+                    uid, chapters, user_progress, best_by_user_chapter, subs_by_user_chapter, assignment_by_id_str
+                ),
+            }
+        )
+
+    return {
+        "course_id": course_id,
+        "course_title": course.title,
+        "total_chapters": len(gradable_chapter_ids),
+        "total_students": len(enrollments),
+        "modules": list(module_map.values()),
+        "students": students,
     }

--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -2063,6 +2063,21 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/progress/course/{course_id}/gradebook",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/progress/course/{course_id}/my-progress",
     "params": [
       [
@@ -2082,6 +2097,25 @@
     "params": [
       [
         "course_id",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/progress/course/{course_id}/students/{student_id}/detail",
+    "params": [
+      [
+        "course_id",
+        "path"
+      ],
+      [
+        "student_id",
         "path"
       ]
     ],

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -1084,8 +1084,12 @@ def _seed_teacher_progress_dashboard(db: Session) -> tuple[str, uuid.UUID, uuid.
 class TestCourseStudentProgress:
     """GET /api/v1/progress/course/{course_id}/students — teacher dashboard."""
 
-    def test_happy_path_includes_quiz_assignment_and_chapters(self, client: TestClient, db: Session):
-        course_id, quiz_id, _asg_id, ch_quiz_id, ch_asg_id, ch_read_id = _seed_teacher_progress_dashboard(db)
+    def test_list_returns_summary_with_server_computed_averages(self, client: TestClient, db: Session):
+        # The list endpoint is a lightweight per-student summary: scalars plus
+        # server-computed quiz/assignment/overall averages. The heavy per-chapter
+        # breakdown + result arrays are NOT in the list payload — they're fetched
+        # per-student via the /detail endpoint on row expand.
+        course_id, *_ = _seed_teacher_progress_dashboard(db)
         r = client.get(f"/api/v1/progress/course/{course_id}/students")
         assert r.status_code == 200, r.text
         body = r.json()
@@ -1101,26 +1105,89 @@ class TestCourseStudentProgress:
         assert st["progress"] == 40
         assert st["chapters_completed"] == 1
         assert st["total_chapters"] == 2
-        assert len(st["quiz_results"]) == 1
-        qr = st["quiz_results"][0]
+        assert st["last_activity"] is not None
+        # Best quiz = 9/10 = 90%; assignment submitted but ungraded -> no avg.
+        assert st["quiz_avg"] == 90
+        assert st["assignment_avg"] is None
+        assert st["overall_grade"] == 90
+        # The list payload must stay slim — no per-student arrays.
+        assert "quiz_results" not in st
+        assert "assignment_results" not in st
+        assert "chapters" not in st
+
+    def test_detail_endpoint_returns_chapter_breakdown_and_arrays(self, client: TestClient, db: Session):
+        course_id, quiz_id, _asg_id, ch_quiz_id, ch_asg_id, ch_read_id = _seed_teacher_progress_dashboard(db)
+        r = client.get(f"/api/v1/progress/course/{course_id}/students/{STUDENT_ID}/detail")
+        assert r.status_code == 200, r.text
+        detail = r.json()
+        assert detail["student_id"] == str(STUDENT_ID)
+        assert len(detail["quiz_results"]) == 1
+        qr = detail["quiz_results"][0]
         assert qr["chapter_id"] == ch_quiz_id
         assert qr["quiz_id"] == str(quiz_id)
         assert qr["score"] == 9
         assert qr["passed"] is True
         assert qr["attempts_used"] == 2
-        assert len(st["assignment_results"]) == 1
-        ar = st["assignment_results"][0]
+        assert len(detail["assignment_results"]) == 1
+        ar = detail["assignment_results"][0]
         assert ar["chapter_id"] == ch_asg_id
         assert ar["title"] == "Essay"
         assert ar["status"] == "submitted"
         assert ar["max_score"] == 100
-        assert st["last_activity"] is not None
-        ch_infos = {c["id"]: c for c in st["chapters"]}
+        ch_infos = {c["id"]: c for c in detail["chapters"]}
         assert ch_infos[ch_quiz_id]["quiz_result"]["score"] == 9
         assert ch_infos[ch_quiz_id]["quiz_result"]["passed"] is True
         assert ch_infos[ch_asg_id]["assignment_result"]["status"] == "submitted"
         assert ch_infos[ch_read_id]["quiz_result"] is None
         assert ch_infos[ch_read_id]["assignment_result"] is None
+
+    def test_detail_404_when_student_not_enrolled(self, client: TestClient, db: Session):
+        course_id, *_ = _seed_teacher_progress_dashboard(db)
+        stranger = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+        r = client.get(f"/api/v1/progress/course/{course_id}/students/{stranger}/detail")
+        assert r.status_code == 404
+
+    def test_detail_403_for_non_owner(self, client: TestClient, db: Session):
+        _ensure_student(db)
+        _seed_foreign_course(db, course_id="foreign-prog-detail")
+        r = client.get(f"/api/v1/progress/course/foreign-prog-detail/students/{STUDENT_ID}/detail")
+        assert r.status_code == 403
+
+    def test_detail_403_for_student_role(self, student_client: TestClient, db: Session):
+        course_id, *_ = _seed_teacher_progress_dashboard(db)
+        r = student_client.get(f"/api/v1/progress/course/{course_id}/students/{STUDENT_ID}/detail")
+        assert r.status_code == 403
+
+    def test_gradebook_matrix_returns_per_student_chapters(self, client: TestClient, db: Session):
+        # The gradebook endpoint is the full students x chapters matrix: every
+        # enrolled student carries the per-chapter breakdown (with embedded
+        # quiz/assignment result), but NOT the top-level result arrays the
+        # board's detail endpoint uses.
+        course_id, _quiz_id, _asg_id, ch_quiz_id, ch_asg_id, ch_read_id = _seed_teacher_progress_dashboard(db)
+        r = client.get(f"/api/v1/progress/course/{course_id}/gradebook")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["course_id"] == course_id
+        assert body["total_students"] == 1
+        assert len(body["modules"]) == 1
+        assert len(body["students"]) == 1
+        st = body["students"][0]
+        assert st["id"] == str(STUDENT_ID)
+        assert st["chapters_completed"] == 1
+        assert st["total_chapters"] == 2
+        # Matrix carries chapters with embedded results, not the board arrays.
+        assert "quiz_results" not in st
+        assert "assignment_results" not in st
+        ch_infos = {c["id"]: c for c in st["chapters"]}
+        assert ch_infos[ch_quiz_id]["quiz_result"]["score"] == 9
+        assert ch_infos[ch_asg_id]["assignment_result"]["status"] == "submitted"
+        assert ch_infos[ch_read_id]["quiz_result"] is None
+
+    def test_gradebook_matrix_403_for_non_owner(self, client: TestClient, db: Session):
+        _ensure_student(db)
+        _seed_foreign_course(db, course_id="foreign-gradebook")
+        r = client.get("/api/v1/progress/course/foreign-gradebook/gradebook")
+        assert r.status_code == 403
 
     def test_deactivated_student_excluded(self, client: TestClient, db: Session):
         # A soft-deleted student must not appear on the teacher progress board

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1188,6 +1188,9 @@
       "chaptersCompletedValue": "{{done}} of {{total}}",
       "progress": "Progress",
       "chapterBreakdown": "Chapter Breakdown",
+      "loadingDetail": "Loading chapter breakdown…",
+      "detailFailed": "Couldn't load the chapter breakdown.",
+      "retry": "Retry",
       "gradebookButton": "Gradebook",
       "viewAnalytics": "View Analytics"
     },

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -785,6 +785,9 @@
       "chaptersCompletedValue": "{{done}} из {{total}}",
       "progress": "Прогресс",
       "chapterBreakdown": "По главам",
+      "loadingDetail": "Загрузка разбивки по главам…",
+      "detailFailed": "Не удалось загрузить разбивку по главам.",
+      "retry": "Повторить",
       "gradebookButton": "Журнал оценок",
       "viewAnalytics": "Аналитика"
     },

--- a/frontend/src/pages/Teacher/StudentProgress.tsx
+++ b/frontend/src/pages/Teacher/StudentProgress.tsx
@@ -123,32 +123,25 @@ export default function StudentProgress() {
   }, [data, search, sortBy, sortDir])
 
   const handleStudentChapterUpdate = useCallback(
-    (
-      studentId: string,
-      chapterId: string,
-      completed: boolean,
-      completedBy: "teacher" | "self" | null,
-    ) => {
+    (studentId: string, _chapterId: string, completed: boolean) => {
+      // The per-chapter detail now lives inside the expanded StudentRow; here
+      // we only optimistically bump the summary row's completion count +
+      // progress bar. Authoritative values refresh on next board load.
       setData((prev) => {
         if (!prev) return prev
         return {
           ...prev,
           students: prev.students.map((s) => {
             if (s.id !== studentId) return s
-            const updatedChapters = s.chapters?.map((ch) =>
-              ch.id === chapterId ? { ...ch, completed, completed_by: completedBy } : ch,
-            )
-            const completedCount =
-              updatedChapters?.filter((ch) => ch.completed).length ?? s.chapters_completed
+            const chaptersCompleted = completed
+              ? s.chapters_completed + 1
+              : Math.max(0, s.chapters_completed - 1)
             return {
               ...s,
-              chapters: updatedChapters,
-              chapters_completed: completed
-                ? s.chapters_completed + 1
-                : Math.max(0, s.chapters_completed - 1),
+              chapters_completed: chaptersCompleted,
               progress:
                 prev.total_chapters > 0
-                  ? Math.round((completedCount / prev.total_chapters) * 100)
+                  ? Math.min(100, Math.round((chaptersCompleted / prev.total_chapters) * 100))
                   : s.progress,
             }
           }),

--- a/frontend/src/pages/Teacher/TeacherGradebook.tsx
+++ b/frontend/src/pages/Teacher/TeacherGradebook.tsx
@@ -122,7 +122,7 @@ export default function TeacherGradebook() {
           coursesService.getCourse(courseId),
           coursesService.getCourseGrades(courseId).catch(() => []),
           coursesService.getGradeSummary(courseId).catch(() => null),
-          coursesService.getStudentProgress(courseId).catch(() => null),
+          coursesService.getGradebookMatrix(courseId).catch(() => null),
         ])
         if (cancelled) return
         setCourseTitle(course.title)

--- a/frontend/src/pages/Teacher/gradebook/types.ts
+++ b/frontend/src/pages/Teacher/gradebook/types.ts
@@ -41,18 +41,6 @@ export interface StudentProgressData {
   chapters_completed: number
   total_chapters: number
   chapters: ChapterInfo[]
-  quiz_results: Array<{
-    chapter_id: string
-    score: number
-    max_score: number
-    passed: boolean
-  }>
-  assignment_results: Array<{
-    chapter_id: string
-    status: string
-    grade: number | null
-    max_score: number
-  }>
 }
 
 export interface ModuleInfo {

--- a/frontend/src/pages/Teacher/progress/StudentRow.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentRow.tsx
@@ -1,15 +1,17 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { toast } from "@/lib/toast"
 import { coursesService } from "@/services/courses"
+import type { StudentProgressDetail } from "@/types"
 import {
   BookOpen,
   ChevronDown,
   ChevronRight,
   ClipboardList,
   FileText,
+  Loader2,
 } from "lucide-react"
 import { ChapterBreakdownRow } from "./ChapterBreakdownRow"
 import { ProgressBar, ScoreBadge } from "./ProgressBar"
@@ -63,33 +65,73 @@ export function StudentRow({
   const { t } = useTranslation()
   const [togglingChapter, setTogglingChapter] = useState<string | null>(null)
   const [grantingQuiz, setGrantingQuiz] = useState<string | null>(null)
+  // The per-chapter breakdown is fetched lazily the first time a row expands —
+  // the list payload only carries summary scalars, so each student's full
+  // chapter/quiz/assignment detail is pulled on demand here.
+  const [detail, setDetail] = useState<StudentProgressDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState(false)
+
+  useEffect(() => {
+    if (!isExpanded || detail || detailLoading) return
+    let cancelled = false
+    setDetailLoading(true)
+    setDetailError(false)
+    coursesService
+      .getStudentProgressDetail(courseId, student.id)
+      .then((d) => {
+        if (!cancelled) setDetail(d)
+      })
+      .catch(() => {
+        if (!cancelled) setDetailError(true)
+      })
+      .finally(() => {
+        if (!cancelled) setDetailLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isExpanded, detail, detailLoading, courseId, student.id])
 
   const allChapters = useMemo(() => {
     const map = new Map<string, ChapterEntry>()
-    for (const ch of student.chapters ?? []) {
+    if (!detail) return map
+    for (const ch of detail.chapters) {
       map.set(ch.id, { ...(map.get(ch.id) ?? {}), chapterInfo: ch })
     }
-    for (const q of student.quiz_results) {
+    for (const q of detail.quiz_results) {
       map.set(q.chapter_id, { ...(map.get(q.chapter_id) ?? {}), quiz: q })
     }
-    for (const a of student.assignment_results) {
+    for (const a of detail.assignment_results) {
       map.set(a.chapter_id, { ...(map.get(a.chapter_id) ?? {}), assignment: a })
     }
     return map
-  }, [student.chapters, student.quiz_results, student.assignment_results])
+  }, [detail])
 
   const handleToggleComplete = async (chapterInfo: ChapterInfo) => {
     setTogglingChapter(chapterInfo.id)
+    const nowCompleted = !chapterInfo.completed
     try {
       if (chapterInfo.completed) {
         await coursesService.teacherMarkIncomplete(chapterInfo.id, student.id)
-        onChapterUpdate(student.id, chapterInfo.id, false, null)
         toast({ title: t("studentProgress.row.markedIncomplete"), variant: "success" })
       } else {
         await coursesService.teacherMarkComplete(chapterInfo.id, student.id)
-        onChapterUpdate(student.id, chapterInfo.id, true, "teacher")
         toast({ title: t("studentProgress.row.markedComplete"), variant: "success" })
       }
+      // Update the locally-held detail so the expanded breakdown reflects the
+      // flip immediately, and bump the parent summary row's progress counts.
+      setDetail((prev) =>
+        prev
+          ? {
+              ...prev,
+              chapters: prev.chapters.map((ch) =>
+                ch.id === chapterInfo.id ? { ...ch, completed: nowCompleted } : ch,
+              ),
+            }
+          : prev,
+      )
+      onChapterUpdate(student.id, chapterInfo.id, nowCompleted, nowCompleted ? "teacher" : null)
     } catch {
       toast({ title: t("studentProgress.row.toggleFailed"), variant: "destructive" })
     } finally {
@@ -168,7 +210,28 @@ export function StudentRow({
                 </SummaryStat>
               </div>
 
-              {allChapters.size > 0 && (
+              {detailLoading && (
+                <div className="flex items-center gap-2 py-4 text-sm text-ink-muted">
+                  <Loader2 className="h-4 w-4 animate-spin" strokeWidth={1.75} aria-hidden />
+                  {t("studentProgress.row.loadingDetail")}
+                </div>
+              )}
+              {detailError && !detailLoading && (
+                <div className="flex items-center gap-3 py-4 text-sm text-ink-muted">
+                  <span>{t("studentProgress.row.detailFailed")}</span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setDetail(null)
+                      setDetailError(false)
+                    }}
+                  >
+                    {t("studentProgress.row.retry")}
+                  </Button>
+                </div>
+              )}
+              {detail && !detailLoading && allChapters.size > 0 && (
                 <div>
                   <h4 className="text-sm font-semibold mb-3 flex items-center gap-1.5">
                     <BookOpen className="h-4 w-4" strokeWidth={1.75} />

--- a/frontend/src/pages/Teacher/progress/StudentTable.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentTable.tsx
@@ -10,9 +10,6 @@ import { Users } from "lucide-react"
 import { EmptyState as DesignEmptyState } from "@/components/patterns/EmptyState"
 import { StudentRow } from "./StudentRow"
 import {
-  assignmentAvg,
-  overallGrade,
-  quizAvg,
   type SortColumn,
   type SortDirection,
   type StudentData,
@@ -102,9 +99,9 @@ export function StudentTable({
                     student={student}
                     isExpanded={expandedId === student.id}
                     onToggle={() => onExpandToggle(student.id)}
-                    quizAvg={quizAvg(student)}
-                    assignmentAvg={assignmentAvg(student)}
-                    overallGrade={overallGrade(student)}
+                    quizAvg={student.quiz_avg}
+                    assignmentAvg={student.assignment_avg}
+                    overallGrade={student.overall_grade}
                     courseId={courseId}
                     onChapterUpdate={onChapterUpdate}
                   />

--- a/frontend/src/pages/Teacher/progress/helpers.ts
+++ b/frontend/src/pages/Teacher/progress/helpers.ts
@@ -14,38 +14,10 @@ export type ChapterInfo = StudentChapterInfo
 export type SortColumn = "name" | "progress" | "last_activity"
 export type SortDirection = "asc" | "desc"
 
-/** Average quiz percentage, or null if the student has no quiz attempts. */
-export function quizAvg(student: StudentData): number | null {
-  if (student.quiz_results.length === 0) return null
-  const total = student.quiz_results.reduce(
-    (sum, q) => sum + (q.score / q.max_score) * 100,
-    0,
-  )
-  return Math.round(total / student.quiz_results.length)
-}
-
-/** Average graded-assignment percentage, or null if nothing has been graded. */
-export function assignmentAvg(student: StudentData): number | null {
-  const graded = student.assignment_results.filter((a) => a.grade !== null)
-  if (graded.length === 0) return null
-  const total = graded.reduce((sum, a) => sum + (a.grade! / a.max_score) * 100, 0)
-  return Math.round(total / graded.length)
-}
-
-/**
- * Simple mean of quizAvg and assignmentAvg. We intentionally do NOT weight
- * by attempt count — a single low quiz shouldn't skew the grade more than
- * graded assignments would.
- */
-export function overallGrade(student: StudentData): number | null {
-  const scores: number[] = []
-  const qAvg = quizAvg(student)
-  const aAvg = assignmentAvg(student)
-  if (qAvg !== null) scores.push(qAvg)
-  if (aAvg !== null) scores.push(aAvg)
-  if (scores.length === 0) return null
-  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
-}
+// quizAvg / assignmentAvg / overallGrade are now computed server-side and
+// arrive on the summary row (``quiz_avg`` / ``assignment_avg`` /
+// ``overall_grade``) so the board never has to load every student's full
+// result arrays. The per-chapter breakdown is fetched lazily on row expand.
 
 export function formatDate(d: string | null): string {
   if (!d) return "—"

--- a/frontend/src/services/progress.ts
+++ b/frontend/src/services/progress.ts
@@ -1,17 +1,25 @@
 import api from "./api"
 import { cached, cacheInvalidatePrefix, CACHE_TTL } from "@/lib/cache"
-import type { StudentProgressResponse } from "@/types"
+import type {
+  CourseGradebookMatrix,
+  StudentProgressDetail,
+  StudentProgressResponse,
+} from "@/types"
 
 export const progressService = {
   async teacherMarkComplete(chapterId: string, studentId: string): Promise<void> {
     await api.put(`/progress/chapter/${chapterId}/student/${studentId}/complete`)
     cacheInvalidatePrefix("progress:students:")
+    cacheInvalidatePrefix("progress:detail:")
+    cacheInvalidatePrefix("progress:gradebook:")
     cacheInvalidatePrefix("analytics:course:")
   },
 
   async teacherMarkIncomplete(chapterId: string, studentId: string): Promise<void> {
     await api.put(`/progress/chapter/${chapterId}/student/${studentId}/incomplete`)
     cacheInvalidatePrefix("progress:students:")
+    cacheInvalidatePrefix("progress:detail:")
+    cacheInvalidatePrefix("progress:gradebook:")
     cacheInvalidatePrefix("analytics:course:")
   },
 
@@ -29,5 +37,35 @@ export const progressService = {
       )
       return response.data
     })
+  },
+
+  async getGradebookMatrix(courseId: string): Promise<CourseGradebookMatrix> {
+    // Full students x chapters matrix for the gradebook spreadsheet. Separate
+    // from getStudentProgress (the slim progress-board list) because the
+    // gradebook needs every student's per-chapter breakdown at once.
+    return cached(`progress:gradebook:${courseId}`, CACHE_TTL.THIRTY_SECONDS, async () => {
+      const response = await api.get<CourseGradebookMatrix>(
+        `/progress/course/${courseId}/gradebook`,
+      )
+      return response.data
+    })
+  },
+
+  async getStudentProgressDetail(
+    courseId: string,
+    studentId: string,
+  ): Promise<StudentProgressDetail> {
+    // Per-student chapter breakdown, fetched lazily when a progress-board row
+    // expands. Cached per (course, student) so re-expanding a row is instant.
+    return cached(
+      `progress:detail:${courseId}:${studentId}`,
+      CACHE_TTL.THIRTY_SECONDS,
+      async () => {
+        const response = await api.get<StudentProgressDetail>(
+          `/progress/course/${courseId}/students/${studentId}/detail`,
+        )
+        return response.data
+      },
+    )
   },
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -403,6 +403,13 @@ export interface StudentAssignmentResult {
   max_score: number
 }
 
+/**
+ * Lightweight per-student summary row for the progress-board LIST. The heavy
+ * per-chapter breakdown + quiz/assignment result arrays are NOT here — they're
+ * fetched per student via ``getStudentProgressDetail`` when a row expands. The
+ * averages are computed server-side so the board never has to hold every
+ * student's full result set in memory.
+ */
 export interface StudentProgressEntry {
   id: string
   full_name: string
@@ -411,10 +418,43 @@ export interface StudentProgressEntry {
   progress: number
   chapters_completed: number
   total_chapters: number
+  quiz_avg: number | null
+  assignment_avg: number | null
+  overall_grade: number | null
+  last_activity: string | null
+}
+
+/** Per-student detail fetched lazily on progress-board row expansion. */
+export interface StudentProgressDetail {
+  student_id: string
+  chapters: StudentChapterInfo[]
   quiz_results: StudentQuizResult[]
   assignment_results: StudentAssignmentResult[]
-  last_activity: string | null
+}
+
+/** One row of the gradebook spreadsheet: a student + their full chapter matrix. */
+export interface StudentGradebookEntry {
+  id: string
+  full_name: string
+  email: string
+  progress: number
+  chapters_completed: number
+  total_chapters: number
   chapters: StudentChapterInfo[]
+}
+
+/**
+ * Full students x chapters matrix for the gradebook. Distinct from the slim
+ * ``StudentProgressResponse`` (progress-board list) because the gradebook
+ * renders every student against every chapter at once.
+ */
+export interface CourseGradebookMatrix {
+  course_id: string
+  course_title: string
+  total_chapters: number
+  total_students: number
+  modules: { id: string; title: string; order_index: number }[]
+  students: StudentGradebookEntry[]
 }
 
 export interface StudentProgressResponse {


### PR DESCRIPTION
perf(progress): slim the teacher progress-board list + lazy per-student detail

`GET /progress/course/{id}/students` previously emitted the full per-chapter
breakdown for EVERY enrolled student — ~60k objects on a 250-student ×
240-chapter course (flagged HIGH in the fat-course scale audit). The progress
board renders a one-row-per-student table and only expands ONE student at a
time, so it never needs the whole matrix up front.

Progress board:
- `/students` is now a lightweight per-student summary: scalars plus
  server-computed `quiz_avg` / `assignment_avg` / `overall_grade` (the averages
  the collapsed row shows). The per-chapter arrays are gone from the list.
- New `GET /students/{student_id}/detail` returns one student's chapter
  breakdown + quiz/assignment arrays, fetched lazily when a row expands
  (every aggregation scoped to that student id, so it's cheap at any roster
  size). The list is now O(students), not O(students × chapters).
- Frontend: `StudentRow` lazy-loads + caches detail on expand (loading/retry
  states added); averages come from the server; client search/sort still work
  over the slim rows.

Gradebook:
- The gradebook genuinely needs the full students × chapters matrix (it renders
  an always-visible spreadsheet), so it gets its own purpose-named endpoint
  `GET /progress/course/{id}/gradebook` rather than overloading the board list.
  Its unused top-level `quiz_results`/`assignment_results` type fields are
  dropped (the matrix only reads the per-chapter embedded results).

Shared `_build_chapter_infos` / `_build_quiz_results` / `_build_assignment_results`
helpers are extracted so the three builders don't duplicate the rollup logic.
No schema/migration change. OpenAPI contract snapshot updated for the 2 new routes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
