### PR TITLE
fix(db): ship ck_courses_weights_sum_100 CHECK to prod (model drift)

### DIFF
--- a/supabase/migrations/20260611201000_add_courses_weights_sum_check.sql
+++ b/supabase/migrations/20260611201000_add_courses_weights_sum_check.sql
@@ -1,0 +1,17 @@
+-- Close a model↔prod CHECK drift found by the 2026-06-11 audit.
+--
+-- backend/app/models/course.py has declared
+--   CheckConstraint("quiz_weight + assignment_weight + participation_weight = 100",
+--                   name="ck_courses_weights_sum_100")
+-- since the grade-weights feature, so SQLite tests and the schema-smoke CI
+-- job enforce the invariant — but no migration ever shipped it to prod. The
+-- grade calculator divides by the sum assuming it is 100; the API's Pydantic
+-- validator enforces it on the write path, but a direct DB write (service
+-- script, MCP) could persist weights that break the math silently.
+--
+-- Prod data verified compliant before this migration: 12 courses, 0 rows
+-- where the three weights do not sum to 100.
+
+ALTER TABLE public.courses
+  ADD CONSTRAINT ck_courses_weights_sum_100
+  CHECK (quiz_weight + assignment_weight + participation_weight = 100);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -432,6 +432,7 @@ CREATE TABLE public.courses (
     source_locale character varying(8) DEFAULT 'ru'::character varying NOT NULL,
     access_mode text DEFAULT 'public'::text NOT NULL,
     CONSTRAINT chk_courses_status CHECK ((status = ANY (ARRAY['draft'::text, 'published'::text]))),
+    CONSTRAINT ck_courses_weights_sum_100 CHECK ((((quiz_weight + assignment_weight) + participation_weight) = 100)),
     CONSTRAINT courses_access_mode_check CHECK ((access_mode = ANY (ARRAY['public'::text, 'institute'::text]))),
     CONSTRAINT courses_source_locale_check CHECK (((source_locale)::text = ANY (ARRAY[('ru'::character varying)::text, ('en'::character varying)::text])))
 );


### PR DESCRIPTION
## Why

`backend/app/models/course.py` declares `ck_courses_weights_sum_100` (`quiz_weight + assignment_weight + participation_weight = 100`) but no migration ever shipped it — prod has only `chk_courses_status` / `courses_access_mode_check` / `courses_source_locale_check`. So the SQLite test DB and schema-smoke CI enforce an invariant prod does not, and a direct DB write could silently break `grade_calculator` math (it divides assuming the sum is 100). Found by the 2026-06-11 audit schema-mirror pass; adversarially verified.

## What

Migration `20260611201000` adds the CHECK with the model's exact name/expression; `schema.sql` updated in the same PR (will re-dump from prod post-apply to confirm zero drift). Prod data checked first: **12 courses, 0 violators**.

## Verify

Schema-replay + schema-smoke + rls-policy CI jobs run on this PR (schema path filter). Backend suite unaffected (model already declared the constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
