### PR TITLE
feat(backend): add one-time email invite system for teacher/student roles

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -19,6 +19,7 @@ from app.api.v1 import (
     health,
     internal_daily_challenge_worker,
     internal_translation_worker,
+    invitations,
     notifications,
     prerequisites,
     progress,
@@ -57,3 +58,4 @@ api_router.include_router(internal_daily_challenge_worker.router)
 api_router.include_router(daily_challenge.router)
 api_router.include_router(daily_challenge_archive.router)
 api_router.include_router(admin_daily_challenge.router)
+api_router.include_router(invitations.router)

--- a/backend/app/api/v1/invitations.py
+++ b/backend/app/api/v1/invitations.py
@@ -1,0 +1,118 @@
+from typing import cast
+
+from fastapi import APIRouter, Depends, Path, Query, Request
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_current_user, require_admin
+from app.core.database import get_db
+from app.models.invitation import Invitation
+from app.models.user import User
+from app.schemas.invitation import (
+    InvitationAcceptRequest,
+    InvitationAcceptResponse,
+    InvitationCreate,
+    InvitationPreview,
+    InvitationResponse,
+    InvitationRoleLiteral,
+    InvitationStatusLiteral,
+)
+from app.services.invitation_service import (
+    accept_invitation,
+    create_or_resend_invitation,
+    get_invitation_by_token,
+    is_invitation_expired,
+    list_invitations,
+)
+
+router = APIRouter(prefix="/invitations", tags=["invitations"])
+
+
+def _to_response(invitation: Invitation) -> InvitationResponse:
+    is_expired = invitation.status == "pending" and is_invitation_expired(invitation)
+    return InvitationResponse(
+        id=invitation.id,
+        email=invitation.email,
+        role=cast("InvitationRoleLiteral", invitation.role),
+        status=cast("InvitationStatusLiteral", invitation.status),
+        invited_by=invitation.invited_by,
+        created_at=invitation.created_at,
+        accepted_at=invitation.accepted_at,
+        expires_at=invitation.expires_at,
+        is_expired=is_expired,
+    )
+
+
+@router.post("", response_model=InvitationResponse, status_code=201)
+def create_invitation(
+    body: InvitationCreate,
+    request: Request,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> InvitationResponse:
+    """Admin-only: invite an email to join as teacher or student.
+
+    Idempotent on re-invite while a prior invitation for the same
+    (email, role) is still pending and unexpired -- see
+    ``create_or_resend_invitation`` for the dedupe/resend contract.
+    """
+    invitation, _is_new = create_or_resend_invitation(
+        db, email=body.email, role=body.role, invited_by=admin.id, request=request
+    )
+    return _to_response(invitation)
+
+
+@router.get("", response_model=list[InvitationResponse])
+def list_invitations_route(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    role: str | None = Query(None),
+    invite_status: str | None = Query(None, alias="status"),
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> list[InvitationResponse]:
+    rows = list_invitations(db, skip=skip, limit=limit, role=role, status_filter=invite_status)
+    return [_to_response(r) for r in rows]
+
+
+@router.get("/token/{token}", response_model=InvitationPreview)
+def preview_invitation(
+    token: str = Path(..., max_length=128),
+    db: Session = Depends(get_db),
+) -> InvitationPreview:
+    """Unauthenticated preview of an invite, for the accept-invite page
+    to render "you've been invited as a teacher" copy before the visitor
+    has signed in. Deliberately returns 200 with ``is_expired``/``status``
+    rather than 404/410 for a stale token, so the accept page can render
+    a clear "this invite expired" state instead of a generic not-found.
+    """
+    invitation = get_invitation_by_token(db, token)
+    return InvitationPreview(
+        email=invitation.email,
+        role=cast("InvitationRoleLiteral", invitation.role),
+        status=cast("InvitationStatusLiteral", invitation.status),
+        is_expired=invitation.status == "pending" and is_invitation_expired(invitation),
+    )
+
+
+@router.post("/accept", response_model=InvitationAcceptResponse)
+def accept_invitation_route(
+    body: InvitationAcceptRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> InvitationAcceptResponse:
+    """Redeem an invite token for the signed-in caller.
+
+    The caller must already have an account (self-registered as student,
+    or logged in via Google) under the exact email the invite was sent
+    to -- see the migration docstring for why the backend doesn't mint
+    the Supabase Auth user itself.
+    """
+    invitation = accept_invitation(
+        db,
+        token=body.token,
+        current_user_id=current_user.id,
+        current_user_email=current_user.email,
+        request=request,
+    )
+    return InvitationAcceptResponse(role=cast("InvitationRoleLiteral", invitation.role))

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -76,6 +76,22 @@ class Settings(BaseSettings):
     # the verse service raises ``VerseOfTheDayUnavailable`` and the route
     # returns 404 so the frontend quietly hides the card.
     YOUVERSION_API_KEY: SecretStr | None = Field(default=None, description="YouVersion Platform API key (server-only)")
+    # Direct backend→Resend calls for transactional mail that isn't a
+    # Supabase Auth lifecycle event (signup/recovery/magic_link don't go
+    # through here -- those stay on supabase/functions/send-email, which is
+    # a Supabase Auth email hook and can't be reused for arbitrary sends).
+    # Invitation emails are the first user of this. Optional the same way
+    # the other provider keys are: unset means the invite is created but
+    # send_invitation_email logs and no-ops instead of raising, so a missing
+    # key degrades to "admin must share the link manually" rather than a
+    # 500 on invite creation.
+    RESEND_API_KEY: SecretStr | None = Field(default=None, description="Resend API key (server-only)")
+    # Base URL for links embedded in backend-sent emails (invite accept
+    # link, etc). No existing Settings field carried this -- other call
+    # sites hardcode "https://equipbible.com" inline (see app/main.py,
+    # calendar_ical.py). Kept as a real setting (not another hardcode) so
+    # a preview/staging deployment can point invite links at itself.
+    FRONTEND_URL: str = Field(default="https://equipbible.com", description="Public frontend origin for email links")
     # gemini-2.5-flash-lite: no "thinking" tokens (translation doesn't need
     # them) so the full GEMINI_MAX_OUTPUT_TOKENS budget goes to the actual
     # translation. The previous default ``gemini-flash-latest`` resolves to

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -128,6 +128,23 @@ class ErrorCode(enum.StrEnum):
     those are owned by the live ``/today`` surface. Frontend should
     redirect the user back to today's card."""
 
+    # ── Invitations ──────────────────────────────────────────────────────
+    INVITATION_NOT_FOUND = "invitation.not_found"
+    """No invitation matches the given token."""
+
+    INVITATION_EXPIRED = "invitation.expired"
+    """The invitation's ``expires_at`` has passed. Still ``status='pending'``
+    in the DB -- expiry is computed at read/accept time, not a stored
+    transition."""
+
+    INVITATION_ALREADY_USED = "invitation.already_used"
+    """The invitation's ``status`` is no longer ``pending`` (already
+    accepted, or revoked by an admin re-inviting with a fresh row)."""
+
+    INVITATION_EMAIL_MISMATCH = "invitation.email_mismatch"
+    """The authenticated caller's email does not match the email the
+    invitation was issued to."""
+
     # ── Validation ──────────────────────────────────────────────────────
     VALIDATION_FAILED = "validation.failed"
     """Request body / params failed semantic validation beyond the

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -73,6 +73,18 @@ ENDPOINT_LIMITS: dict[str, tuple[int, int]] = {
     # that's a small UX cost for the safety net.
     "/api/v1/users/admin/": (30, 60),
     "/api/v1/cohorts": (60, 60),
+    # Unauthenticated token lookup (accept-invite page preview). Same
+    # ceiling as the certificate-number verify route for the same
+    # reason: one guess per legitimate visit, cheap defence-in-depth
+    # against enumeration even though the token itself is a 32-byte
+    # random value. Declared BEFORE the broader "/invitations" prefix
+    # below so its longer, more specific match wins (``_resolve_limit``
+    # returns the first prefix match in insertion order).
+    "/api/v1/invitations/token/": (30, 60),
+    # Admin create/list + the authenticated accept-by-token route share
+    # this bucket. Mirrors the admin-mutation ceiling above; accept is a
+    # one-time action per invitee so 30/min/IP is generous.
+    "/api/v1/invitations": (30, 60),
 }
 
 MAX_BUCKETS = 10_000

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.content_version import ContentVersion
 from app.models.course import Chapter, Course, Module
 from app.models.course_event import CourseEvent
 from app.models.enrollment import Enrollment
+from app.models.invitation import Invitation, InvitationRole, InvitationStatus
 from app.models.notification import Notification
 from app.models.prerequisite import CoursePrerequisite
 from app.models.quiz import (
@@ -39,6 +40,9 @@ __all__ = [
     "CoursePrerequisite",
     "CourseReview",
     "Enrollment",
+    "Invitation",
+    "InvitationRole",
+    "InvitationStatus",
     "Module",
     "Notification",
     "Quiz",

--- a/backend/app/models/invitation.py
+++ b/backend/app/models/invitation.py
@@ -1,0 +1,55 @@
+import enum
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class InvitationRole(enum.StrEnum):
+    TEACHER = "teacher"
+    STUDENT = "student"
+
+
+class InvitationStatus(enum.StrEnum):
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REVOKED = "revoked"
+
+
+def _default_expires_at() -> datetime:
+    return datetime.now(UTC) + timedelta(days=7)
+
+
+class Invitation(Base):
+    __tablename__ = "invitations"
+    __table_args__ = (
+        # Mirror the prod CHECK constraints (see the migration) so the
+        # SQLite test path and the Postgres schema-smoke job enforce the
+        # same value domains.
+        CheckConstraint("role IN ('teacher', 'student')", name="chk_invitations_role"),
+        CheckConstraint("status IN ('pending', 'accepted', 'revoked')", name="chk_invitations_status"),
+        Index("ix_invitations_email_role", "email", "role", "created_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column()
+    role: Mapped[str] = mapped_column()
+    # ``unique=True`` already creates a B-tree index for token lookups.
+    token: Mapped[str] = mapped_column(unique=True)
+    status: Mapped[str] = mapped_column(default=InvitationStatus.PENDING.value)
+    invited_by: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("profiles.id", ondelete="SET NULL"))
+    created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_default_expires_at)
+
+    inviter: Mapped["User | None"] = relationship(foreign_keys=[invited_by])
+
+    def __repr__(self) -> str:
+        return f"<Invitation id={self.id} email={self.email!r} role={self.role!r} status={self.status!r}>"

--- a/backend/app/schemas/invitation.py
+++ b/backend/app/schemas/invitation.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+# Mirrors the Postgres CHECK constraints on invitations.role / .status
+# (see supabase/migrations/20260707120000_add_invitations_table.sql) and
+# the SQLAlchemy model's CheckConstraints. Deliberately excludes "admin" --
+# an invite can never grant admin, only the manual role-change route can.
+InvitationRoleLiteral = Literal["teacher", "student"]
+InvitationStatusLiteral = Literal["pending", "accepted", "revoked"]
+
+
+class InvitationCreate(BaseModel):
+    email: EmailStr
+    role: InvitationRoleLiteral
+
+
+class InvitationResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    email: str
+    role: InvitationRoleLiteral
+    status: InvitationStatusLiteral
+    invited_by: UUID | None
+    created_at: datetime | None
+    accepted_at: datetime | None
+    expires_at: datetime
+    # Derived, not stored -- a 'pending' row past its expiry is treated as
+    # expired at read time rather than requiring a cron to flip a stored
+    # status. Only meaningful when status == "pending".
+    is_expired: bool
+
+
+class InvitationPreview(BaseModel):
+    """Public, token-scoped preview shown on the accept-invite page.
+
+    Deliberately excludes ``id`` / ``invited_by`` -- the token alone
+    should not let a caller enumerate other fields of the invite.
+    """
+
+    email: str
+    role: InvitationRoleLiteral
+    status: InvitationStatusLiteral
+    is_expired: bool
+
+
+class InvitationAcceptRequest(BaseModel):
+    token: str = Field(min_length=1, max_length=128)
+
+
+class InvitationAcceptResponse(BaseModel):
+    role: InvitationRoleLiteral

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,91 @@
+"""Direct backend -> Resend transactional email.
+
+``supabase/functions/send-email`` is a Supabase Auth "send email" webhook
+hook -- it only fires for Auth lifecycle events (signup/recovery/
+magic_link/email_change) carrying a signed payload from Supabase Auth
+itself. An invitation is not an Auth event, so it can't go through that
+hook. This module calls the Resend API directly instead, mirroring that
+edge function's brand styling (``BRAND`` / ``FROM`` / the inline CSS
+constants) so invite emails look consistent with the rest of Equip's mail.
+
+Failure here is non-blocking by design, same rationale as the edge
+function: a Resend hiccup (or a missing ``RESEND_API_KEY`` in a preview
+deployment) must not fail invite *creation* -- the row and token already
+exist, an admin can re-trigger the send via the resend path, and the
+accept link still works if shared manually.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_RESEND_URL = "https://api.resend.com/emails"
+_BRAND = "Equip"
+_FROM = "Equip <noreply@equipbible.com>"
+_BTN_STYLE = (
+    "display: inline-block; background: #2563eb; color: #fff; text-decoration: none; "
+    "padding: 12px 32px; border-radius: 8px; font-weight: 600; margin: 24px 0;"
+)
+_WRAP_STYLE = (
+    "font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; "
+    "max-width: 560px; margin: 0 auto; padding: 40px 20px;"
+)
+_H1_STYLE = "color: #1a1a2e; font-size: 24px; margin-bottom: 16px;"
+_P_STYLE = "color: #4a4a6a; font-size: 16px; line-height: 1.6;"
+_SMALL_STYLE = "color: #8888a8; font-size: 13px;"
+
+_ROLE_LABEL = {"teacher": "teacher", "student": "student"}
+
+
+def _invitation_html(role: str, accept_url: str) -> str:
+    role_label = _ROLE_LABEL.get(role, role)
+    return f"""
+      <div style="{_WRAP_STYLE}">
+        <h1 style="{_H1_STYLE}">You're invited to {_BRAND}</h1>
+        <p style="{_P_STYLE}">You've been invited to join {_BRAND} as a {role_label}. Click below to accept the invitation and set up your account.</p>
+        <a href="{accept_url}" style="{_BTN_STYLE}">Accept Invitation</a>
+        <p style="{_SMALL_STYLE}">This invitation expires in 7 days. If you weren't expecting this, you can safely ignore this email.</p>
+      </div>
+    """
+
+
+def send_invitation_email(*, to_email: str, role: str, accept_url: str) -> bool:
+    """Send the invite email via Resend. Returns whether it was sent.
+
+    Never raises -- a delivery failure is logged and swallowed so the
+    invite row (and its usable token/link) still exists regardless of
+    whether the actual email got out. Callers should not treat a
+    ``False`` return as invite creation having failed.
+    """
+    api_key = settings.RESEND_API_KEY.get_secret_value() if settings.RESEND_API_KEY else None
+    if not api_key:
+        logger.warning("RESEND_API_KEY not configured; skipping invitation email to %s", to_email)
+        return False
+
+    role_label = _ROLE_LABEL.get(role, role)
+    try:
+        resp = httpx.post(
+            _RESEND_URL,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json={
+                "from": _FROM,
+                "to": [to_email],
+                "subject": f"You're invited to join {_BRAND} as a {role_label}",
+                "html": _invitation_html(role, accept_url),
+            },
+            timeout=10.0,
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("Resend delivery failed for invitation to %s: %s", to_email, exc)
+        return False
+
+    if resp.status_code >= 400:
+        logger.warning("Resend rejected invitation email to %s: %s %s", to_email, resp.status_code, resp.text)
+        return False
+    return True

--- a/backend/app/services/invitation_service.py
+++ b/backend/app/services/invitation_service.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from fastapi import status
+
+from app.core.config import settings
+from app.core.errors import ErrorCode, equip_error
+from app.models.invitation import Invitation, InvitationStatus
+from app.models.user import User
+from app.services.audit_service import log_action
+from app.services.email_service import send_invitation_email
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from fastapi import Request
+    from sqlalchemy.orm import Session
+
+_TOKEN_BYTES = 32
+
+
+def _generate_token() -> str:
+    return secrets.token_urlsafe(_TOKEN_BYTES)
+
+
+def is_invitation_expired(invitation: Invitation) -> bool:
+    expires_at = invitation.expires_at
+    if expires_at.tzinfo is None:
+        # SQLite (tests) round-trips naive datetimes; Postgres always
+        # returns tz-aware. Normalise to UTC before comparing either way.
+        expires_at = expires_at.replace(tzinfo=UTC)
+    return expires_at < datetime.now(UTC)
+
+
+def _accept_url(token: str) -> str:
+    return f"{settings.FRONTEND_URL.rstrip('/')}/invite/accept?token={token}"
+
+
+def create_or_resend_invitation(
+    db: Session,
+    *,
+    email: str,
+    role: str,
+    invited_by: UUID,
+    request: Request | None = None,
+) -> tuple[Invitation, bool]:
+    """Create a new invitation, or resend the existing pending one.
+
+    Returns ``(invitation, is_new)``. Dedup key is ``(email, role)`` while
+    ``status == 'pending'`` -- mirrors the partial unique index in the
+    migration, which is the real race guard; this lookup is the
+    happy-path short-circuit that avoids hitting it on a normal "resend"
+    click. A resend does NOT rotate the token or reset ``expires_at`` --
+    a link already shared/clicked stays valid on its original clock.
+
+    An expired-but-still-``pending`` row is revoked first so the fresh
+    insert doesn't collide with the partial unique index.
+    """
+    normalized_email = email.strip().lower()
+
+    existing = (
+        db.query(Invitation)
+        .filter(
+            Invitation.email == normalized_email,
+            Invitation.role == role,
+            Invitation.status == InvitationStatus.PENDING.value,
+        )
+        .first()
+    )
+    if existing is not None and not is_invitation_expired(existing):
+        send_invitation_email(to_email=normalized_email, role=role, accept_url=_accept_url(existing.token))
+        return existing, False
+
+    if existing is not None:
+        existing.status = InvitationStatus.REVOKED.value
+
+    invitation = Invitation(
+        email=normalized_email,
+        role=role,
+        token=_generate_token(),
+        invited_by=invited_by,
+    )
+    db.add(invitation)
+    db.commit()
+    db.refresh(invitation)
+
+    log_action(
+        db,
+        invited_by,
+        "create",
+        "invitation",
+        str(invitation.id),
+        details={"email": normalized_email, "role": role},
+        request=request,
+    )
+
+    send_invitation_email(to_email=normalized_email, role=role, accept_url=_accept_url(invitation.token))
+    return invitation, True
+
+
+def list_invitations(
+    db: Session,
+    *,
+    skip: int = 0,
+    limit: int = 50,
+    role: str | None = None,
+    status_filter: str | None = None,
+) -> list[Invitation]:
+    query = db.query(Invitation)
+    if role is not None:
+        query = query.filter(Invitation.role == role)
+    if status_filter is not None:
+        query = query.filter(Invitation.status == status_filter)
+    return query.order_by(Invitation.created_at.desc()).offset(skip).limit(limit).all()
+
+
+def get_invitation_by_token(db: Session, token: str) -> Invitation:
+    invitation = db.query(Invitation).filter(Invitation.token == token).first()
+    if invitation is None:
+        raise equip_error(
+            ErrorCode.INVITATION_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
+            message="Invitation not found",
+            context={"resource_type": "invitation"},
+        )
+    return invitation
+
+
+def accept_invitation(
+    db: Session,
+    *,
+    token: str,
+    current_user_id: UUID,
+    current_user_email: str,
+    request: Request | None = None,
+) -> Invitation:
+    """Redeem a token: validate, atomically flip it to accepted, then
+    promote the caller's role.
+
+    The caller must already be authenticated as a user whose email
+    matches the invitation -- see the migration/module docstrings for why
+    the backend doesn't mint the Supabase Auth user itself. Role
+    promotion piggybacks on the same DB session/commit as the invitation
+    UPDATE isn't strictly atomic with it (two statements), but the
+    single-use guard (UPDATE ... WHERE status='pending') is what prevents
+    a double-redeem; a crash between the two commits leaves, at worst, an
+    accepted invitation with the role not yet flipped, which is safely
+    retryable (accept is idempotent for the row's owner: hitting it again
+    just meets `already_used` -- to recover, an admin can re-invite).
+    """
+    invitation = get_invitation_by_token(db, token)
+
+    if invitation.status != InvitationStatus.PENDING.value:
+        raise equip_error(
+            ErrorCode.INVITATION_ALREADY_USED,
+            status_code=status.HTTP_409_CONFLICT,
+            message="This invitation has already been used",
+            context={"resource_type": "invitation"},
+        )
+    if is_invitation_expired(invitation):
+        raise equip_error(
+            ErrorCode.INVITATION_EXPIRED,
+            status_code=status.HTTP_410_GONE,
+            message="This invitation has expired",
+            context={"resource_type": "invitation"},
+        )
+    if invitation.email != current_user_email.strip().lower():
+        raise equip_error(
+            ErrorCode.INVITATION_EMAIL_MISMATCH,
+            status_code=status.HTTP_403_FORBIDDEN,
+            message="This invitation was sent to a different email address",
+            context={"resource_type": "invitation"},
+        )
+
+    # Single-use guard: only flips a row still 'pending'. A concurrent
+    # accept (double click, retried request) loses the race here rather
+    # than in application logic.
+    updated = (
+        db.query(Invitation)
+        .filter(Invitation.id == invitation.id, Invitation.status == InvitationStatus.PENDING.value)
+        .update(
+            {Invitation.status: InvitationStatus.ACCEPTED.value, Invitation.accepted_at: datetime.now(UTC)},
+            synchronize_session="fetch",
+        )
+    )
+    if updated == 0:
+        raise equip_error(
+            ErrorCode.INVITATION_ALREADY_USED,
+            status_code=status.HTTP_409_CONFLICT,
+            message="This invitation has already been used",
+            context={"resource_type": "invitation"},
+        )
+
+    db.query(User).filter(User.id == current_user_id).update({User.role: invitation.role})
+    db.commit()
+    db.refresh(invitation)
+
+    log_action(
+        db,
+        current_user_id,
+        "accept",
+        "invitation",
+        str(invitation.id),
+        details={"role": invitation.role},
+        request=request,
+    )
+
+    return invitation

--- a/backend/tests/contracts/openapi_routes.json
+++ b/backend/tests/contracts/openapi_routes.json
@@ -1920,6 +1920,68 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/invitations",
+    "params": [
+      [
+        "limit",
+        "query"
+      ],
+      [
+        "role",
+        "query"
+      ],
+      [
+        "skip",
+        "query"
+      ],
+      [
+        "status",
+        "query"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/invitations",
+    "params": [],
+    "responses": [
+      "201",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/invitations/accept",
+    "params": [],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": true
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/invitations/token/{token}",
+    "params": [
+      [
+        "token",
+        "path"
+      ]
+    ],
+    "responses": [
+      "200",
+      "422"
+    ],
+    "body": false
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/notifications",
     "params": [
       [

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -64,6 +64,10 @@ def test_enum_values_are_stable_strings():
         "daily_challenge.already_attempted",
         "daily_challenge.invalid_option",
         "daily_challenge.archive_date_not_allowed",
+        "invitation.not_found",
+        "invitation.expired",
+        "invitation.already_used",
+        "invitation.email_mismatch",
         "validation.failed",
     }
     assert {member.value for member in ErrorCode} == expected

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -1,0 +1,282 @@
+"""Coverage for the invitation system (POST/GET /invitations, accept-by-token).
+
+RESEND_API_KEY is unset in the test environment (see conftest.py), so
+``send_invitation_email`` always short-circuits on the missing-key branch
+without making a real HTTP call -- no mocking needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import get_current_user, get_optional_user
+from app.core.database import get_db
+from app.main import app
+from app.models.invitation import Invitation
+from app.models.user import User, UserRole
+from tests.conftest import ADMIN_ID
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+INVITATIONS_PREFIX = "/api/v1/invitations"
+INVITEE_ID = uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+INVITEE_EMAIL = "invitee@example.com"
+
+
+def _seed_invitation(db: Session, *, email: str, role: str, invited_by: uuid.UUID = ADMIN_ID) -> Invitation:
+    """Insert an invitation directly rather than through ``admin_client``.
+
+    ``admin_client`` and ``invitee_client`` both mutate the SAME
+    ``app.dependency_overrides`` slot (there's one FastAPI ``app``
+    instance) -- whichever TestClient fixture was constructed LAST wins
+    for every request made through EITHER client, per the
+    ``anon_client`` docstring in conftest.py. Tests that need "an admin
+    created this invite, then a different user accepts it" can't express
+    that with two conflicting-identity TestClients in one test, so admin
+    invite creation is seeded directly here instead of through the API.
+    """
+    invitation = Invitation(email=email, role=role, token=uuid.uuid4().hex, invited_by=invited_by)
+    db.add(invitation)
+    db.commit()
+    db.refresh(invitation)
+    return invitation
+
+
+def _make_invitee(db: Session, *, email: str = INVITEE_EMAIL, role: str = UserRole.STUDENT.value) -> User:
+    """A signed-up account under the invited email -- the accept route
+    requires the caller to already exist (self-registered as student or
+    logged in via Google) before redeeming a token; see invitation_service.
+    """
+    user = User(id=INVITEE_ID, email=email, full_name="Invitee", role=role)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def invitee_client(db: Session, teacher: User, admin: User):
+    invitee = _make_invitee(db)
+
+    def _override_db():
+        yield db
+
+    def _override_user():
+        return invitee
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_user] = _override_user
+    app.dependency_overrides[get_optional_user] = _override_user
+
+    with TestClient(app, raise_server_exceptions=False) as tc:
+        yield tc
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Create (admin-only)
+# ---------------------------------------------------------------------------
+
+
+def test_create_invitation_admin_ok(admin_client: TestClient):
+    resp = admin_client.post(INVITATIONS_PREFIX, json={"email": "new.teacher@example.com", "role": "teacher"})
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["email"] == "new.teacher@example.com"
+    assert body["role"] == "teacher"
+    assert body["status"] == "pending"
+    assert body["is_expired"] is False
+    assert body["invited_by"] == str(ADMIN_ID)
+
+
+def test_create_invitation_normalizes_email_case(admin_client: TestClient):
+    resp = admin_client.post(INVITATIONS_PREFIX, json={"email": "Mixed.Case@Example.com", "role": "student"})
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["email"] == "mixed.case@example.com"
+
+
+def test_create_invitation_rejects_admin_role(admin_client: TestClient):
+    # Literal["teacher", "student"] on the schema -- an invite can never
+    # grant admin, regardless of what the request body claims.
+    resp = admin_client.post(INVITATIONS_PREFIX, json={"email": "x@example.com", "role": "admin"})
+    assert resp.status_code == 422, resp.text
+
+
+def test_create_invitation_forbidden_for_student(student_client: TestClient):
+    resp = student_client.post(INVITATIONS_PREFIX, json={"email": "x@example.com", "role": "student"})
+    assert resp.status_code == 403, resp.text
+
+
+def test_create_invitation_forbidden_for_teacher(client: TestClient):
+    # ``client`` fixture is teacher-authenticated by default.
+    resp = client.post(INVITATIONS_PREFIX, json={"email": "x@example.com", "role": "student"})
+    assert resp.status_code == 403, resp.text
+
+
+def test_create_invitation_forbidden_anonymous(anon_client: TestClient):
+    resp = anon_client.post(INVITATIONS_PREFIX, json={"email": "x@example.com", "role": "student"})
+    assert resp.status_code == 401, resp.text
+
+
+def test_create_invitation_dedupes_pending(admin_client: TestClient, db: Session):
+    first = admin_client.post(INVITATIONS_PREFIX, json={"email": "dup@example.com", "role": "teacher"})
+    second = admin_client.post(INVITATIONS_PREFIX, json={"email": "dup@example.com", "role": "teacher"})
+    assert first.status_code == 201
+    assert second.status_code == 201
+    # Same row resent, not a fresh duplicate -- same id/token, and the
+    # DB has exactly one row for this (email, role).
+    assert first.json()["id"] == second.json()["id"]
+    rows = db.query(Invitation).filter(Invitation.email == "dup@example.com").all()
+    assert len(rows) == 1
+
+
+def test_create_invitation_new_row_after_prior_revoked_or_accepted(admin_client: TestClient, db: Session):
+    first = admin_client.post(INVITATIONS_PREFIX, json={"email": "again@example.com", "role": "student"})
+    invitation_id = uuid.UUID(first.json()["id"])
+    row = db.query(Invitation).filter(Invitation.id == invitation_id).one()
+    row.status = "revoked"
+    db.commit()
+
+    second = admin_client.post(INVITATIONS_PREFIX, json={"email": "again@example.com", "role": "student"})
+    assert second.status_code == 201, second.text
+    assert second.json()["id"] != str(invitation_id)
+
+
+# ---------------------------------------------------------------------------
+# List (admin-only)
+# ---------------------------------------------------------------------------
+
+
+def test_list_invitations_admin_ok(admin_client: TestClient):
+    admin_client.post(INVITATIONS_PREFIX, json={"email": "a@example.com", "role": "teacher"})
+    admin_client.post(INVITATIONS_PREFIX, json={"email": "b@example.com", "role": "student"})
+
+    resp = admin_client.get(INVITATIONS_PREFIX)
+    assert resp.status_code == 200, resp.text
+    emails = {row["email"] for row in resp.json()}
+    assert {"a@example.com", "b@example.com"} <= emails
+
+
+def test_list_invitations_filters_by_role_and_status(admin_client: TestClient):
+    admin_client.post(INVITATIONS_PREFIX, json={"email": "t1@example.com", "role": "teacher"})
+    admin_client.post(INVITATIONS_PREFIX, json={"email": "s1@example.com", "role": "student"})
+
+    resp = admin_client.get(INVITATIONS_PREFIX, params={"role": "teacher"})
+    assert resp.status_code == 200
+    assert all(row["role"] == "teacher" for row in resp.json())
+
+    resp = admin_client.get(INVITATIONS_PREFIX, params={"status": "pending"})
+    assert resp.status_code == 200
+    assert all(row["status"] == "pending" for row in resp.json())
+
+
+def test_list_invitations_forbidden_for_non_admin(student_client: TestClient):
+    resp = student_client.get(INVITATIONS_PREFIX)
+    assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Token preview (unauthenticated)
+# ---------------------------------------------------------------------------
+
+
+def test_preview_invitation_by_token_ok(admin_client: TestClient, anon_client: TestClient, db: Session):
+    admin_client.post(INVITATIONS_PREFIX, json={"email": "preview@example.com", "role": "teacher"})
+    token = db.query(Invitation).filter(Invitation.email == "preview@example.com").one().token
+
+    resp = anon_client.get(f"{INVITATIONS_PREFIX}/token/{token}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["email"] == "preview@example.com"
+    assert body["role"] == "teacher"
+    assert body["status"] == "pending"
+    assert body["is_expired"] is False
+
+
+def test_preview_invitation_unknown_token_404(anon_client: TestClient):
+    resp = anon_client.get(f"{INVITATIONS_PREFIX}/token/does-not-exist")
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"]["code"] == "invitation.not_found"
+
+
+# ---------------------------------------------------------------------------
+# Accept
+# ---------------------------------------------------------------------------
+
+
+def test_accept_invitation_promotes_role(invitee_client: TestClient, db: Session):
+    token = _seed_invitation(db, email=INVITEE_EMAIL, role="teacher").token
+
+    resp = invitee_client.post(f"{INVITATIONS_PREFIX}/accept", json={"token": token})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["role"] == "teacher"
+
+    updated = db.query(User).filter(User.id == INVITEE_ID).one()
+    assert updated.role == "teacher"
+    row = db.query(Invitation).filter(Invitation.token == token).one()
+    assert row.status == "accepted"
+    assert row.accepted_at is not None
+
+
+def test_accept_invitation_rejects_replay(invitee_client: TestClient, db: Session):
+    token = _seed_invitation(db, email=INVITEE_EMAIL, role="teacher").token
+
+    first = invitee_client.post(f"{INVITATIONS_PREFIX}/accept", json={"token": token})
+    assert first.status_code == 200
+
+    second = invitee_client.post(f"{INVITATIONS_PREFIX}/accept", json={"token": token})
+    assert second.status_code == 409, second.text
+    assert second.json()["detail"]["code"] == "invitation.already_used"
+
+
+def test_accept_invitation_rejects_unknown_token(invitee_client: TestClient):
+    resp = invitee_client.post(f"{INVITATIONS_PREFIX}/accept", json={"token": "bogus-token"})
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"]["code"] == "invitation.not_found"
+
+
+def test_accept_invitation_rejects_expired(invitee_client: TestClient, db: Session):
+    row = _seed_invitation(db, email=INVITEE_EMAIL, role="student")
+    row.expires_at = datetime.now(UTC) - timedelta(days=1)
+    db.commit()
+
+    resp = invitee_client.post(f"{INVITATIONS_PREFIX}/accept", json={"token": row.token})
+    assert resp.status_code == 410, resp.text
+    assert resp.json()["detail"]["code"] == "invitation.expired"
+
+
+def test_accept_invitation_rejects_email_mismatch(invitee_client: TestClient, db: Session):
+    # Invite issued to a DIFFERENT email than the authenticated caller's.
+    token = _seed_invitation(db, email="someone.else@example.com", role="teacher").token
+
+    resp = invitee_client.post(f"{INVITATIONS_PREFIX}/accept", json={"token": token})
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"]["code"] == "invitation.email_mismatch"
+
+    # And the caller's role must NOT have been touched by the attempt.
+    unchanged = db.query(User).filter(User.id == INVITEE_ID).one()
+    assert unchanged.role == UserRole.STUDENT.value
+
+
+def test_accept_invitation_cannot_be_used_to_tamper_role_via_body(invitee_client: TestClient):
+    # The accept schema only accepts a token -- there is no ``role`` field
+    # a tampered request could set; a stray one is silently ignored.
+    resp = invitee_client.post(
+        f"{INVITATIONS_PREFIX}/accept",
+        json={"token": "whatever", "role": "admin"},
+    )
+    # Fails on the (nonexistent) token, not a role validation error --
+    # proves the extra field had no effect on request handling.
+    assert resp.status_code == 404, resp.text
+
+
+def test_accept_invitation_requires_auth(anon_client: TestClient):
+    resp = anon_client.post(f"{INVITATIONS_PREFIX}/accept", json={"token": "whatever"})
+    assert resp.status_code == 401, resp.text

--- a/supabase/migrations/20260707120000_add_invitations_table.sql
+++ b/supabase/migrations/20260707120000_add_invitations_table.sql
@@ -1,0 +1,57 @@
+-- One-time, unique-token email invites for the teacher/student roles.
+--
+-- Context
+-- =======
+-- Self-signup always lands as 'student' (20260531120000 rewrote
+-- handle_new_user so a claimed role in signup metadata is ignored, and
+-- 20260515183845 blocks role escalation at signup). There is no
+-- self-service path to a teacher account. This table backs an
+-- admin-issued, single-use invite link that promotes the invited email
+-- to 'teacher' or 'student' once redeemed. Admin escalation is
+-- deliberately NOT invitable here -- an admin role can only be granted
+-- via the existing manual PUT /users/admin/users/{id}/role route.
+--
+-- Redemption model
+-- ================
+-- The backend never calls the Supabase Auth admin API to mint the user.
+-- The invited person signs up or logs in normally (landing as 'student'
+-- via the existing trigger), then calls the authenticated
+-- POST /invitations/accept with the token. The backend checks the
+-- token against THIS table (connects as postgres, bypassing grants
+-- below entirely) and, once it confirms the caller's email matches the
+-- invite, flips profiles.role. The token itself -- not RLS -- is the
+-- capability; no direct client access to this table is ever needed, so
+-- every grant is revoked below (mirrors the "GRANTS are the boundary"
+-- posture from 20260611200000).
+--
+-- Single-use race safety: the accept path UPDATEs WHERE status='pending'
+-- and checks the affected row count, so two concurrent accepts (double
+-- click, retried request) can't both succeed. The partial unique index
+-- below additionally stops two 'pending' rows for the same
+-- (email, role) pair from ever coexisting, so a rapid double "Invite"
+-- click in the admin UI can't fan out duplicate rows either.
+
+CREATE TABLE invitations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('teacher', 'student')),
+    token TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'revoked')),
+    invited_by UUID REFERENCES profiles(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    accepted_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '7 days')
+);
+
+-- Admin list view: "invitations for this email/role, most recent first".
+CREATE INDEX ix_invitations_email_role ON invitations (email, role, created_at DESC);
+
+-- Resend/dedupe guard at the DB level, not just app logic.
+CREATE UNIQUE INDEX ix_invitations_one_pending_per_email_role
+    ON invitations (email, role) WHERE status = 'pending';
+
+-- No direct client access -- every read/write goes through the FastAPI
+-- backend (service role / postgres connection, unaffected by these
+-- grants). Applies even to SELECT: a token is a bearer secret and an
+-- email is PII, neither belongs in a PostgREST-reachable table.
+REVOKE ALL ON public.invitations FROM anon, authenticated;


### PR DESCRIPTION
## Summary
- New `invitations` table (email, role `teacher|student`, single-use `token`, `status pending|accepted|revoked`, `expires_at` default +7d) with a DB-level partial-unique-index dedupe guard and grants revoked from anon/authenticated (backend-only access, mirrors the "grants are the boundary" posture).
- `POST /api/v1/invitations` (admin-only): create/resend an invite, sends the accept-link email via direct backend->Resend call (mirrors `send-email` edge function's brand styling). Resend reuses the existing pending row/token rather than duplicating.
- `GET /api/v1/invitations` (admin-only): paginated list, filterable by role/status.
- `GET /api/v1/invitations/token/{token}` (public): preview for the accept-invite page copy.
- `POST /api/v1/invitations/accept` (authenticated): redeems a token for the *signed-in* caller — validates token/expiry/email-match, atomically flips `pending -> accepted` (race-safe via a conditional UPDATE), then promotes the caller's `profiles.role`. Deliberately does **not** call the Supabase Auth admin API to mint the user — the invitee signs up/logs in normally first (landing as `student` via the existing trigger), then redeems. Admin role is never invitable (schema-level `Literal["teacher","student"]`).
- New `RESEND_API_KEY` / `FRONTEND_URL` backend settings (optional, graceful no-op if unset). `RESEND_API_KEY` added to Vercel prod env for `equip-backend`.
- Rate-limit buckets added for `/invitations/token/` and `/invitations`.

## Test plan
- [x] `ruff check .` / `ruff format --check .` / `mypy` — clean
- [x] `pytest tests/` — 1541 passed (incl. 20 new invitation tests: token replay/reuse rejected, expired rejected, email-mismatch rejected, role can't be tampered via request body, admin-only endpoints reject non-admin/anonymous, dedupe-on-resend, fresh row after prior revoked)
- [ ] Frontend admin UI + accept-invite page ship in a follow-up PR (this PR is backend-only)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
