### PR TITLE
perf(frontend): dedupe katex + lazy-load it (and its CSS) only when math exists

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -113,31 +113,6 @@
         "@tiptap/pm": "^3.0.0"
       }
     },
-    "node_modules/@aarkue/tiptap-math-extension/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@aarkue/tiptap-math-extension/node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
     "node_modules/@adobe/css-tools": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -106,5 +106,10 @@
     "vite": "^8.0.12",
     "vitest": "^4.1.5",
     "wait-on": "^9.0.10"
+  },
+  "overrides": {
+    "@aarkue/tiptap-math-extension": {
+      "katex": "$katex"
+    }
   }
 }

--- a/frontend/src/lib/__tests__/katex-render.test.ts
+++ b/frontend/src/lib/__tests__/katex-render.test.ts
@@ -8,54 +8,54 @@ function makeContainer(innerHTML: string): HTMLDivElement {
 }
 
 describe("renderMathIn", () => {
-  it("renders an inline math marker via KaTeX", () => {
+  it("renders an inline math marker via KaTeX", async () => {
     const container = makeContainer(
       '<p><span data-type="inlineMath" data-latex="x^2" data-display="no">$x^2$</span></p>',
     )
-    renderMathIn(container)
+    await renderMathIn(container)
     const span = container.querySelector('span[data-type="inlineMath"]')
     expect(span?.getAttribute("data-katex-rendered")).toBe("true")
     // KaTeX emits a ``.katex`` wrapper inside the marker.
     expect(span?.querySelector(".katex")).not.toBeNull()
   })
 
-  it("respects data-display=yes for block math", () => {
+  it("respects data-display=yes for block math", async () => {
     const container = makeContainer(
       '<span data-type="inlineMath" data-latex="\\sum_{i=0}^n i" data-display="yes">$$\\sum$$</span>',
     )
-    renderMathIn(container)
+    await renderMathIn(container)
     const span = container.querySelector('span[data-type="inlineMath"]')
     expect(span?.querySelector(".katex-display")).not.toBeNull()
   })
 
-  it("is idempotent: the rendered flag stops a second pass", () => {
+  it("is idempotent: the rendered flag stops a second pass", async () => {
     const container = makeContainer(
       '<span data-type="inlineMath" data-latex="a" data-display="no">$a$</span>',
     )
-    renderMathIn(container)
+    await renderMathIn(container)
     const firstHtml = container.innerHTML
-    renderMathIn(container)
+    await renderMathIn(container)
     expect(container.innerHTML).toBe(firstHtml)
   })
 
-  it("skips markers with no data-latex (corrupt HTML)", () => {
+  it("skips markers with no data-latex (corrupt HTML)", async () => {
     const container = makeContainer(
       '<span data-type="inlineMath" data-display="no">$x$</span>',
     )
-    expect(() => renderMathIn(container)).not.toThrow()
+    await expect(renderMathIn(container)).resolves.toBeUndefined()
     const span = container.querySelector('span[data-type="inlineMath"]')
     // No render attempted → no rendered flag set.
     expect(span?.getAttribute("data-katex-rendered")).toBeNull()
     expect(span?.querySelector(".katex")).toBeNull()
   })
 
-  it("one bad expression doesn't blank out neighbouring markers", () => {
+  it("one bad expression doesn't blank out neighbouring markers", async () => {
     const container = makeContainer(
       '<span data-type="inlineMath" data-latex="x^2" data-display="no">$x^2$</span>' +
         '<span data-type="inlineMath" data-latex="\\unknown{" data-display="no">bad</span>' +
         '<span data-type="inlineMath" data-latex="y_1" data-display="no">$y_1$</span>',
     )
-    expect(() => renderMathIn(container)).not.toThrow()
+    await expect(renderMathIn(container)).resolves.toBeUndefined()
     const spans = container.querySelectorAll('span[data-type="inlineMath"]')
     // First + third are valid → flagged. Middle one with ``strict: "ignore"``
     // also renders (KaTeX shows the broken source) → also flagged.
@@ -63,7 +63,7 @@ describe("renderMathIn", () => {
     expect(spans[2]?.getAttribute("data-katex-rendered")).toBe("true")
   })
 
-  it("does nothing when container is null", () => {
-    expect(() => renderMathIn(null)).not.toThrow()
+  it("does nothing when container is null", async () => {
+    await expect(renderMathIn(null)).resolves.toBeUndefined()
   })
 })

--- a/frontend/src/lib/katex-render.ts
+++ b/frontend/src/lib/katex-render.ts
@@ -1,5 +1,3 @@
-import katex from "katex";
-
 /**
  * Walks ``container`` for math markers emitted by
  * ``@aarkue/tiptap-math-extension`` and replaces each marker's text
@@ -19,11 +17,27 @@ import katex from "katex";
  * KaTeX output. Idempotent — markers that have already been rendered
  * carry a ``data-katex-rendered`` flag we skip on the second pass.
  *
+ * KaTeX (~60 KB gz) and its stylesheet load LAZILY, and only when the
+ * chapter actually contains math markers — most chapters have none, so
+ * the student path pays nothing. The CSS import matters as much as the
+ * JS: katex.min.css used to ship only in the (teacher-only) editor
+ * chunk, so a formula looked perfect in the editor and rendered as
+ * broken un-styled markup for every student.
+ *
  * Throws are caught per-marker: a single malformed expression must
  * never blank out the rest of the chapter.
  */
-export function renderMathIn(container: HTMLElement | null): void {
+export async function renderMathIn(container: HTMLElement | null): Promise<void> {
   if (!container) return;
+  if (!container.querySelector('span[data-type="inlineMath"]:not([data-katex-rendered])')) {
+    return;
+  }
+  const [{ default: katex }] = await Promise.all([
+    import("katex"),
+    import("katex/dist/katex.min.css"),
+  ]);
+  // Re-query after the await: the injected HTML may have changed while
+  // the chunk loaded, and the import is the slow part anyway.
   const nodes = container.querySelectorAll<HTMLSpanElement>(
     'span[data-type="inlineMath"]:not([data-katex-rendered])',
   );

--- a/frontend/src/pages/Course/ChapterView.tsx
+++ b/frontend/src/pages/Course/ChapterView.tsx
@@ -62,7 +62,10 @@ function TextBlockRender({ html }: { html: string }) {
     // ``<summary>`` and the rendered spans go along intact — but
     // toggle-first avoids extra DOM churn.
     renderToggleCalloutsIn(ref.current)
-    renderMathIn(ref.current)
+    // Async fire-and-forget: KaTeX (and its stylesheet) load lazily and
+    // only when the chapter actually contains math markers. Copy-button
+    // wiring below doesn't depend on math rendering, so no need to await.
+    void renderMathIn(ref.current)
     attachCopyButtonsIn(ref.current, {
       copy: t("blockEditor.codeBlock.copy"),
       copied: t("blockEditor.codeBlock.copied"),


### PR DESCRIPTION
## Why
Audit (adversarially verified, HIGH): katex shipped as TWO full copies (nested 0.16.47 in the editor chunk + 0.17.0 in ChapterView), loaded eagerly on every student chapter view (~60KB gz) with **zero math content in prod**, and `katex.min.css` lived only in the teacher editor chunk — the first formula a teacher inserts would render **broken for every student** while looking perfect in the editor.

## What
- npm `overrides`: math extension forced onto the app's katex → one shared copy.
- `renderMathIn` now checks for math markers first and lazy-imports katex **and its CSS** only when found (fixes the student-CSS trap in the same motion).
- Tests updated for the async API.

## Impact (gzip)
ChapterView **84.2 → 9.9 KB**, ChapterEditor **294.4 → 219.2 KB**, all budgets green; eslint/tsc clean, 551/551 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
