### PR TITLE
fix: unify admin bypass across the content tree

### DIFF
--- a/backend/app/api/v1/courses/chapters.py
+++ b/backend/app/api/v1/courses/chapters.py
@@ -34,7 +34,7 @@ def create_new_chapter(
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> Chapter:
-    verify_course_owner(db, course_id, teacher.id, allow_admin=False)
+    verify_course_owner(db, course_id, teacher.id)
     module = get_module(db, course_id, module_id)
     if not module:
         raise equip_error(
@@ -62,7 +62,7 @@ def update_existing_chapter(
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> Chapter:
-    verify_course_owner(db, course_id, teacher.id, allow_admin=False)
+    verify_course_owner(db, course_id, teacher.id)
     chapter = get_chapter(db, course_id, module_id, chapter_id)
     if not chapter:
         raise equip_error(
@@ -94,7 +94,7 @@ def remove_chapter(
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> None:
-    verify_course_owner(db, course_id, teacher.id, allow_admin=False)
+    verify_course_owner(db, course_id, teacher.id)
     chapter = get_chapter(db, course_id, module_id, chapter_id)
     if not chapter:
         raise equip_error(

--- a/backend/app/api/v1/courses/crud.py
+++ b/backend/app/api/v1/courses/crud.py
@@ -89,7 +89,7 @@ def update_existing_course(
             message=f"Course '{course_id}' not found",
             context={"resource_type": "course", "resource_id": course_id},
         )
-    assert_course_owner(course, teacher, allow_admin=False)
+    assert_course_owner(course, teacher)
     # ``access_mode`` (public vs institute) controls solo-enrollment
     # access per ADR-010. Letting any course owner flip it would let a
     # teacher promote their institute course to public, bypassing the
@@ -148,7 +148,7 @@ def remove_course(
             message=f"Course '{course_id}' not found",
             context={"resource_type": "course", "resource_id": course_id},
         )
-    assert_course_owner(course, teacher, allow_admin=False)
+    assert_course_owner(course, teacher)
     # Phase 5bi: ``course.title`` is a runtime attribute hydrated by
     # ``populate_spine_texts``. ``get_course`` does NOT hydrate, so the
     # log_action below would stamp ``None`` into the audit row without
@@ -219,7 +219,7 @@ def restore_deleted_course(
             message="Course is not deleted",
             context={"resource_type": "course", "course_id": course_id},
         )
-    assert_course_owner(course, teacher, allow_admin=False)
+    assert_course_owner(course, teacher)
     result = restore_course(db, course)
     log_action(db, teacher.id, "restore", "course", course_id, request=request)
     return result
@@ -240,7 +240,7 @@ def permanently_remove_course(
             message="Course not found",
             context={"resource_type": "course", "resource_id": course_id},
         )
-    assert_course_owner(course, teacher, allow_admin=False)
+    assert_course_owner(course, teacher)
     if course.deleted_at is None:
         raise equip_error(
             ErrorCode.VALIDATION_FAILED,

--- a/backend/app/api/v1/courses/modules.py
+++ b/backend/app/api/v1/courses/modules.py
@@ -31,7 +31,7 @@ def create_new_module(
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> Module:
-    verify_course_owner(db, course_id, teacher.id, allow_admin=False)
+    verify_course_owner(db, course_id, teacher.id)
     created = create_module(db, course_id, data)
     reconcile_entity_if_course_published(db, "module", created)
     return created
@@ -45,7 +45,7 @@ def update_existing_module(
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> Module:
-    verify_course_owner(db, course_id, teacher.id, allow_admin=False)
+    verify_course_owner(db, course_id, teacher.id)
     module = get_module(db, course_id, module_id)
     if not module:
         raise equip_error(
@@ -66,7 +66,7 @@ def remove_module(
     teacher: User = Depends(require_teacher),
     db: Session = Depends(get_db),
 ) -> None:
-    verify_course_owner(db, course_id, teacher.id, allow_admin=False)
+    verify_course_owner(db, course_id, teacher.id)
     module = get_module(db, course_id, module_id)
     if not module:
         raise equip_error(

--- a/backend/app/services/certificate_service.py
+++ b/backend/app/services/certificate_service.py
@@ -172,6 +172,9 @@ def teacher_approve(db: Session, cert_id: UUID, teacher: User, request: Request)
 
     ownership_detail = "You can only approve certificates for your own courses"
     course = _load_active_course_or_403(db, cert.course_id, ownership_detail=ownership_detail)
+    # Deliberately owner-only (NOT the admin-allowed default used across the
+    # content tree): certificate approval is two-stage (teacher -> admin), and
+    # letting an admin act as the teacher here would collapse the two-man rule.
     assert_course_owner(course, teacher, allow_admin=False, detail=ownership_detail)
 
     cert.status = CertificateStatus.TEACHER_APPROVED

--- a/backend/tests/test_courses.py
+++ b/backend/tests/test_courses.py
@@ -136,6 +136,69 @@ class TestUpdateCourse:
         assert resp.status_code == 404
 
 
+class TestAdminManagesForeignCourse:
+    """Admin-bypass unification: the whole content tree (course CRUD,
+    modules, chapters) accepts admin as well as the owner, matching
+    blocks/quizzes/assignments. Certificate teacher-approval remains
+    deliberately owner-only (two-stage approval)."""
+
+    def test_admin_updates_foreign_course(self, admin_client: TestClient, client: TestClient):
+        course = _create_course(client)
+        resp = admin_client.put(f"{PREFIX}/{course['id']}", json={"title": "Admin Edit"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["title"] == "Admin Edit"
+
+    def test_admin_deletes_and_restores_foreign_course(self, admin_client: TestClient, client: TestClient):
+        course = _create_course(client)
+        resp = admin_client.delete(f"{PREFIX}/{course['id']}")
+        assert resp.status_code == 204, resp.text
+        resp = admin_client.post(f"{PREFIX}/{course['id']}/restore")
+        assert resp.status_code == 200, resp.text
+
+    def test_admin_manages_foreign_modules_and_chapters(self, admin_client: TestClient, client: TestClient):
+        course = _create_course(client)
+        created = admin_client.post(f"{PREFIX}/{course['id']}/modules", json={"title": "Admin Module"})
+        assert created.status_code == 201, created.text
+        module_id = created.json()["id"]
+
+        updated = admin_client.put(f"{PREFIX}/{course['id']}/modules/{module_id}", json={"title": "Renamed"})
+        assert updated.status_code == 200, updated.text
+
+        chapter = admin_client.post(
+            f"{PREFIX}/{course['id']}/modules/{module_id}/chapters",
+            json={"title": "Admin Chapter"},
+        )
+        assert chapter.status_code == 201, chapter.text
+        chapter_id = chapter.json()["id"]
+
+        resp = admin_client.delete(f"{PREFIX}/{course['id']}/modules/{module_id}/chapters/{chapter_id}")
+        assert resp.status_code == 204, resp.text
+
+        resp = admin_client.delete(f"{PREFIX}/{course['id']}/modules/{module_id}")
+        assert resp.status_code == 204, resp.text
+
+    def test_other_teacher_still_forbidden(self, db: Session, client: TestClient):
+        """Unifying admin access must not loosen the teacher boundary."""
+        from app.api.dependencies import get_current_user, get_optional_user
+        from app.main import app
+        from app.models.user import User, UserRole
+
+        course = _create_course(client)
+        other = User(
+            id="dddddddd-dddd-dddd-dddd-dddddddddddd",
+            email="other-teacher@example.com",
+            full_name="Other Teacher",
+            role=UserRole.TEACHER.value,
+        )
+        db.add(other)
+        db.commit()
+
+        app.dependency_overrides[get_current_user] = lambda: other
+        app.dependency_overrides[get_optional_user] = lambda: other
+        resp = client.put(f"{PREFIX}/{course['id']}", json={"title": "Steal"})
+        assert resp.status_code == 403, resp.text
+
+
 class TestDeleteCourse:
     def test_delete_existing_course(self, client: TestClient):
         course = _create_course(client)


### PR DESCRIPTION
Course update/delete/restore/permanent-delete + modules + chapters used `allow_admin=False` while every other owner gate allows admin - an admin could delete every block inside a chapter but not rename the chapter. Unified to the admin-allowed default (Vadym's call).

**Kept owner-only on purpose:** certificate teacher-approval (two-stage teacher->admin flow; admin acting as teacher would collapse the two-man rule) - now documented at the call site.

Tests: admin manages foreign course/module/chapter (update/delete/restore/create); non-owner teacher still 403. Full suite 1521 passed locally; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)