### PR TITLE
ci: run authenticated e2e specs against staging when STAGING_ACTIVE

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -77,15 +77,24 @@ jobs:
         # (missing tree-shake-safe markers, env wiring) the same way
         # a real prod deploy would.
         env:
-          # Smoke tests don't hit a real backend, BUT the build must still
-          # be given Supabase vars: src/lib/supabase.ts THROWS at module
-          # load if VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY are unset,
-          # which blanks the whole SPA (React never mounts) and fails every
-          # public-flow spec with "element not found". These are throwaway
-          # placeholders — the public routes never call Supabase.
-          VITE_API_URL: http://localhost:8000
-          VITE_SUPABASE_URL: https://example.supabase.co
-          VITE_SUPABASE_ANON_KEY: e2e-placeholder-anon-key-not-real
+          # Two modes, switched by the repo variable STAGING_ACTIVE:
+          #
+          # * STAGING_ACTIVE == 'true' — build against the live staging
+          #   stack (api-staging.equipbible.com + the staging Supabase
+          #   branch), which lets global.setup.ts sign the role users in
+          #   and unlocks the authenticated student/teacher specs.
+          # * otherwise — placeholder env; src/lib/supabase.ts THROWS at
+          #   module load if VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY are
+          #   unset (blanking the SPA), so placeholders keep the public
+          #   smoke specs alive. Fork/Dependabot PRs see no secrets and
+          #   land here automatically.
+          #
+          # Staging is ephemeral by design — tearing it down only requires
+          # flipping STAGING_ACTIVE to 'false'; the auth'd specs then skip
+          # instead of failing.
+          VITE_API_URL: ${{ vars.STAGING_ACTIVE == 'true' && 'https://api-staging.equipbible.com' || 'http://localhost:8000' }}
+          VITE_SUPABASE_URL: ${{ vars.STAGING_ACTIVE == 'true' && secrets.STAGING_SUPABASE_URL || 'https://example.supabase.co' }}
+          VITE_SUPABASE_ANON_KEY: ${{ vars.STAGING_ACTIVE == 'true' && secrets.STAGING_SUPABASE_ANON_KEY || 'e2e-placeholder-anon-key-not-real' }}
         run: |
           npm run build
           npx vite preview --host 127.0.0.1 --port 5173 &
@@ -97,6 +106,18 @@ jobs:
         env:
           CI: "true"
           E2E_BASE_URL: http://127.0.0.1:5173
+          # Role-user credentials for the staging Supabase branch. Empty
+          # when STAGING_ACTIVE != 'true' (or on fork/Dependabot PRs) —
+          # global.setup.ts and the auth'd specs skip gracefully then.
+          E2E_STUDENT_EMAIL: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_STUDENT_EMAIL || '' }}
+          E2E_STUDENT_PASSWORD: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_STUDENT_PASSWORD || '' }}
+          E2E_STUDENT_ID: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_STUDENT_ID || '' }}
+          E2E_TEACHER_EMAIL: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_TEACHER_EMAIL || '' }}
+          E2E_TEACHER_PASSWORD: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_TEACHER_PASSWORD || '' }}
+          E2E_TEACHER_ID: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_TEACHER_ID || '' }}
+          E2E_ADMIN_EMAIL: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_ADMIN_EMAIL || '' }}
+          E2E_ADMIN_PASSWORD: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_ADMIN_PASSWORD || '' }}
+          E2E_ADMIN_ID: ${{ vars.STAGING_ACTIVE == 'true' && secrets.E2E_ADMIN_ID || '' }}
         run: npx playwright test
 
       - name: Upload Playwright report on failure

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -1,0 +1,90 @@
+# Staging environment
+
+Staging is a full, isolated copy of the production stack, designed to be
+**ephemeral**: cheap to spin up, safe to tear down, never a hard dependency
+of CI (see `STAGING_ACTIVE` below).
+
+| Piece | Production | Staging |
+|---|---|---|
+| Database | Supabase project `rrisqutxlkamwfhcashl` | Supabase **branch** `staging` (own project ref, own auth/storage) |
+| Backend | Vercel `equip-backend` → `api.equipbible.com` (deploys from `main`) | Vercel `equip-backend-staging` → `api-staging.equipbible.com` (deploys from the `staging` git branch) |
+| Frontend | Vercel `equip-frontend` → `equipbible.com` (deploys from `main`) | Vercel `equip-frontend-staging` → `staging.equipbible.com` (deploys from `staging`) |
+| Data | Real users | Synthetic only (`scripts/seed_fat_test_course.py` + three `e2e-*@staging.equipbible.com` role users) |
+
+## How deploys flow
+
+The long-lived git branch `staging` is the deploy source for both staging
+projects (their "production" environment). To put code on staging:
+
+```powershell
+git checkout staging
+git merge --ff-only origin/main   # or cherry-pick a feature branch
+git push origin staging
+```
+
+Both staging Vercel projects have an ignored-build-step that skips every
+branch except `staging`, so PR pushes never double-build.
+
+## Spin-up (from nothing, ~15 min)
+
+1. **DB branch**: create a Supabase branch named `staging` (MCP
+   `create_branch` or dashboard). The branch runner cannot replay our
+   migration history (it predates the initial schema), so bootstrap from the
+   DR baseline instead:
+   - load `supabase/schema.sql` **minus the `CREATE SCHEMA public;` line**;
+   - apply `supabase/ci/rls_grants.sql`;
+   - replay the write-surface lockdown (branch default-privileges re-grant
+     writes): `REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN
+     SCHEMA public FROM anon, authenticated; GRANT UPDATE ON public.profiles
+     TO authenticated; REVOKE SELECT ON public.quiz_options,
+     public.daily_challenge_options, public.content_versions FROM anon,
+     authenticated;` + the matching `ALTER DEFAULT PRIVILEGES`;
+   - recreate `on_auth_user_created` (lives on `auth.users`, so it is NOT in
+     the public-schema dump): `CREATE TRIGGER on_auth_user_created AFTER
+     INSERT ON auth.users FOR EACH ROW EXECUTE FUNCTION
+     public.handle_new_user();`
+   - create the three storage buckets + the ten `storage.objects` policies
+     (copy from prod `pg_policies`);
+   - copy `supabase_migrations.schema_migrations` rows from prod so future
+     `db push` stays idempotent.
+2. **JWT parity**: new branches sign tokens with ES256; the backend expects
+   the legacy HS256 secret (prod parity). Promote the branch's HS256 key:
+   `previously_used` → `standby` → `in_use` via the Management API
+   (`/config/auth/signing-keys`).
+3. **Role users**: create `e2e-student|teacher|admin@staging.equipbible.com`
+   via the branch auth admin API, promote roles in `profiles`.
+4. **Seed**: `python -m scripts.seed_fat_test_course --course-id staging-fat
+   --teacher-email e2e-teacher@staging.equipbible.com --modules 10
+   --chapters-per-module 4 --students 30` with `DATABASE_URL` pointing at
+   the branch pooler.
+5. **Vercel env**: point the staging projects' env at the branch (URL, keys,
+   `JWT_SECRET_KEY` = branch secret, `DD_ENV=staging`,
+   `TRANSLATION_QUEUE_ENABLED=false`), then push `staging` to deploy.
+6. Flip the repo variable `STAGING_ACTIVE` to `true`.
+
+## Teardown
+
+1. `gh variable set STAGING_ACTIVE --body "false"` — the authenticated e2e
+   specs go back to skipping instead of failing.
+2. Delete the Supabase branch (stops the ~$0.013/hr compute).
+3. The Vercel projects, domains, and repo secrets can stay — they cost
+   nothing while the branch is gone.
+
+## e2e in CI
+
+`frontend-e2e.yml` builds against staging when `STAGING_ACTIVE == 'true'`,
+which unlocks the authenticated student/teacher/admin specs
+(`E2E_*` repository secrets). In any other state — flag off, fork PR,
+Dependabot PR — the build falls back to placeholder env and only the public
+smoke/a11y specs run. CI therefore never turns red because staging is down.
+
+## Guard-rails
+
+- The staging cron workers are neutered: `TRANSLATION_QUEUE_ENABLED=false`;
+  the daily-challenge worker runs but against staging data only.
+- `DD_ENV=staging` keeps staging logs out of the production monitors.
+- Synthetic students live on `@seed.invalid` (RFC 2606 — can never receive
+  mail); role users live on `@staging.equipbible.com`.
+- Never point staging env at the production database or vice versa; the
+  backend's CORS origin (`staging.equipbible.com` + localhost for the e2e
+  preview server) would be the first thing to break loudly.


### PR DESCRIPTION
Closes the ''e2e coverage illusion'' audit finding. `frontend-e2e.yml` gets two modes via the `STAGING_ACTIVE` repo variable (currently `true`): staging mode builds against `api-staging.equipbible.com` + the staging Supabase branch and feeds the `E2E_*` secrets to Playwright, unlocking the authenticated student/teacher/admin specs. Flag off / fork PR / Dependabot = old placeholder behavior, public smoke only - CI never reddens because staging is down.

Also adds `docs/STAGING.md`: full staging architecture + spin-up/teardown runbooks (branch bootstrap from the schema.sql DR baseline, HS256 signing-key promotion, seeding, env map).

Staging is LIVE now: https://staging.equipbible.com / https://api-staging.equipbible.com (branch `fruxgkasrzhpofqgsvpf`, synthetic data, 3 e2e role users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)