### PR TITLE
perf(frontend): split the motion runtime out of the entry chunk

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,6 +36,15 @@ export default defineConfig({
         // imported from the lazy teacher routes (CourseEditor / ChapterEditor).
         manualChunks(id) {
           if (id.includes('node_modules/@supabase/supabase-js')) return 'supabase'
+          // The `motion` runtime (motion / motion-dom / motion-utils) is used
+          // only by lazy routes + a few shared components (CourseCard,
+          // PressFeedback, DashboardPage, …) — never by the eager shell, since
+          // HeaderNavLink dropped its layoutId underline. Left to rollup's
+          // default heuristic it gets hoisted into the entry `index` chunk
+          // (several async chunks share it), so every anonymous / login load
+          // pays ~30 KB gzip it never uses. Pin it to its own chunk so it
+          // loads in parallel only when a motion-using route mounts.
+          if (/node_modules[\\/]motion(-dom|-utils)?[\\/]/.test(id)) return 'motion'
           if (
             id.includes('node_modules/react-router-dom') ||
             id.includes('node_modules/react-router') ||


### PR DESCRIPTION
perf(frontend): split the motion runtime out of the entry chunk

The `motion` runtime (motion / motion-dom / motion-utils, ~30 KB gzip) is
used only by lazy routes and a few shared components — never by the eager
shell, since HeaderNavLink dropped its layoutId underline. Left to
rollup's default heuristic it gets hoisted into the entry `index` chunk
because several async chunks share it, so every anonymous / login load
downloads motion it never executes until navigating to a motion-using
route.

Pin it to its own `motion` chunk via manualChunks. Build confirms a
standalone motion-*.js (30.7 KB gzip) and a correspondingly lighter
index; the landing / login paths no longer fetch it. Motion-using routes
load the chunk in parallel with their own (HTTP/2 multiplexed), so the
"waterfall" cost is negligible while the initial-load win is real.

Local: tsc + eslint clean, vite build + bundle-size sentinel green,
vitest 555 passed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
