### PR TITLE
perf(db): add missing indexes for progress/quiz/certificate read paths

### DIFF
--- a/backend/app/models/chapter_progress.py
+++ b/backend/app/models/chapter_progress.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, UniqueConstraint, func
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, UniqueConstraint, func, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -23,6 +23,14 @@ class ChapterProgress(Base):
         # ``user_id`` via its leading column; keep only the chapter-side
         # index for the "all progress rows for chapter X" access pattern.
         Index("ix_chapter_progress_chapter_id", "chapter_id"),
+        # Partial composite for _load_completed_progress: filters
+        # `chapter_id IN (...) AND completed [AND user_id IN (...)]`.
+        Index(
+            "ix_chapter_progress_chapter_user_completed",
+            "chapter_id",
+            "user_id",
+            postgresql_where=text("completed"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)

--- a/backend/app/models/quiz.py
+++ b/backend/app/models/quiz.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -66,6 +66,14 @@ class QuizAttempt(Base):
     __table_args__ = (
         Index("ix_quiz_attempts_user_quiz", "user_id", "quiz_id"),
         Index("ix_quiz_attempts_quiz_id", "quiz_id"),
+        # Partial composite for _aggregate_quiz_results: filters
+        # `quiz_id IN (...) AND completed_at IS NOT NULL`, windows by user/quiz.
+        Index(
+            "ix_quiz_attempts_quiz_user_completed",
+            "quiz_id",
+            "user_id",
+            postgresql_where=text("completed_at IS NOT NULL"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)

--- a/supabase/migrations/20260610174624_add_perf_indexes.sql
+++ b/supabase/migrations/20260610174624_add_perf_indexes.sql
@@ -1,0 +1,27 @@
+-- Performance indexes surfaced by the fat-course scale audit (240-chapter,
+-- multi-hundred-student course). All three are additive and transparent to
+-- application code — they only speed up existing read paths.
+--
+-- 1. quiz_attempts: _aggregate_quiz_results (teacher progress board + gradebook)
+--    filters `quiz_id IN (...) AND completed_at IS NOT NULL` then windows by
+--    (user_id, quiz_id). A partial composite on (quiz_id, user_id) over only
+--    completed attempts serves the IN-list + the completed predicate directly,
+--    instead of scanning ix_quiz_attempts_quiz_id and filtering rows out.
+CREATE INDEX IF NOT EXISTS ix_quiz_attempts_quiz_user_completed
+  ON public.quiz_attempts USING btree (quiz_id, user_id)
+  WHERE completed_at IS NOT NULL;
+
+-- 2. chapter_progress: _load_completed_progress filters
+--    `chapter_id IN (...) AND completed = true [AND user_id IN (...)]`. A partial
+--    composite on (chapter_id, user_id) over completed rows matches that access
+--    pattern; ix_chapter_progress_chapter_id alone can't skip incomplete rows.
+CREATE INDEX IF NOT EXISTS ix_chapter_progress_chapter_user_completed
+  ON public.chapter_progress USING btree (chapter_id, user_id)
+  WHERE completed;
+
+-- 3. certificates: the SQLAlchemy model has declared ix_certificates_status
+--    (status) for a while, but it was never migrated onto prod — a model<->prod
+--    drift. Add it so the pending-certificate admin query (status = 'pending')
+--    has its index and the schema matches the model's 4-way mirror.
+CREATE INDEX IF NOT EXISTS ix_certificates_status
+  ON public.certificates USING btree (status);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1176,6 +1176,13 @@ CREATE INDEX ix_certificates_course_id ON public.certificates USING btree (cours
 
 
 --
+-- Name: ix_certificates_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_certificates_status ON public.certificates USING btree (status);
+
+
+--
 -- Name: ix_certificates_teacher_approved_by; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1208,6 +1215,13 @@ CREATE INDEX ix_chapter_blocks_quiz_id ON public.chapter_blocks USING btree (qui
 --
 
 CREATE INDEX ix_chapter_progress_chapter_id ON public.chapter_progress USING btree (chapter_id);
+
+
+--
+-- Name: ix_chapter_progress_chapter_user_completed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_chapter_progress_chapter_user_completed ON public.chapter_progress USING btree (chapter_id, user_id) WHERE completed;
 
 
 --
@@ -1488,6 +1502,13 @@ CREATE INDEX ix_quiz_answers_selected_option_id ON public.quiz_answers USING btr
 --
 
 CREATE INDEX ix_quiz_attempts_quiz_id ON public.quiz_attempts USING btree (quiz_id);
+
+
+--
+-- Name: ix_quiz_attempts_quiz_user_completed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_quiz_attempts_quiz_user_completed ON public.quiz_attempts USING btree (quiz_id, user_id) WHERE (completed_at IS NOT NULL);
 
 
 --


### PR DESCRIPTION
perf(db): add missing indexes for progress/quiz/certificate read paths

Three additive indexes surfaced by the fat-course scale audit. All are
transparent to application code (pure read-path accelerators):

1. `ix_quiz_attempts_quiz_user_completed` — partial `(quiz_id, user_id)
   WHERE completed_at IS NOT NULL`. Serves `_aggregate_quiz_results`
   (teacher progress board + gradebook), which filters
   `quiz_id IN (...) AND completed_at IS NOT NULL` then windows by
   (user_id, quiz_id). The existing `ix_quiz_attempts_quiz_id` couldn't skip
   incomplete attempts.
2. `ix_chapter_progress_chapter_user_completed` — partial `(chapter_id,
   user_id) WHERE completed`. Serves `_load_completed_progress`
   (`chapter_id IN (...) AND completed [AND user_id IN (...)]`).
3. `ix_certificates_status` — `(status)`. The SQLAlchemy model has declared
   this index for a while but it was never migrated onto prod (a real
   model<->prod drift the audit caught); this closes it and indexes the
   pending-certificate admin query.

Already applied to prod via Supabase MCP (migration version 20260610174624)
and verified present — index adds are non-destructive, reversible, and have no
code dependency, so they were safe to apply directly per the pre-release
risk-window policy. This PR records the migration file, mirrors the two new
partial indexes in the SQLAlchemy models, and refreshes `supabase/schema.sql`
so the schema-replay baseline stays faithful to prod.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
