### PR TITLE
fix(frontend): invalidate gradebook caches on grading + settle animations before axe

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -25,12 +25,33 @@
  * each individual test scopes the run to the actual rendered region
  * via `.include()`.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
+
+/**
+ * Wait for every FINITE animation/transition to finish before axe runs.
+ *
+ * The entrance fade (`animate-fade-in`, ~0.55s) animates opacity, and axe
+ * computes color contrast against the rendered frame — sampling mid-fade
+ * produced phantom contrast violations with a different blended color on
+ * every retry (the long-standing login-page flake). Infinite animations
+ * (spinners) are skipped so this can never hang.
+ */
+async function settleAnimations(page: Page): Promise<void> {
+  await page.evaluate(() =>
+    Promise.all(
+      document
+        .getAnimations()
+        .filter((a) => a.effect?.getTiming().iterations !== Infinity)
+        .map((a) => a.finished.catch(() => undefined)),
+    ),
+  );
+}
 
 test.describe("page-level a11y (public)", () => {
   test("home page has no WCAG 2.1 AA violations", async ({ page }) => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
+    await settleAnimations(page);
 
     const accessibilityScanResults = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
@@ -49,6 +70,7 @@ test.describe("page-level a11y (public)", () => {
 
   test("login page has no WCAG 2.1 AA violations", async ({ page }) => {
     await page.goto("/login", { waitUntil: "domcontentloaded" });
+    await settleAnimations(page);
 
     const accessibilityScanResults = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])

--- a/frontend/src/services/assignments.ts
+++ b/frontend/src/services/assignments.ts
@@ -86,6 +86,11 @@ export const assignmentsService = {
     cacheInvalidatePrefix("grades:my")
     cacheInvalidatePrefix("analytics:course:")
     cacheInvalidatePrefix("progress:students:")
+    // The gradebook matrix and the row-expand detail cache the same data the
+    // grade just changed — without these, a remounted gradebook can show the
+    // pre-grade value for up to 30s.
+    cacheInvalidatePrefix("progress:gradebook:")
+    cacheInvalidatePrefix("progress:detail:")
     return response.data
   },
 }

--- a/frontend/src/services/quizzes.ts
+++ b/frontend/src/services/quizzes.ts
@@ -121,6 +121,16 @@ export const quizzesService = {
       points_earned: pointsEarned,
       grader_comment: graderComment ?? null,
     })
+    // Grading an essay/short-answer changes the same aggregates assignment
+    // grading does — keep the invalidation set in sync with gradeSubmission
+    // (assignments.ts), or stale gradebook/progress values survive up to 30s.
+    cacheInvalidatePrefix("grades:course:")
+    cacheInvalidatePrefix("grades:summary:")
+    cacheInvalidatePrefix("grades:my")
+    cacheInvalidatePrefix("analytics:course:")
+    cacheInvalidatePrefix("progress:students:")
+    cacheInvalidatePrefix("progress:gradebook:")
+    cacheInvalidatePrefix("progress:detail:")
     return response.data
   },
 


### PR DESCRIPTION
## Why
Audit follow-ups: grading left ≤30s-stale gradebook/detail caches (#788 gap; quiz grading invalidated nothing at all), and the e2e a11y login flake is axe racing the 0.55s entrance fade — adversarially confirmed NOT a real WCAG regression (resting token contrast ≈6.7:1) but it keeps E2E on main red.

## What
- `gradeSubmission` + `gradeQuizAnswer` now invalidate `progress:gradebook:`/`progress:detail:` (+ the full shared set for quiz grading).
- `settleAnimations(page)` in `e2e/a11y.spec.ts` awaits all finite animations before each axe scan.

## Verify
eslint 0 warnings, tsc clean, 551/551 vitest. E2E runs on its own workflow (non-required) — watch the next main run go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
