### PR TITLE
feat(ui): card progress, recently-viewed, route focus + memoization/empty-state cleanup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react"
+import { lazy, Suspense, useEffect, useRef } from "react"
 import { BrowserRouter, Route, Navigate, useLocation } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { Routes } from "@datadog/browser-rum-react/react-router-v6"
@@ -55,6 +55,29 @@ const DailyChallengeArchivePage = lazy(() => import("./pages/DailyChallengeArchi
 const DailyChallengeReviewPage = lazy(() => import("./pages/Admin/dailyChallenge/DailyChallengeReviewPage"))
 const DailyChallengeReviewDetailPage = lazy(() => import("./pages/Admin/dailyChallenge/DailyChallengeReviewDetailPage"))
 
+/**
+ * a11y: after a client-side route change, move keyboard / screen-reader
+ * focus to the ``#main-content`` landmark so the next Tab starts inside
+ * the freshly-rendered page instead of wherever the clicked link left
+ * it (often back at the top of the persistent Header). The initial mount
+ * is skipped — a hard page load already lands focus at the document
+ * start, and stealing it on first paint would fight the skip-link and
+ * any autofocused field. ``preventScroll`` so focusing the landmark
+ * doesn't yank the viewport; ``ScrollToTop`` owns scroll position.
+ */
+function useRouteFocus() {
+  const { pathname } = useLocation()
+  const isInitialMount = useRef(true)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    const main = document.getElementById("main-content")
+    main?.focus({ preventScroll: true })
+  }, [pathname])
+}
+
 type RouteMode = "private" | "public" | "teacher" | "admin"
 
 function Gate({ mode, children }: { mode: RouteMode; children: React.ReactNode }) {
@@ -82,6 +105,7 @@ function AppRoutes() {
   const isAuthPage = AUTH_PATHS.some((p) => location.pathname.startsWith(p))
   usePageTitle()
   useLocaleSync()
+  useRouteFocus()
   // Grand tour lives here so it has access to React Router (for
   // programmatic navigation between steps) and AuthContext (for the
   // role gate). Mounts after auth is resolved; the hook itself gates

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -5,7 +5,7 @@ import { motion, useReducedMotion } from "motion/react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import type { Course } from "@/types"
-import { BookOpen, ArrowRight } from "lucide-react"
+import { BookOpen, ArrowRight, CheckCircle } from "lucide-react"
 import { toProxyImage } from "@/lib/images"
 import { formatDate } from "@/i18n/format"
 import { EDITORIAL_EASE } from "@/lib/motion"
@@ -13,6 +13,14 @@ import { EDITORIAL_EASE } from "@/lib/motion"
 interface CourseCardProps {
   course: Course
   style?: React.CSSProperties
+  /**
+   * Completion percent (0–100) for an ENROLLED student, surfaced as a
+   * thin progress bar in the card footer. ``undefined`` / ``null`` means
+   * the viewer isn't enrolled (or progress is unknown) and no bar shows.
+   * Passed down from the catalog page off a single ``getMyCourses``
+   * lookup — never fetched per-card.
+   */
+  progress?: number | null
 }
 
 type EnrollmentState = "opens" | "closed" | "open" | null
@@ -52,12 +60,15 @@ function EnrollmentBadge({ start, end }: { start?: string | null; end?: string |
   )
 }
 
-function CourseCard({ course, style }: CourseCardProps) {
+function CourseCard({ course, style, progress }: CourseCardProps) {
   const { t } = useTranslation()
   const prefersReducedMotion = useReducedMotion()
   const [imgError, setImgError] = useState(false)
   const coverSrc = toProxyImage(course.image_url)
   const moduleCount = course.modules?.length ?? 0
+  const isEnrolled = typeof progress === "number"
+  const progressPct = isEnrolled ? Math.max(0, Math.min(100, Math.round(progress!))) : 0
+  const isComplete = isEnrolled && progressPct >= 100
 
   const cardInner = (
     <Card className="flex h-full flex-col overflow-hidden border-edge/60 transition-colors hover:border-brand/40">
@@ -107,6 +118,32 @@ function CourseCard({ course, style }: CourseCardProps) {
           />
         </span>
       </CardContent>
+      {isEnrolled && (
+        <div className="px-6 pb-4 pt-0">
+          <div className="mb-1 flex items-center justify-between text-[11px] font-medium text-ink-muted">
+            <span className="inline-flex items-center gap-1">
+              {isComplete && (
+                <CheckCircle className="h-3.5 w-3.5 text-success" strokeWidth={1.75} aria-hidden />
+              )}
+              {isComplete ? t("courseCard.completed") : t("courseCard.inProgress")}
+            </span>
+            <span className="tabular-nums">{progressPct}%</span>
+          </div>
+          <div
+            className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+            role="progressbar"
+            aria-valuenow={progressPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={t("courseCard.progressLabel", { percent: progressPct })}
+          >
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${isComplete ? "bg-success" : "bg-brand"}`}
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        </div>
+      )}
     </Card>
   )
 

--- a/frontend/src/components/dashboard/RecentlyViewedRow.tsx
+++ b/frontend/src/components/dashboard/RecentlyViewedRow.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+import { History, BookOpen } from "lucide-react"
+import { coursesService } from "@/services/courses"
+import { useAsyncData } from "@/hooks/useAsyncData"
+import { useAuth } from "@/context/useAuth"
+import { getRecentCourses } from "@/lib/recentlyViewed"
+import type { Enrollment } from "@/types"
+
+/**
+ * "Recently viewed" — a compact horizontal row of the last few courses
+ * the student opened (tracked in localStorage by ``recordCourseView``).
+ *
+ * The localStorage list is just opaque course IDs; we intersect it with
+ * the user's real enrollments (``getMyCourses``, the same 1-min-cached
+ * call ``MyCoursesSection`` already makes, so no extra round-trip on a
+ * normal dashboard load) to (a) resolve titles and (b) drop stale IDs
+ * for courses the student no longer has access to. Renders nothing when
+ * the intersection is empty, so a brand-new user never sees an empty
+ * shell.
+ */
+export function RecentlyViewedRow() {
+  const { t, i18n } = useTranslation()
+  const { user } = useAuth()
+  const { data: enrollments } = useAsyncData<Enrollment[]>(
+    async () => (user ? coursesService.getMyCourses().catch(() => []) : []),
+    [user?.id, i18n.language],
+  )
+
+  const recent = useMemo(() => {
+    const byId = new Map<string, Enrollment>()
+    for (const e of enrollments ?? []) {
+      if (e.course?.id) byId.set(e.course.id, e)
+    }
+    return getRecentCourses()
+      .map((r) => byId.get(r.id))
+      .filter((e): e is Enrollment => !!e)
+      .slice(0, 5)
+  }, [enrollments])
+
+  if (recent.length === 0) return null
+
+  return (
+    <section aria-labelledby="recently-viewed-heading" className="animate-fade-in">
+      <div className="mb-2 flex items-center gap-2">
+        <History className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
+        <h2
+          id="recently-viewed-heading"
+          className="font-serif text-sm font-semibold tracking-tight text-ink"
+        >
+          {t("dashboard.recentlyViewed")}
+        </h2>
+      </div>
+      <ul className="flex gap-2.5 overflow-x-auto pb-1">
+        {recent.map((enrollment) => {
+          const course = enrollment.course!
+          return (
+            <li key={course.id} className="shrink-0">
+              <Link
+                to={`/courses/${course.id}`}
+                className="group flex w-44 items-center gap-2 rounded-md border border-edge bg-card px-3 py-2 transition-colors hover:border-brand/30 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-brand/10 text-brand">
+                  <BookOpen className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+                </span>
+                <span className="min-w-0 flex-1 truncate font-serif text-xs font-medium leading-tight text-ink transition-colors group-hover:text-brand">
+                  {course.title || t("dashboard.course")}
+                </span>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -123,6 +123,7 @@
     "course": "Course",
     "grade": "Grade: {{grade}}",
     "browseAllCta": "Browse all courses",
+    "recentlyViewed": "Recently viewed",
     "votd": {
       "eyebrow": "Today",
       "title": "Verse of the Day"
@@ -664,7 +665,10 @@
     "byInvitation": "By invitation",
     "openCourse": "Open",
     "modulesLabel_one": "{{count}} module",
-    "modulesLabel_other": "{{count}} modules"
+    "modulesLabel_other": "{{count}} modules",
+    "inProgress": "In progress",
+    "completed": "Completed",
+    "progressLabel": "{{percent}}% complete"
   },
   "pageTitle": {
     "login": "Sign In",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -243,7 +243,10 @@
     "modulesLabel_one": "{{count}} модуль",
     "modulesLabel_few": "{{count}} модуля",
     "modulesLabel_many": "{{count}} модулей",
-    "modulesLabel_other": "{{count}} модуля"
+    "modulesLabel_other": "{{count}} модуля",
+    "inProgress": "В процессе",
+    "completed": "Завершён",
+    "progressLabel": "Пройдено {{percent}}%"
   },
   "pageTitle": {
     "login": "Вход",
@@ -1786,6 +1789,7 @@
     "course": "Курс",
     "grade": "Оценка: {{grade}}",
     "browseAllCta": "Открыть каталог",
+    "recentlyViewed": "Недавно открытые",
     "votd": {
       "eyebrow": "Сегодня",
       "title": "Стих дня"

--- a/frontend/src/lib/__tests__/recentlyViewed.test.ts
+++ b/frontend/src/lib/__tests__/recentlyViewed.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { getRecentCourses, recordCourseView } from "../recentlyViewed"
+
+describe("recentlyViewed", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("returns an empty list when nothing has been viewed", () => {
+    expect(getRecentCourses()).toEqual([])
+  })
+
+  it("records a course view and reads it back", () => {
+    recordCourseView("course-a")
+    const recent = getRecentCourses()
+    expect(recent).toHaveLength(1)
+    const first = recent[0]!
+    expect(first.id).toBe("course-a")
+    expect(typeof first.ts).toBe("number")
+  })
+
+  it("orders most-recently-viewed first", () => {
+    recordCourseView("course-a")
+    recordCourseView("course-b")
+    recordCourseView("course-c")
+    expect(getRecentCourses().map((r) => r.id)).toEqual(["course-c", "course-b", "course-a"])
+  })
+
+  it("de-duplicates and moves a re-viewed course to the front", () => {
+    recordCourseView("course-a")
+    recordCourseView("course-b")
+    recordCourseView("course-a")
+    const ids = getRecentCourses().map((r) => r.id)
+    expect(ids).toEqual(["course-a", "course-b"])
+    expect(ids).toHaveLength(2)
+  })
+
+  it("caps the list at 5 entries", () => {
+    for (let i = 0; i < 8; i++) {
+      recordCourseView(`course-${i}`)
+    }
+    const recent = getRecentCourses()
+    expect(recent).toHaveLength(5)
+    // The five most recent (3..7), newest first.
+    expect(recent.map((r) => r.id)).toEqual([
+      "course-7",
+      "course-6",
+      "course-5",
+      "course-4",
+      "course-3",
+    ])
+  })
+
+  it("ignores empty ids", () => {
+    recordCourseView("")
+    expect(getRecentCourses()).toEqual([])
+  })
+
+  it("tolerates corrupt storage and returns an empty list", () => {
+    window.localStorage.setItem("equip.recently-viewed.courses", "not-json{")
+    expect(getRecentCourses()).toEqual([])
+  })
+
+  it("drops malformed entries when reading", () => {
+    window.localStorage.setItem(
+      "equip.recently-viewed.courses",
+      JSON.stringify([{ id: "good", ts: 123 }, { id: 42 }, "garbage", { ts: 1 }]),
+    )
+    expect(getRecentCourses().map((r) => r.id)).toEqual(["good"])
+  })
+})

--- a/frontend/src/lib/recentlyViewed.ts
+++ b/frontend/src/lib/recentlyViewed.ts
@@ -1,0 +1,68 @@
+/**
+ * "Recently viewed courses" — a tiny localStorage-backed MRU list of the
+ * last few course IDs a student opened, used to render a quick-return row
+ * on the dashboard. Pure frontend: no backend, no PII (just course IDs +
+ * timestamps). Stale / no-longer-enrolled IDs are filtered out at render
+ * time against the user's known courses, so a deleted or unenrolled
+ * course silently drops off.
+ *
+ * Not user-scoped on purpose: course IDs are opaque UUIDs that carry no
+ * personal data, and the dashboard always intersects this list with the
+ * signed-in user's actual enrollments before showing anything — so a
+ * shared device never leaks one account's course list into another's row.
+ */
+
+const STORAGE_KEY = "equip.recently-viewed.courses"
+const MAX_ENTRIES = 5
+
+export interface RecentCourse {
+  id: string
+  /** Epoch millis of the most recent open. */
+  ts: number
+}
+
+function read(): RecentCourse[] {
+  if (typeof window === "undefined") return []
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .filter(
+        (e): e is RecentCourse =>
+          !!e &&
+          typeof e === "object" &&
+          typeof (e as RecentCourse).id === "string" &&
+          typeof (e as RecentCourse).ts === "number",
+      )
+      .sort((a, b) => b.ts - a.ts)
+      .slice(0, MAX_ENTRIES)
+  } catch {
+    // Corrupt JSON or denied storage (private browsing): treat as empty.
+    return []
+  }
+}
+
+/** The most-recent-first list of recently opened course IDs. */
+export function getRecentCourses(): RecentCourse[] {
+  return read()
+}
+
+/**
+ * Record a course open. Moves the id to the front (de-duplicating), caps
+ * the list at ``MAX_ENTRIES``, and is a no-op when storage is unavailable.
+ * Safe to call from any course/chapter mount.
+ */
+export function recordCourseView(courseId: string): void {
+  if (typeof window === "undefined") return
+  if (!courseId) return
+  try {
+    const now = Date.now()
+    const existing = read().filter((e) => e.id !== courseId)
+    const next = [{ id: courseId, ts: now }, ...existing].slice(0, MAX_ENTRIES)
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // localStorage can be denied / full; recently-viewed is best-effort.
+  }
+}

--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -37,6 +37,7 @@ import {
 import { ErrorState } from "@/components/patterns"
 import { useUserTour } from "@/hooks/useUserTour"
 import { chapterViewSteps } from "@/lib/tourSteps"
+import { recordCourseView } from "@/lib/recentlyViewed"
 
 /**
  * Renders a sanitised text-block via ``dangerouslySetInnerHTML`` and
@@ -451,6 +452,15 @@ export default function ChapterView() {
     // title + chapter list. ``t`` is intentionally not a dep.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courseId, moduleId, user?.id, i18n.language])
+
+  // Studying a chapter counts as opening the course for the dashboard's
+  // "recently viewed" row. Signed-in only; filtered against real
+  // enrollments at render time.
+  useEffect(() => {
+    if (user && courseId) {
+      recordCourseView(courseId)
+    }
+  }, [user, courseId])
 
   const sortedChapters = useMemo(
     () => [...(mod?.chapters ?? [])].sort((a, b) => a.order_index - b.order_index),

--- a/frontend/src/pages/Course/CourseDetail.tsx
+++ b/frontend/src/pages/Course/CourseDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useParams, Link } from "react-router-dom"
 import { BookOpen } from "lucide-react"
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { ErrorState } from "@/components/patterns"
 import { coursesService } from "@/services/courses"
 import { storageService } from "@/services/storage"
+import { recordCourseView } from "@/lib/recentlyViewed"
 import { useAuth } from "@/context/useAuth"
 import { toast } from "@/lib/toast"
 import { ROLES } from "@/types"
@@ -121,6 +122,16 @@ export default function CourseDetail() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, user?.id, i18n.language])
 
+  // Track this course in the dashboard's "recently viewed" row. Only for
+  // signed-in users (anonymous visitors don't have a dashboard) and only
+  // once the course actually resolved, so a 404 / failed load doesn't
+  // pin a dead id. Filtered against real enrollments at render time.
+  useEffect(() => {
+    if (user && course?.id) {
+      recordCourseView(course.id)
+    }
+  }, [user, course?.id])
+
   const doEnroll = async (cohortId?: string) => {
     if (!id || !user) return
     setEnrolling(true)
@@ -145,6 +156,26 @@ export default function CourseDetail() {
     }
   }
 
+  // Derived module ordering + chapter count, memoised on ``course`` so
+  // EnrolledView receives stable array/scalar identities across renders
+  // that don't change the course payload (e.g. a certificate update).
+  // Hooks must run before the early returns below — they no-op to safe
+  // defaults while ``course`` is still null during load.
+  const sortedModules = useMemo(
+    () =>
+      [...(course?.modules ?? [])].sort((a, b) => {
+        const da = a.due_date ? new Date(a.due_date).getTime() : Infinity
+        const db = b.due_date ? new Date(b.due_date).getTime() : Infinity
+        if (da !== db) return da - db
+        return a.order_index - b.order_index
+      }),
+    [course],
+  )
+  const totalChapters = useMemo(
+    () => sortedModules.reduce((sum, m) => sum + (m.chapters?.length ?? 0), 0),
+    [sortedModules],
+  )
+
   if (loading) {
     return <CourseDetailSkeleton />
   }
@@ -168,16 +199,6 @@ export default function CourseDetail() {
   }
 
   const isOwner = user?.id === course.created_by || user?.role === ROLES.ADMIN
-  const sortedModules = [...(course.modules ?? [])].sort((a, b) => {
-    const da = a.due_date ? new Date(a.due_date).getTime() : Infinity
-    const db = b.due_date ? new Date(b.due_date).getTime() : Infinity
-    if (da !== db) return da - db
-    return a.order_index - b.order_index
-  })
-  const totalChapters = sortedModules.reduce(
-    (sum, m) => sum + (m.chapters?.length ?? 0),
-    0,
-  )
 
   if (!enrollment) {
     return (

--- a/frontend/src/pages/Course/ModuleView.tsx
+++ b/frontend/src/pages/Course/ModuleView.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useParams, Link } from "react-router-dom"
 import { formatDateLong } from "@/i18n/format"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { coursesService } from "@/services/courses"
 import { useAuth } from "@/context/useAuth"
@@ -20,7 +20,7 @@ import {
 } from "lucide-react"
 import { isGradableChapterType } from "@/lib/chapterTypes"
 import ChapterTypeBadge from "@/components/course/ChapterTypeBadge"
-import { ErrorState } from "@/components/patterns"
+import { EmptyState, ErrorState } from "@/components/patterns"
 import { Skeleton } from "@/components/ui/skeleton"
 
 // Module ID + course ID come from the route, locale from i18n; bundle the
@@ -265,11 +265,10 @@ export default function ModuleView() {
             })}
           </div>
         ) : (
-          <Card className="border-dashed">
-            <CardContent className="py-12 text-center text-ink-muted text-sm">
-              {t("module.noChaptersYet")}
-            </CardContent>
-          </Card>
+          <EmptyState
+            icon={<Book strokeWidth={1.75} aria-hidden />}
+            title={t("module.noChaptersYet")}
+          />
         )}
       </div>
 

--- a/frontend/src/pages/Course/detail/ModuleList.tsx
+++ b/frontend/src/pages/Course/detail/ModuleList.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import {
@@ -69,7 +70,7 @@ interface ModuleRowProps {
   completedChapterIds: Set<string>
 }
 
-function ModuleRow({
+const ModuleRow = memo(function ModuleRow({
   courseId,
   module,
   idx,
@@ -179,4 +180,4 @@ function ModuleRow({
       </CardHeader>
     </Card>
   )
-}
+})

--- a/frontend/src/pages/Courses/CoursesPage.tsx
+++ b/frontend/src/pages/Courses/CoursesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { Input } from "@/components/ui/input"
@@ -49,6 +49,22 @@ export default function CoursesPage() {
     // its reference-change behaviour is implementation-defined.
     [query, reloadKey, i18n.language],
   )
+  // Enrollment progress for the signed-in viewer, so each catalog card
+  // can show a completion bar for courses they're enrolled in. ONE call
+  // to the (1-min cached, shared) ``getMyCourses`` endpoint — not a
+  // per-card fetch. Anonymous users skip it entirely and see plain
+  // cards. A failure degrades silently to "no bars".
+  const { data: myEnrollments } = useAsyncData(
+    async () => (user ? coursesService.getMyCourses().catch(() => []) : []),
+    [user?.id],
+  )
+  const progressByCourseId = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const e of myEnrollments ?? []) {
+      if (e.course_id) map.set(e.course_id, e.progress)
+    }
+    return map
+  }, [myEnrollments])
   // Token-key error so a locale flip while the error is on screen
   // updates the message without a refetch.
   const error: string | null = fetchError ? t("courses.loadFailed") : null
@@ -164,7 +180,12 @@ export default function CoursesPage() {
       ) : (
         <div data-tour="catalog-grid" className="stagger-fade-in grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-7 lg:grid-cols-3">
           {courses.map((course, index) => (
-            <CourseCard key={course.id} course={course} style={{ "--stagger-index": index } as React.CSSProperties} />
+            <CourseCard
+              key={course.id}
+              course={course}
+              progress={progressByCourseId.get(course.id)}
+              style={{ "--stagger-index": index } as React.CSSProperties}
+            />
           ))}
         </div>
       )}

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -13,6 +13,7 @@ import { VerseOfTheDayCard } from "@/components/home/VerseOfTheDayCard"
 import { DailyChallengeCard } from "@/components/dashboard/DailyChallengeCard"
 import { TodayCard } from "@/components/dashboard/TodayCard"
 import { WelcomeCard } from "@/components/dashboard/WelcomeCard"
+import { RecentlyViewedRow } from "@/components/dashboard/RecentlyViewedRow"
 import { useUserTour } from "@/hooks/useUserTour"
 import { studentDashboardSteps } from "@/lib/tourSteps"
 import { firstNameOf } from "@/lib/names"
@@ -280,7 +281,17 @@ export default function DashboardPage() {
   return (
     <div className="container mx-auto h-full px-4 py-4 sm:py-6 lg:h-[calc(100dvh-3rem-3rem)]">
       <div className="grid h-full grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:gap-5">
-        <MyCoursesSection onTourStart={startTour} />
+        {/* Left column: an optional "recently viewed" strip (renders
+            nothing when empty, so it costs no vertical space for new
+            users) above the scrollable My Courses panel. ``min-h-0``
+            lets My Courses keep its own internal scroll within the
+            single-viewport grid. */}
+        <div className="flex min-h-0 flex-col gap-4 lg:gap-5">
+          <RecentlyViewedRow />
+          <div className="min-h-0 flex-1">
+            <MyCoursesSection onTourStart={startTour} />
+          </div>
+        </div>
         {/* Right rail on lg+ as ``[auto auto minmax(0,1fr)]``. Verse and
             Today are light, bounded cards (a single verse; at most three
             events) so they take exactly their content height (``auto``)

--- a/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
@@ -134,7 +134,7 @@ export function GradeTableTab({
 const STICKY_COL_SHADOW =
   "after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-2 after:-mr-2 after:bg-gradient-to-r after:from-foreground/[0.06] after:to-transparent"
 
-function GradeTableHead({
+const GradeTableHead = memo(function GradeTableHead({
   orderedModules,
   moduleChapterMap,
   allChapters,
@@ -190,7 +190,7 @@ function GradeTableHead({
       </tr>
     </thead>
   )
-}
+})
 
 interface GradeTableRowProps {
   student: StudentProgressData


### PR DESCRIPTION
Five small, additive, behavior-safe frontend improvements. All changes follow existing patterns (semantic tokens, lucide 1.75, EmptyState, useAsyncData, localStorage helpers).

## What's in here

- **#71 — course-card progress.** Catalog `CourseCard` now shows a thin completion bar for **enrolled** courses only (green + checkmark at 100%, brand color otherwise). Progress comes from a single `getMyCourses()` lookup on `CoursesPage` (the same 1-min-cached endpoint the dashboard uses) and is passed down per-card — **no per-card fetch / no N+1**. Anonymous viewers see plain cards. Bar has `role="progressbar"` + aria values.
- **#72 — recently viewed.** A compact "Recently viewed" course row on the student dashboard, backed by a new `localStorage` MRU helper (`recordCourseView` / `getRecentCourses`, capped at 5, de-duped, corruption-tolerant). Written on course **and** chapter open. The list is intersected with the user's real enrollments at render time, so stale / no-longer-accessible course ids drop off automatically. Hidden entirely when empty. Pure frontend, no backend.
- **#68 — route focus.** Added a `useRouteFocus()` hook in `App.tsx` that moves focus to the existing `<main id="main-content" tabIndex={-1}>` landmark after each client-side navigation (skips initial mount; `preventScroll` so `ScrollToTop` still owns scroll). Improves keyboard / screen-reader flow.
- **#203 — memoization (behavior-neutral).** `GradeTableHead` and `ModuleRow` wrapped in `React.memo`; `CourseDetail` now `useMemo`s the derived sorted module list + chapter count passed to `EnrolledView` so they keep stable identity across unrelated re-renders. (`GradeTableRow` / `SummaryTab` were already memo'd — untouched.)
- **#200 — empty-state consistency.** Replaced the last hand-rolled inline `<Card border-dashed>` empty state in `ModuleView` with the design-system `<EmptyState>` component.

## New i18n keys (added to both en.json + ru.json)

- `courseCard.inProgress`, `courseCard.completed`, `courseCard.progressLabel`
- `dashboard.recentlyViewed`

`npm run i18n:check` → locale bundles in parity.

## Tests / gates

Added `recentlyViewed.test.ts` (8 cases: ordering, de-dup, 5-cap, empty-id, corrupt-storage, malformed-entry filtering).

All frontend gates green locally (tests run with CI placeholder Supabase env):
- `npm run lint` — clean (max-warnings 0)
- `npx tsc --noEmit` — clean
- `npm run build` — all chunks within budget
- `npm run test:run` — 73 files / 551 tests pass
- `npm run i18n:check` — parity

Closes #203
Closes #200
Closes #68
Closes #71
Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
