### PR TITLE
fix(e2e): make authenticated specs match the real UI

### DIFF
--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -81,6 +81,52 @@ export async function signInViaForm(
 }
 
 /**
+ * Pre-set the onboarding/tour localStorage flags for a user so the
+ * first-run flow (Privacy → Quick Setup → picker) and the auto-firing
+ * driver.js tours don't cover the surface under test. Keys mirror
+ * ``src/lib/storageKeys.ts`` — kept in sync by hand because the e2e
+ * suite can't import app internals. Call after sign-in and before
+ * ``storageState()`` so the flags persist into the saved session.
+ */
+export async function suppressOnboarding(
+  page: Page,
+  userId: string,
+): Promise<void> {
+  // Every per-page tourId in the app (src/pages/**/* `tourId:` values).
+  // driver.js auto-fires these on first visit and its full-screen
+  // overlay intercepts pointer events, so specs must pre-mark them seen.
+  const TOUR_IDS = [
+    "student-dashboard-v1",
+    "courses-catalog-v1",
+    "profile-v1",
+    "certificates-v1",
+    "calendar-v1",
+    "course-detail-enrolled-v1",
+    "chapter-view-v1",
+    "teacher-dashboard-v1",
+    "gradebook-v1",
+    "analytics-v1",
+    "student-progress-v1",
+    "chapter-editor-v1",
+    "module-editor-v1",
+    "course-editor-v1",
+  ];
+  await page.evaluate(
+    ({ id, tourIds }) => {
+      const flags = [
+        `equip.privacy.accepted.${id}`,
+        `equip.first-run.setup.${id}`,
+        `equip.first-run.completed.${id}`,
+        `equip.grand-tour.seen.${id}`,
+        ...tourIds.map((t) => `equip.tour.seen.${id}.${t}`),
+      ];
+      for (const k of flags) window.localStorage.setItem(k, "1");
+    },
+    { id: userId, tourIds: TOUR_IDS },
+  );
+}
+
+/**
  * Inject a Supabase session into localStorage so the SPA boots
  * already authenticated. Faster than the form sign-in and isolated
  * from any login-form regression in the SUT.

--- a/frontend/e2e/global.setup.ts
+++ b/frontend/e2e/global.setup.ts
@@ -1,7 +1,7 @@
 import { test as setup } from "@playwright/test";
 import { mkdirSync, existsSync } from "node:fs";
 
-import { getTestUser, signInViaForm } from "./fixtures/auth";
+import { getTestUser, signInViaForm, suppressOnboarding } from "./fixtures/auth";
 
 /**
  * Global setup for the Playwright suite.
@@ -28,6 +28,7 @@ setup("authenticate as student", async ({ page }) => {
   if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true });
   const user = getTestUser("student");
   await signInViaForm(page, user);
+  await suppressOnboarding(page, user.id);
   await page.context().storageState({ path: `${AUTH_DIR}/student.json` });
 });
 
@@ -39,6 +40,7 @@ setup("authenticate as teacher", async ({ page }) => {
   if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true });
   const user = getTestUser("teacher");
   await signInViaForm(page, user);
+  await suppressOnboarding(page, user.id);
   await page.context().storageState({ path: `${AUTH_DIR}/teacher.json` });
 });
 
@@ -50,5 +52,6 @@ setup("authenticate as admin", async ({ page }) => {
   if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true });
   const user = getTestUser("admin");
   await signInViaForm(page, user);
+  await suppressOnboarding(page, user.id);
   await page.context().storageState({ path: `${AUTH_DIR}/admin.json` });
 });

--- a/frontend/e2e/student-flow.spec.ts
+++ b/frontend/e2e/student-flow.spec.ts
@@ -26,10 +26,11 @@ test.beforeEach(async () => {
 test.describe("student golden path", () => {
   test("dashboard renders the daily challenge card", async ({ studentPage }) => {
     await studentPage.goto("/", { waitUntil: "domcontentloaded" });
-    // The daily challenge is a load-bearing card on the student
-    // dashboard; the heading text is bilingual.
+    // The daily-challenge card is load-bearing on the student
+    // dashboard. Its heading is the localized "question of the day"
+    // title (ru: «Сегодняшний вопрос» / eyebrow «Вопрос дня»).
     const card = studentPage.getByRole("heading", {
-      name: /(daily\s*challenge|испытание|ежедневн)/i,
+      name: /(daily\s*challenge|вопрос\s*дня|сегодняшний\s*вопрос)/i,
     });
     await expect(card).toBeVisible({ timeout: 10_000 });
   });
@@ -39,17 +40,23 @@ test.describe("student golden path", () => {
     // The catalog renders either: course cards, or an "empty state"
     // when there are no published courses. Either is OK for the
     // golden path; both pin that the route resolved + the layout
-    // chrome mounted.
-    const body = await studentPage.locator("body").innerText();
-    expect(body).toMatch(/(course|курс|no\s*courses|нет\s*курсов)/i);
+    // chrome mounted. Use a web-first assertion so the check retries
+    // past the initial "Загрузка…" spinner instead of reading once.
+    await expect(studentPage.locator("body")).toContainText(
+      /(course|курс|no\s*courses|нет\s*курсов)/i,
+      { timeout: 10_000 },
+    );
   });
 
   test("profile page reachable from authenticated state", async ({ studentPage }) => {
     await studentPage.goto("/profile", { waitUntil: "domcontentloaded" });
-    // Profile renders the user's display name + the locale picker.
-    // We don't assert on the specific name; only that one of the
-    // shared profile-page sections is visible.
-    const body = await studentPage.locator("body").innerText();
-    expect(body).toMatch(/(profile|профил|account|account\s*settings|locale|язык)/i);
+    // Profile renders the user's display name + the locale picker. We
+    // don't assert on the specific name; only that one of the shared
+    // profile-page sections resolves (web-first assertion retries past
+    // the loading spinner).
+    await expect(studentPage.locator("body")).toContainText(
+      /(profile|профил|account|account\s*settings|locale|язык)/i,
+      { timeout: 10_000 },
+    );
   });
 });

--- a/frontend/e2e/teacher-flow.spec.ts
+++ b/frontend/e2e/teacher-flow.spec.ts
@@ -42,17 +42,27 @@ test.describe("teacher golden path", () => {
 
   test("create-course CTA is reachable from dashboard", async ({ teacherPage }) => {
     await teacherPage.goto("/teacher", { waitUntil: "domcontentloaded" });
+    // The teacher dashboard's primary CTA (ru: «Новый курс»).
     const cta = teacherPage.getByRole("button", {
-      name: /(create\s*course|new\s*course|создать\s*курс)/i,
+      name: /(create\s*course|new\s*course|создать\s*курс|новый\s*курс)/i,
     });
     await expect(cta).toBeVisible({ timeout: 10_000 });
   });
 
-  test("teacher analytics tab is reachable", async ({ teacherPage }) => {
-    await teacherPage.goto("/teacher/analytics", { waitUntil: "domcontentloaded" });
-    // The analytics surface always lays out at least one of:
-    // engagement heading, KPI tile, or empty-state copy.
-    const body = await teacherPage.locator("body").innerText();
-    expect(body).toMatch(/(analytics|аналитика|engagement|enrollments|stat)/i);
+  test("teacher analytics is reachable from a course", async ({ teacherPage }) => {
+    // Analytics is per-course (route /teacher/courses/:id/analytics),
+    // surfaced as an "Аналитика" action on each course card of the
+    // dashboard — there is no standalone /teacher/analytics route.
+    await teacherPage.goto("/teacher", { waitUntil: "domcontentloaded" });
+    const analyticsLink = teacherPage
+      .getByRole("link", { name: /(analytics|аналитика)/i })
+      .first();
+    await expect(analyticsLink).toBeVisible({ timeout: 10_000 });
+    await analyticsLink.click();
+    await teacherPage.waitForURL(/\/teacher\/courses\/.+\/analytics/);
+    await expect(teacherPage.locator("body")).toContainText(
+      /(analytics|аналитика|engagement|enrollments|stat|вовлечён|запис)/i,
+      { timeout: 10_000 },
+    );
   });
 });


### PR DESCRIPTION
Wiring the authenticated specs against the **live staging stack** surfaced that they were written blind against UI that never matched:

- `global.setup` now suppresses first-run onboarding + all 14 per-page driver.js tours via localStorage before capturing storage state — the tour overlay was intercepting every click
- DC card asserted `daily challenge/испытание`; real heading is **Вопрос дня / Сегодняшний вопрос**
- teacher analytics navigated to `/teacher/analytics` (a **404** — it's per-course at `/teacher/courses/:id/analytics`); now clicks the dashboard `Аналитика` action
- create-course regex missing ru `Новый курс`
- catalog/profile/analytics read `innerText()` once after `domcontentloaded` (caught the `Загрузка…` spinner) → web-first `toContainText()`

**19/19 specs green locally against staging.** Runs in CI when `STAGING_ACTIVE=true`; public smoke path unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)