### PR TITLE
fix: deactivated-user filters, 404 consistency, and query cleanups

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,8 +2,8 @@
 # ------------------------------------------------------------------------------
 # Copy this file to .env (which is gitignored) and fill in real values.
 # Most variables below are read by app/core/config.py (see that file for the
-# fallback / aliasing logic); a few (YOUVERSION_API_KEY, the DD_* group) are
-# read directly via os.environ at the point of use, noted inline.
+# fallback / aliasing logic); a few (the DD_* group) are read directly via
+# os.environ at the point of use, noted inline.
 #
 # NEVER commit a real .env. Never paste secrets into chat, logs, or issues.
 # ------------------------------------------------------------------------------
@@ -105,7 +105,7 @@ GEMINI_MODEL=gemini-2.5-flash-lite
 
 # ──── Verse of the Day (YouVersion) ───────────────────────────────────────────
 # Enables /api/v1/verse-of-the-day. Missing → endpoint 404s, frontend hides the
-# card. Read directly via os.environ in app/services/verse_of_the_day.py.
+# card. Read via app/core/config.py (Settings.YOUVERSION_API_KEY).
 # YOUVERSION_API_KEY=your-youversion-api-key
 
 # ──── Observability (Datadog) ─────────────────────────────────────────────────

--- a/backend/app/api/v1/announcements.py
+++ b/backend/app/api/v1/announcements.py
@@ -131,7 +131,7 @@ def list_announcements(
 ) -> list[AnnouncementResponse]:
     response.headers["Vary"] = "Accept-Language"
     query = db.query(Announcement)
-    is_admin = current_user.role in (UserRole.ADMIN.value, "admin")
+    is_admin = current_user.role == UserRole.ADMIN.value
     # ``?source=1`` is editor-only: it returns unredacted source text
     # for the announcements of a specific course, so gate it to a
     # course_id filter that the caller actually owns (or admin). A
@@ -146,8 +146,16 @@ def list_announcements(
                 context={"resource_type": "announcement"},
             )
         if not is_admin:
+            # Soft-deleted courses don't count for ownership — mirrors the
+            # ``deleted_at`` check on the create path below.
             owns = (
-                db.query(Course.id).filter(Course.id == course_id, Course.created_by == current_user.id).first()
+                db.query(Course.id)
+                .filter(
+                    Course.id == course_id,
+                    Course.created_by == current_user.id,
+                    Course.deleted_at.is_(None),
+                )
+                .first()
                 is not None
             )
             if not owns:
@@ -168,11 +176,17 @@ def list_announcements(
         if not is_admin:
             # Non-admin must be enrolled in or own this course to see its announcements.
             # Previously this branch skipped the check entirely (IDOR). See audit P0.4.
+            # Soft-deleted courses grant no access — an enrollment or
+            # ownership row pointing at a trashed course must not keep its
+            # announcements readable (mirrors the ``deleted_at`` check on
+            # the create path below).
             has_access = (
                 db.query(Enrollment.id)
+                .join(Course, Course.id == Enrollment.course_id)
                 .filter(
                     Enrollment.user_id == current_user.id,
                     Enrollment.course_id == course_id,
+                    Course.deleted_at.is_(None),
                 )
                 .first()
                 is not None
@@ -181,6 +195,7 @@ def list_announcements(
                 .filter(
                     Course.id == course_id,
                     Course.created_by == current_user.id,
+                    Course.deleted_at.is_(None),
                 )
                 .first()
                 is not None
@@ -194,8 +209,20 @@ def list_announcements(
                 )
         query = query.filter(Announcement.course_id == course_id)
     elif not is_admin:
-        enrolled_ids = db.query(Enrollment.course_id).filter(Enrollment.user_id == current_user.id).scalar_subquery()
-        owned_ids = db.query(Course.id).filter(Course.created_by == current_user.id).scalar_subquery()
+        # Exclude soft-deleted courses from both tiers so trashed-course
+        # announcements drop out of the feed the moment the course is
+        # trashed (mirrors the ``deleted_at`` check on the create path).
+        enrolled_ids = (
+            db.query(Enrollment.course_id)
+            .join(Course, Course.id == Enrollment.course_id)
+            .filter(Enrollment.user_id == current_user.id, Course.deleted_at.is_(None))
+            .scalar_subquery()
+        )
+        owned_ids = (
+            db.query(Course.id)
+            .filter(Course.created_by == current_user.id, Course.deleted_at.is_(None))
+            .scalar_subquery()
+        )
         query = query.filter(
             Announcement.course_id.in_(enrolled_ids)
             | Announcement.course_id.in_(owned_ids)
@@ -346,7 +373,12 @@ def create_announcement(
         enrolled_users = (
             db.query(Enrollment.user_id, User.preferred_locale)
             .join(User, User.id == Enrollment.user_id)
-            .filter(Enrollment.course_id == data.course_id)
+            .filter(
+                Enrollment.course_id == data.course_id,
+                # Deactivated accounts keep their enrollment rows but must
+                # not receive notification fan-out (#786 rule).
+                User.deactivated_at.is_(None),
+            )
             .all()
         )
         recipients_by_locale: dict[str, list[uuid.UUID | str]] = {}

--- a/backend/app/api/v1/assignments.py
+++ b/backend/app/api/v1/assignments.py
@@ -350,7 +350,14 @@ def list_submissions(
     verify_chapter_owner(db, assignment.chapter_id, teacher)
     return (
         db.query(AssignmentSubmission)
-        .filter(AssignmentSubmission.assignment_id == assignment_id)
+        # Deactivated students keep their submission rows but drop out of
+        # the teacher grading queue — same rule as the gradebook rosters
+        # (#786).
+        .join(User, User.id == AssignmentSubmission.student_id)
+        .filter(
+            AssignmentSubmission.assignment_id == assignment_id,
+            User.deactivated_at.is_(None),
+        )
         .order_by(AssignmentSubmission.submitted_at.desc())
         .offset(skip)
         .limit(limit)

--- a/backend/app/api/v1/calendar.py
+++ b/backend/app/api/v1/calendar.py
@@ -7,7 +7,7 @@ from app.api.dependencies import get_current_user, require_teacher, verify_cours
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.core.sanitize import sanitize_string
-from app.models.course import Course
+from app.models.course import Course, CourseStatus
 from app.models.course_event import CourseEvent
 from app.models.enrollment import Enrollment
 from app.models.user import User, UserRole
@@ -155,7 +155,7 @@ def list_course_events(
     response.headers["Vary"] = "Accept-Language"
     # Narrow probe: only the columns needed for ownership + soft-delete checks.
     course_row = (
-        db.query(Course.created_by, Course.source_locale)
+        db.query(Course.created_by, Course.source_locale, Course.status)
         .filter(Course.id == course_id, Course.deleted_at.is_(None))
         .first()
     )
@@ -175,6 +175,16 @@ def list_course_events(
             .first()
         )
         if not enrolled:
+            # Mirror the catalog / PDF-export leak guard: an unpublished
+            # course 404s to non-member probes so its existence doesn't
+            # leak; published courses keep the plain 403.
+            if course_row.status != CourseStatus.PUBLISHED:
+                raise equip_error(
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    message="Course not found",
+                    context={"resource_type": "course", "resource_id": course_id},
+                )
             raise equip_error(
                 ErrorCode.AUTH_FORBIDDEN,
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/app/api/v1/certificates.py
+++ b/backend/app/api/v1/certificates.py
@@ -247,10 +247,14 @@ def list_pending_certificates(
     certs = (
         db.query(Certificate)
         .join(Course, Course.id == Certificate.course_id)
+        # Deactivated students keep their certificate rows but drop out of
+        # the review queue — same rule as the gradebook rosters (#786).
+        .join(User, User.id == Certificate.user_id)
         .filter(
             Course.created_by == teacher.id,
             Course.deleted_at.is_(None),
             Certificate.status == CertificateStatus.PENDING,
+            User.deactivated_at.is_(None),
         )
         .order_by(Certificate.requested_at.asc())
         .offset(skip)
@@ -280,7 +284,12 @@ def list_admin_pending_certificates(
     """
     certs = (
         db.query(Certificate)
-        .filter(Certificate.status == CertificateStatus.TEACHER_APPROVED)
+        # Same deactivated-student exclusion as the teacher pending list.
+        .join(User, User.id == Certificate.user_id)
+        .filter(
+            Certificate.status == CertificateStatus.TEACHER_APPROVED,
+            User.deactivated_at.is_(None),
+        )
         .order_by(Certificate.teacher_approved_at.asc())
         .offset(skip)
         .limit(limit)

--- a/backend/app/api/v1/cohorts.py
+++ b/backend/app/api/v1/cohorts.py
@@ -571,9 +571,13 @@ def list_cohort_students(
     cohort = _get_or_404(db, cohort_id)
     # Paginate user_ids first so the row-fetch never crosses page
     # boundaries (a single student's enrollments stay together).
+    # Deactivated (soft-deleted) students keep their enrollment rows but
+    # must not appear as matrix rows — same rule as the gradebook /
+    # analytics rosters (#786).
     user_id_page = (
         db.query(Enrollment.user_id)
-        .filter(Enrollment.cohort_id == cohort.id)
+        .join(User, Enrollment.user_id == User.id)
+        .filter(Enrollment.cohort_id == cohort.id, User.deactivated_at.is_(None))
         .distinct()
         .order_by(Enrollment.user_id)
         .offset(skip)

--- a/backend/app/api/v1/courses/pdf.py
+++ b/backend/app/api/v1/courses/pdf.py
@@ -26,7 +26,6 @@ from app.services.course_pdf import render_course_pdf
 from app.services.course_service import get_course
 from app.services.translation.resolve_for_display import (
     build_localized_course_response_with_tree,
-    populate_module_texts,
     populate_spine_texts,
 )
 
@@ -103,13 +102,10 @@ def export_course_pdf(
     # reads ``course.title`` / ``course.description`` /
     # ``module.title`` / ``chapter.title`` directly.
     display_locale: LocaleCode = normalize_locale(accept_language)
+    # populate_spine_texts already bulk-hydrates every module's
+    # title/description at the course's source locale (hydrate_modules
+    # defaults to True), so no per-module hydration pass is needed.
     populate_spine_texts(db, [course])
-    for module in course.modules or []:
-        populate_module_texts(
-            db,
-            [module],
-            source_locale=normalize_locale(course.source_locale),
-        )
     # build_localized_course_response_with_tree applies the overlay in
     # place via .title attribute hydration on each module + chapter.
     _ = build_localized_course_response_with_tree(db, course, display_locale)

--- a/backend/app/api/v1/grades.py
+++ b/backend/app/api/v1/grades.py
@@ -20,6 +20,7 @@ from app.api.dependencies import (
 )
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
+from app.models.course import CourseStatus
 from app.models.enrollment import Enrollment
 from app.models.student_grade import StudentGrade
 from app.models.user import User, UserRole
@@ -71,6 +72,16 @@ def get_grading_config(
         is not None
     )
     if not (is_owner or is_admin or is_enrolled):
+        # Mirror the catalog / PDF-export leak guard: an unpublished
+        # course 404s to non-member probes so its existence doesn't leak;
+        # published courses keep the plain 403.
+        if course.status != CourseStatus.PUBLISHED:
+            raise equip_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                status_code=status.HTTP_404_NOT_FOUND,
+                message="Course not found",
+                context={"resource_type": "course", "resource_id": course_id},
+            )
         raise equip_error(
             ErrorCode.AUTH_FORBIDDEN,
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/app/api/v1/quizzes/crud.py
+++ b/backend/app/api/v1/quizzes/crud.py
@@ -27,7 +27,11 @@ from app.schemas.quiz import (
     QuizStudentResponse,
     QuizUpdate,
 )
-from app.services.content_versions import delete_entity_cv_rows, dual_write_entity_content
+from app.services.content_versions import (
+    delete_entities_cv_rows,
+    delete_entity_cv_rows,
+    dual_write_entity_content,
+)
 from app.services.translation.pipeline_hooks import (
     reconcile_entity_if_course_published,
     run_course_translation_pipeline_if_published,
@@ -270,10 +274,18 @@ def delete_quiz(
     # options) is hard-deleted via cascade on the entity tables but
     # nothing cascades on cv. Drop the cv rows for every level
     # before db.delete(quiz) so the cascade leaves zero orphans.
-    for question in quiz.questions:
-        for option in question.options:
-            delete_entity_cv_rows(db, entity_type="quiz_option", entity_id=option.id)
-        delete_entity_cv_rows(db, entity_type="quiz_question", entity_id=question.id)
+    # Bulk IN-list deletes (one per entity type) instead of one DELETE
+    # per row — a 50-question quiz used to issue 200+ statements here.
+    delete_entities_cv_rows(
+        db,
+        entity_type="quiz_option",
+        entity_ids=[option.id for question in quiz.questions for option in question.options],
+    )
+    delete_entities_cv_rows(
+        db,
+        entity_type="quiz_question",
+        entity_ids=[question.id for question in quiz.questions],
+    )
     delete_entity_cv_rows(db, entity_type="quiz", entity_id=quiz.id)
     db.delete(quiz)
     db.commit()

--- a/backend/app/api/v1/quizzes/grading.py
+++ b/backend/app/api/v1/quizzes/grading.py
@@ -64,6 +64,9 @@ def list_pending_answers(
             QuizAttempt.completed_at.isnot(None),
             QuizQuestion.question_type.in_(quiz_service.MANUAL_GRADED_QUESTION_TYPES),
             QuizAnswer.text_answer.isnot(None),
+            # Deactivated students keep their attempts but drop out of the
+            # grading queue — same rule as the gradebook rosters (#786).
+            User.deactivated_at.is_(None),
         )
         .order_by(QuizAttempt.completed_at.desc(), QuizQuestion.order_index.asc())
     )

--- a/backend/app/api/v1/reviews.py
+++ b/backend/app/api/v1/reviews.py
@@ -8,7 +8,7 @@ from app.api.dependencies import get_current_user, get_live_course_or_404
 from app.core.database import get_db
 from app.core.errors import ErrorCode, equip_error
 from app.core.metrics import gauge
-from app.models.certificate import Certificate
+from app.models.certificate import Certificate, CertificateStatus
 from app.models.course import CourseStatus
 from app.models.review import CourseReview
 from app.models.user import User
@@ -58,7 +58,7 @@ def create_or_update_review(
         .filter(
             Certificate.user_id == current_user.id,
             Certificate.course_id == course_id,
-            Certificate.status == "approved",
+            Certificate.status == CertificateStatus.APPROVED,
         )
         .first()
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,6 +7,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 logger = logging.getLogger(__name__)
 
 
+def env_flag(*names: str) -> bool:
+    """True when any of the named environment variables is set non-empty.
+
+    Shared helper for the boot-time platform flags (production /
+    serverless / trusted-proxy) that were previously computed with a
+    copy-pasted ``bool(os.environ.get(...) or os.environ.get(...))`` at
+    each site. Reads the environment at call time — call sites evaluate
+    it once at module import, exactly like the inline expressions did.
+    """
+    return any(os.environ.get(name) for name in names)
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", case_sensitive=True, extra="ignore")
 
@@ -59,6 +71,11 @@ class Settings(BaseSettings):
     # ``SecretStr`` keeps the value out of any incidental ``Settings``
     # repr/log dump; callers must use ``.get_secret_value()`` to read it.
     GEMINI_API_KEY: SecretStr | None = Field(default=None, description="Google AI Studio API key (server-only)")
+    # YouVersion Platform key for the Verse of the Day card. Optional the
+    # same way GEMINI_API_KEY is: when unset (CI, local dev without setup)
+    # the verse service raises ``VerseOfTheDayUnavailable`` and the route
+    # returns 404 so the frontend quietly hides the card.
+    YOUVERSION_API_KEY: SecretStr | None = Field(default=None, description="YouVersion Platform API key (server-only)")
     # gemini-2.5-flash-lite: no "thinking" tokens (translation doesn't need
     # them) so the full GEMINI_MAX_OUTPUT_TOKENS budget goes to the actual
     # translation. The previous default ``gemini-flash-latest`` resolves to

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from collections.abc import Generator
 from urllib.parse import urlparse
 
@@ -7,7 +6,7 @@ from sqlalchemy import Connection, Engine, create_engine, event
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
-from app.core.config import settings
+from app.core.config import env_flag, settings
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ class Base(DeclarativeBase):
 _engine: Engine | None = None
 _SessionLocal: sessionmaker | None = None
 
-IS_SERVERLESS = bool(os.environ.get("VERCEL") or os.environ.get("AWS_LAMBDA_FUNCTION_NAME"))
+IS_SERVERLESS = env_flag("VERCEL", "AWS_LAMBDA_FUNCTION_NAME")
 
 
 def _get_engine() -> Engine:

--- a/backend/app/core/http.py
+++ b/backend/app/core/http.py
@@ -6,8 +6,9 @@ and anything else that needs a reliable client IP share one implementation.
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
+
+from app.core.config import env_flag
 
 if TYPE_CHECKING:
     from fastapi import Request
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 # Vercel sets ``VERCEL=1`` in every function invocation, and we also
 # honour an explicit ``TRUST_FORWARDED_HEADERS=1`` for other reverse-
 # proxy deployments (Cloudflare, custom Caddy/nginx, etc).
-_TRUSTED_PROXY = bool(os.environ.get("VERCEL") or os.environ.get("TRUST_FORWARDED_HEADERS"))
+_TRUSTED_PROXY = env_flag("VERCEL", "TRUST_FORWARDED_HEADERS")
 
 
 def get_client_ip(request: Request, fallback: str | None = None) -> str | None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 import uuid
 from pathlib import Path
@@ -11,7 +10,7 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app.api.v1 import api_router
-from app.core.config import settings
+from app.core.config import env_flag, settings
 from app.core.logging import setup_logging, vercel_request_id
 from app.middleware.rate_limit import RateLimitMiddleware
 from app.middleware.security import SecurityHeadersMiddleware
@@ -20,7 +19,7 @@ setup_logging()
 
 logger = logging.getLogger("api")
 
-_IS_PRODUCTION = bool(os.environ.get("VERCEL") or os.environ.get("PRODUCTION"))
+_IS_PRODUCTION = env_flag("VERCEL", "PRODUCTION")
 
 
 def docs_url_config(is_production: bool) -> dict[str, str | None]:

--- a/backend/app/middleware/security.py
+++ b/backend/app/middleware/security.py
@@ -1,7 +1,7 @@
-import os
-
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.core.config import env_flag
 
 # The API only ever serves JSON (or binary blobs via StreamingResponse). It
 # should never execute scripts or load styles, so we lock CSP down as hard as
@@ -13,7 +13,7 @@ _STRICT_API_CSP = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; 
 # the same host over HTTPS — but if a dev ever points a real hostname at a
 # local tunnel, HSTS could pin the browser to HTTPS in confusing ways. Only
 # advertise it in hosted environments.
-_IS_PRODUCTION = bool(os.environ.get("VERCEL") or os.environ.get("PRODUCTION"))
+_IS_PRODUCTION = env_flag("VERCEL", "PRODUCTION")
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):

--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -77,6 +77,25 @@ def _load_cert_or_404(db: Session, cert_id: UUID, *, for_update: bool = False) -
     return cert
 
 
+def _assert_student_active(db: Session, cert: Certificate) -> None:
+    """Refuse to advance a certificate whose student was deactivated.
+
+    Deactivated students are hidden from both pending queues, so an
+    approve-by-id against one is a stale click (or a probe). Surface a
+    409 rather than silently issuing a credential to a soft-deleted
+    account; restoring the student makes the certificate approvable
+    again.
+    """
+    deactivated = db.query(User.deactivated_at).filter(User.id == cert.user_id).scalar()
+    if deactivated is not None:
+        raise equip_error(
+            ErrorCode.VALIDATION_FAILED,
+            status_code=status.HTTP_409_CONFLICT,
+            message="Cannot approve a certificate for a deactivated account",
+            context={"resource_type": "certificate", "resource_id": str(cert.id)},
+        )
+
+
 def _load_active_course_or_403(
     db: Session,
     course_id: str | None,
@@ -149,6 +168,7 @@ def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request)
     cert = _load_cert_or_404(db, cert_id, for_update=True)
     _assert_status(cert, CertificateStatus.PENDING)
     _assert_not_self_approval(cert, teacher)
+    _assert_student_active(db, cert)
 
     ownership_detail = "You can only approve certificates for your own courses"
     course = _load_active_course_or_403(db, cert.course_id, ownership_detail=ownership_detail)
@@ -176,6 +196,7 @@ def admin_approve(db: Session, cert_id: UUID, admin: User, request: Request) -> 
     cert = _load_cert_or_404(db, cert_id, for_update=True)
     _assert_status(cert, CertificateStatus.TEACHER_APPROVED)
     _assert_not_self_approval(cert, admin)
+    _assert_student_active(db, cert)
 
     # Two-eyes guard. An admin who is ALSO the course's teacher can land on
     # the cert at the ``teacher_approved`` stage (they signed it themselves

--- a/backend/app/services/content_versions/__init__.py
+++ b/backend/app/services/content_versions/__init__.py
@@ -13,6 +13,7 @@ from app.services.content_versions.read import (
     fetch_cv_text_bulk,
 )
 from app.services.content_versions.write import (
+    delete_entities_cv_rows,
     delete_entity_cv_rows,
     record_human_version,
     record_mt_failure,
@@ -20,6 +21,7 @@ from app.services.content_versions.write import (
 )
 
 __all__ = [
+    "delete_entities_cv_rows",
     "delete_entity_cv_rows",
     "dual_write_entity_content",
     "fetch_cv_entity_texts_with_fallback",

--- a/backend/app/services/content_versions/write.py
+++ b/backend/app/services/content_versions/write.py
@@ -41,6 +41,8 @@ from app.models.content_version import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -327,6 +329,28 @@ def delete_entity_cv_rows(
     deleted = (
         db.query(ContentVersion)
         .filter(ContentVersion.entity_type == entity_type, ContentVersion.entity_id == eid_str)
+        .delete(synchronize_session=False)
+    )
+    return deleted
+
+
+def delete_entities_cv_rows(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_ids: Sequence[str | uuid.UUID],
+) -> int:
+    """Bulk variant of ``delete_entity_cv_rows`` — one ``IN``-list DELETE
+    for many entities of the same type (e.g. every question of a quiz
+    being hard-deleted). Same caveats apply: leaf entities only, never
+    soft-delete entities. Returns the row count.
+    """
+    if not entity_ids:
+        return 0
+    id_strs = [str(eid) for eid in entity_ids]
+    deleted = (
+        db.query(ContentVersion)
+        .filter(ContentVersion.entity_type == entity_type, ContentVersion.entity_id.in_(id_strs))
         .delete(synchronize_session=False)
     )
     return deleted

--- a/backend/app/services/verse_of_the_day.py
+++ b/backend/app/services/verse_of_the_day.py
@@ -16,12 +16,13 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
-import os
 import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import httpx
+
+from app.core.config import settings
 
 if TYPE_CHECKING:
     from app.schemas.locale import LocaleCode
@@ -526,7 +527,7 @@ def get_verse_of_the_day(locale: LocaleCode, *, today: dt.date | None = None) ->
     if bible_id is None:
         raise VerseOfTheDayUnavailable(f"Unsupported locale: {locale!r}")
 
-    api_key = os.environ.get("YOUVERSION_API_KEY")
+    api_key = settings.YOUVERSION_API_KEY.get_secret_value() if settings.YOUVERSION_API_KEY else None
     if not api_key:
         raise VerseOfTheDayUnavailable("YOUVERSION_API_KEY is not configured")
 

--- a/backend/tests/test_certificates_and_grades.py
+++ b/backend/tests/test_certificates_and_grades.py
@@ -326,6 +326,19 @@ class TestListPendingCertificates:
         assert r.status_code == 200
         assert r.json() == []
 
+    def test_deactivated_student_excluded(self, client: TestClient, db: Session):
+        # A soft-deleted student's pending certificate must drop out of the
+        # teacher review queue — same rule as the gradebook rosters (#786).
+        _seed_enrolled_course(db, progress=100)
+        _seed_certificate(db, "course-1")
+        student = db.query(User).filter(User.id == STUDENT_ID).one()
+        student.deactivated_at = datetime(2026, 1, 1, tzinfo=UTC)
+        db.commit()
+
+        r = client.get("/api/v1/certificates/pending")
+        assert r.status_code == 200
+        assert r.json() == []
+
 
 class TestAdminPendingCertificates:
     """GET /api/v1/certificates/admin/pending"""
@@ -345,6 +358,19 @@ class TestAdminPendingCertificates:
     def test_student_forbidden(self, student_client: TestClient, db: Session):
         r = student_client.get("/api/v1/certificates/admin/pending")
         assert r.status_code == 403
+
+    def test_deactivated_student_excluded(self, client: TestClient, db: Session):
+        # Same deactivated-student exclusion as the teacher pending list.
+        _make_admin(db)
+        _seed_enrolled_course(db, progress=100)
+        _seed_certificate(db, "course-1", cert_status="teacher_approved")
+        student = db.query(User).filter(User.id == STUDENT_ID).one()
+        student.deactivated_at = datetime(2026, 1, 1, tzinfo=UTC)
+        db.commit()
+
+        r = client.get("/api/v1/certificates/admin/pending")
+        assert r.status_code == 200
+        assert r.json() == []
 
 
 class TestTeacherApproveCertificate:
@@ -418,6 +444,22 @@ class TestTeacherApproveCertificate:
         assert r.status_code == 403
         assert "own" in r.json()["detail"]["message"].lower()
 
+    def test_deactivated_student_returns_409(self, client: TestClient, db: Session):
+        """Approving by id must fail for a deactivated student — the cert is
+        hidden from the pending queue, so a direct PUT is a stale click (or
+        a probe) and must not advance the workflow."""
+        _seed_enrolled_course(db, progress=100)
+        cert = _seed_certificate(db, "course-1")
+        student = db.query(User).filter(User.id == STUDENT_ID).one()
+        student.deactivated_at = datetime(2026, 1, 1, tzinfo=UTC)
+        db.commit()
+
+        r = client.put(f"/api/v1/certificates/{cert.id}/teacher-approve")
+        assert r.status_code == 409
+        assert "deactivated" in r.json()["detail"]["message"].lower()
+        db.refresh(cert)
+        assert cert.status == "pending"
+
 
 class TestAdminApproveCertificate:
     """PUT /api/v1/certificates/{cert_id}/admin-approve"""
@@ -451,6 +493,23 @@ class TestAdminApproveCertificate:
         _make_admin(db)
         r = client.put(f"/api/v1/certificates/{uuid.uuid4()}/admin-approve")
         assert r.status_code == 404
+
+    def test_deactivated_student_returns_409(self, client: TestClient, db: Session):
+        # Same deactivated-student guard as teacher-approve: no credential
+        # is issued to a soft-deleted account.
+        _make_admin(db)
+        _seed_enrolled_course(db, progress=100)
+        cert = _seed_certificate(db, "course-1", cert_status="teacher_approved")
+        student = db.query(User).filter(User.id == STUDENT_ID).one()
+        student.deactivated_at = datetime(2026, 1, 1, tzinfo=UTC)
+        db.commit()
+
+        r = client.put(f"/api/v1/certificates/{cert.id}/admin-approve")
+        assert r.status_code == 409
+        assert "deactivated" in r.json()["detail"]["message"].lower()
+        db.refresh(cert)
+        assert cert.status == "teacher_approved"
+        assert cert.certificate_number is None
 
     def test_admin_self_approval_forbidden(self, client: TestClient, db: Session):
         """Admin cannot issue a certificate where they are the recipient.
@@ -770,6 +829,30 @@ class TestGradingConfig:
             json={"quiz_weight": 40, "assignment_weight": 40, "participation_weight": 20},
         )
         assert r.status_code == 403
+
+    def test_get_config_published_non_member_returns_403(self, student_client: TestClient, db: Session):
+        # Published course, not enrolled → plain 403 (unchanged behaviour).
+        _seed_course(db)
+        r = student_client.get("/api/v1/grades/course/course-1/config")
+        assert r.status_code == 403
+
+    def test_get_config_unpublished_non_member_returns_404(self, student_client: TestClient, db: Session):
+        """Probing an unpublished course id must 404, not 403 — a 403 would
+        confirm the course exists (same leak guard as catalog / PDF export)."""
+        from ._cv_helpers import make_course_with_text
+
+        _ensure_other_teacher(db)
+        make_course_with_text(
+            db,
+            course_id="draft-course",
+            title="Draft",
+            status="draft",
+            created_by=OTHER_TEACHER_ID,
+        )
+        db.commit()
+
+        r = student_client.get("/api/v1/grades/course/draft-course/config")
+        assert r.status_code == 404
 
 
 class TestCalculatedGrade:

--- a/backend/tests/test_cohorts_calendar_notifications.py
+++ b/backend/tests/test_cohorts_calendar_notifications.py
@@ -721,6 +721,30 @@ class TestCohortStudents:
         assert rows[0]["user_id"] == str(STUDENT_ID)
         assert set(rows[0]["per_course"].keys()) == {"course-1", "course-2"}
 
+    def test_deactivated_student_excluded_from_matrix(self, admin_client: TestClient, db: Session, student):
+        # A soft-deleted member keeps their enrollment rows but must not
+        # appear as a matrix row — same rule as student_count and the
+        # gradebook rosters (#786).
+        from app.models.user import User, UserRole
+
+        _seed_course(db, course_id="course-1")
+        cohort = _seed_cohort_with_course(db, course_id="course-1")
+        ghost = User(
+            id=uuid.uuid4(),
+            email=f"ghost-{uuid.uuid4().hex[:8]}@test.local",
+            role=UserRole.STUDENT.value,
+            deactivated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        db.add(ghost)
+        db.commit()
+        _seed_enrollment(db, course_id="course-1", cohort_id=cohort.id)  # live student
+        _seed_enrollment(db, user_id=ghost.id, course_id="course-1", cohort_id=cohort.id)  # deactivated
+
+        resp = admin_client.get(f"{COHORT_PREFIX}/{cohort.id}/students")
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert [r["user_id"] for r in rows] == [str(STUDENT_ID)]
+
     def test_nonexistent_cohort_returns_404(self, admin_client: TestClient):
         resp = admin_client.get(f"{COHORT_PREFIX}/{uuid.uuid4()}/students")
         assert resp.status_code == 404
@@ -1216,6 +1240,22 @@ class TestListCourseEvents:
         resp = student_client.get(f"{COURSES_PREFIX}/test-course-1/events")
         assert resp.status_code == 403
 
+    def test_unenrolled_student_unpublished_course_gets_404(self, student_client: TestClient, db: Session):
+        """Probing an unpublished course id must 404, not 403 — a 403 would
+        confirm the course exists (same leak guard as catalog / PDF export)."""
+        from ._cv_helpers import make_course_with_text
+
+        make_course_with_text(
+            db,
+            course_id="draft-course-ev",
+            title="Draft",
+            status="draft",
+            created_by=TEACHER_ID,
+        )
+        db.commit()
+        resp = student_client.get(f"{COURSES_PREFIX}/draft-course-ev/events")
+        assert resp.status_code == 404
+
     def test_nonexistent_course_returns_404(self, client: TestClient):
         resp = client.get(f"{COURSES_PREFIX}/no-such-course/events")
         assert resp.status_code == 404
@@ -1640,6 +1680,32 @@ class TestCreateAnnouncement:
             .all()
         )
         assert len(notifs) == 1
+
+    def test_no_notification_for_deactivated_students(self, client: TestClient, db: Session, student):
+        # A soft-deleted account keeps its enrollment row but must not
+        # receive announcement fan-out — same rule as the roster
+        # exclusions (#786).
+        from app.models.user import User, UserRole
+
+        course = _create_course_via_api(client)
+        ghost = User(
+            id=uuid.uuid4(),
+            email=f"ghost-{uuid.uuid4().hex[:8]}@test.local",
+            role=UserRole.STUDENT.value,
+            deactivated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        db.add(ghost)
+        db.commit()
+        _seed_enrollment(db, user_id=STUDENT_ID, course_id=course["id"])  # live
+        _seed_enrollment(db, user_id=ghost.id, course_id=course["id"])  # deactivated
+
+        client.post(
+            ANNOUNCEMENT_PREFIX,
+            json=_announcement_payload(course_id=course["id"]),
+        )
+
+        recipients = {n.user_id for n in db.query(Notification).filter(Notification.type == "new_announcement").all()}
+        assert recipients == {STUDENT_ID}
 
     def test_notification_text_respects_recipient_preferred_locale(self, client: TestClient, db: Session, student):
         """Phase 5v: notification fan-out groups recipients by

--- a/backend/tests/test_progress_and_assignments.py
+++ b/backend/tests/test_progress_and_assignments.py
@@ -343,6 +343,38 @@ class TestListAssignmentSubmissions:
         r = student_client.get(f"/api/v1/assignments/{asg.id}/submissions")
         assert r.status_code == 403
 
+    def test_deactivated_student_excluded(
+        self,
+        client: TestClient,
+        student_client: TestClient,
+        db: Session,
+        teacher: User,
+    ):
+        """A soft-deleted student's submissions must drop out of the teacher
+        grading queue — same rule as the gradebook rosters (#786)."""
+        from datetime import UTC, datetime
+
+        from ._cv_helpers import make_assignment_with_text
+
+        _course, _mod, chapter = _seed_course_graph(db)
+        asg = make_assignment_with_text(db, chapter_id=chapter.id, title="Ghost sub", max_score=10)
+        aid = asg.id
+        db.commit()
+        sub = student_client.post(
+            f"/api/v1/assignments/{aid}/submit",
+            json={"content": "Before deactivation"},
+        )
+        assert sub.status_code == 201, sub.text
+        ghost = db.query(User).filter(User.id == STUDENT_ID).one()
+        ghost.deactivated_at = datetime(2026, 1, 1, tzinfo=UTC)
+        db.commit()
+
+        app.dependency_overrides[get_current_user] = lambda: teacher
+        app.dependency_overrides[get_optional_user] = lambda: teacher
+        r = client.get(f"/api/v1/assignments/{aid}/submissions")
+        assert r.status_code == 200, r.text
+        assert r.json() == []
+
 
 class TestGradeSubmission:
     """PUT /api/v1/assignments/submissions/{submission_id}/grade"""

--- a/backend/tests/test_quizzes_and_blocks.py
+++ b/backend/tests/test_quizzes_and_blocks.py
@@ -1504,6 +1504,22 @@ def test_grade_essay_answer_recomputes_passed(client: TestClient, student, db: S
     assert graded_list[0]["points_earned"] == 18
 
 
+def test_pending_answers_excludes_deactivated_student(client: TestClient, student, db: Session):
+    """A soft-deleted student's essay answers must drop out of the teacher
+    grading queue — same rule as the gradebook rosters (#786)."""
+    _seed_course_with_enrollment(db)
+    quiz, _essay, _attempt, _essay_answer = _seed_submitted_essay_attempt(db)
+
+    pending = client.get(f"/api/v1/quizzes/{quiz.id}/pending-answers").json()
+    assert len(pending) == 1
+
+    row = db.query(User).filter(User.id == STUDENT_ID).one()
+    row.deactivated_at = _now_utc()
+    db.commit()
+
+    assert client.get(f"/api/v1/quizzes/{quiz.id}/pending-answers").json() == []
+
+
 def test_grade_up_to_passing_emits_chapter_completed_post_commit(client: TestClient, student, db: Session, caplog):
     """Grading an essay up to passing flips the chapter to complete — the
     chapter_completed_total metric must fire (now from the grading route,

--- a/backend/tests/test_users_announcements_error_paths.py
+++ b/backend/tests/test_users_announcements_error_paths.py
@@ -203,3 +203,84 @@ class TestAnnouncementsCourseFilterAccessGate:
         r = client.get(f"/api/v1/announcements?course_id={course_id}")
         assert r.status_code == 200
         assert len(r.json()) >= 1
+
+
+class TestAnnouncementsIgnoreSoftDeletedCourses:
+    """A trashed course's announcements must drop out of the list feed.
+
+    The create path already refuses to post to a soft-deleted course;
+    the read side has to mirror it — an enrollment or ownership row
+    pointing at a trashed course must not keep its announcements
+    readable, in either the ``?course_id=`` filter or the unfiltered
+    enrolled/owned fallback.
+    """
+
+    @staticmethod
+    def _soft_delete_course(db: Session, course_id: str) -> None:
+        from datetime import UTC, datetime
+
+        from app.models.course import Course
+
+        row = db.query(Course).filter(Course.id == course_id).one()
+        row.deleted_at = datetime.now(UTC)
+        db.commit()
+
+    def test_enrolled_student_course_filter_returns_403_after_trash(
+        self,
+        student_client: TestClient,
+        db: Session,
+    ) -> None:
+        course_id = _seed_course_with_announcement(db, "annc-del-1")
+        db.add(
+            Enrollment(
+                id=f"enr-{course_id}",
+                user_id=STUDENT_ID,
+                course_id=course_id,
+                progress=0,
+            )
+        )
+        db.commit()
+        self._soft_delete_course(db, course_id)
+
+        r = student_client.get(f"/api/v1/announcements?course_id={course_id}")
+        assert r.status_code == 403
+
+    def test_enrolled_student_feed_excludes_trashed_course(
+        self,
+        student_client: TestClient,
+        db: Session,
+    ) -> None:
+        course_id = _seed_course_with_announcement(db, "annc-del-2")
+        db.add(
+            Enrollment(
+                id=f"enr-{course_id}",
+                user_id=STUDENT_ID,
+                course_id=course_id,
+                progress=0,
+            )
+        )
+        db.commit()
+        # Visible before the trash…
+        assert len(student_client.get("/api/v1/announcements").json()) == 1
+        self._soft_delete_course(db, course_id)
+        # …gone after.
+        assert student_client.get("/api/v1/announcements").json() == []
+
+    def test_owner_feed_excludes_trashed_course(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        course_id = _seed_course_with_announcement(db, "annc-del-3")
+        self._soft_delete_course(db, course_id)
+        assert client.get("/api/v1/announcements").json() == []
+
+    def test_source_gate_denies_owner_of_trashed_course(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        course_id = _seed_course_with_announcement(db, "annc-del-4")
+        self._soft_delete_course(db, course_id)
+        r = client.get(f"/api/v1/announcements?source=1&course_id={course_id}")
+        assert r.status_code == 403

--- a/backend/tests/test_verse_of_the_day.py
+++ b/backend/tests/test_verse_of_the_day.py
@@ -2,7 +2,7 @@
 
 We never hit YouVersion in tests — both the service-level cases and the
 route case monkeypatch the single ``_fetch_passage`` seam in the service
-module. CI does not have ``YOUVERSION_API_KEY`` set; the
+module. ``settings.YOUVERSION_API_KEY`` is patched per-test; the
 ``apikey_missing`` route case relies on that.
 """
 
@@ -12,7 +12,9 @@ import datetime as dt
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import SecretStr
 
+from app.core.config import settings
 from app.main import app
 from app.services import verse_of_the_day as svc
 
@@ -47,7 +49,7 @@ def test_pick_reference_varies_by_date():
 
 
 def test_get_verse_of_the_day_returns_localized_payload(monkeypatch):
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     monkeypatch.setattr(
         svc,
         "_fetch_passage",
@@ -63,7 +65,7 @@ def test_get_verse_of_the_day_returns_localized_payload(monkeypatch):
 
 def test_get_verse_of_the_day_caches_within_day(monkeypatch):
     """Two calls on the same UTC date hit the upstream API exactly once."""
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     calls = {"n": 0}
 
     def _counting(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
@@ -80,7 +82,7 @@ def test_get_verse_of_the_day_caches_within_day(monkeypatch):
 def test_get_verse_of_the_day_evicts_stale_dates(monkeypatch):
     """Yesterday's cache entry must be dropped when today's lands so the
     cache never grows unbounded across long-lived warm instances."""
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     monkeypatch.setattr(svc, "_fetch_passage", _stub_fetch())
     svc.get_verse_of_the_day("en", today=dt.date(2026, 5, 13))
     svc.get_verse_of_the_day("en", today=dt.date(2026, 5, 14))
@@ -89,13 +91,13 @@ def test_get_verse_of_the_day_evicts_stale_dates(monkeypatch):
 
 
 def test_get_verse_of_the_day_raises_without_api_key(monkeypatch):
-    monkeypatch.delenv("YOUVERSION_API_KEY", raising=False)
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", None)
     with pytest.raises(svc.VerseOfTheDayUnavailable):
         svc.get_verse_of_the_day("en")
 
 
 def test_get_verse_of_the_day_raises_for_unsupported_locale(monkeypatch):
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     with pytest.raises(svc.VerseOfTheDayUnavailable):
         # Cast through ``str`` since the function's signature is
         # ``LocaleCode``; we want to exercise the runtime guard for
@@ -109,7 +111,7 @@ def test_strip_html_collapses_paragraph_wrapper():
 
 
 def test_route_returns_verse_when_service_succeeds(monkeypatch):
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     monkeypatch.setattr(svc, "_fetch_passage", _stub_fetch())
     with TestClient(app) as tc:
         resp = tc.get("/api/v1/verse-of-the-day?locale=en")
@@ -122,7 +124,7 @@ def test_route_returns_verse_when_service_succeeds(monkeypatch):
 
 
 def test_route_normalizes_bcp47_locales(monkeypatch):
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     monkeypatch.setattr(svc, "_fetch_passage", _stub_fetch())
     with TestClient(app) as tc:
         # en-US should match the 'en' catalog; ru-RU should match 'ru'.
@@ -132,7 +134,7 @@ def test_route_normalizes_bcp47_locales(monkeypatch):
 
 
 def test_route_returns_404_when_apikey_missing(monkeypatch):
-    monkeypatch.delenv("YOUVERSION_API_KEY", raising=False)
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", None)
     with TestClient(app) as tc:
         resp = tc.get("/api/v1/verse-of-the-day?locale=en")
     assert resp.status_code == 404
@@ -144,7 +146,7 @@ def test_walks_forward_on_verse_not_in_bible(monkeypatch):
     numbering differences. The service must walk forward in the
     catalog until a present reference is found, and the chosen
     fallback must be deterministic for (date, locale)."""
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     today = dt.date(2026, 5, 31)
     primary = svc._pick_reference(today)
     fallback = svc._pick_reference_offset(today, 1)
@@ -168,7 +170,7 @@ def test_walks_forward_on_verse_not_in_bible(monkeypatch):
 def test_walks_forward_then_caches_the_fallback(monkeypatch):
     """A successful walk-forward fallback must cache so the second
     call on the same UTC date does NOT walk again."""
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     today = dt.date(2026, 5, 31)
     primary = svc._pick_reference(today)
     calls = {"n": 0}
@@ -191,7 +193,7 @@ def test_gives_up_after_walk_cap(monkeypatch):
     """If every reference in the walk window is absent, surface the
     standard ``VerseOfTheDayUnavailable`` so the frontend hides the
     card silently — never expose a partial / broken state."""
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
 
     def _always_missing(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
         raise svc.VerseNotInBible(f"no {ref} in {bible_id}")
@@ -210,7 +212,7 @@ def test_walk_does_not_consume_transient_errors(monkeypatch):
     the route 404s and the frontend hides; the next page load tries
     again. (Walking forward on transient errors would silently mask
     upstream outages by always serving the second verse.)"""
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
 
     def _transient(api_key: str, bible_id: int, ref: str) -> tuple[str, str]:
         raise svc.VerseOfTheDayUnavailable("YouVersion 503")
@@ -253,7 +255,7 @@ def test_walk_skips_complex_psalm_chapters_for_ru(monkeypatch) -> None:
     """When today's catalog ref falls on a complex psalm boundary
     for RU, the walk must advance to the next catalog entry rather
     than serving wrong content."""
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     today = dt.date(2026, 5, 31)
     # Find an offset where the catalog hits a complex chapter; fall
     # back to monkey-stubbing the picker so the test is deterministic.
@@ -279,7 +281,7 @@ def test_psalm_for_ru_uses_remapped_chapter(monkeypatch) -> None:
     """For an RU Psalm in the simple-offset range, the route must
     call the upstream API with chapter-1 so the returned content
     matches the catalog's intent (the Hebrew-numbered verse)."""
-    monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
     today = dt.date(2026, 6, 1)
     requested: list[str] = []
 

--- a/backend/tests/test_verse_of_the_day_internals.py
+++ b/backend/tests/test_verse_of_the_day_internals.py
@@ -24,7 +24,9 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
+from app.core.config import settings
 from app.services import verse_of_the_day as svc
 
 if TYPE_CHECKING:
@@ -227,7 +229,7 @@ class TestGetVerseOfTheDayHttpErrorPath:
     serve stale content silently."""
 
     def test_httpx_transport_error_aborts_walk(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+        monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
         call_count = {"n": 0}
 
         def fail(*_a: object, **_k: object) -> Any:
@@ -250,7 +252,7 @@ class TestGetVerseOfTheDayWalkExhausted:
     ``VerseNotInBible`` attached so the runbook has a starting point."""
 
     def test_walk_cap_exceeded_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("YOUVERSION_API_KEY", "test-key")
+        monkeypatch.setattr(settings, "YOUVERSION_API_KEY", SecretStr("test-key"))
 
         def always_missing(*_a: object, **_k: object) -> Any:
             raise svc.VerseNotInBible("ref missing")


### PR DESCRIPTION
Reviewed backend fix-pack implementing the confirmed audit findings.

### 1. Deactivated-user filters (`User.deactivated_at IS NULL`, #786 style)
- **cohorts** — `GET /cohorts/{id}/students` matrix rows: deactivated students no longer appear (pagination semantics preserved; filter applied to the paginated user-id page query)
- **quizzes/grading** — pending-answers grading queue excludes deactivated students
- **assignments** — `GET /assignments/{id}/submissions` joins `User` and excludes deactivated students
- **announcements** — notification fan-out skips deactivated accounts
- **certificates** — teacher `/pending` and admin `/admin/pending` lists exclude deactivated students; `teacher-approve` / `admin-approve` on such a certificate now returns **409** (`_assert_student_active` in `certificate_service`), so no credential is issued to a soft-deleted account

### 2. 403 → 404 unpublished-course existence leak
- `grades.py` `GET /grades/course/{id}/config` and `calendar.py` `GET /courses/{id}/events`: non-members probing an **unpublished** course id now get 404 (`COURSE_NOT_FOUND` shape), matching `catalog.py` / `pdf.py` / `dependencies.py`. Published-course non-member behavior (403) unchanged.

### 3. Announcements ignore soft-deleted courses
- List feed: `?source=1` ownership gate, the `course_id` access check, and the enrolled/owned fallback all exclude `deleted_at IS NOT NULL` courses — mirrors the existing create-path check.

### 4. PDF export redundant hydration
- Dropped the per-module `populate_module_texts` loop; `populate_spine_texts` already bulk-hydrates every module at the course source locale.

### 5. delete_quiz bulk cv deletes
- Per-row `delete_entity_cv_rows` loop replaced with bulk `entity_id.in_(...)` deletes via new `delete_entities_cv_rows` helper (one statement per entity type).

### 6. Literals
- `reviews.py`: `CertificateStatus.APPROVED` instead of `"approved"`
- `announcements.py`: dropped duplicate `"admin"` literal in the is_admin check

### 7. `env_flag()` dedup
- One helper in `core/config.py` replaces the four copy-pasted `bool(os.environ.get(...))` platform flags in `main.py`, `middleware/security.py`, `core/http.py`, `core/database.py`. Behavior identical; unused `import os` removed.

### 8. YOUVERSION_API_KEY into Settings
- Now a `SecretStr | None` field on `Settings` (same env var name, default-None semantics); verse tests patch `settings` instead of env vars; `.env.example` comments updated.

### Tests
Added deactivated-exclusion tests (cohort matrix, grading queue, submissions list, notification fan-out, cert pending lists + 409 approve guards), unpublished-probe 404 tests (grades config + course events, with published-403 pin), and soft-deleted-course announcement feed tests. Local: ruff clean, mypy clean, 1517 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)