### PR TITLE
fix(backend): bump api function maxDuration to 300s to stop daily-challenge-worker timeouts

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
     "api/index.py": {
-      "maxDuration": 60
+      "maxDuration": 300
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary
- Bumps `functions."api/index.py".maxDuration` in `backend/vercel.json` from `60` to `300`.
- Root cause of a real, currently-recurring prod issue: the daily-challenge-worker cron (`GET /api/v1/internal/daily-challenge-worker`, fires daily 09:00 UTC) has returned `504` with `Vercel Runtime Timeout Error: Task timed out after 60 seconds` in 10 of the last 14 daily invocations (confirmed via Datadog logs).
- The route's own code comment (`backend/app/api/v1/internal_daily_challenge_worker.py`) already documents a "Vercel Fluid Compute Pro: 300s effective function timeout (verified 2026-06-11)" and a 65-135s worst-case tick — `vercel.json` was just never updated to actually request that duration, so the platform kept enforcing the default 60s ceiling.
- Pure config-ceiling change, no code logic touched. Live user-facing impact was masked so far because `daily_challenge_schedule` already has a pre-seeded manifest through 2026-12-31, but the self-replenish worker itself has been failing most days.

## Test plan
- [x] `ruff check .` / `ruff format --check .` green (JSON-only change, no Python touched)
- [x] Confirmed via Datadog logs: 10/14 recent daily-challenge-worker invocations 504'd at exactly 60s; translation-worker (unaffected, same function) runs consistently in 359-1485ms
- [ ] Post-merge: watch tomorrow's 09:00 UTC cron tick in Datadog for `status=200` instead of `504`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
