### PR TITLE
fix(observability): unblind two monitors + stop local logs firing prod alerts

### DIFF
--- a/backend/app/api/v1/internal_translation_worker.py
+++ b/backend/app/api/v1/internal_translation_worker.py
@@ -120,9 +120,17 @@ def _emit_queue_gauges(db: Session) -> None:
     """
     try:
         counts = get_queue_status(db)
+        processing = int(counts.get("processing", 0))
         gauge("equip.translation.queue_depth", float(counts.get("queued", 0) + counts.get("failed", 0)))
-        gauge("equip.translation.queue_processing", float(counts.get("processing", 0)))
+        gauge("equip.translation.queue_processing", float(processing))
         gauge("equip.translation.queue_failed_permanent", float(counts.get("failed_permanent", 0)))
+        if processing > 3:
+            # WARNING so it actually ships to Datadog (the in-process handler
+            # is WARNING+; the INFO gauge lines above only reach stdout). The
+            # "[Equip] Translation jobs stuck in processing" monitor watches
+            # this message — its previous form queried a custom metric that
+            # no pipeline ever produced, so it could never fire.
+            logger.warning("translation worker: %s jobs stuck in processing", processing)
     except Exception:
         return
 

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -106,13 +106,19 @@ def setup_logging() -> None:
     root.addHandler(handler)
 
     api_key = os.environ.get("DD_API_KEY")
-    if api_key:
+    dd_env = os.environ.get("DD_ENV")
+    # BOTH keys must be explicitly set. DD_ENV used to default to
+    # "production", which meant any machine with a User-scoped DD_API_KEY
+    # (e.g. the dev box) shipped local pytest ERRORs tagged env:production —
+    # they passed the prod error-spike monitor's filter and fired a false
+    # alert (observed 2026-06-11). Prod sets both vars in Vercel env.
+    if api_key and dd_env:
         version = (os.environ.get("VERCEL_GIT_COMMIT_SHA") or "dev")[:7]
         dd_handler = DatadogHTTPHandler(
             api_key=api_key,
             site=os.environ.get("DD_SITE", "datadoghq.com"),
             service=os.environ.get("DD_SERVICE", "equip-backend"),
-            env=os.environ.get("DD_ENV", "production"),
+            env=dd_env,
             version=version,
             vercel_region=os.environ.get("VERCEL_REGION", "unknown"),
         )

--- a/backend/app/services/daily_challenge/schedule.py
+++ b/backend/app/services/daily_challenge/schedule.py
@@ -78,7 +78,11 @@ def _autofill_today_schedule(db: Session, target_date: date) -> DailyChallengeSc
         return (
             db.query(DailyChallengeSchedule).filter(DailyChallengeSchedule.challenge_date == target_date).one_or_none()
         )
-    logger.info(
+    # WARNING, not info: the in-process Datadog handler ships WARNING+ only,
+    # and the "[Equip] Daily Challenge schedule ran dry" log monitor watches
+    # this exact message — at INFO it never reached Datadog and the monitor
+    # was permanently blind to the silent outage it exists to catch.
+    logger.warning(
         "daily_challenge: auto-filled schedule for %s from published pool (question %s)",
         target_date.isoformat(),
         question_id,

--- a/backend/tests/test_dd_logging.py
+++ b/backend/tests/test_dd_logging.py
@@ -150,8 +150,24 @@ def test_setup_logging_skips_dd_handler_when_key_missing(monkeypatch: pytest.Mon
 def test_setup_logging_installs_dd_handler_when_key_present(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DD_API_KEY", "x")
     monkeypatch.setenv("DD_SITE", "us5.datadoghq.com")
+    monkeypatch.setenv("DD_ENV", "production")
     setup_logging()
     root = logging.getLogger()
     dd_handlers = [h for h in root.handlers if isinstance(h, DatadogHTTPHandler)]
     assert len(dd_handlers) == 1
     assert dd_handlers[0].level == logging.WARNING
+
+
+def test_setup_logging_skips_dd_handler_without_explicit_dd_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DD_API_KEY alone must NOT activate shipping.
+
+    DD_ENV used to default to "production", so any machine with a
+    User-scoped DD_API_KEY (the dev box) shipped local pytest ERRORs that
+    matched the prod error-spike monitor's env:production filter and fired
+    a false alert (2026-06-11).
+    """
+    monkeypatch.setenv("DD_API_KEY", "x")
+    monkeypatch.delenv("DD_ENV", raising=False)
+    setup_logging()
+    root = logging.getLogger()
+    assert not any(isinstance(h, DatadogHTTPHandler) for h in root.handlers)


### PR DESCRIPTION
## Why

The audit found the two newest Datadog monitors **permanently blind** and a false-alert source, all confirmed against live Datadog:

1. **Local pytest fired the prod error-spike monitor** (today 15:13 UTC): `logging.py` defaulted `DD_ENV` to `"production"`, and this machine has a User-scoped `DD_API_KEY`, so local test ERRORs (`env:production`, `version:dev`, `host=vercel-unknown`) passed monitor 19730778's filter and emailed a false alert. All 20 of the last-24h "prod errors" were local test artifacts.
2. **DC ran-dry monitor (20391511)** watches `"auto-filled schedule"` — emitted at INFO, but the in-process handler ships WARNING+ and the Vercel drain delivers nothing → could never fire.
3. **Translation-stuck monitor (20393856)** queries `equip.translation.queue_processing` — a metric that does not exist (no logs-to-metrics rules in the org; the INFO gauge line never reaches Datadog). Sits in No Data with `notify_no_data=false` forever.

## What

- Datadog handler now requires **both** `DD_API_KEY` and explicit `DD_ENV` (prod sets both in Vercel env; dev box sets neither → no shipping at all). Regression test.
- `auto-filled schedule` log → WARNING (ships; monitor 20391511 starts working unchanged).
- Worker emits `translation worker: N jobs stuck in processing` WARNING when processing > 3; monitor 20393856 will be retargeted to this log line via the Datadog API after merge (same threshold semantics).

## Verify

Backend: ruff + format + mypy clean, 1495/1495 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
