### PR TITLE
fix(daily-challenge): reject orphaned questions on failed ticks + cap options at 6

### DIFF
--- a/backend/app/services/daily_challenge/admin.py
+++ b/backend/app/services/daily_challenge/admin.py
@@ -166,6 +166,13 @@ def create_question(
         raise ValueError(f"daily challenge question must have exactly one correct option, got {correct_count}")
     if len(options) < 2:
         raise ValueError("daily challenge question needs at least two options")
+    # Upper bound mirrors daily_challenge_options_order_check (order_index
+    # BETWEEN 0 AND 5): a 7th option would die as an IntegrityError deep in
+    # the generation pipeline ("persist failed", question silently dropped)
+    # instead of a clear gate error here — same failure class as the verse
+    # range fixed in #791.
+    if len(options) > 6:
+        raise ValueError(f"daily challenge question allows at most six options, got {len(options)}")
     if question_type == "true_false" and len(options) != 2:
         raise ValueError("true_false questions need exactly two options")
 

--- a/backend/app/services/daily_challenge/replenish.py
+++ b/backend/app/services/daily_challenge/replenish.py
@@ -16,9 +16,20 @@ Per tick it:
   3. promotes the surviving draft → published,
   4. schedules it on the next unscheduled date (the end of the list).
 
-Any failure (quota 429, gate rejection, publish/schedule error) returns a
-status string and leaves the DB clean — the next day's tick simply tries
-again. Autofill keeps the live challenge working in the meantime.
+Failure handling: generation failures before any question exists simply
+return an ``error`` status (nothing persisted by this tick survives the
+rollback... except commits made inside the orchestrator — see below). Once
+a question row HAS been committed by the generation pipeline, a later
+promote/publish failure cannot be rolled back (the orchestrator and the
+editorial helpers commit as they go), so the orphan is terminally
+``rejected`` with an audit reason instead of lingering as a zombie draft
+in the editorial panel. A failed *schedule* step intentionally rejects
+nothing: the question is already published, and the autofill pool serves
+published questions, so it is usable inventory. Autofill keeps the live
+challenge working in the meantime; ``_pick_passage``'s cursor counts every
+question row (including rejected), so a failed passage is skipped until
+the 210-passage list wraps rather than stalling the pipeline by being
+retried into the same deterministic failure every day.
 """
 
 from __future__ import annotations
@@ -39,6 +50,7 @@ from app.models.user import User, UserRole
 from app.services.daily_challenge.admin import (
     promote_status,
     publish_question,
+    reject_question,
     schedule_for_date,
 )
 from app.services.daily_challenge.orchestrator import GenerationRequest, run_generation
@@ -87,9 +99,12 @@ def _next_unscheduled_date(db: Session, *, start: date) -> date:
 
 
 def _pick_passage(db: Session) -> dict[str, object]:
-    """Cursor = current question count, so each success advances the
-    pointer and the worker cycles through the seed list without repeats
-    until it wraps (210 days)."""
+    """Cursor = current question count (rejected rows included), so every
+    tick that persisted a question — even one that later failed and was
+    terminally rejected — advances the pointer. The worker cycles through
+    the seed list without repeats until it wraps (~210 days); a failed
+    passage gets its retry on the next wrap instead of stalling the
+    pipeline on a deterministic failure."""
     count = db.query(func.count(DailyChallengeQuestion.id)).scalar() or 0
     return SEED_PASSAGES[count % len(SEED_PASSAGES)]
 
@@ -105,6 +120,22 @@ def _system_actor_id(db: Session) -> uuid.UUID | None:
         .limit(1)
         .scalar()
     )
+
+
+def _reject_orphan(db: Session, *, question: DailyChallengeQuestion, actor: uuid.UUID, reason: str) -> None:
+    """Best-effort terminal cleanup for a question the tick cannot finish.
+
+    ``reject_question`` keeps the row + its audit trail (Agent C's
+    philosophy) while taking it out of the editorial panel's active list.
+    Never raises — the caller is already on its error path and the orphan
+    being left behind is the lesser failure.
+    """
+    try:
+        reject_question(db, question=question, actor_id=actor, reason=reason[:500])
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.warning("replenish: failed to reject orphan question %s", question.id)
 
 
 def replenish_one_question(
@@ -150,6 +181,7 @@ def replenish_one_question(
         for _ in range(_PROMOTE_STAGES_FROM_DRAFT):
             question = promote_status(db, question=question, actor_id=actor)
         if question.status != DailyChallengeQuestionStatus.PILOT_PASSED.value:
+            _reject_orphan(db, question=question, actor=actor, reason=f"replenish: stuck at status={question.status}")
             return ReplenishOutcome(
                 status="error", question_id=str(qid), passage=label, detail=f"stuck at status={question.status}"
             )
@@ -157,6 +189,10 @@ def replenish_one_question(
     except Exception as exc:
         db.rollback()
         logger.warning("replenish: publish failed for %s: %s", qid, exc)
+        # The generation pipeline committed the question; a plain rollback
+        # cannot undo that. Terminally reject it (with audit reason) so it
+        # neither lingers as a zombie draft nor blocks the passage cursor.
+        _reject_orphan(db, question=question, actor=actor, reason=f"replenish: publish failed: {exc}")
         return ReplenishOutcome(status="error", question_id=str(qid), passage=label, detail=f"publish: {exc}")
 
     cursor = _next_unscheduled_date(db, start=start_date or datetime.now(UTC).date())

--- a/backend/tests/test_daily_challenge_replenish.py
+++ b/backend/tests/test_daily_challenge_replenish.py
@@ -101,6 +101,54 @@ class TestReplenishOneQuestion:
         assert out.status == "error"
         assert "429" in (out.detail or "")
 
+    def test_publish_failure_rejects_orphan(self, db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The generation pipeline commits its question; if a later
+        # promote/publish step dies, the row cannot be rolled back. The tick
+        # must terminally reject it (audit reason intact) so it neither
+        # lingers as a zombie draft nor gets reused by the passage cursor.
+        admin = _admin(db)
+
+        def _fake_generate(db_: Session, *, client: object, request: object) -> GenerationOutcome:
+            q = _draft(db_, created_by=admin.id)
+            return GenerationOutcome(generation_run_id=uuid.uuid4(), created_question_ids=[q.id])
+
+        def _fake_promote(
+            db_: Session, *, question: DailyChallengeQuestion, actor_id: uuid.UUID
+        ) -> DailyChallengeQuestion:
+            question.status = DailyChallengeQuestionStatus.PILOT_PASSED.value
+            db_.flush()
+            return question
+
+        def _publish_boom(*_a: object, **_k: object) -> DailyChallengeQuestion:
+            raise RuntimeError("publish exploded")
+
+        monkeypatch.setattr(R, "run_generation", _fake_generate)
+        monkeypatch.setattr(R, "promote_status", _fake_promote)
+        monkeypatch.setattr(R, "publish_question", _publish_boom)
+
+        out = R.replenish_one_question(db, client=object())  # type: ignore[arg-type]
+        assert out.status == "error"
+        orphan = db.query(DailyChallengeQuestion).filter_by(id=uuid.UUID(out.question_id)).one()
+        assert orphan.rejected is True
+        assert "publish failed" in (orphan.rejection_reason or "")
+
+    def test_stuck_promotion_rejects_orphan(self, db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Promotion that never reaches pilot_passed is the same orphan class.
+        admin = _admin(db)
+
+        def _fake_generate(db_: Session, *, client: object, request: object) -> GenerationOutcome:
+            q = _draft(db_, created_by=admin.id)
+            return GenerationOutcome(generation_run_id=uuid.uuid4(), created_question_ids=[q.id])
+
+        monkeypatch.setattr(R, "run_generation", _fake_generate)
+        monkeypatch.setattr(R, "promote_status", lambda db_, *, question, actor_id: question)  # no-op: stays draft
+
+        out = R.replenish_one_question(db, client=object())  # type: ignore[arg-type]
+        assert out.status == "error"
+        assert "stuck at status=draft" in (out.detail or "")
+        orphan = db.query(DailyChallengeQuestion).filter_by(id=uuid.UUID(out.question_id)).one()
+        assert orphan.rejected is True
+
     def test_happy_path_publishes_and_appends(self, db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
         admin = _admin(db)
 

--- a/backend/tests/test_daily_challenge_service.py
+++ b/backend/tests/test_daily_challenge_service.py
@@ -206,6 +206,33 @@ class TestNormalizeVerseRange:
         assert q.bible_verse_from is None
         assert q.bible_verse_to is None
 
+    def test_create_question_rejects_more_than_six_options(self, db: Session, author: User):
+        """daily_challenge_options_order_check caps order_index at 5; a 7th
+        option must die as a clear gate ValueError, not an IntegrityError
+        deep in the generation pipeline (same class as the verse-range bug)."""
+        import pytest
+
+        from app.services.daily_challenge.admin import OptionDraft, create_question
+
+        opts = [OptionDraft(text="Correct", is_correct=True)] + [
+            OptionDraft(text=f"Wrong {i}", is_correct=False) for i in range(6)
+        ]
+        with pytest.raises(ValueError, match="at most six options"):
+            create_question(
+                db,
+                question_type="multiple_choice",
+                bible_book="Genesis",
+                bible_chapter=1,
+                bible_verse_from=None,
+                bible_verse_to=None,
+                question_text="Too many options?",
+                options=opts,
+                explanation=None,
+                category="passage_exegesis",
+                created_by=author.id,
+                fallback_locale="en",
+            )
+
     def test_create_question_preserves_valid_range(self, db: Session, author: User):
         from app.services.daily_challenge.admin import OptionDraft, create_question
 


### PR DESCRIPTION
## Why
2026-06-11 audit follow-ups (low batch): failed replenish ticks left committed zombie drafts AND silently skipped the passage; 7+-option survivors died as IntegrityError instead of a clear gate error.

## What
- Failed promote/publish → orphan question is terminally `rejected` with audit reason (`_reject_orphan`, never raises). Schedule-failure rejects nothing — published questions feed the autofill pool. Cursor semantics documented.
- `create_question` caps options at 6 (mirrors `daily_challenge_options_order_check`).
- 3 new tests.

## Verify
ruff + mypy clean, 1500/1500 backend tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
