### PR TITLE
fix(progress): gradebook matrix marks completed non-gradable chapters

### DIFF
--- a/backend/app/services/student_progress_service.py
+++ b/backend/app/services/student_progress_service.py
@@ -560,7 +560,12 @@ def build_course_gradebook_matrix(db: Session, course: Course, course_id: str) -
     quiz_map, assignment_map = _load_chapter_quizzes_and_assignments(db, chapter_ids)
     best_by_user_chapter, _attempts, _latest_quiz = _aggregate_quiz_results(db, quiz_map)
     subs_by_user_chapter, assignment_by_id_str, _latest_sub = _aggregate_assignment_submissions(db, assignment_map)
-    progress_by_user = _load_completed_progress(db, gradable_chapter_ids)
+    # The matrix renders a completion cell for EVERY chapter (reading/video/
+    # audio included), so load progress for all of them — the gradable subset
+    # is only the denominator of the chapters_completed/total_chapters counts.
+    # (Loading just gradable_chapter_ids here made every completed
+    # non-gradable chapter render as not-completed and undercount totals.)
+    progress_by_user = _load_completed_progress(db, chapter_ids)
 
     enrollments = (
         db.query(Enrollment, User)

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -1164,6 +1164,19 @@ class TestCourseStudentProgress:
         # quiz/assignment result), but NOT the top-level result arrays the
         # board's detail endpoint uses.
         course_id, _quiz_id, _asg_id, ch_quiz_id, ch_asg_id, ch_read_id = _seed_teacher_progress_dashboard(db)
+        # Complete the READING chapter too: the matrix must reflect completion
+        # of non-gradable chapters (regression: the matrix once loaded progress
+        # only for gradable chapters, so completed reading/video/audio chapters
+        # rendered as not-completed and the totals column undercounted).
+        db.add(
+            ChapterProgress(
+                user_id=STUDENT_ID,
+                chapter_id=ch_read_id,
+                completed=True,
+                completion_type="self",
+            )
+        )
+        db.commit()
         r = client.get(f"/api/v1/progress/course/{course_id}/gradebook")
         assert r.status_code == 200, r.text
         body = r.json()
@@ -1182,6 +1195,10 @@ class TestCourseStudentProgress:
         assert ch_infos[ch_quiz_id]["quiz_result"]["score"] == 9
         assert ch_infos[ch_asg_id]["assignment_result"]["status"] == "submitted"
         assert ch_infos[ch_read_id]["quiz_result"] is None
+        # Non-gradable completion shows in the matrix cell, and matches what
+        # the row-expand detail endpoint reports for the same chapter.
+        assert ch_infos[ch_read_id]["completed"] is True
+        assert ch_infos[ch_asg_id]["completed"] is True
 
     def test_gradebook_matrix_403_for_non_owner(self, client: TestClient, db: Session):
         _ensure_student(db)


### PR DESCRIPTION
## Why

The 2026-06-11 audit's recent-PR review found a real regression from #788, confirmed by in-memory repro: `build_course_gradebook_matrix` loaded completed progress only for **gradable** chapter ids while building cells for **all** chapters. Every completed reading/video/audio chapter rendered `completed: false`, and the teacher gradebook's earned/total column (`computeStudentTotals` in `GradeTableTab.tsx`) undercounted each student by 1 per completed non-gradable chapter. The row-expand detail path (`build_student_chapter_detail`) loads the full set, so the gradebook and the progress board disagreed about the same chapter.

## What

One-line fix: load `_load_completed_progress(db, chapter_ids)` (all chapters); `gradable_chapter_ids` stays the denominator for `chapters_completed`/`total_chapters`. Regression test seeds a completed reading chapter and asserts the matrix cell shows completed.

## Verify

Backend: ruff + format + mypy clean, 1494/1494 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
