### PR TITLE
refactor(frontend): useAsyncData gains refetch(); CertificatesPage adopts it

### DIFF
--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -115,10 +115,13 @@ def update_my_preferences(
     previous = current_user.preferred_locale
     current_user.preferred_locale = body.preferred_locale
 
-    # Audit log MUST share a transaction with the locale change. Writing
-    # the audit row before the commit means a single COMMIT either makes
-    # both visible or rolls both back — there is never a window in which
-    # the new locale is durable but the audit trail is missing.
+    # ``log_action`` COMMITS the session itself (its trailing commit is
+    # load-bearing — see audit_service.py). Calling it here, after the
+    # locale mutation, makes the locale change and the audit row durable
+    # in the SAME commit — both visible or both rolled back. The explicit
+    # ``db.commit()`` below is then a no-op kept for readability; do NOT
+    # reorder this call after other uncommitted writes you don't want
+    # committed along with it.
     log_action(
         db,
         current_user.id,

--- a/frontend/src/hooks/__tests__/useAsyncData.test.ts
+++ b/frontend/src/hooks/__tests__/useAsyncData.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { describe, it, expect, vi } from "vitest"
 import { useAsyncData } from "@/hooks/useAsyncData"
 
@@ -76,5 +76,19 @@ describe("useAsyncData", () => {
 
     // Newer result should win
     expect(result.current.data).toBe("second result")
+  })
+  it("refetch re-runs the fetcher and cancels the superseded run", async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce("first")
+      .mockResolvedValueOnce("second")
+
+    const { result } = renderHook(() => useAsyncData(fetcher, []))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toBe("first")
+
+    act(() => result.current.refetch())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toBe("second")
+    expect(fetcher).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/src/hooks/useAsyncData.ts
+++ b/frontend/src/hooks/useAsyncData.ts
@@ -1,9 +1,15 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 export interface AsyncDataState<T> {
   data: T | undefined;
   loading: boolean;
   error: Error | null;
+  /**
+   * Re-runs the fetcher (e.g. after a mutation). Cancellation semantics
+   * match the deps-change path: an in-flight fetch from the previous run
+   * is marked cancelled and its result discarded.
+   */
+  refetch: () => void;
 }
 
 export function useAsyncData<T>(
@@ -13,6 +19,12 @@ export function useAsyncData<T>(
   const [data, setData] = useState<T | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  // Internal reload key: bumping it re-fires the effect without callers
+  // having to thread their own reloadKey through deps (the hand-rolled
+  // pattern this hook exists to replace).
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const refetch = useCallback(() => setReloadKey((k) => k + 1), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -38,7 +50,7 @@ export function useAsyncData<T>(
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+  }, [...deps, reloadKey]);
 
-  return { data, loading, error };
+  return { data, loading, error, refetch };
 }

--- a/frontend/src/pages/Certificates/CertificatesPage.tsx
+++ b/frontend/src/pages/Certificates/CertificatesPage.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { Card, CardContent } from "@/components/ui/card"
@@ -10,58 +9,39 @@ import { Award, ArrowLeft, RefreshCw, ScrollText } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatDateLong } from "@/i18n/format"
 import { useUserTour } from "@/hooks/useUserTour"
+import { useAsyncData } from "@/hooks/useAsyncData"
 import { certificatesSteps } from "@/lib/tourSteps"
 
 export default function CertificatesPage() {
   const { t, i18n } = useTranslation()
-  const [certificates, setCertificates] = useState<Certificate[]>([])
-  const [enrollments, setEnrollments] = useState<Enrollment[]>([])
-  const [loading, setLoading] = useState(true)
-  // Distinguish load-failure from genuine empty so the user doesn't see
-  // "no certificates yet — start learning" when the request actually
-  // 500'd. The empty-state copy is a call to action that's wrong (and
-  // misleading) when we never knew whether they have any.
-  const [loadError, setLoadError] = useState(false)
-  const [reloadKey, setReloadKey] = useState(0)
-  useUserTour({
-    tourId: "certificates-v1",
-    steps: certificatesSteps(t),
-    ready: !loading,
-  })
-
-  const retry = useCallback(() => {
-    setReloadKey((k) => k + 1)
-  }, [])
-
   // ``i18n.language`` in deps so a locale flip re-pulls the
   // localised course-title overlay without a hard reload. We
   // deliberately do NOT include ``t`` — its reference change is
   // implementation-defined across react-i18next versions and using
   // it as a dep was the brittle pattern in this codebase.
-  useEffect(() => {
-    let cancelled = false
-    setLoading(true)
-    setLoadError(false)
-    const load = async () => {
-      try {
-        const [certs, courses] = await Promise.all([
-          coursesService.getMyCertificates(),
-          coursesService.getMyCourses().catch(() => []),
-        ])
-        if (cancelled) return
-        setCertificates(certs)
-        setEnrollments(courses)
-      } catch {
-        if (!cancelled) setLoadError(true)
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    }
-    load()
-    return () => {
-      cancelled = true
-    }
-  }, [i18n.language, reloadKey])
+  const { data, loading, error, refetch: retry } = useAsyncData(
+    async () => {
+      const [certs, courses] = await Promise.all([
+        coursesService.getMyCertificates(),
+        coursesService.getMyCourses().catch(() => [] as Enrollment[]),
+      ])
+      return { certificates: certs, enrollments: courses }
+    },
+    [i18n.language],
+  )
+  const certificates: Certificate[] = data?.certificates ?? []
+  const enrollments: Enrollment[] = data?.enrollments ?? []
+  // Distinguish load-failure from genuine empty so the user doesn't see
+  // "no certificates yet — start learning" when the request actually
+  // 500'd. The empty-state copy is a call to action that's wrong (and
+  // misleading) when we never knew whether they have any.
+  const loadError = error !== null
+
+  useUserTour({
+    tourId: "certificates-v1",
+    steps: certificatesSteps(t),
+    ready: !loading,
+  })
 
   const courseTitle = (courseId: string | null) => {
     if (!courseId) return t("certificates.courseFallback", { id: "—" })


### PR DESCRIPTION
Audit follow-up: `refetch()` on `useAsyncData` (internal reload key, deps-path cancellation semantics) + CertificatesPage as first adopter (−30 LOC hand-rolled state). Also fixes the `users.py` comment misdescribing `log_action` transaction semantics. eslint/tsc clean, 552 vitest, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)