### PR TITLE
docs(datadog): align dashboards with real log-based metrics; import live

### DIFF
--- a/docs/datadog/README.md
+++ b/docs/datadog/README.md
@@ -1,13 +1,15 @@
 # Datadog dashboards
 
 This directory holds the JSON specs for Datadog dashboards Equip
-keeps in source control. Each spec corresponds to one dashboard
-that's importable via the Datadog UI:
+keeps in source control. Each spec corresponds to one **live**
+dashboard (US5 site):
 
-| Spec | Purpose |
-|---|---|
-| `teacher-load-dashboard.json` | Per-teacher grading-queue depth, response time, active courses, enrollment counts. |
-| `course-engagement-dashboard.json` | Per-course DAU, completion rate, time-to-first-drop-off, top drop-off chapters, locale split, average rating. |
+| Spec | Live ID | Purpose |
+|---|---|---|
+| — (UI-managed) | `shf-kq8-bgf` | Equip overview. |
+| — (UI-managed) | `x7b-cua-zrm` | Equip backend. |
+| `teacher-load-dashboard.json` | `54n-cn8-nhm` | Per-teacher grading throughput + median time-to-grade, platform enrollment context. |
+| `course-engagement-dashboard.json` | `dgr-dh4-n4x` | Per-course active users (RUM), completion rate, drop-off, translation queue, locale split, average rating. |
 
 ## Why JSON, not Terraform
 
@@ -19,117 +21,103 @@ weekly, it's worth converting these to
 
 ## Importing a dashboard
 
+Via UI:
+
 1. Datadog UI → `Dashboards` → `New Dashboard`.
 2. Click the `Configure` (gear) icon → `Import dashboard JSON`.
 3. Paste the file's contents.
 4. Set sharing: `Teamwide` for the Equip team.
 
-After import, the dashboard exists by ID. If you tweak it in the
-UI, export the updated JSON and paste it back into the file in
-this directory in the SAME PR — keeping source-of-truth out of
-sync with prod is the fastest way for dashboards to silently rot.
+Via API: `POST https://api.us5.datadoghq.com/api/v1/dashboard` with
+`DD-API-KEY` / `DD-APPLICATION-KEY` headers and the file body
+(strip any top-level `id` / `url` / `created_at` / `author_handle`
+fields first — POST rejects them).
 
-## Required metrics
+After import, the dashboard exists by ID — record it in the table
+above. If you tweak it in the UI, export the updated JSON and paste
+it back into the file in this directory in the SAME PR — keeping
+source-of-truth out of sync with prod is the fastest way for
+dashboards to silently rot.
 
-Both dashboards reference custom metrics with the `equip.*` namespace.
-They're emitted via **log-based metrics** — structured INFO lines
-under the `equip.metric` logger that Datadog parses into time series.
-See `app/core/metrics.py` for the emitter contract.
+## How the metrics work
 
-Live emission today (sites tagged with the route file that wires them):
+All `equip.*` custom metrics are **log-based distribution metrics**:
+the backend logs structured `equip.metric:` lines (see
+`app/core/metrics.py` for the emitter contract), the Vercel log
+drain ships them to Datadog, and the log pipeline **'Equip — drain
+metric parsing'** parses them into generated metrics
+(type: distribution).
 
-* **`equip.grading.graded_total`** + **`equip.grading.time_to_grade.p50`**
-  — `app/api/v1/quizzes/grading.py` fires on the
-  `pending → graded` transition (guarded against re-grade
-  double-count).
-* **`equip.activity.requests_total`** + **`equip.activity.duration_ms`**
-  — the request-logging middleware in `app/main.py` tags every
-  request with `course_id`, `locale`, `status_code`.
-* **`equip.completion.course_avg_pct`** — `app/services/course_service/
-  _enrollment.py::sync_enrollment_progress` emits a gauge on every
-  progress recompute.
-* **`equip.engagement.chapter_completed_total`** — emitted by all
-  three chapter-completion paths (teacher-mark / quiz-pass /
-  assignment-submit), tagged with `completion_type`, idempotent on
-  no-op re-completion.
-* **`equip.enrollments.created_total`** — `app/services/
-  course_service/_enrollment.py::enroll_user_in_course` emits once
-  per *new* row (idempotent on re-enroll).
-* **`equip.reviews.rating_latest`** — `app/api/v1/reviews.py` emits
-  per (user, course) on review create/update; the dashboard takes
-  `avg` to produce the rating tile.
-* **`equip.errors.unhandled_total`** — the global FastAPI exception
-  handler in `app/main.py` fires this counter for every uncategorised
-  exception (i.e. not IntegrityError → 409 and not SQLAlchemyError →
-  503; those have hand-built handlers). Tagged with `method`,
-  `path_prefix` (first 4 url segments), and `exception_type` (class
-  name, never the message — message could carry PII). Drives the
-  P1 `backend-unhandled-exception-rate` monitor.
-* **`equip.translation.queue_depth`** +
-  **`equip.translation.queue_processing`** +
-  **`equip.translation.queue_failed_permanent`** — `app/api/v1/
-  internal_translation_worker.py::_emit_queue_gauges` fires three
-  per-status gauges on every cron tick. Drives the Course
-  Engagement dashboard's *Translation queue health* group and the
-  `translation-queue-backlog` monitor.
-* **`equip.translation.duration_ms`** — `app/api/v1/
-  internal_translation_worker.py::_emit_translation_duration` times
-  each `translate_course_content` run. Tagged with
-  `outcome={done,failed}` so the dashboard can split the latency
-  curve by success vs failure — a sustained gap usually means the
-  failure path is timing out on an upstream call.
-* **`equip.gemini.calls_total`** + **`equip.gemini.tokens_input_total`**
-  + **`equip.gemini.tokens_output_total`** —
-  `app/services/translation/gemini.py::translate` emits per Gemini
-  API call. Tagged with `model` (so a future flash → pro migration
-  keeps cost curves separable) and `outcome={success,retry,fatal,transport}`
-  (`transport` + `status_code=0` = a network-level failure with no HTTP
-  response, so a full Gemini outage still registers).
-  `tokens_*_total` use the token count as the metric VALUE so
-  `sum:` over the window equals cumulative token spend → multiply
-  by Gemini's $/million rate to get $-burn.
-* **`equip.daily_challenge.attempt_total`** — `app/api/v1/
-  daily_challenge.py::submit_attempt` fires per **new** attempt
-  (`is_new_attempt=True`); idempotent re-submits return 201 but
-  do NOT increment. Tagged with `challenge_date` + `is_correct`
-  so the dashboard can chart attempts-per-day and derive a correct-
-  rate without a second metric.
-* **`equip.youversion.api_calls_total`** —
-  `app/services/verse_of_the_day.py::_fetch_passage` fires per
-  YouVersion REST call. Tagged with `bible_id` (which locale's
-  bible), `outcome={success,not_in_bible,fatal}`, and `status_code`.
-  Lets the dashboard track API budget burn separately from app-side
-  errors (`not_in_bible` is the version-difference walk-forward
-  case, not a real failure).
+Consequences for queries:
 
-Drop-off rate is computed in the dashboard query as:
+* `avg:` / `max:` / `sum:` query shapes work on every metric;
+  counters take `.as_count()`.
+* Percentile queries (`p50:`, `p95:`, …) work ONLY where noted below.
+* There is **no `env` tag** — Equip runs a single prod env, and the
+  backend skips non-main builds, so dashboards don't carry an `env`
+  template variable. (RUM data does have `env`, but the RUM widgets
+  here don't need it.)
+* `teacher_id` exists ONLY on the two grading metrics — on the
+  Teacher Load dashboard, the `$teacher_id` template variable
+  affects the Grading group only.
 
-```
-100 * (1 - (chapter_completed_total / enrollments.created_total))
-```
+## Metrics that exist today (2026-06-11)
 
-over the chosen window — no separate emitter required.
+| Metric | Tags | Percentiles | Emitter |
+|---|---|---|---|
+| `equip.activity.requests_total` | `locale`, `course_id`, `status_code` | — | request-logging middleware, `app/main.py` |
+| `equip.activity.duration_ms` | `locale`, `course_id` | yes | request-logging middleware, `app/main.py` |
+| `equip.errors.unhandled_total` | `method`, `path_prefix`, `exception_type` | — | global exception handler, `app/main.py`; drives the P1 `backend-unhandled-exception-rate` monitor; `exception_type` is the class name, never the message (PII) |
+| `equip.engagement.chapter_completed_total` | `course_id`, `completion_type` | — | all three completion paths (teacher-mark / quiz-pass / assignment-submit), idempotent on re-completion |
+| `equip.reviews.rating_latest` | `course_id` | — | `app/api/v1/reviews.py`, gauge per (user, course) on create/update; dashboard takes `avg` |
+| `equip.daily_challenge.attempt_total` | `is_correct` | — | `app/api/v1/daily_challenge.py::submit_attempt`, fires per NEW attempt only |
+| `equip.grading.graded_total` | `teacher_id` | — | `app/api/v1/quizzes/grading.py` on the `pending → graded` transition (guarded against re-grade double-count) |
+| `equip.grading.time_to_grade.p50` | `teacher_id` | yes | same site; submission → grade latency in seconds |
+| `equip.youversion.api_calls_total` | `bible_id`, `outcome` | — | `app/services/verse_of_the_day.py::_fetch_passage`; `outcome=not_in_bible` is the version-difference walk-forward case, not a failure |
+| `equip.enrollments.created_total` | `course_id`, `cohort_id` | — | `app/services/course_service/_enrollment.py::enroll_user_in_course`, once per NEW row |
+| `equip.completion.course_avg_pct` | `course_id` | — | `..._enrollment.py::sync_enrollment_progress`, gauge on every progress recompute |
+| `equip.translation.queue_depth` / `equip.translation.queue_processing` / `equip.translation.queue_failed_permanent` | (none) | — | `app/api/v1/internal_translation_worker.py::_emit_queue_gauges` on every cron tick; drives the `translation-queue-backlog` monitor |
+| `equip.translation.duration_ms` | `outcome` (`done`/`failed`) | yes | `..._emit_translation_duration` times each `translate_course_content` run |
+| `equip.gemini.calls_total` | `model`, `outcome` (`success`/`retry`/`fatal`/`transport`) | — | `app/services/translation/gemini.py::translate` per Gemini API call |
 
-Still TODO (panels render "no data" gracefully). These metric names are
-referenced by dashboard widgets but **not emitted yet** — the
-`test_every_dashboard_metric_is_emitted_or_documented` sentinel requires
-every dashboard metric to be either emitted or listed here, so a dead
-tile can't sneak in silently:
+Emitted in logs but **no generated-metric rule yet** (logged values
+are queryable in Log Explorer, not as metrics):
 
-* `equip.questions.*` — course Q&A surface when it lands
-  (covers `questions.open` + `questions.response_time.p50`).
-* `equip.completion.chapter_avg_pct` — per-chapter aggregate.
-* `equip.engagement.first_dropoff.p50` — needs session-window
-  computation; deferred until session_id tagging lands.
-* `equip.activity.daily_active_users` — needs a distinct-user rollup
-  (the request-logging middleware emits `requests_total`, not DAU).
-* `equip.enrollments.count` — point-in-time enrollment gauge; today we
-  only emit `enrollments.created_total` (a counter).
-* `equip.courses.active_7d` — rolling 7-day active-course gauge; no
-  emitter yet.
-* `equip.grading.pending` — pending-grade depth gauge; today we emit
-  `grading.graded_total` + `grading.time_to_grade.p50` on grade, not a
-  pending-queue gauge.
+* `equip.gemini.tokens_input_total` + `equip.gemini.tokens_output_total`
+  — `app/services/translation/gemini.py` uses the token count as the
+  log value; add a distribution rule on the pipeline if $-burn
+  tracking should move from logs to metrics.
+
+## Derived / replaced panels
+
+* **Active users** (Course Engagement) comes from **RUM**, not a
+  custom metric: unique `@usr.id` over `@type:session
+  service:equip-frontend`. There is no
+  `equip.activity.daily_active_users` metric.
+* **Cumulative enrollments** (Teacher Load) is
+  `cumsum(sum:equip.enrollments.created_total{*}.as_count())` —
+  cumulative over the dashboard window, not an all-time gauge
+  (there is no `equip.enrollments.count` point-in-time metric).
+* **Grading load** (Teacher Load) is graded **throughput** +
+  median time-to-grade — there is no pending-queue depth gauge
+  (`equip.grading.pending` does not exist).
+* **Drop-off rate** is computed in the dashboard query as
+  `100 * (1 - (chapter_completed_total / enrollments.created_total))`
+  over the chosen window — no separate emitter required.
+
+Metrics that earlier drafts referenced but that do NOT exist (do not
+re-add widgets for these without wiring an emitter + pipeline rule
+first): `equip.grading.pending`, `equip.questions.open`,
+`equip.questions.response_time.p50`,
+`equip.activity.daily_active_users`,
+`equip.completion.chapter_avg_pct`,
+`equip.engagement.first_dropoff.p50`, `equip.courses.active_7d`,
+`equip.enrollments.count`.
+
+The `test_every_dashboard_metric_is_emitted_or_documented` sentinel
+(`backend/tests/test_metric_readme_sentinel.py`) enforces both
+directions: every emitted metric must appear in this README, and
+every metric a dashboard queries must be emitted or documented here.
 
 ## See also
 

--- a/docs/datadog/course-engagement-dashboard.json
+++ b/docs/datadog/course-engagement-dashboard.json
@@ -1,6 +1,6 @@
 {
   "title": "Equip — Course Engagement",
-  "description": "Per-course health: DAU, completion rate, time-to-first-drop-off, locale split.\n\nUseful when:\n* Deciding which courses are pilot-ready vs. need more material.\n* Spotting the chapter where students consistently abandon.\n* Showing a school director the impact data after a cohort wraps.\n\nFilter by `course_id:<id>` to scope. The default view aggregates across all courses for a quick \"is anything obviously off\" scan.\n\nDeploy: Datadog UI -> Dashboards -> New Dashboard -> Import JSON.",
+  "description": "Per-course health: active users, completion rate, translation queue, locale split.\n\nUseful when:\n* Deciding which courses are pilot-ready vs. need more material.\n* Spotting a course where students abandon early (drop-off rate).\n* Showing a school director the impact data after a cohort wraps.\n\nFilter by `course_id:<id>` to scope (metric widgets only — the RUM active-user widgets are platform-wide). The default view aggregates across all courses for a quick \"is anything obviously off\" scan.\n\nDeploy: Datadog UI -> Dashboards -> New Dashboard -> Import JSON, or POST to /api/v1/dashboard.",
   "layout_type": "ordered",
   "reflow_type": "auto",
   "template_variables": [
@@ -8,19 +8,13 @@
       "name": "course_id",
       "prefix": "course_id",
       "default": "*"
-    },
-    {
-      "name": "env",
-      "prefix": "env",
-      "available_values": ["prod", "preview"],
-      "default": "prod"
     }
   ],
   "widgets": [
     {
       "definition": {
         "type": "note",
-        "content": "## How to read this\n\n- **DAU** (daily active users) — students who hit any course-scoped route today.\n- **Completion rate** — `completed_chapters / total_chapters` per enrollment, averaged across the course.\n- **Time-to-first-drop-off** — median time from first chapter open to last activity, for students who never completed.\n- **Locale split** — RU vs EN traffic; if one drops to 0, the i18n pipeline may have broken.",
+        "content": "## How to read this\n\n- **Active users** — unique RUM users with a session on `equip-frontend` in the window (RUM data, platform-wide; the `$course_id` filter does NOT apply to these two widgets).\n- **Completion rate** — `completed_chapters / total_chapters` per enrollment, averaged across the course (`equip.completion.course_avg_pct`, re-emitted on every progress recompute).\n- **Drop-off rate** — derived: `100 * (1 - chapter_completions / new_enrollments)` over the window. Rough proxy, noisy at low volume.\n- **Locale split** — RU vs EN traffic from `equip.activity.requests_total`; if one drops to 0, the i18n pipeline may have broken.\n\nAll `equip.*` metrics are log-based distributions parsed from `equip.metric:` log lines (pipeline: 'Equip — drain metric parsing'). Single prod env — no env tag exists. Per-chapter completion aggregates are not emitted (no `chapter_avg_pct` metric).",
         "background_color": "blue",
         "font_size": "14",
         "text_align": "left"
@@ -35,11 +29,21 @@
           {
             "definition": {
               "type": "query_value",
-              "title": "DAU (today)",
+              "title": "Active users (RUM, window)",
               "requests": [
                 {
-                  "q": "sum:equip.activity.daily_active_users{env:$env.value,course_id:$course_id.value}",
-                  "aggregator": "last"
+                  "response_format": "scalar",
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "query1",
+                      "search": { "query": "@type:session service:equip-frontend" },
+                      "compute": { "aggregation": "cardinality", "metric": "@usr.id" },
+                      "group_by": [],
+                      "storage": "hot"
+                    }
+                  ]
                 }
               ],
               "precision": 0
@@ -48,11 +52,23 @@
           {
             "definition": {
               "type": "timeseries",
-              "title": "DAU over time",
+              "title": "Active users over time (RUM sessions)",
+              "show_legend": false,
               "requests": [
                 {
-                  "q": "sum:equip.activity.daily_active_users{env:$env.value,course_id:$course_id.value} by {course_id}",
-                  "display_type": "area"
+                  "response_format": "timeseries",
+                  "display_type": "area",
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "query1",
+                      "search": { "query": "@type:session service:equip-frontend" },
+                      "compute": { "aggregation": "cardinality", "metric": "@usr.id", "interval": 86400000 },
+                      "group_by": [],
+                      "storage": "hot"
+                    }
+                  ]
                 }
               ],
               "yaxis": { "min": "0", "include_zero": true }
@@ -64,7 +80,7 @@
               "title": "New enrollments (7d)",
               "requests": [
                 {
-                  "q": "sum:equip.enrollments.created_total{env:$env.value,course_id:$course_id.value}.rollup(sum, 604800)",
+                  "q": "sum:equip.enrollments.created_total{course_id:$course_id.value}.as_count().rollup(sum, 604800)",
                   "aggregator": "last"
                 }
               ],
@@ -77,7 +93,7 @@
               "title": "Enrollments per day (by course)",
               "requests": [
                 {
-                  "q": "sum:equip.enrollments.created_total{env:$env.value,course_id:$course_id.value} by {course_id}.rollup(sum, 86400)",
+                  "q": "sum:equip.enrollments.created_total{course_id:$course_id.value} by {course_id}.as_count().rollup(sum, 86400)",
                   "display_type": "bars"
                 }
               ],
@@ -99,7 +115,7 @@
               "title": "Completion rate (avg %)",
               "requests": [
                 {
-                  "q": "avg:equip.completion.course_avg_pct{env:$env.value,course_id:$course_id.value}",
+                  "q": "avg:equip.completion.course_avg_pct{course_id:$course_id.value}",
                   "aggregator": "avg",
                   "conditional_formats": [
                     { "comparator": ">", "value": 70, "palette": "white_on_green" },
@@ -115,10 +131,10 @@
           {
             "definition": {
               "type": "timeseries",
-              "title": "Per-chapter completion (heatmap)",
+              "title": "Completion rate over time (by course)",
               "requests": [
                 {
-                  "q": "avg:equip.completion.chapter_avg_pct{env:$env.value,course_id:$course_id.value} by {chapter_id}",
+                  "q": "avg:equip.completion.course_avg_pct{course_id:$course_id.value} by {course_id}",
                   "display_type": "line"
                 }
               ],
@@ -131,7 +147,7 @@
               "title": "Chapter completions (7d)",
               "requests": [
                 {
-                  "q": "sum:equip.engagement.chapter_completed_total{env:$env.value,course_id:$course_id.value}.rollup(sum, 604800)",
+                  "q": "sum:equip.engagement.chapter_completed_total{course_id:$course_id.value}.as_count().rollup(sum, 604800)",
                   "aggregator": "last"
                 }
               ],
@@ -141,10 +157,10 @@
           {
             "definition": {
               "type": "toplist",
-              "title": "Completion paths (by type, last 7d)",
+              "title": "Completion paths (by type, window)",
               "requests": [
                 {
-                  "q": "top(sum:equip.engagement.chapter_completed_total{env:$env.value,course_id:$course_id.value} by {completion_type}.rollup(sum, 604800), 5, 'sum', 'desc')"
+                  "q": "top(sum:equip.engagement.chapter_completed_total{course_id:$course_id.value} by {completion_type}.as_count(), 5, 'sum', 'desc')"
                 }
               ]
             }
@@ -155,7 +171,7 @@
               "title": "Drop-off rate (7d, derived)",
               "requests": [
                 {
-                  "q": "100 * (1 - (sum:equip.engagement.chapter_completed_total{env:$env.value,course_id:$course_id.value}.rollup(sum, 604800) / sum:equip.enrollments.created_total{env:$env.value,course_id:$course_id.value}.rollup(sum, 604800)))",
+                  "q": "100 * (1 - (sum:equip.engagement.chapter_completed_total{course_id:$course_id.value}.as_count().rollup(sum, 604800) / sum:equip.enrollments.created_total{course_id:$course_id.value}.as_count().rollup(sum, 604800)))",
                   "aggregator": "last",
                   "conditional_formats": [
                     { "comparator": "<", "value": 30, "palette": "white_on_green" },
@@ -180,10 +196,10 @@
           {
             "definition": {
               "type": "query_value",
-              "title": "Backlog (queued + failed)",
+              "title": "Backlog (queued)",
               "requests": [
                 {
-                  "q": "avg:equip.translation.queue_depth{env:$env.value}",
+                  "q": "max:equip.translation.queue_depth{*}",
                   "aggregator": "last",
                   "conditional_formats": [
                     { "comparator": "<", "value": 10, "palette": "white_on_green" },
@@ -201,7 +217,7 @@
               "title": "In-flight (processing)",
               "requests": [
                 {
-                  "q": "avg:equip.translation.queue_processing{env:$env.value}",
+                  "q": "max:equip.translation.queue_processing{*}",
                   "aggregator": "last"
                 }
               ],
@@ -214,7 +230,7 @@
               "title": "Dead-lettered (failed_permanent)",
               "requests": [
                 {
-                  "q": "avg:equip.translation.queue_failed_permanent{env:$env.value}",
+                  "q": "max:equip.translation.queue_failed_permanent{*}",
                   "aggregator": "last",
                   "conditional_formats": [
                     { "comparator": ">", "value": 0, "palette": "white_on_red" }
@@ -230,7 +246,7 @@
               "title": "Translation p50 (5m)",
               "requests": [
                 {
-                  "q": "p50:equip.translation.duration_ms{env:$env.value,outcome:done}.rollup(p50, 300)",
+                  "q": "p50:equip.translation.duration_ms{outcome:done}.rollup(300)",
                   "aggregator": "last",
                   "conditional_formats": [
                     { "comparator": "<", "value": 5000, "palette": "white_on_green" },
@@ -249,17 +265,17 @@
               "title": "Translation duration (done vs failed)",
               "requests": [
                 {
-                  "q": "p50:equip.translation.duration_ms{env:$env.value,outcome:done}",
+                  "q": "p50:equip.translation.duration_ms{outcome:done}",
                   "display_type": "line",
                   "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
                 },
                 {
-                  "q": "p95:equip.translation.duration_ms{env:$env.value,outcome:done}",
+                  "q": "p95:equip.translation.duration_ms{outcome:done}",
                   "display_type": "line",
                   "style": { "palette": "cool", "line_type": "dashed", "line_width": "normal" }
                 },
                 {
-                  "q": "p50:equip.translation.duration_ms{env:$env.value,outcome:failed}",
+                  "q": "p50:equip.translation.duration_ms{outcome:failed}",
                   "display_type": "line",
                   "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
                 }
@@ -273,12 +289,12 @@
               "title": "Queue depth over time",
               "requests": [
                 {
-                  "q": "avg:equip.translation.queue_depth{env:$env.value}",
+                  "q": "max:equip.translation.queue_depth{*}",
                   "display_type": "area",
                   "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
                 },
                 {
-                  "q": "avg:equip.translation.queue_processing{env:$env.value}",
+                  "q": "max:equip.translation.queue_processing{*}",
                   "display_type": "line",
                   "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
                 }
@@ -301,7 +317,7 @@
               "title": "Average rating (out of 5)",
               "requests": [
                 {
-                  "q": "avg:equip.reviews.rating_latest{env:$env.value,course_id:$course_id.value}",
+                  "q": "avg:equip.reviews.rating_latest{course_id:$course_id.value}",
                   "aggregator": "avg",
                   "conditional_formats": [
                     { "comparator": ">", "value": 4, "palette": "white_on_green" },
@@ -319,7 +335,7 @@
               "title": "Locale split (RU vs EN)",
               "requests": [
                 {
-                  "q": "sum:equip.activity.requests_total{env:$env.value,course_id:$course_id.value} by {locale}",
+                  "q": "sum:equip.activity.requests_total{course_id:$course_id.value} by {locale}.as_count()",
                   "display_type": "area"
                 }
               ]

--- a/docs/datadog/teacher-load-dashboard.json
+++ b/docs/datadog/teacher-load-dashboard.json
@@ -1,6 +1,6 @@
 {
   "title": "Equip — Teacher Load",
-  "description": "Per-teacher activity + grading-backlog dashboard.\n\nGoals:\n* Spot a teacher whose grading queue is growing (pending_grade events without matching graded events).\n* Spot a teacher whose response time on student questions has crept up.\n* Compare cohort sizes so a teacher with a 200-student backlog isn't asked to take more on.\n\nFilter the entire dashboard by `teacher_id:<uuid>` to scope to one teacher.\n\nDeploy: import this JSON via Datadog UI -> Dashboards -> New Dashboard -> Import JSON. After import, set the dashboard share with the Equip team.",
+  "description": "Per-teacher grading activity + platform enrollment context.\n\nGoals:\n* Spot a teacher whose grading throughput stalls (graded events stop arriving while submissions keep coming).\n* Spot a teacher whose median time-to-grade has crept up.\n* See enrollment distribution so a teacher with a 200-student course isn't asked to take more on.\n\nFilter by `teacher_id:<uuid>` to scope — NOTE: only the Grading widgets respond to the filter; enrollment metrics carry no teacher_id tag.\n\nDeploy: import this JSON via Datadog UI -> Dashboards -> New Dashboard -> Import JSON, or POST to /api/v1/dashboard. After import, set the dashboard share with the Equip team.",
   "layout_type": "ordered",
   "reflow_type": "auto",
   "template_variables": [
@@ -9,19 +9,13 @@
       "prefix": "teacher_id",
       "available_values": [],
       "default": "*"
-    },
-    {
-      "name": "env",
-      "prefix": "env",
-      "available_values": ["prod", "preview"],
-      "default": "prod"
     }
   ],
   "widgets": [
     {
       "definition": {
         "type": "note",
-        "content": "## How to read this dashboard\n\n- **Pending grading items**: should hover near 0 between sprints. Sustained > 20 for one teacher → outreach.\n- **Median time to grade**: > 72h sustained → outreach.\n- **Active courses**: courses with at least one enrolled student in the last 7 days.\n- **Student message response time**: how long the teacher took to reply after a student posted to the course Q&A.",
+        "content": "## How to read this dashboard\n\n- **Graded items**: throughput of teacher-graded answers (essay / short_answer). A teacher with active courses but zero graded events for days → backlog is probably building.\n- **Median time to grade**: > 72h sustained → outreach. Computed from submission → grade timestamps (seconds).\n- **Enrollments**: `created_total` is a counter of NEW enrollments; the cumulative tile sums it over the dashboard's time window (not all-time).\n- **`$teacher_id` filter applies ONLY to the Grading group** — `equip.enrollments.created_total` is tagged with `course_id`/`cohort_id`, not `teacher_id`.\n\nAll metrics are log-based distributions parsed from `equip.metric:` log lines (pipeline: 'Equip — drain metric parsing'). Single prod env — no env tag exists.",
         "background_color": "blue",
         "font_size": "14",
         "text_align": "left",
@@ -33,24 +27,19 @@
     {
       "definition": {
         "type": "group",
-        "title": "Grading queue",
+        "title": "Grading",
         "layout_type": "ordered",
         "widgets": [
           {
             "definition": {
               "type": "query_value",
-              "title": "Pending grading items (now)",
+              "title": "Graded items (last 7d)",
               "title_size": "16",
               "title_align": "left",
               "requests": [
                 {
-                  "q": "sum:equip.grading.pending{env:$env.value,teacher_id:$teacher_id.value}",
-                  "aggregator": "last",
-                  "conditional_formats": [
-                    { "comparator": "<", "value": 5, "palette": "white_on_green" },
-                    { "comparator": "<", "value": 20, "palette": "white_on_yellow" },
-                    { "comparator": ">=", "value": 20, "palette": "white_on_red" }
-                  ]
+                  "q": "sum:equip.grading.graded_total{teacher_id:$teacher_id.value}.as_count().rollup(sum, 604800)",
+                  "aggregator": "last"
                 }
               ],
               "precision": 0
@@ -59,29 +48,29 @@
           {
             "definition": {
               "type": "timeseries",
-              "title": "Grading queue depth over time",
+              "title": "Graded throughput by teacher",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
               "requests": [
                 {
-                  "q": "max:equip.grading.pending{env:$env.value,teacher_id:$teacher_id.value} by {teacher_id}",
-                  "display_type": "line",
-                  "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
+                  "q": "sum:equip.grading.graded_total{teacher_id:$teacher_id.value} by {teacher_id}.as_count()",
+                  "display_type": "bars",
+                  "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
                 }
               ],
-              "yaxis": { "label": "items", "scale": "linear", "min": "0", "include_zero": true }
+              "yaxis": { "label": "items graded", "scale": "linear", "min": "0", "include_zero": true }
             }
           },
           {
             "definition": {
               "type": "query_value",
-              "title": "Median time to grade (last 7d)",
+              "title": "Median time to grade",
               "title_size": "16",
               "title_align": "left",
               "requests": [
                 {
-                  "q": "avg:equip.grading.time_to_grade.p50{env:$env.value,teacher_id:$teacher_id.value}",
+                  "q": "p50:equip.grading.time_to_grade.p50{teacher_id:$teacher_id.value}",
                   "aggregator": "avg",
                   "conditional_formats": [
                     { "comparator": "<", "value": 86400, "palette": "white_on_green" },
@@ -93,40 +82,22 @@
               "custom_unit": "s",
               "precision": 0
             }
-          }
-        ]
-      }
-    },
-    {
-      "definition": {
-        "type": "group",
-        "title": "Student questions",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "definition": {
-              "type": "query_value",
-              "title": "Open student questions",
-              "requests": [
-                {
-                  "q": "sum:equip.questions.open{env:$env.value,teacher_id:$teacher_id.value}",
-                  "aggregator": "last"
-                }
-              ],
-              "precision": 0
-            }
           },
           {
             "definition": {
-              "type": "query_value",
-              "title": "Median response time (last 7d)",
+              "type": "timeseries",
+              "title": "Median time to grade by teacher",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
               "requests": [
                 {
-                  "q": "avg:equip.questions.response_time.p50{env:$env.value,teacher_id:$teacher_id.value}",
-                  "aggregator": "avg"
+                  "q": "p50:equip.grading.time_to_grade.p50{teacher_id:$teacher_id.value} by {teacher_id}",
+                  "display_type": "line",
+                  "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
                 }
               ],
-              "custom_unit": "s"
+              "yaxis": { "label": "seconds", "scale": "linear", "min": "0", "include_zero": true }
             }
           }
         ]
@@ -135,16 +106,16 @@
     {
       "definition": {
         "type": "group",
-        "title": "Courses + cohorts",
+        "title": "Enrollments (platform-wide — teacher_id filter does not apply)",
         "layout_type": "ordered",
         "widgets": [
           {
             "definition": {
               "type": "query_value",
-              "title": "Active courses (≥1 enrolled in last 7d)",
+              "title": "Enrollments created (cumulative over window)",
               "requests": [
                 {
-                  "q": "max:equip.courses.active_7d{env:$env.value,teacher_id:$teacher_id.value}",
+                  "q": "cumsum(sum:equip.enrollments.created_total{*}.as_count())",
                   "aggregator": "last"
                 }
               ],
@@ -154,12 +125,26 @@
           {
             "definition": {
               "type": "toplist",
-              "title": "Enrollments per course",
+              "title": "New enrollments per course (window)",
               "requests": [
                 {
-                  "q": "top(sum:equip.enrollments.count{env:$env.value,teacher_id:$teacher_id.value} by {course_id}.rollup(last_1h), 10, 'sum', 'desc')"
+                  "q": "top(sum:equip.enrollments.created_total{*} by {course_id}.as_count(), 10, 'sum', 'desc')"
                 }
               ]
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "New enrollments per day (by cohort)",
+              "requests": [
+                {
+                  "q": "sum:equip.enrollments.created_total{*} by {cohort_id}.as_count().rollup(sum, 86400)",
+                  "display_type": "bars",
+                  "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "include_zero": true }
             }
           }
         ]


### PR DESCRIPTION
## Why
The teacher-load + course-engagement dashboard JSONs referenced custom metrics that never existed (`equip.grading.pending`, `equip.questions.*`, `daily_active_users`, …) and were never imported. Today the log drain was repaired (415 ndjson root cause), a parsing pipeline + 18 logs-to-metrics rules were wired, so metrics finally flow — these dashboards now match reality and are LIVE.

## What
- Both JSONs rebuilt on the 16+2 real log-based metrics (table in docs/datadog/README.md); dead widgets removed, DAU → RUM-based, enrollments → `cumsum(created_total)`, grading → throughput + `p50:` time-to-grade.
- Imported live: Teacher Load `54n-cn8-nhm`, Course Engagement `dgr-dh4-n4x` (+ existing `shf-kq8-bgf`, `x7b-cua-zrm` documented).
- Verified via API: `max:equip.translation.queue_depth{*}` and `requests_total by {locale}` return series.

## Verify
JSON valid, metric-README sentinel tests pass, docs-only PR (backend/frontend CI auto-pass via path filters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
