### PR TITLE
docs: sync security/observability/deployment docs with 2026-06-11 reality

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -110,9 +110,14 @@ GEMINI_MODEL=gemini-2.5-flash-lite
 
 # ──── Observability (Datadog) ─────────────────────────────────────────────────
 # Enables DatadogHTTPHandler log shipping for WARNING+ records. All read via
-# os.environ in app/core/logging.py (NOT the Settings model). Missing DD_API_KEY
-# → logs stay on stdout only (Vercel's own viewer still captures them).
+# os.environ in app/core/logging.py (NOT the Settings model). The handler
+# attaches only when BOTH DD_API_KEY and DD_ENV are set — there is no default
+# env. Missing either → logs stay on stdout only (Vercel's own viewer still
+# captures them).
+# WARNING: never set DD_ENV=production on a non-prod machine. DD_ENV used to
+# default to "production", so local pytest ERRORs shipped tagged env:production
+# and fired the prod error-spike monitor (happened 2026-06-11).
 # DD_API_KEY=your-datadog-api-key
 # DD_SITE=us5.datadoghq.com
 # DD_SERVICE=equip-backend
-# DD_ENV=production
+# DD_ENV=development

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,7 +13,7 @@ The repo has **two Vercel projects** and **one Supabase project**:
 
 | Surface | Project | Triggers | Output |
 |---|---|---|---|
-| Frontend (Vite SPA) | `equip-frontend` | Push to `main` matching `frontend/**` | `equipbible.com` + `www.equipbible.com` (apex) |
+| Frontend (Vite SPA) | `equip-frontend` | Push to `main` matching `frontend/**` | `equipbible.com` (`www.equipbible.com` 308-redirects to apex since 2026-06-11) |
 | Backend (FastAPI on Python serverless) | `equip-backend` | Push to `main` matching `backend/**` | `api.equipbible.com` |
 | Database schema | Supabase project `Equip` | **Manual** (see below) | Postgres schema |
 
@@ -226,9 +226,9 @@ Build-time only on Vercel (not in the bundle):
 | Max function duration | n/a (static) | default (10 s on Pro plan) |
 | Function memory | n/a | default (1024 MB) |
 | Region | All edge / IAD1 | IAD1 (default Python serverless) |
-| Custom domains | `equipbible.com`, `www.equipbible.com` | `api.equipbible.com` |
+| Custom domains | `equipbible.com` (`www` 308-redirects to apex) | `api.equipbible.com` |
 | Auto-deploy branch | `main` | `main` |
-| Log Drain | Same drain | `drn_JWO7AolUh4PEEUXB` → Datadog us5 |
+| Log Drain | Same drain | `drn_DJUgg6MWFVruo4qV` → Datadog us5 (json) |
 
 `backend/vercel.json` sets `maxLambdaSize: 50mb` and a single catch-all
 route to `index.py`. There are no other custom Vercel settings on the

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -17,7 +17,7 @@ Configured 2026-05-11 to 2026-05-13. Org `arvavitcorp`, Datadog site
 |---|---|---|
 | Frontend errors, sessions, replays, Core Web Vitals | Datadog RUM (`equip-frontend`) | 100 % session + 100 % replay sampling; React-Router integration so dashboards aggregate by route template |
 | Backend WARNING / ERROR / CRITICAL logs | `DatadogHTTPHandler` in `backend/app/core/logging.py` | Per-record HTTPS POST to Datadog intake, tagged with env / service / version / vercel_region / vercel.request_id |
-| Backend INFO logs + build logs + edge events | Vercel Log Drain `drn_JWO7AolUh4PEEUXB` | ndjson stream from Vercel → Datadog intake; covers both `equip-frontend` and `equip-backend` projects |
+| Backend INFO logs + build logs + edge events | Vercel Log Drain `drn_DJUgg6MWFVruo4qV` ("Datadog (us5)", `deliveryFormat: json`) | json stream from Vercel → Datadog intake (the intake URL carries `ddtags` such as `env:production`); covers both `equip-frontend` and `equip-backend` projects. Replaced the original ndjson drain on 2026-06-11 -- Datadog intake answered 415 to ndjson payloads. |
 | External uptime | 3 Datadog synthetic monitors (30 min cadence, 2 retries, aws:us-east-1) | `https://api.equipbible.com/health`, `https://equipbible.com/`, `https://api.equipbible.com/api/v1/courses` |
 | Transactional email delivery | Supabase Edge Function `send-email` → Resend (verified domain `equipbible.com`) | Function ships its own logs to Datadog when `DD_API_KEY` is set; one monitor on its error stream |
 
@@ -40,9 +40,9 @@ root logger configured in app.core.logging.setup_logging()
        ↓                                                    ↓
 StreamHandler → stdout                          DatadogHTTPHandler.emit()
        ↓                                                    ↓
-Vercel captures stdout                          synchronous POST with 2s timeout
+Vercel captures stdout                          synchronous POST with 0.5s timeout
        ↓                                          to https://http-intake.logs.us5.datadoghq.com
-Vercel Log Drain drn_JWO7AolUh4PEEUXB                       ↓
+Vercel Log Drain drn_DJUgg6MWFVruo4qV                       ↓
        ↓                                          Datadog index "main" (15-day retention)
 Datadog index "main"                                        ↓
                                               tagged: env, service, version (git SHA[:7]),
@@ -92,16 +92,39 @@ Datadog inbox are the routes.
 | 19728791 | RUM alert | ≥ 10 frontend errors in 10 min (warn at 5) | `priority:2` |
 | 19728792 | RUM alert | ≥ 5 rage clicks in 30 min (warn at 3) | warn |
 | 19728793 | RUM alert | avg LCP > 4 s over 15 min (warn 2.5 s). LCP is in **nanoseconds** in RUM events -- never use ms thresholds | warn |
-| 19730778 | Log alert | ≥ 5 ERROR / CRITICAL backend log lines in 10 min (warn at 2) | `priority:2` |
-| 19730779 | Log alert | ≥ 20 WARNING backend log lines in 15 min (warn at 10) -- usually IntegrityError noise | warn |
+| 19730778 | Log alert | ≥ 10 ERROR / CRITICAL backend log lines in 10 min (warn at 6), scoped `source:python` | `priority:2` |
+| 19730779 | Log alert | ≥ 20 WARNING backend log lines in 15 min (warn at 10) -- usually IntegrityError noise. Scoped `source:python` | warn |
 | 19761387 | Log alert | ≥ 3 error logs from `service:send-email status:error` in 10 min (warn at 1) | `priority:2` |
+| 20465339 | Log alert | Translation jobs stuck in `processing` -- watches the worker's "jobs stuck in processing" WARNING line. (Replaced metric monitor `20393856`, deleted 2026-06-11 -- the metric it queried never existed, so it could never fire.) | `priority:3` |
+| 20391511 | Log alert | Daily Challenge schedule ran dry -- watches the "auto-filled schedule" line, now logged at WARNING so it reaches Datadog (at INFO the monitor was blind) | warn |
+
+The backend spike monitors (19730778 / 19730779) are scoped to
+`source:python` so each record counts once -- without the scope, lines
+arriving via both the in-process handler and the log drain would
+double-count toward the threshold.
 
 Dashboards:
 
 - [Equip overview (RUM)](https://app.us5.datadoghq.com/dashboard/shf-kq8-bgf) -- `shf-kq8-bgf`
 - [Equip backend (logs + synthetics)](https://app.us5.datadoghq.com/dashboard/x7b-cua-zrm) -- `x7b-cua-zrm`
+- [Equip teacher load](https://app.us5.datadoghq.com/dashboard/54n-cn8-nhm) -- `54n-cn8-nhm` (grading throughput, time-to-grade)
+- [Equip course engagement](https://app.us5.datadoghq.com/dashboard/dgr-dh4-n4x) -- `dgr-dh4-n4x` (active users, completion, drop-off, locale split)
 
-Both have a `$env` template variable that defaults to `production`.
+The first two have a `$env` template variable that defaults to
+`production`; the teacher-load and course-engagement dashboards are
+JSON-managed in git -- see
+[`docs/datadog/README.md`](datadog/README.md), the **source of truth
+for custom metrics and dashboard specs**.
+
+Behind those dashboards: the backend logs structured `equip.metric:`
+lines, the log drain ships them, and the **'Equip — drain metric
+parsing'** log pipeline parses them into the **18 `equip.*` log-based
+distribution metrics**. The `main` index also carries **3 exclusion
+filters** (translation-worker-tick INFO noise, the `equip.metric` lines
+themselves, and lambda `START`/`END`/`REPORT` lines) to keep ingest
+under the daily cap. Log-based metrics are generated **before** index
+exclusion, so excluding the `equip.metric` lines from the index does
+not affect the metrics.
 
 ## How to debug a production issue
 
@@ -169,7 +192,7 @@ These are deliberate omissions; revisit when traffic or budget grows.
   path), so the extra check is low-value today. `GET /health/db` exists
   but is admin-gated. Add `/health/ready` if we ever hit a real outage
   where the serverless function answers but DB writes are timing out.
-- **No alert routing beyond email.** All 9 monitors notify
+- **No alert routing beyond email.** All monitors notify
   `arvavitcorp@gmail.com`. Add SMS / Slack / PagerDuty if the
   on-call rotation grows past one person.
 - **No daily Resend send-count or bounce-rate monitor.** Resend Free

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -29,27 +29,17 @@ Dashboard) — a single config flag, no schema impact.
 
 ## CSP enforcement promotion
 
-**Status:** `Content-Security-Policy-Report-Only` ships from `vercel.json`.
-Promotion to enforcing CSP is **not** done yet.
+**Status:** ENFORCING (promoted June 2026). `frontend/vercel.json` ships
+a real `Content-Security-Policy` header -- the Report-Only burn-in
+surfaced no violations and the header key was flipped.
+`frontend/src/__tests__/vercelCsp.test.ts` asserts the enforcing header
+is present and that the report-only key has not been reintroduced.
 
-**Why report-only first:** the policy enumerates every external origin
-the SPA touches today (`api.equipbible.com`, Supabase, Datadog RUM,
-YouTube embeds). It is highly likely we missed something -- a transitive
-dep that quietly loads an analytics pixel, a future content block that
-points at a new CDN, etc. Enforcing CSP before a real-traffic burn-in
-risks a 100%-blocked page for users.
-
-**Promotion checklist (do these in one PR):**
-
-1. Watch `Content-Security-Policy-Report-Only` console violations for a
-   week of normal usage (you / staging users / a Datadog RUM query for
-   `error.message LIKE "%violated directive%"`).
-2. Add any legitimately-blocked origin to the appropriate directive.
-3. Rename the header key from `Content-Security-Policy-Report-Only` to
-   `Content-Security-Policy` in `frontend/vercel.json`.
-4. Update `src/__tests__/vercelCsp.test.ts` -- the "ships as Report-Only,
-   not enforcing" assertion needs to flip.
-5. Ship; watch Datadog for the first 24h.
+**When adding a new external origin** (a new CDN, analytics endpoint,
+embed host, etc.): extend the matching directive in
+`frontend/vercel.json` AND update `vercelCsp.test.ts` in the same PR --
+the test enumerates the allowed origins, so a directive change without
+the test change fails CI.
 
 ## Rate-limiting topology
 
@@ -132,10 +122,26 @@ Postgres directly). All of these are proven every CI run by
   (`profiles_select_self`); another user's row returns 0 rows.
 - **Grades / scores** — `student_grades`, `quiz_attempts`,
   `certificates` are not client-writable; a student can't self-grade,
-  tamper a score, or self-approve a certificate.
+  tamper a score, or self-approve a certificate. (Subsumed by the
+  blanket write lockdown below.)
 - **Audit trail + privilege** — `audit_logs`, `quiz_extra_attempts`,
-  `quiz_answers` writes are revoked from client roles; `profiles.role`
-  escalation is blocked by the immutable-fields trigger.
+  `quiz_answers` writes are revoked from client roles (likewise subsumed
+  by the lockdown below); `profiles.role` escalation is blocked by the
+  immutable-fields trigger.
+
+**Client Write Surface (server-only since 2026-06-11):** migration
+`20260611200000_server_only_writes_lockdown` revoked
+INSERT / UPDATE / DELETE / TRUNCATE on **all** public tables from `anon`
++ `authenticated`, dropped the 22 write policies those revokes made
+inert, and flipped DEFAULT PRIVILEGES so tables created by future
+migrations are born without client write grants. The **only** remaining
+client write is the `profiles` safe-fields UPDATE (row-scoped by policy,
+column-protected by `trg_profiles_protect_immutable_fields`). As defense
+in depth, the public `/certificates/verify` endpoint additionally honors
+only rows with `status='approved'` -- a forged row in any other status is
+never reported valid. Enforcement is asserted every CI run by 10 denial
+probes in `supabase/ci/rls_assertions.sql` (certificate forgery, attempt
+/ answer fabrication, progress faking, enrollment deletion, and more).
 
 **What is intentionally backend-gated, not RLS-gated:** reading the
 *teaching text* of a non-public course. The API filters by publish state
@@ -154,7 +160,10 @@ and quiz *prompts* (never the answer key, never another user's data).
    joining `enrollments` on every content table (courses, modules,
    chapters, blocks, …) — a large, perf-sensitive surface that would have
    to stay in lockstep with the enrollment model.
-3. Blast radius today is one institute course and zero real users.
+3. Blast radius is course *teaching text* only. Real pilot users exist
+   since 2026-06-10, but every actual secret (answer keys, PII, grades,
+   audit trail) is already hard-walled at the RLS layer above -- what a
+   direct reader can reach is lesson prose and question prompts.
 
 **Revisit if** Equip ever hosts genuinely confidential paid content where
 the lesson text itself (not just credentials) must be enrollment-gated.

--- a/docs/datadog/monitors/backend-error-log-spike.json
+++ b/docs/datadog/monitors/backend-error-log-spike.json
@@ -1,7 +1,7 @@
 {
   "name": "equip backend: error log spike",
   "type": "log alert",
-  "query": "logs(\"service:equip-backend env:production status:(error OR critical)\").index(\"*\").rollup(\"count\").last(\"10m\") >= 10",
+  "query": "logs(\"service:equip-backend env:production source:python status:(error OR critical)\").index(\"*\").rollup(\"count\").last(\"10m\") >= 10",
   "message": "5+ backend error logs in 10 minutes. Check https://app.us5.datadoghq.com/logs?query=service%3Aequip-backend%20env%3Aproduction%20status%3A%28error%20OR%20critical%29\n\nNotify: @arvavitcorp@gmail.com",
   "tags": [
     "env:production",

--- a/docs/datadog/monitors/equip-backend-warning-log-spike.json
+++ b/docs/datadog/monitors/equip-backend-warning-log-spike.json
@@ -1,7 +1,7 @@
 {
   "name": "equip backend: warning log spike",
   "type": "log alert",
-  "query": "logs(\"service:equip-backend env:production status:warning\").index(\"*\").rollup(\"count\").last(\"15m\") >= 20",
+  "query": "logs(\"service:equip-backend env:production source:python status:warning\").index(\"*\").rollup(\"count\").last(\"15m\") >= 20",
   "message": "20+ backend WARNING logs in 15 minutes. Often integrity errors. https://app.us5.datadoghq.com/logs?query=service%3Aequip-backend%20status%3Awarning\n\nNotify:\n\n(Dashboard-only: no email — watch on the Datadog dashboard. UX/warning signal, kept quiet to avoid inbox noise.)",
   "tags": [
     "env:production",

--- a/docs/datadog/monitors/translation-jobs-stuck-processing.json
+++ b/docs/datadog/monitors/translation-jobs-stuck-processing.json
@@ -1,19 +1,21 @@
 {
   "name": "[Equip] Translation jobs stuck in processing",
-  "type": "metric alert",
-  "query": "avg(last_30m):avg:equip.translation.queue_processing{env:production} > 3",
+  "type": "log alert",
+  "query": "logs(\"service:equip-backend \\\"jobs stuck in processing\\\"\").index(\"*\").rollup(\"count\").last(\"30m\") >= 1",
   "message": "Translation jobs are piling up in 'processing' (workers dying mid-run). The 15-min reaper re-claims them but a sustained backlog means repeated worker failures. @arvavitcorp@gmail.com",
   "tags": [],
-  "priority": 3,
+  "priority": null,
   "options": {
-    "renotify_interval": 0,
     "notify_no_data": false,
     "thresholds": {
-      "critical": 3.0
+      "critical": 1.0
     },
+    "enable_logs_sample": true,
+    "renotify_interval": 0,
     "notify_audit": false,
     "new_host_delay": 300,
     "include_tags": true,
+    "groupby_simple_monitor": false,
     "silenced": {}
   }
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -24,3 +24,7 @@ VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 # VITE_DATADOG_SITE=us5.datadoghq.com
 # VITE_DATADOG_SERVICE=equip-frontend
 # VITE_DATADOG_ENV=production
+
+# Note: DATADOG_API_KEY / DATADOG_SITE (no VITE_ prefix) are BUILD-TIME only —
+# read by scripts/upload-sourcemaps.mjs (and the datadog-ci CLI it invokes) to
+# upload source maps after `vite build`; they are never exposed to the bundle.

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -33,19 +33,16 @@ still has pending work.
    so tests (which bootstrap the schema via `Base.metadata.create_all()`)
    stay aligned with production.
 
-## Rebuilding a fresh database from these files
+## Rebuilding a fresh database
 
-Any standard Postgres will accept the files — they contain pure Postgres
-DDL plus Supabase-managed schemas (`auth`, `storage`). On a new Supabase
-project:
-
-```bash
-supabase db push --linked
-```
-
-On a non-Supabase Postgres you'd first need to create the `auth` and
-`storage` schemas (or strip out references to `auth.uid()` and
-`storage.objects`, depending on the target stack).
+These files alone **cannot** rebuild a fresh database — the base tables
+(`users`, `courses`, …) pre-date migration tracking, so the earliest
+migrations here `ALTER` tables that no file in this directory creates.
+The replayable baseline is [`supabase/schema.sql`](../schema.sql), a
+`pg_dump --schema-only` of prod regenerated in the same PR as every
+schema change. See [`supabase/ci/README.md`](../ci/README.md) for the
+`schema-replay-postgres` CI job that proves it loads on a clean
+Postgres, and for the regeneration recipe.
 
 ## Relationship with the app code
 


### PR DESCRIPTION
## Why
Today's wave (RLS lockdown, drain repair, monitor recreation, www redirect, DD_ENV gate) left six docs/state files stale — audit verified each claim against the repo and live services.

## What
SECURITY.md (CSP=ENFORCING, client-write-surface lockdown section, blast-radius wording), backend/.env.example (DD_ENV now required), OBSERVABILITY.md (drain id/json format, 0.5s timeout, live monitor table, new dashboards+pipeline+exclusions), migrations/README (replayability myth → schema.sql pointer), DEPLOYMENT.md (www 308), frontend/.env.example (build-time DATADOG note). Plus re-exported live monitor mirrors (source:python scope, 20465339 log alert).

## Verify
Docs-only; every claim grep-verified against repo + live Datadog/Vercel state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
