### PR TITLE
refactor(ui): dedupe Daily Challenge option UI, add Eyebrow pattern, fold CardTitle serif into base

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -48,14 +48,17 @@ One scale, one serif, one sans.
 
 - **Serif (`Fraunces`):** page titles (H1, H2), chapter reader body.
 - **Sans (`Inter`):** everything else.
-- **Scale:** `32 / 24 / 18 / 16 / 14 / 13` px. No `text-[Npx]` arbitrary values.
+- **Scale:** `32 / 24 / 18 / 16 / 14 / 13` px. No `text-[Npx]` arbitrary
+  values — the single documented exception is the 11px eyebrow below.
 - **Weights:** 400 body, 500 UI, 600 emphasis, 700 display. No 800/900.
 - **Editorial eyebrow:** the tiny uppercase label that sits above a heading
-  (e.g. VerseOfTheDayCard, CourseReadinessCard) is `text-xs font-medium
-  uppercase tracking-[0.18em] text-muted-foreground`. The wide tracking is
+  (e.g. VerseOfTheDayCard, CourseReadinessCard) is `text-[11px] font-medium
+  uppercase tracking-[0.18em] text-ink-muted`. The wide tracking is
   load-bearing — that's what makes it read as an eyebrow rather than a
-  shrunk body line. Inline is fine; only worth extracting a component if it
-  appears more than ~4 times.
+  shrunk body line. Use the `<Eyebrow>` pattern component
+  (`@/components/patterns`) instead of retyping the recipe; its
+  `tone="accent"` variant (`tracking-[0.22em] text-accent`) covers the
+  first-run / celebration surfaces.
 
 ## Spacing, radius, elevation
 

--- a/frontend/src/components/assignment/AssignmentPanel.tsx
+++ b/frontend/src/components/assignment/AssignmentPanel.tsx
@@ -52,6 +52,15 @@ export default function AssignmentPanel({ chapterId, assignmentId, onSubmitted, 
         // per-module ``inflightChapterAssignments`` Map duplicated
         // that behaviour and would have diverged if the api-layer
         // policy ever changed.
+        // When the panel is scoped to a single assignment we already know
+        // the submissions endpoint we'll need — kick it off in parallel
+        // with the assignment list instead of waterfalling behind it.
+        // Errors degrade to "no submission" exactly like the per-item
+        // fetches below (the .catch is attached at creation so a failed
+        // prefetch can never surface as an unhandled rejection).
+        const prefetchedSubmissions = assignmentId
+          ? coursesService.getMySubmissions(assignmentId).catch(() => [] as AssignmentSubmission[])
+          : null
         const all = await coursesService.getChapterAssignments(chapterId)
         if (cancelled) return
         const data = assignmentId ? all.filter((a) => a.id === assignmentId) : all
@@ -60,7 +69,11 @@ export default function AssignmentPanel({ chapterId, assignmentId, onSubmitted, 
 
         if (data.length > 0) {
           const subResults = await Promise.all(
-            data.map((a) => coursesService.getMySubmissions(a.id).catch(() => [] as AssignmentSubmission[]))
+            data.map((a) =>
+              prefetchedSubmissions && a.id === assignmentId
+                ? prefetchedSubmissions
+                : coursesService.getMySubmissions(a.id).catch(() => [] as AssignmentSubmission[])
+            )
           )
           if (cancelled) return
           const map: Record<string, AssignmentSubmission | null> = {}

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -98,7 +98,7 @@ function CourseCard({ course, style, progress }: CourseCardProps) {
         )}
       </div>
       <CardHeader className="pb-2">
-        <CardTitle className="font-serif text-lg leading-snug line-clamp-2 text-wrap-safe">
+        <CardTitle className="leading-snug line-clamp-2 text-wrap-safe">
           {course.title}
         </CardTitle>
         {course.description && (

--- a/frontend/src/components/course/CourseReviews.tsx
+++ b/frontend/src/components/course/CourseReviews.tsx
@@ -69,7 +69,7 @@ export default function CourseReviews({ courseId }: Props) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-lg flex items-center gap-2">
+        <CardTitle className="flex items-center gap-2">
           <MessageSquare className="h-5 w-5" strokeWidth={1.75} />
           {t("reviews.heading")}
           {reviews.length > 0 && (

--- a/frontend/src/components/dailyChallenge/OptionButton.tsx
+++ b/frontend/src/components/dailyChallenge/OptionButton.tsx
@@ -1,0 +1,74 @@
+import { Check, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { DailyChallengeOption } from "@/services/dailyChallenge"
+
+/**
+ * The slice of reveal state the option button needs. Both the dashboard
+ * card and the archive detail panel keep richer reveal objects
+ * (streak, explanation, …) — structural typing lets them pass those
+ * straight through.
+ */
+export interface OptionRevealView {
+  correct_option_id: string
+  selected_option_id: string
+}
+
+interface OptionButtonProps {
+  option: DailyChallengeOption
+  reveal: OptionRevealView | null
+  disabled: boolean
+  onClick: () => void
+}
+
+/**
+ * One answer option for a Daily Challenge question — the canonical
+ * option row shared by the dashboard card and the archive replay panel.
+ *
+ * States: neutral (pre-answer, hover affordance on row + letter chip),
+ * revealed-correct (green), revealed-wrong (red, only on the user's
+ * pick), revealed-other (muted).
+ */
+export function OptionButton({ option, reveal, disabled, onClick }: OptionButtonProps) {
+  const isSelected = reveal?.selected_option_id === option.id
+  const isCorrect = reveal?.correct_option_id === option.id
+  const showAsCorrect = reveal !== null && isCorrect
+  const showAsWrong = reveal !== null && isSelected && !isCorrect
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={isSelected}
+      className={cn(
+        "group flex w-full items-center gap-2.5 rounded-md border px-3 py-2 text-left text-xs transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+        reveal === null && "border-edge bg-surface hover:border-brand/30 hover:bg-muted/30",
+        showAsCorrect && "border-success/40 bg-success/10 text-ink",
+        showAsWrong && "border-destructive/40 bg-destructive/10 text-ink",
+        reveal !== null && !showAsCorrect && !showAsWrong && "border-edge bg-surface text-ink-muted",
+        disabled && "cursor-default",
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold",
+          reveal === null && "border-edge text-ink-muted group-hover:border-brand/40",
+          showAsCorrect && "border-success bg-success text-success-foreground",
+          showAsWrong && "border-destructive bg-destructive text-destructive-foreground",
+          reveal !== null && !showAsCorrect && !showAsWrong && "border-edge text-ink-muted",
+        )}
+      >
+        {showAsCorrect ? (
+          <Check className="h-3 w-3" strokeWidth={1.75} />
+        ) : showAsWrong ? (
+          <X className="h-3 w-3" strokeWidth={1.75} />
+        ) : (
+          String.fromCharCode(65 + option.order_index)
+        )}
+      </span>
+      <span className="min-w-0 flex-1 truncate">{option.option_text}</span>
+    </button>
+  )
+}

--- a/frontend/src/components/dailyChallenge/RevealPanel.tsx
+++ b/frontend/src/components/dailyChallenge/RevealPanel.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from "react-i18next"
+import { cn } from "@/lib/utils"
+
+interface RevealPanelProps {
+  isCorrect: boolean
+  explanation: string | null
+}
+
+/**
+ * Post-answer verdict + explanation block for a Daily Challenge
+ * question — shared by the dashboard card and the archive replay
+ * panel so the reveal reads identically in both places.
+ */
+export function RevealPanel({ isCorrect, explanation }: RevealPanelProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-1.5 rounded-md bg-muted/20 px-3 py-2.5">
+      <p
+        className={cn(
+          "text-[11px] font-semibold uppercase tracking-[0.14em]",
+          isCorrect ? "text-success" : "text-ink-muted",
+        )}
+      >
+        {isCorrect ? t("dailyChallenge.reveal.correct") : t("dailyChallenge.reveal.wrong")}
+      </p>
+      {explanation && <p className="text-xs leading-snug text-ink">{explanation}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/dailyChallenge/index.ts
+++ b/frontend/src/components/dailyChallenge/index.ts
@@ -1,0 +1,2 @@
+export { OptionButton, type OptionRevealView } from "./OptionButton"
+export { RevealPanel } from "./RevealPanel"

--- a/frontend/src/components/dashboard/DailyChallengeCard.tsx
+++ b/frontend/src/components/dashboard/DailyChallengeCard.tsx
@@ -1,16 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
-import { ArrowRight, Check, Flame, Sparkles, X } from "lucide-react"
+import { ArrowRight, Flame, Sparkles } from "lucide-react"
 import { toast } from "sonner"
-import { cn } from "@/lib/utils"
 import { getErrorCode } from "@/lib/errorCode"
 import { Skeleton } from "@/components/ui/skeleton"
-import { EmptyState } from "@/components/patterns"
+import { EmptyState, Eyebrow } from "@/components/patterns"
+import { OptionButton, RevealPanel } from "@/components/dailyChallenge"
 import {
   dailyChallengeService,
   type DailyChallengeAttemptResponse,
-  type DailyChallengeOption,
   type DailyChallengeTodayResponse,
 } from "@/services/dailyChallenge"
 
@@ -32,58 +31,6 @@ function revealFromAttempt(
     streak_after: res.streak_after,
     selected_option_id: res.selected_option_id,
   }
-}
-
-interface OptionButtonProps {
-  option: DailyChallengeOption
-  reveal: RevealState | null
-  disabled: boolean
-  onClick: () => void
-}
-
-function OptionButton({ option, reveal, disabled, onClick }: OptionButtonProps) {
-  const isSelected = reveal?.selected_option_id === option.id
-  const isCorrect = reveal?.correct_option_id === option.id
-  const showAsCorrect = reveal !== null && isCorrect
-  const showAsWrong = reveal !== null && isSelected && !isCorrect
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      aria-pressed={isSelected}
-      className={cn(
-        "group flex w-full items-center gap-2.5 rounded-md border px-3 py-1.5 text-left text-xs transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-        reveal === null && "border-edge bg-surface hover:border-brand/30 hover:bg-muted/30",
-        showAsCorrect && "border-success/40 bg-success/10 text-ink",
-        showAsWrong && "border-destructive/40 bg-destructive/10 text-ink",
-        reveal !== null && !showAsCorrect && !showAsWrong && "border-edge bg-surface text-ink-muted",
-        disabled && "cursor-default",
-      )}
-    >
-      <span
-        aria-hidden
-        className={cn(
-          "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold",
-          reveal === null && "border-edge text-ink-muted group-hover:border-brand/40",
-          showAsCorrect && "border-success bg-success text-success-foreground",
-          showAsWrong && "border-destructive bg-destructive text-destructive-foreground",
-          reveal !== null && !showAsCorrect && !showAsWrong && "border-edge text-ink-muted",
-        )}
-      >
-        {showAsCorrect ? (
-          <Check className="h-3 w-3" strokeWidth={1.75} />
-        ) : showAsWrong ? (
-          <X className="h-3 w-3" strokeWidth={1.75} />
-        ) : (
-          String.fromCharCode(65 + option.order_index)
-        )}
-      </span>
-      <span className="min-w-0 flex-1 truncate">{option.option_text}</span>
-    </button>
-  )
 }
 
 interface CandleStreakProps {
@@ -234,9 +181,7 @@ export function DailyChallengeCard() {
         <div className="flex min-w-0 items-center gap-2.5">
           <Sparkles className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
           <div className="min-w-0">
-            <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted">
-              {t("dailyChallenge.eyebrow")}
-            </p>
+            <Eyebrow>{t("dailyChallenge.eyebrow")}</Eyebrow>
             <h2
               id="dc-card-heading"
               className="truncate font-serif text-sm font-semibold tracking-tight text-ink"
@@ -293,21 +238,7 @@ export function DailyChallengeCard() {
                 ))}
             </ul>
             {reveal !== null && (
-              <div className="space-y-1.5 rounded-md bg-muted/20 px-3 py-2.5">
-                <p
-                  className={cn(
-                    "text-[11px] font-semibold uppercase tracking-[0.14em]",
-                    reveal.is_correct ? "text-success" : "text-ink-muted",
-                  )}
-                >
-                  {reveal.is_correct
-                    ? t("dailyChallenge.reveal.correct")
-                    : t("dailyChallenge.reveal.wrong")}
-                </p>
-                {reveal.explanation && (
-                  <p className="text-xs leading-snug text-ink">{reveal.explanation}</p>
-                )}
-              </div>
+              <RevealPanel isCorrect={reveal.is_correct} explanation={reveal.explanation} />
             )}
           </>
         ) : null}

--- a/frontend/src/components/dashboard/TodayCard.tsx
+++ b/frontend/src/components/dashboard/TodayCard.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { ArrowRight, CalendarDays } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
-import { EmptyState } from "@/components/patterns"
+import { EmptyState, Eyebrow } from "@/components/patterns"
 import { coursesService } from "@/services/courses"
 import { useAuth } from "@/context/useAuth"
 import type { CalendarEvent } from "@/types"
@@ -86,9 +86,7 @@ export function TodayCard() {
         <div className="flex min-w-0 items-center gap-2.5">
           <CalendarDays className="h-4 w-4 shrink-0 text-ink-muted" strokeWidth={1.75} aria-hidden />
           <div className="min-w-0">
-            <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted">
-              {t("dashboard.today.eyebrow")}
-            </p>
+            <Eyebrow>{t("dashboard.today.eyebrow")}</Eyebrow>
             <h2
               id="today-card-heading"
               className="truncate font-serif text-sm font-semibold capitalize tracking-tight text-ink"

--- a/frontend/src/components/home/VerseOfTheDayCard.tsx
+++ b/frontend/src/components/home/VerseOfTheDayCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { BookOpenText } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Eyebrow } from "@/components/patterns"
 import {
   verseOfTheDayService,
   type VerseOfTheDay,
@@ -68,9 +69,7 @@ export function VerseOfTheDayCard() {
           aria-hidden
         />
         <div className="min-w-0">
-          <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted">
-            {t("dashboard.votd.eyebrow")}
-          </p>
+          <Eyebrow>{t("dashboard.votd.eyebrow")}</Eyebrow>
           <h2
             id="verse-of-the-day-heading"
             className="font-serif text-sm font-semibold leading-tight tracking-tight text-ink"

--- a/frontend/src/components/patterns/Eyebrow.tsx
+++ b/frontend/src/components/patterns/Eyebrow.tsx
@@ -1,0 +1,35 @@
+import type { ElementType, LabelHTMLAttributes } from "react"
+import { cn } from "@/lib/utils"
+
+interface EyebrowProps extends LabelHTMLAttributes<HTMLElement> {
+  /** Rendered element — `p` by default; use `label` (with `htmlFor`)
+   *  or `div` where semantics require it. */
+  as?: ElementType
+  /**
+   * - `muted` (default): the canonical DESIGN.md eyebrow —
+   *   `text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted`.
+   * - `accent`: the celebration/first-run variant with wider tracking
+   *   and the academic-gold accent color.
+   */
+  tone?: "muted" | "accent"
+}
+
+/**
+ * Editorial eyebrow — the tiny uppercase label that sits above a
+ * heading. Encodes the DESIGN.md recipe (11px is the one documented
+ * arbitrary-size exception; the wide tracking is load-bearing) so
+ * call sites stop drifting between 10px/11px/text-xs re-typings.
+ */
+export function Eyebrow({ as: Comp = "p", tone = "muted", className, ...props }: EyebrowProps) {
+  return (
+    <Comp
+      className={cn(
+        "text-[11px] font-medium uppercase",
+        tone === "muted" && "tracking-[0.18em] text-ink-muted",
+        tone === "accent" && "tracking-[0.22em] text-accent",
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/components/patterns/__tests__/Eyebrow.test.tsx
+++ b/frontend/src/components/patterns/__tests__/Eyebrow.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Eyebrow } from "../Eyebrow"
+
+describe("Eyebrow", () => {
+  it("renders a <p> with the canonical muted recipe by default", () => {
+    render(<Eyebrow>Section label</Eyebrow>)
+    const el = screen.getByText("Section label")
+    expect(el.tagName).toBe("P")
+    // The DESIGN.md recipe — 11px is the one documented arbitrary-size
+    // exception and the wide tracking is load-bearing.
+    expect(el).toHaveClass(
+      "text-[11px]",
+      "font-medium",
+      "uppercase",
+      "tracking-[0.18em]",
+      "text-ink-muted",
+    )
+  })
+
+  it("supports the accent tone (wider tracking, accent color)", () => {
+    render(<Eyebrow tone="accent">Celebration</Eyebrow>)
+    const el = screen.getByText("Celebration")
+    expect(el).toHaveClass("tracking-[0.22em]", "text-accent")
+    expect(el).not.toHaveClass("text-ink-muted")
+  })
+
+  it("renders as a <label> with htmlFor when used for form field eyebrows", () => {
+    render(
+      <>
+        <Eyebrow as="label" htmlFor="field-1">
+          Status
+        </Eyebrow>
+        <select id="field-1" />
+      </>,
+    )
+    const label = screen.getByText("Status")
+    expect(label.tagName).toBe("LABEL")
+    expect(screen.getByLabelText("Status")).toBeInTheDocument()
+  })
+
+  it("merges caller className on top of the recipe", () => {
+    render(
+      <Eyebrow as="div" className="pb-1 text-center">
+        Mon
+      </Eyebrow>,
+    )
+    const el = screen.getByText("Mon")
+    expect(el.tagName).toBe("DIV")
+    expect(el).toHaveClass("pb-1", "text-center", "text-[11px]")
+  })
+})

--- a/frontend/src/components/patterns/index.ts
+++ b/frontend/src/components/patterns/index.ts
@@ -1,3 +1,4 @@
+export { Eyebrow } from "./Eyebrow"
 export { InlineEdit } from "./InlineEdit"
 export { InlineEditCover } from "./InlineEditCover"
 export { PageHeader } from "./PageHeader"

--- a/frontend/src/components/ui/CalendarPopover.tsx
+++ b/frontend/src/components/ui/CalendarPopover.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Eyebrow } from "@/components/patterns"
 import { addMonths, buildMonthMatrix, ymdKey } from "@/lib/calendar"
 import { cn } from "@/lib/utils"
 
@@ -131,12 +132,9 @@ export function CalendarPopover({
         <div className="p-2">
           <div className="grid grid-cols-7 gap-0.5">
             {weekdayHeads.map((d, i) => (
-              <div
-                key={i}
-                className="pb-1 text-center text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted"
-              >
+              <Eyebrow as="div" key={i} className="pb-1 text-center">
                 {d}
-              </div>
+              </Eyebrow>
             ))}
             {days.map((date, i) => {
               const inCurrentMonth = date.getMonth() === anchorMonth

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -50,8 +50,11 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
+    // Editorial convention: card titles are serif (Fraunces) + tight
+    // tracking everywhere — folded into the base so call sites stop
+    // re-adding (and occasionally forgetting) `font-serif tracking-tight`.
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "font-serif text-lg font-semibold leading-none tracking-tight",
       className
     )}
     {...props}

--- a/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortDetailPage.tsx
@@ -276,7 +276,7 @@ export default function CohortDetailPage() {
 
       <Card className="mb-6">
         <CardHeader className="pb-3">
-          <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
+          <CardTitle className="flex items-center gap-2">
             <Calendar className="h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.detailsHeading")}
           </CardTitle>
@@ -363,7 +363,7 @@ export default function CohortDetailPage() {
 
       <Card className="mb-6">
         <CardHeader className="flex-row items-center justify-between space-y-0 pb-3">
-          <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+          <CardTitle>
             {t("admin.cohorts.coursesHeading", { count: courses.length })}
           </CardTitle>
           <Button size="sm" className="h-9" onClick={() => setAttachOpen(true)}>
@@ -626,7 +626,7 @@ function StudentsCard({
     <Card>
       <CardHeader className="gap-3 space-y-0">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
+          <CardTitle className="flex items-center gap-2">
             <Users className="h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.studentsHeading", { count: students.length })}
           </CardTitle>

--- a/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
+++ b/frontend/src/pages/Admin/cohorts/CohortsTab.tsx
@@ -196,7 +196,7 @@ export function CohortsTab() {
     <Card className="flex max-h-[calc(100dvh-240px)] flex-col md:max-h-[calc(100dvh-200px)] md:min-h-[420px]">
       <CardHeader className="shrink-0 gap-3 space-y-0 border-b">
         <div className="flex items-center justify-between gap-3">
-          <CardTitle className="font-serif text-xl font-semibold tracking-tight">{t("admin.cohorts.title")}</CardTitle>
+          <CardTitle className="text-xl">{t("admin.cohorts.title")}</CardTitle>
           <Button size="sm" onClick={() => setCreateOpen(true)} className="h-9 shrink-0">
             <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
             {t("admin.cohorts.createButton")}

--- a/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
+++ b/frontend/src/pages/Admin/dashboard/AuditLogTab.tsx
@@ -94,7 +94,7 @@ export function AuditLogTab({
   return (
     <Card className="flex max-h-[calc(100dvh-240px)] flex-col md:max-h-[calc(100dvh-200px)] md:min-h-[420px]">
       <CardHeader className="shrink-0 gap-3 space-y-0 border-b">
-        <CardTitle className="flex items-center gap-2 font-serif text-xl font-semibold tracking-tight">
+        <CardTitle className="flex items-center gap-2 text-xl">
           <FileText className="h-5 w-5 shrink-0" strokeWidth={1.75} aria-hidden />
           {t("admin.audit.title")}
           <span className="ml-1.5 text-sm font-normal text-ink-muted">

--- a/frontend/src/pages/Admin/dashboard/FilterField.tsx
+++ b/frontend/src/pages/Admin/dashboard/FilterField.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 import { cn } from "@/lib/utils"
+import { Eyebrow } from "@/components/patterns"
 
 interface Props {
   label: string
@@ -40,15 +41,9 @@ export function FilterField({ label, children, hideLabel = false, className }: P
   const id = genId()
   return (
     <div className={cn("flex flex-col gap-1", className)}>
-      <label
-        htmlFor={id}
-        className={cn(
-          "text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted",
-          hideLabel && "sr-only",
-        )}
-      >
+      <Eyebrow as="label" htmlFor={id} className={cn(hideLabel && "sr-only")}>
         {label}
-      </label>
+      </Eyebrow>
       {children({ id })}
     </div>
   )

--- a/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/PendingCertsCard.tsx
@@ -23,7 +23,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
   return (
     <Card className="mb-6 border-l-stripe border-l-primary">
       <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
+        <CardTitle className="flex items-center gap-2">
           <Award className="h-4 w-4 text-brand" strokeWidth={1.75} aria-hidden />
           {t("admin.pendingCerts.title")}
           <Badge variant="default" className="font-normal">

--- a/frontend/src/pages/Admin/dashboard/UsersCard.tsx
+++ b/frontend/src/pages/Admin/dashboard/UsersCard.tsx
@@ -111,7 +111,7 @@ export function UsersCard({
             single flex-wrap row, and at laptop widths the chip strip
             below would wrap up under the search input creating an
             orphan visual that looked unfinished. */}
-        <CardTitle className="font-serif text-lg font-semibold tracking-tight">{t("admin.users.title")}</CardTitle>
+        <CardTitle>{t("admin.users.title")}</CardTitle>
 
         {/* Row 2: filter + search aligned right. ``items-center`` so
             the search h-9 input and select line up; ``ml-auto`` pushes

--- a/frontend/src/pages/Calendar/MonthGrid.tsx
+++ b/frontend/src/pages/Calendar/MonthGrid.tsx
@@ -51,7 +51,7 @@ export function MonthGrid({
             <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted tabular-nums">
               {year}
             </p>
-            <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+            <CardTitle>
               {getMonthName(month, locale)}
             </CardTitle>
           </div>

--- a/frontend/src/pages/Calendar/SelectedDayPanel.tsx
+++ b/frontend/src/pages/Calendar/SelectedDayPanel.tsx
@@ -35,7 +35,7 @@ export function SelectedDayPanel({ selectedDay, events }: SelectedDayPanelProps)
           <CalendarDays className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
           {weekday}
         </p>
-        <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+        <CardTitle>
           {dateLine}
         </CardTitle>
         {events.length > 0 && (

--- a/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
+++ b/frontend/src/pages/Calendar/UpcomingEventsPanel.tsx
@@ -23,7 +23,7 @@ export function UpcomingEventsPanel({ events }: UpcomingEventsPanelProps) {
         <p className="text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
           {t("calendar.upcomingEyebrow")}
         </p>
-        <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+        <CardTitle>
           {t("calendar.upcomingTitle")}
         </CardTitle>
       </CardHeader>

--- a/frontend/src/pages/Certificates/CertificatesPage.tsx
+++ b/frontend/src/pages/Certificates/CertificatesPage.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { EmptyState, ErrorState } from "@/components/patterns"
+import { EmptyState, ErrorState, Eyebrow } from "@/components/patterns"
 import { coursesService } from "@/services/courses"
 import type { Certificate, Enrollment } from "@/types"
 import { Award, ArrowLeft, RefreshCw, ScrollText } from "lucide-react"
@@ -155,9 +155,9 @@ export default function CertificatesPage() {
                       </div>
                     )}
                     <div>
-                      <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-muted">
+                      <Eyebrow>
                         {isApproved ? t("certificates.issuedOrStatus") : t("certificates.statusColumn")}
-                      </p>
+                      </Eyebrow>
                       <p className={`mt-0.5 text-sm font-medium ${isApproved ? "text-ink" : "text-ink-muted"}`}>
                         {statusLabel}
                       </p>

--- a/frontend/src/pages/Course/ModuleView.tsx
+++ b/frontend/src/pages/Course/ModuleView.tsx
@@ -214,7 +214,7 @@ export default function ModuleView() {
                     style={{ animationDelay: `${idx * 50}ms` }}
                   >
                     <CardHeader className="pb-2">
-                      <CardTitle className="flex min-w-0 items-center gap-2 font-serif text-base font-semibold tracking-tight">
+                      <CardTitle className="flex min-w-0 items-center gap-2 text-base">
                         <Lock className="h-5 w-5 text-ink-muted/50 shrink-0" strokeWidth={1.75} aria-hidden />
                         <span className="min-w-0 flex-1 truncate text-ink-muted">
                           {chapter.title}
@@ -240,7 +240,7 @@ export default function ModuleView() {
                     style={{ animationDelay: `${idx * 50}ms` }}
                   >
                     <CardHeader className="pb-2">
-                      <CardTitle className="flex min-w-0 items-center gap-2 font-serif text-base font-semibold tracking-tight">
+                      <CardTitle className="flex min-w-0 items-center gap-2 text-base">
                         {isGradable ? (
                           isCompleted ? (
                             <CheckCircle className="h-5 w-5 shrink-0 text-success" strokeWidth={1.75} aria-hidden />

--- a/frontend/src/pages/Course/detail/ModuleList.tsx
+++ b/frontend/src/pages/Course/detail/ModuleList.tsx
@@ -103,7 +103,7 @@ const ModuleRow = memo(function ModuleRow({
     <Card className={`group transition-colors ${isLocked ? "opacity-60" : "hover:border-brand/25"}`}>
       <CardHeader className="py-3 px-4">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="flex min-w-0 items-center gap-2 font-serif text-sm font-semibold tracking-tight">
+          <CardTitle className="flex min-w-0 items-center gap-2 text-sm">
             <span
               className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${
                 isLocked

--- a/frontend/src/pages/DailyChallengeArchive/DailyChallengeArchivePage.tsx
+++ b/frontend/src/pages/DailyChallengeArchive/DailyChallengeArchivePage.tsx
@@ -5,7 +5,8 @@ import { Calendar, Check, ChevronLeft, Sparkles, X } from "lucide-react"
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
 import { getErrorCode } from "@/lib/errorCode"
-import { PageHeader, EmptyState, ErrorState } from "@/components/patterns"
+import { PageHeader, EmptyState, ErrorState, Eyebrow } from "@/components/patterns"
+import { OptionButton, RevealPanel } from "@/components/dailyChallenge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 import {
@@ -220,9 +221,7 @@ function CalendarGrid({ entries, selectedDate, onSelect, t }: CalendarGridProps)
         )
         return (
           <div key={monthKey} className="space-y-2">
-            <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted">
-              {monthLabel}
-            </p>
+            <Eyebrow>{monthLabel}</Eyebrow>
             <div className="grid grid-cols-7 gap-1.5 sm:gap-2">
               {monthEntries
                 .slice()
@@ -457,68 +456,19 @@ function DetailPanel({ challengeDate, onBack, t }: DetailPanelProps) {
             <ul className="space-y-1.5">
               {[...data.options]
                 .sort((a, b) => a.order_index - b.order_index)
-                .map((opt) => {
-                  const isCorrect = reveal?.correct_option_id === opt.id
-                  const isSelected = reveal?.selected_option_id === opt.id
-                  const showCorrect = reveal !== null && isCorrect
-                  const showWrong = reveal !== null && isSelected && !isCorrect
-                  return (
-                    <li key={opt.id}>
-                      <button
-                        type="button"
-                        onClick={() => void handleSelect(opt.id)}
-                        disabled={reveal !== null || submitting}
-                        aria-pressed={isSelected}
-                        className={cn(
-                          "flex w-full items-center gap-2.5 rounded-md border px-3 py-2 text-left text-xs transition-colors",
-                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                          reveal === null && "border-edge bg-surface hover:border-brand/30 hover:bg-muted/30",
-                          showCorrect && "border-success/40 bg-success/10 text-ink",
-                          showWrong && "border-destructive/40 bg-destructive/10 text-ink",
-                          reveal !== null && !showCorrect && !showWrong && "border-edge bg-surface text-ink-muted",
-                          (reveal !== null || submitting) && "cursor-default",
-                        )}
-                      >
-                        <span
-                          aria-hidden
-                          className={cn(
-                            "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold",
-                            reveal === null && "border-edge text-ink-muted",
-                            showCorrect && "border-success bg-success text-success-foreground",
-                            showWrong && "border-destructive bg-destructive text-destructive-foreground",
-                            reveal !== null && !showCorrect && !showWrong && "border-edge text-ink-muted",
-                          )}
-                        >
-                          {showCorrect ? (
-                            <Check className="h-3 w-3" strokeWidth={1.75} />
-                          ) : showWrong ? (
-                            <X className="h-3 w-3" strokeWidth={1.75} />
-                          ) : (
-                            String.fromCharCode(65 + opt.order_index)
-                          )}
-                        </span>
-                        <span className="min-w-0 flex-1 truncate">{opt.option_text}</span>
-                      </button>
-                    </li>
-                  )
-                })}
+                .map((opt) => (
+                  <li key={opt.id}>
+                    <OptionButton
+                      option={opt}
+                      reveal={reveal}
+                      disabled={reveal !== null || submitting}
+                      onClick={() => void handleSelect(opt.id)}
+                    />
+                  </li>
+                ))}
             </ul>
             {reveal !== null && (
-              <div className="space-y-1.5 rounded-md bg-muted/20 px-3 py-2.5">
-                <p
-                  className={cn(
-                    "text-[11px] font-semibold uppercase tracking-[0.14em]",
-                    reveal.is_correct ? "text-success" : "text-ink-muted",
-                  )}
-                >
-                  {reveal.is_correct
-                    ? t("dailyChallenge.reveal.correct")
-                    : t("dailyChallenge.reveal.wrong")}
-                </p>
-                {reveal.explanation && (
-                  <p className="text-xs leading-snug text-ink">{reveal.explanation}</p>
-                )}
-              </div>
+              <RevealPanel isCorrect={reveal.is_correct} explanation={reveal.explanation} />
             )}
           </>
         ) : null}

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -226,7 +226,7 @@ export default function ProfilePage() {
 
         <Card className="transition-[border-color] duration-200 hover:border-brand/25">
           <CardHeader className="space-y-1">
-            <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+            <CardTitle>
               {t("profile.learningProgress")}
             </CardTitle>
             <CardDescription>{t("profile.learningProgressDescription")}</CardDescription>
@@ -266,7 +266,7 @@ export default function ProfilePage() {
 
         <Card className="transition-[border-color] duration-200 hover:border-brand/25">
           <CardHeader>
-            <CardTitle className="font-serif text-lg font-semibold tracking-tight">{t("profile.accountDetails")}</CardTitle>
+            <CardTitle>{t("profile.accountDetails")}</CardTitle>
           </CardHeader>
           <CardContent>
             <dl className="divide-y divide-border rounded-md ">
@@ -294,7 +294,7 @@ export default function ProfilePage() {
 
         <Card className="transition-[border-color] duration-200 hover:border-brand/25">
           <CardHeader>
-            <CardTitle className="font-serif text-lg font-semibold tracking-tight">{t("profile.preferences")}</CardTitle>
+            <CardTitle>{t("profile.preferences")}</CardTitle>
           </CardHeader>
           <CardContent className="divide-y divide-border rounded-md px-0">
             <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-4">

--- a/frontend/src/pages/Teacher/TeacherAnalytics.tsx
+++ b/frontend/src/pages/Teacher/TeacherAnalytics.tsx
@@ -165,7 +165,7 @@ export default function TeacherAnalytics() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+          <CardTitle>
             {t("teacherAnalytics.enrollments.heading")}
           </CardTitle>
           <CardDescription>

--- a/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CreateCourseForm.tsx
@@ -34,7 +34,7 @@ export function CreateCourseForm({
   return (
     <Card className="mb-8 border-dashed">
       <CardHeader>
-        <CardTitle className="font-serif text-lg font-semibold tracking-tight">
+        <CardTitle>
           {t("teacherDashboard.createForm.title")}
         </CardTitle>
       </CardHeader>

--- a/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/PendingCertsCard.tsx
@@ -19,7 +19,7 @@ export function PendingCertsCard({ certs, actionId, onApprove, onReject }: Props
   return (
     <Card data-tour="pending-certs" className="mb-8 border-l-stripe border-l-warning">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
+        <CardTitle className="flex items-center gap-2">
           <Award className="h-5 w-5 text-warning" strokeWidth={1.75} aria-hidden />
           {t("teacherDashboard.pendingCerts.title")}
           <Badge variant="warning" className="font-normal">

--- a/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradeTableTab.tsx
@@ -90,7 +90,7 @@ export function GradeTableTab({
     <div className="space-y-4">
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="font-serif text-lg font-semibold tracking-tight">{t("gradebook.table.title")}</CardTitle>
+          <CardTitle>{t("gradebook.table.title")}</CardTitle>
           <CardDescription className="text-xs">{t("gradebook.table.description")}</CardDescription>
         </CardHeader>
         <CardContent>

--- a/frontend/src/pages/Teacher/gradebook/GradingConfigCard.tsx
+++ b/frontend/src/pages/Teacher/gradebook/GradingConfigCard.tsx
@@ -54,7 +54,7 @@ export function GradingConfigCard({
         <div className="flex items-center gap-2">
           <Settings2 className="h-5 w-5 text-ink-muted" strokeWidth={1.75} aria-hidden />
           <div>
-            <CardTitle className="font-serif text-lg font-semibold tracking-tight">{t("gradebook.config.title")}</CardTitle>
+            <CardTitle>{t("gradebook.config.title")}</CardTitle>
             <CardDescription className="text-xs">
               {t("gradebook.config.description")}
             </CardDescription>

--- a/frontend/src/pages/Teacher/progress/StudentTable.tsx
+++ b/frontend/src/pages/Teacher/progress/StudentTable.tsx
@@ -47,7 +47,7 @@ export function StudentTable({
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-2 font-serif text-lg font-semibold tracking-tight">
+        <CardTitle className="flex items-center gap-2">
           <Users className="h-5 w-5" strokeWidth={1.75} aria-hidden />
           {t("studentProgress.table.heading")}
           <span className="text-sm font-normal text-ink-muted">


### PR DESCRIPTION
Reviewed frontend consolidation pack (audit findings, all confirmed):

1. **Daily Challenge UI dedup** — extracted shared `OptionButton` + `RevealPanel` into `frontend/src/components/dailyChallenge/` and use them in both `DailyChallengeCard` and `DailyChallengeArchivePage`, killing the drifted inline copy. Canonical variant kept: `py-2` row + letter-chip `group-hover:border-brand/40` hover affordance. i18n keys and behavior unchanged.
2. **DESIGN.md eyebrow spec fix** — the eyebrow recipe now documents the shipped convention (`text-[11px] font-medium uppercase tracking-[0.18em] text-ink-muted`); the "no arbitrary `text-[Npx]`" rule now carves out the 11px eyebrow as the single documented exception.
3. **`<Eyebrow>` pattern component** — `tone="muted"` (default, canonical recipe) / `tone="accent"` (`tracking-[0.22em] text-accent` first-run variant), polymorphic `as` for label/div use. Converted the known drifted 10px sites (TodayCard, VerseOfTheDayCard, CertificatesPage, DailyChallengeCard, CalendarPopover) plus the canonical sites (FilterField, archive month label). Intentionally NOT a mass conversion — remaining sites adopt over time.
4. **CardTitle base** — folded `font-serif` into the CardTitle base classes (`tracking-tight` was already there) and stripped the now-redundant `font-serif`/`tracking-tight`/`font-semibold` re-adds from 20 call sites, keeping size overrides (`text-xl`, `text-base`, `text-sm`, `leading-snug`).
5. **AssignmentPanel waterfall** — when scoped to a single `assignmentId`, `getMySubmissions(assignmentId)` now starts in parallel with `getChapterAssignments` instead of waiting on it; error/loading semantics preserved (`.catch` attached at creation, degrades to "no submission" exactly as before).
6. **Tests** — added `Eyebrow` component tests; existing DailyChallengeCard behavioral tests pass unchanged.

Checks (local): `npm run lint` ✅ `npx tsc --noEmit` ✅ `npm run build` ✅ (chunks in budget) `npm run test:run` ✅ 74 files / 559 tests `npm run i18n:check` ✅ (bundles untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)