### PR TITLE
fix(daily-challenge): keep generated verse range CHECK-safe

### DIFF
--- a/backend/app/services/daily_challenge/admin.py
+++ b/backend/app/services/daily_challenge/admin.py
@@ -114,6 +114,30 @@ def _log_event(
     )
 
 
+def _normalize_verse_range(verse_from: int | None, verse_to: int | None) -> tuple[int | None, int | None]:
+    """Coerce a (verse_from, verse_to) pair so it satisfies the
+    ``daily_challenge_questions`` CHECK constraints:
+
+      * ``bible_verse_from IS NULL OR bible_verse_from > 0``
+      * ``bible_verse_to IS NULL OR (bible_verse_from IS NOT NULL AND bible_verse_to >= bible_verse_from)``
+
+    LLM-generated survivors (``verse_start`` / ``verse_end`` from the model) can
+    carry a dangling ``verse_to`` with no ``verse_from``, a reversed range, or a
+    non-positive value — all rejected by the DB, which silently dropped the
+    generated question (the fat-bank run lost ~27% of whole-chapter passages this
+    way, and the daily replenish cron fell back to recycling on such days).
+    Normalising at the persistence chokepoint keeps every path CHECK-safe.
+    """
+    vf = verse_from if isinstance(verse_from, int) and not isinstance(verse_from, bool) and verse_from > 0 else None
+    vt = verse_to if isinstance(verse_to, int) and not isinstance(verse_to, bool) and verse_to > 0 else None
+    if vf is None:
+        # No start verse → can't anchor an end; treat as whole-chapter/unspecified.
+        return None, None
+    if vt is None or vt < vf:
+        return vf, None
+    return vf, vt
+
+
 def create_question(
     db: Session,
     *,
@@ -144,6 +168,10 @@ def create_question(
         raise ValueError("daily challenge question needs at least two options")
     if question_type == "true_false" and len(options) != 2:
         raise ValueError("true_false questions need exactly two options")
+
+    # Keep the verse range CHECK-safe regardless of what the generator/admin
+    # passed (dangling end, reversed range, non-positive). See _normalize_verse_range.
+    bible_verse_from, bible_verse_to = _normalize_verse_range(bible_verse_from, bible_verse_to)
 
     detected = detect_locale(" ".join(t for t in (question_text, explanation) if t))
     source_locale = detected or fallback_locale or "en"

--- a/backend/tests/test_daily_challenge_service.py
+++ b/backend/tests/test_daily_challenge_service.py
@@ -152,6 +152,80 @@ def _schedule_for_today(db: Session, question: DailyChallengeQuestion, scheduled
 
 
 # ---------------------------------------------------------------------------
+# Verse-range normalization (create_question CHECK-safety)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeVerseRange:
+    """``_normalize_verse_range`` must coerce any (from, to) pair to satisfy the
+    daily_challenge_questions CHECK. The fat-bank run lost ~27% of whole-chapter
+    passages because the LLM emitted a dangling verse_end with no verse_start."""
+
+    @pytest.mark.parametrize(
+        ("vf", "vt", "expected"),
+        [
+            (None, None, (None, None)),  # whole-chapter
+            (None, 16, (None, None)),  # dangling end (the real bug) -> drop it
+            (5, None, (5, None)),  # start only
+            (5, 10, (5, 10)),  # valid range
+            (10, 5, (10, None)),  # reversed -> keep start
+            (0, 5, (None, None)),  # non-positive start
+            (5, 0, (5, None)),  # non-positive end
+            (-3, 4, (None, None)),  # negative start
+        ],
+    )
+    def test_normalize(self, vf, vt, expected):
+        from app.services.daily_challenge.admin import _normalize_verse_range
+
+        assert _normalize_verse_range(vf, vt) == expected
+
+    def test_create_question_with_dangling_verse_to_does_not_violate_check(self, db: Session, author: User):
+        """The model mirrors the prod CHECK, so SQLite enforces it: before the
+        fix this raised IntegrityError; now it persists CHECK-safe (None/None)."""
+        from app.services.daily_challenge.admin import OptionDraft, create_question
+
+        q = create_question(
+            db,
+            question_type="multiple_choice",
+            bible_book="Jonah",
+            bible_chapter=1,
+            bible_verse_from=None,
+            bible_verse_to=16,  # dangling end, no start — the bug case
+            question_text="What did Jonah do when called to Nineveh?",
+            options=[OptionDraft(text="Fled to Tarshish", is_correct=True), OptionDraft(text="Obeyed", is_correct=False)],
+            explanation="Jonah 1 — he fled toward Tarshish.",
+            category="narrative_meaning",
+            created_by=author.id,
+            fallback_locale="en",
+        )
+        db.commit()
+        db.refresh(q)
+        assert q.bible_verse_from is None
+        assert q.bible_verse_to is None
+
+    def test_create_question_preserves_valid_range(self, db: Session, author: User):
+        from app.services.daily_challenge.admin import OptionDraft, create_question
+
+        q = create_question(
+            db,
+            question_type="multiple_choice",
+            bible_book="Psalms",
+            bible_chapter=119,
+            bible_verse_from=1,
+            bible_verse_to=16,
+            question_text="What does Psalm 119:1-16 commend?",
+            options=[OptionDraft(text="Walking in the law", is_correct=True), OptionDraft(text="Riches", is_correct=False)],
+            explanation="Psalm 119 exalts God's word.",
+            category="passage_exegesis",
+            created_by=author.id,
+            fallback_locale="en",
+        )
+        db.commit()
+        db.refresh(q)
+        assert (q.bible_verse_from, q.bible_verse_to) == (1, 16)
+
+
+# ---------------------------------------------------------------------------
 # Streak math
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_daily_challenge_service.py
+++ b/backend/tests/test_daily_challenge_service.py
@@ -192,7 +192,10 @@ class TestNormalizeVerseRange:
             bible_verse_from=None,
             bible_verse_to=16,  # dangling end, no start — the bug case
             question_text="What did Jonah do when called to Nineveh?",
-            options=[OptionDraft(text="Fled to Tarshish", is_correct=True), OptionDraft(text="Obeyed", is_correct=False)],
+            options=[
+                OptionDraft(text="Fled to Tarshish", is_correct=True),
+                OptionDraft(text="Obeyed", is_correct=False),
+            ],
             explanation="Jonah 1 — he fled toward Tarshish.",
             category="narrative_meaning",
             created_by=author.id,
@@ -214,7 +217,10 @@ class TestNormalizeVerseRange:
             bible_verse_from=1,
             bible_verse_to=16,
             question_text="What does Psalm 119:1-16 commend?",
-            options=[OptionDraft(text="Walking in the law", is_correct=True), OptionDraft(text="Riches", is_correct=False)],
+            options=[
+                OptionDraft(text="Walking in the law", is_correct=True),
+                OptionDraft(text="Riches", is_correct=False),
+            ],
             explanation="Psalm 119 exalts God's word.",
             category="passage_exegesis",
             created_by=author.id,


### PR DESCRIPTION
fix(daily-challenge): keep generated verse range CHECK-safe (verse_to never dangles)

The full-year Daily-Challenge bank fill lost ~27% of whole-chapter passages
(57/210) to a silent `daily_challenge_questions_check` CHECK violation:

  verse_to IS NULL OR (verse_from IS NOT NULL AND verse_to >= verse_from)

For whole-chapter passages (verse_from/to = None) the LLM survivor sometimes
returns a `verse_end` with no `verse_start` (or a reversed/zero range). The
orchestrator passed those straight through (`survivor["verse_start"|"verse_end"]`
→ `create_question`), so the INSERT was rejected and the question dropped. The
SAME bug hits the daily replenish cron — on such days it generated nothing and
fell back to recycling an old question.

Fix: normalise the (from, to) pair at the persistence chokepoint
`create_question` via `_normalize_verse_range`, alongside the existing
service-level invariants:
- dangling end (from=None, to=N) -> (None, None) whole-chapter
- reversed range (to < from)     -> (from, None)
- non-positive / non-int values  -> dropped
This guarantees all three verse CHECKs hold on every path (orchestrator + cron
+ admin), so generated questions are never silently lost again.

Tests: `TestNormalizeVerseRange` — 8 parametrized cases + 2 integration tests
through `create_question` (the model mirrors the prod CHECK, so SQLite enforces
it; the dangling-end case raised IntegrityError before this fix). No migration
(the CHECK already exists in prod + the model).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
