### PR TITLE
fix(csp): allow staging Supabase + API origins in connect-src

### DIFF
--- a/frontend/src/__tests__/vercelCsp.test.ts
+++ b/frontend/src/__tests__/vercelCsp.test.ts
@@ -80,11 +80,17 @@ const REQUIRED_TOKENS: ReadonlyArray<string> = [
   "https://*.browser-intake-datadoghq.com",
   "https://browser-intake-us5-datadoghq.com",
   "https://session-replay-us5-datadoghq.com",
-  // Supabase project endpoint (auth + REST + realtime websocket).
-  "https://rrisqutxlkamwfhcashl.supabase.co",
-  "wss://rrisqutxlkamwfhcashl.supabase.co",
-  // Backend API.
+  // Supabase endpoint (auth + REST + realtime websocket). Wildcarded to
+  // ``*.supabase.co`` so the same static CSP works for the production
+  // project AND any ephemeral staging branch (whose project ref differs
+  // and changes on every respawn). The anon key + RLS are the real
+  // boundary; broadening from one Supabase project to "any Supabase
+  // project" is a marginal relaxation, not a script-exec surface.
+  "https://*.supabase.co",
+  "wss://*.supabase.co",
+  // Backend API — prod + the staging deployment.
   "https://api.equipbible.com",
+  "https://api-staging.equipbible.com",
   // YouTube embeds -- the only iframe origin we whitelist on the SPA.
   "https://www.youtube.com",
   "https://www.youtube-nocookie.com",

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -23,7 +23,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://rrisqutxlkamwfhcashl.supabase.co; font-src 'self' data:; connect-src 'self' https://api.equipbible.com https://rrisqutxlkamwfhcashl.supabase.co wss://rrisqutxlkamwfhcashl.supabase.co https://*.datadoghq.com https://*.browser-intake-datadoghq.com https://browser-intake-us5-datadoghq.com https://session-replay-us5-datadoghq.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; worker-src 'self' blob:"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co; font-src 'self' data:; connect-src 'self' https://api.equipbible.com https://api-staging.equipbible.com https://*.supabase.co wss://*.supabase.co https://*.datadoghq.com https://*.browser-intake-datadoghq.com https://browser-intake-us5-datadoghq.com https://session-replay-us5-datadoghq.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; worker-src 'self' blob:"
         }
       ]
     }


### PR DESCRIPTION
**Bug:** the frontend CSP hardcoded the prod Supabase ref + only allowed `api.equipbible.com`, so on **staging** every supabase-js call (auth included) and backend request was browser-blocked (`Failed to fetch`) — login on staging.equipbible.com was impossible. Surfaced while screenshotting the live staging build.

**Fix:** widen Supabase hosts to `https://*.supabase.co` / `wss://*.supabase.co` (covers prod + any ephemeral staging branch) and add `https://api-staging.equipbible.com`. Prod unaffected (wildcard still matches prod ref; `script-src 'self'` untouched, no script wildcard; anon key + RLS remain the boundary). `vercelCsp.test.ts` updated in the same PR per its own comment — 4/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)