### PR TITLE
refactor(api): extract get_live_course_or_404 + lookup_enrollment (dedup, #205)

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -134,6 +134,37 @@ def is_owner_or_admin(entity: object, user: User | None) -> bool:
 from app.services.domain_access import assert_course_owner  # noqa: E402, F401  (re-export)
 
 
+def get_live_course_or_404(db: Session, course_id: str) -> Course:
+    """Fetch a non-deleted course or raise the canonical 404.
+
+    Consolidates the course-fetch-or-404 boilerplate that several route
+    modules duplicated. The error envelope (code / status / message /
+    context) is byte-identical to those hand-written call sites so the
+    HTTP contract is unchanged. Soft-deleted courses (``deleted_at``)
+    are treated as not found.
+    """
+    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
+    if course is None:
+        raise equip_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Course not found",
+            context={"resource_type": "course", "resource_id": course_id},
+        )
+    return course
+
+
+def lookup_enrollment(db: Session, user_id: object, course_id: object) -> Enrollment | None:
+    """Return the enrollment row for ``(user_id, course_id)`` or ``None``.
+
+    Pure query helper: it deliberately does NOT raise. Each call site keeps
+    its own ``if not enrolled: raise ...`` because the not-enrolled contract
+    varies per endpoint (403 vs 400 vs 404, with different messages / staff
+    bypasses). One indexed PK lookup on ``(user_id, course_id)``.
+    """
+    return db.query(Enrollment).filter(Enrollment.user_id == user_id, Enrollment.course_id == course_id).first()
+
+
 def verify_course_owner(
     db: Session,
     course_id: str,

--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import (
     get_current_user,
+    lookup_enrollment,
     require_teacher,
     resolve_chapter_course_id,
     verify_chapter_access,
@@ -18,7 +19,6 @@ from app.core.metrics import increment
 from app.models.assignment import Assignment, AssignmentSubmission
 from app.models.chapter_progress import ChapterProgress
 from app.models.course import Chapter, Course, Module
-from app.models.enrollment import Enrollment
 from app.models.user import User, UserRole
 from app.schemas.assignment import (
     AssignmentCreate,
@@ -267,9 +267,7 @@ def submit_assignment(
         )
 
     course_id = resolve_chapter_course_id(db, assignment.chapter_id)
-    enrolled = (
-        db.query(Enrollment).filter(Enrollment.user_id == current_user.id, Enrollment.course_id == course_id).first()
-    )
+    enrolled = lookup_enrollment(db, current_user.id, course_id)
     if not enrolled:
         raise equip_error(
             ErrorCode.AUTH_FORBIDDEN,
@@ -387,9 +385,7 @@ def list_my_submissions(
         )
 
     course_id = resolve_chapter_course_id(db, assignment.chapter_id)
-    enrolled = (
-        db.query(Enrollment).filter(Enrollment.user_id == current_user.id, Enrollment.course_id == course_id).first()
-    )
+    enrolled = lookup_enrollment(db, current_user.id, course_id)
     if not enrolled and current_user.role not in (UserRole.TEACHER.value, UserRole.ADMIN.value):
         raise equip_error(
             ErrorCode.AUTH_FORBIDDEN,

--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -4,12 +4,17 @@ from fastapi import APIRouter, Depends, Header, Path, Query, Request, Response, 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_current_user, require_admin, require_teacher
+from app.api.dependencies import (
+    get_current_user,
+    get_live_course_or_404,
+    lookup_enrollment,
+    require_admin,
+    require_teacher,
+)
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.models.certificate import Certificate, CertificateStatus
 from app.models.course import Course
-from app.models.enrollment import Enrollment
 from app.models.user import User
 from app.schemas.certificate import CertificateResponse, CertificateVerifyResponse
 from app.schemas.locale import LocaleCode, normalize_locale
@@ -58,18 +63,9 @@ def request_certificate(
     certificate stays rejected and the student must re-request".
     """
     # Soft-deleted courses must not accept new certificate requests.
-    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
-    if not course:
-        raise equip_error(
-            ErrorCode.RESOURCE_NOT_FOUND,
-            status_code=status.HTTP_404_NOT_FOUND,
-            message="Course not found",
-            context={"resource_type": "course", "resource_id": course_id},
-        )
+    get_live_course_or_404(db, course_id)
 
-    enrollment = (
-        db.query(Enrollment).filter(Enrollment.user_id == current_user.id, Enrollment.course_id == course_id).first()
-    )
+    enrollment = lookup_enrollment(db, current_user.id, course_id)
     if not enrollment:
         raise equip_error(
             ErrorCode.VALIDATION_FAILED,

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -29,7 +29,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_optional_user, is_owner_or_admin, require_admin
+from app.api.dependencies import get_live_course_or_404, get_optional_user, is_owner_or_admin, require_admin
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.models.cohort import Cohort, CohortCourse, CohortStatus
@@ -185,15 +185,7 @@ def _get_or_404(db: Session, cohort_id: UUID) -> Cohort:
 
 
 def _course_or_404(db: Session, course_id: str) -> Course:
-    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
-    if not course:
-        raise equip_error(
-            ErrorCode.RESOURCE_NOT_FOUND,
-            status_code=status.HTTP_404_NOT_FOUND,
-            message="Course not found",
-            context={"resource_type": "course", "resource_id": course_id},
-        )
-    return course
+    return get_live_course_or_404(db, course_id)
 
 
 # ----------------------------- admin CRUD -----------------------------
@@ -808,14 +800,7 @@ def list_cohorts_for_course(
     owner or an admin. Cohort name is localized via the translation
     overlay just like the legacy endpoint did."""
     response.headers["Vary"] = "Accept-Language"
-    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
-    if not course:
-        raise equip_error(
-            ErrorCode.RESOURCE_NOT_FOUND,
-            status_code=status.HTTP_404_NOT_FOUND,
-            message="Course not found",
-            context={"resource_type": "course", "resource_id": course_id},
-        )
+    course = get_live_course_or_404(db, course_id)
     if course.status != CourseStatus.PUBLISHED and not is_owner_or_admin(course, current_user):
         # Unpublished course leaks 404 to non-owners by design so the
         # response is indistinguishable from a missing course id.

--- a/backend/app/api/v1/courses/enrollment.py
+++ b/backend/app/api/v1/courses/enrollment.py
@@ -6,7 +6,7 @@ from fastapi import Depends, Request, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_current_user
+from app.api.dependencies import get_current_user, lookup_enrollment
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.models.cohort import Cohort, CohortCourse
@@ -35,9 +35,7 @@ def get_enrollment_status(
     # Lightweight yes/no endpoint used by CourseDetail so the page does not have
     # to load the full ``/users/me/courses`` payload just to check whether the
     # viewer is enrolled. One indexed PK lookup on (user_id, course_id).
-    enrollment = (
-        db.query(Enrollment).filter(Enrollment.user_id == current_user.id, Enrollment.course_id == course_id).first()
-    )
+    enrollment = lookup_enrollment(db, current_user.id, course_id)
     if not enrollment:
         return {"enrolled": False, "enrollment": None}
     return {

--- a/backend/app/api/v1/grades.py
+++ b/backend/app/api/v1/grades.py
@@ -11,10 +11,15 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_current_user, require_teacher, verify_course_owner
+from app.api.dependencies import (
+    get_current_user,
+    get_live_course_or_404,
+    lookup_enrollment,
+    require_teacher,
+    verify_course_owner,
+)
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
-from app.models.course import Course
 from app.models.enrollment import Enrollment
 from app.models.student_grade import StudentGrade
 from app.models.user import User, UserRole
@@ -57,14 +62,7 @@ def get_grading_config(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
-    if not course:
-        raise equip_error(
-            ErrorCode.RESOURCE_NOT_FOUND,
-            status_code=status.HTTP_404_NOT_FOUND,
-            message="Course not found",
-            context={"resource_type": "course", "resource_id": course_id},
-        )
+    course = get_live_course_or_404(db, course_id)
 
     is_owner = str(course.created_by) == str(current_user.id)
     is_admin = current_user.role == UserRole.ADMIN.value
@@ -111,9 +109,7 @@ def get_calculated_grade(
 ):
     course = verify_course_owner(db, course_id, teacher)
 
-    enrolled = (
-        db.query(Enrollment).filter(Enrollment.user_id == str(student_id), Enrollment.course_id == course_id).first()
-    )
+    enrolled = lookup_enrollment(db, str(student_id), course_id)
     if not enrolled:
         raise equip_error(
             ErrorCode.RESOURCE_NOT_FOUND,
@@ -351,7 +347,7 @@ def upsert_student_grade(
 ) -> StudentGrade:
     verify_course_owner(db, course_id, teacher)
 
-    enrolled = db.query(Enrollment).filter(Enrollment.user_id == student_id, Enrollment.course_id == course_id).first()
+    enrolled = lookup_enrollment(db, student_id, course_id)
     if not enrolled:
         raise equip_error(
             ErrorCode.RESOURCE_NOT_FOUND,

--- a/backend/app/api/v1/prerequisites.py
+++ b/backend/app/api/v1/prerequisites.py
@@ -2,7 +2,12 @@ from fastapi import APIRouter, Depends, Header, Response, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_current_user, require_teacher, verify_course_owner
+from app.api.dependencies import (
+    get_current_user,
+    get_live_course_or_404,
+    require_teacher,
+    verify_course_owner,
+)
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.models.course import Course, CourseStatus
@@ -55,14 +60,7 @@ def get_prerequisites(
     # this endpoint was public and would happily leak draft-course
     # relationships to anonymous callers (audit P1.4). Trashed courses are
     # treated as not found so deleted prerequisites don't leak either.
-    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
-    if not course:
-        raise equip_error(
-            ErrorCode.RESOURCE_NOT_FOUND,
-            status_code=status.HTTP_404_NOT_FOUND,
-            message="Course not found",
-            context={"resource_type": "course", "resource_id": course_id},
-        )
+    course = get_live_course_or_404(db, course_id)
 
     is_admin = current_user.role == UserRole.ADMIN.value
     is_owner = str(course.created_by) == str(current_user.id)

--- a/backend/app/api/v1/progress.py
+++ b/backend/app/api/v1/progress.py
@@ -5,7 +5,13 @@ from fastapi import APIRouter, Depends, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_current_user, require_teacher, verify_chapter_owner, verify_course_owner
+from app.api.dependencies import (
+    get_current_user,
+    lookup_enrollment,
+    require_teacher,
+    verify_chapter_owner,
+    verify_course_owner,
+)
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.core.metrics import increment
@@ -29,9 +35,7 @@ def get_my_chapter_progress(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    enrolled = (
-        db.query(Enrollment).filter(Enrollment.user_id == current_user.id, Enrollment.course_id == course_id).first()
-    )
+    enrolled = lookup_enrollment(db, current_user.id, course_id)
     if not enrolled:
         raise equip_error(
             ErrorCode.AUTH_FORBIDDEN,

--- a/backend/app/api/v1/reviews.py
+++ b/backend/app/api/v1/reviews.py
@@ -4,12 +4,12 @@ from fastapi import APIRouter, Depends, Query, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_current_user
+from app.api.dependencies import get_current_user, get_live_course_or_404
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.core.metrics import gauge
 from app.models.certificate import Certificate
-from app.models.course import Course, CourseStatus
+from app.models.course import CourseStatus
 from app.models.review import CourseReview
 from app.models.user import User
 from app.schemas.review import ReviewCreate, ReviewResponse
@@ -24,8 +24,11 @@ def list_course_reviews(
     limit: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
 ):
-    course = db.query(Course).filter(Course.id == course_id, Course.deleted_at.is_(None)).first()
-    if not course or course.status != CourseStatus.PUBLISHED:
+    # ``get_live_course_or_404`` raises the canonical 404 for a missing /
+    # soft-deleted course; an unpublished course is masked behind the same
+    # 404 here so its existence does not leak to anonymous callers.
+    course = get_live_course_or_404(db, course_id)
+    if course.status != CourseStatus.PUBLISHED:
         raise equip_error(
             ErrorCode.RESOURCE_NOT_FOUND,
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/tests/test_api_dependencies.py
+++ b/backend/tests/test_api_dependencies.py
@@ -24,7 +24,7 @@ from fastapi import HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 
 from app.api import dependencies as deps
-from app.models.course import Chapter, CourseStatus, Module
+from app.models.course import Chapter, Course, CourseStatus, Module
 from app.models.enrollment import Enrollment
 from app.models.user import User, UserRole
 
@@ -530,3 +530,139 @@ class TestVerifyChapterOwner:
         with pytest.raises(HTTPException) as exc:
             deps.verify_chapter_owner(db, chapter_id, teacher)
         assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# get_live_course_or_404 — the dedup'd course-fetch-or-404 helper (#205)
+# ---------------------------------------------------------------------------
+
+
+class TestGetLiveCourseOr404:
+    """Consolidates the course-fetch-or-404 boilerplate that
+    certificates / cohorts / grades / prerequisites / reviews duplicated.
+    The 404 envelope must stay byte-identical to those hand-written
+    raises (code / status / message / context)."""
+
+    def test_returns_live_course(self, db: Session) -> None:
+        _seed_teacher(db)
+        course_id, _, _ = _seed_published_course_with_chapter(db, course_id="glc-1", owner=TEACHER_ID)
+        course = deps.get_live_course_or_404(db, course_id)
+        assert course.id == course_id
+
+    def test_unknown_course_raises_canonical_404(self, db: Session) -> None:
+        with pytest.raises(HTTPException) as exc:
+            deps.get_live_course_or_404(db, "missing-course")
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        # Byte-identical envelope to the migrated call sites.
+        assert exc.value.detail["code"] == "resource.not_found"
+        assert exc.value.detail["message"] == "Course not found"
+        assert exc.value.detail["context"] == {
+            "resource_type": "course",
+            "resource_id": "missing-course",
+        }
+
+    def test_soft_deleted_course_is_404(self, db: Session) -> None:
+        """A soft-deleted course is treated as missing — same as the
+        hand-written ``deleted_at.is_(None)`` filters it replaced."""
+        from datetime import UTC, datetime
+
+        _seed_teacher(db)
+        course_id, _, _ = _seed_published_course_with_chapter(db, course_id="glc-2", owner=TEACHER_ID)
+        db.query(Course).filter(Course.id == course_id).update({"deleted_at": datetime.now(UTC)})
+        db.commit()
+        with pytest.raises(HTTPException) as exc:
+            deps.get_live_course_or_404(db, course_id)
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# lookup_enrollment — the non-raising enrollment query helper (#205)
+# ---------------------------------------------------------------------------
+
+
+class TestLookupEnrollment:
+    """Pure query helper: returns the row or ``None`` and never raises.
+    Each call site keeps its own ``if not enrolled: raise ...`` because
+    the not-enrolled contract differs per endpoint (403 / 400 / 404)."""
+
+    def test_returns_enrollment_when_present(self, db: Session) -> None:
+        _seed_teacher(db)
+        student = _seed_student(db)
+        course_id, _, _ = _seed_published_course_with_chapter(db, course_id="le-1", owner=TEACHER_ID)
+        db.add(Enrollment(id=f"enr-{course_id}", user_id=student.id, course_id=course_id, progress=0))
+        db.commit()
+        row = deps.lookup_enrollment(db, student.id, course_id)
+        assert row is not None
+        assert str(row.course_id) == course_id
+        assert str(row.user_id) == str(student.id)
+
+    def test_returns_none_when_not_enrolled(self, db: Session) -> None:
+        _seed_teacher(db)
+        student = _seed_student(db)
+        course_id, _, _ = _seed_published_course_with_chapter(db, course_id="le-2", owner=TEACHER_ID)
+        assert deps.lookup_enrollment(db, student.id, course_id) is None
+
+
+# ---------------------------------------------------------------------------
+# #205 regression: migrated endpoints keep their ORIGINAL status codes.
+#
+# The helpers above are behavior-preserving only if each migrated route
+# still emits the SAME not-enrolled / not-found contract it did before
+# the dedup. These exercise the real wired-up routes (via the conftest
+# auth-override clients) and pin the divergent status codes that the
+# enrollment ``if not enrolled: raise`` blocks intentionally keep.
+# ---------------------------------------------------------------------------
+
+
+class TestMigratedEndpointContractsUnchanged:
+    def test_certificates_not_enrolled_still_400(
+        self,
+        db: Session,
+        student_client,
+    ) -> None:
+        """certificates.request_certificate keeps its 400 (VALIDATION_FAILED)
+        not-enrolled contract — NOT the helper's 404 / not a 403.
+
+        The ``student_client`` fixture already seeds the teacher + student,
+        so the course just needs an owner (TEACHER_ID)."""
+        course_id, _, _ = _seed_published_course_with_chapter(db, course_id="reg-cert", owner=TEACHER_ID)
+        resp = student_client.post(f"/api/v1/certificates/course/{course_id}")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.json()["detail"]["message"] == "Not enrolled in this course"
+
+    def test_progress_not_enrolled_still_403(
+        self,
+        db: Session,
+        student_client,
+    ) -> None:
+        """progress.get_my_chapter_progress keeps its 403 (AUTH_FORBIDDEN)
+        not-enrolled contract."""
+        course_id, _, _ = _seed_published_course_with_chapter(db, course_id="reg-prog", owner=TEACHER_ID)
+        resp = student_client.get(f"/api/v1/progress/course/{course_id}/my-progress")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.json()["detail"]["message"] == "Not enrolled in this course"
+
+    def test_assignment_submit_not_enrolled_still_403(
+        self,
+        db: Session,
+        student_client,
+    ) -> None:
+        """assignments.submit_assignment keeps its 403 (AUTH_FORBIDDEN)
+        not-enrolled contract with its endpoint-specific message — NOT the
+        helper's 404. (The grades enrollment-404 path binds a raw-string
+        UUID and is covered by the Postgres schema-smoke job, not SQLite.)"""
+        from app.models.assignment import Assignment
+
+        _course_id, _module_id, chapter_id = _seed_published_course_with_chapter(
+            db, course_id="reg-asg", owner=TEACHER_ID
+        )
+        assignment = Assignment(chapter_id=chapter_id, max_score=100)
+        db.add(assignment)
+        db.commit()
+        db.refresh(assignment)
+        resp = student_client.post(
+            f"/api/v1/assignments/{assignment.id}/submit",
+            json={"content": "my answer"},
+        )
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.json()["detail"]["message"] == "You must be enrolled in this course to submit assignments"


### PR DESCRIPTION
## What

Dedup the repeated course-fetch-or-404 and enrollment-lookup boilerplate into two helpers in `app/api/dependencies.py`, **without changing any HTTP error contract** (status codes / messages / error codes / context stay byte-identical per call site — this is a live pilot).

### New helpers

- **`get_live_course_or_404(db, course_id) -> Course`** — `Course.id == course_id, deleted_at.is_(None)`; on `None` raises the canonical `RESOURCE_NOT_FOUND` / `404` / `"Course not found"` / `{"resource_type": "course", "resource_id": course_id}` envelope.
- **`lookup_enrollment(db, user_id, course_id) -> Enrollment | None`** — pure, non-raising query helper. Each call site keeps its own `if not enrolled: raise ...` because the not-enrolled contract differs per endpoint (403 / 400 / 404).

## Sites migrated

**course-fetch-or-404 → `get_live_course_or_404`** (each verified byte-identical to the canonical envelope *before* migrating):

| Site | Note |
|---|---|
| `certificates.request_certificate` | also dropped now-unused `course` binding |
| `cohorts._course_or_404` | local helper now delegates |
| `cohorts.list_course_cohorts` (inline) | |
| `grades.get_grading_config` | |
| `prerequisites` (get prerequisites) | |
| `reviews.list_course_reviews` | helper does the fetch+404; the separate `status != PUBLISHED` → identical-404 masking branch is **kept** so unpublished-course existence still doesn't leak |

**enrollment query line → `lookup_enrollment`** (every `if not enrolled: raise ...` left exactly as-is):

`progress.get_my_chapter_progress` (403), `assignments.submit_assignment` (403) + `assignments.my-submissions` (403 w/ staff bypass), `certificates.request_certificate` (400), `grades.get_calculated_grade` (404) + `grades.upsert_student_grade` (404), `courses/enrollment.get_enrollment_status` (`{enrolled}` probe).

## Left untouched (on purpose)

- A `lookup_enrollment`-shaped `is_enrolled` boolean in `grades.get_grading_config` and three teacher-facing enrollment queries in `progress.py` — **not in the issue's enumerated site list**, so left alone to keep the change surgical.
- No raise blocks were touched anywhere — the divergent not-enrolled contracts are intentional and preserved.

## Tests

Added to `tests/test_api_dependencies.py`:
- `get_live_course_or_404`: returns live course / canonical-404 envelope assertion / soft-deleted-is-404.
- `lookup_enrollment`: returns row when present / `None` when absent.
- Regression: migrated endpoints keep their **original** status codes — certificates not-enrolled still **400**, progress not-enrolled still **403**, assignment-submit not-enrolled still **403** (with its endpoint-specific message). The grades enrollment-404 path binds a raw-string UUID that SQLite's bind processor rejects, so it's covered by the existing Postgres schema-smoke CI job rather than the in-memory suite — the 403/400 paths give equivalent regression coverage.

## Gates (local, Python 3.12 venv)

- `ruff check .` → All checks passed
- `ruff format . --check` → 266 files already formatted
- `mypy --config-file mypy.ini` → Success, no issues (153 files)
- `pytest tests/` → **1484 passed**

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
