### PR TITLE
feat(course): auto-generate typographic covers for courses without art

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -5,7 +5,8 @@ import { motion, useReducedMotion } from "motion/react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import type { Course } from "@/types"
-import { BookOpen, ArrowRight, CheckCircle } from "lucide-react"
+import { ArrowRight, CheckCircle } from "lucide-react"
+import { CourseCoverFallback } from "./CourseCoverFallback"
 import { toProxyImage } from "@/lib/images"
 import { formatDate } from "@/i18n/format"
 import { EDITORIAL_EASE } from "@/lib/motion"
@@ -92,8 +93,8 @@ function CourseCard({ course, style, progress }: CourseCardProps) {
             />
           </div>
         ) : (
-          <div className="flex aspect-[16/10] w-full items-center justify-center bg-muted">
-            <BookOpen className="h-10 w-10 text-ink-muted/30" strokeWidth={1.75} aria-hidden />
+          <div className="aspect-[16/10] w-full">
+            <CourseCoverFallback courseId={course.id} title={course.title} size="md" />
           </div>
         )}
       </div>

--- a/frontend/src/components/course/CourseCoverFallback.tsx
+++ b/frontend/src/components/course/CourseCoverFallback.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react"
+import { cn } from "@/lib/utils"
+
+interface CourseCoverFallbackProps {
+  /** Course id — hashed to deterministically pick one of the five tint
+   *  variants, so the same course always renders the same cover. */
+  courseId: string
+  title: string
+  /** Controls the monogram scale. ``sm`` for small list thumbnails
+   *  (teacher dashboard row), ``md`` for catalog/dashboard grid cards,
+   *  ``lg`` for full-width hero covers (course detail header). */
+  size?: "sm" | "md" | "lg"
+  className?: string
+}
+
+// Full, literal class names — NOT built via template-literal
+// interpolation. Tailwind's JIT content scanner only keeps hand-authored
+// `@layer utilities` rules whose selector class appears as a complete,
+// literal token somewhere in the scanned source; a `` `course-cover-tint-${n}` ``
+// interpolation never produces that literal, so the matching CSS rules
+// get silently purged from the build. Spelling out the array keeps every
+// variant's full class name visible to the scanner.
+const TINT_CLASSES = [
+  "course-cover-tint-1",
+  "course-cover-tint-2",
+  "course-cover-tint-3",
+  "course-cover-tint-4",
+  "course-cover-tint-5",
+] as const
+
+// Small, fast, deterministic string hash (djb2-ish) — good enough to
+// spread course ids evenly across the five chart tints without pulling
+// in a hashing library for a purely cosmetic pick.
+function hashToIndex(input: string, modulo: number): number {
+  let hash = 5381
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 33) ^ input.charCodeAt(i)
+  }
+  return Math.abs(hash) % modulo
+}
+
+const LETTER_SIZE: Record<NonNullable<CourseCoverFallbackProps["size"]>, string> = {
+  sm: "text-xl",
+  md: "text-6xl",
+  lg: "text-8xl",
+}
+
+/**
+ * Deterministic auto-generated cover art for courses without an
+ * uploaded image — a tinted diagonal wash (picked from the existing
+ * ``--chart-{1..5}`` categorical palette) plus the course's initial
+ * letter, so the catalog and dashboards show varied, editorial-looking
+ * cards instead of a repeated flat gray rectangle + generic icon.
+ *
+ * Purely decorative — the course title is always rendered as real text
+ * next to/below this, so the monogram is ``aria-hidden``.
+ */
+export function CourseCoverFallback({ courseId, title, size = "md", className }: CourseCoverFallbackProps) {
+  const tintClass = useMemo(
+    () => TINT_CLASSES[hashToIndex(courseId, TINT_CLASSES.length)],
+    [courseId],
+  )
+  const letter = useMemo(() => {
+    const trimmed = title.trim()
+    return trimmed ? trimmed.charAt(0).toUpperCase() : "?"
+  }, [title])
+
+  return (
+    <div
+      className={cn(
+        "flex h-full w-full items-center justify-center overflow-hidden",
+        tintClass,
+        className,
+      )}
+      aria-hidden="true"
+    >
+      <span
+        className={cn(
+          "course-cover-letter select-none font-serif font-semibold leading-none",
+          LETTER_SIZE[size],
+        )}
+      >
+        {letter}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/course/__tests__/CourseCoverFallback.test.tsx
+++ b/frontend/src/components/course/__tests__/CourseCoverFallback.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { axe } from "@/test/a11y"
+import { CourseCoverFallback } from "../CourseCoverFallback"
+
+describe("CourseCoverFallback", () => {
+  it("renders the uppercase initial of the title", () => {
+    const { getByText } = render(<CourseCoverFallback courseId="course-1" title="genesis foundations" />)
+    expect(getByText("G")).toBeInTheDocument()
+  })
+
+  it("is deterministic — the same course id always gets the same tint class", () => {
+    const first = render(<CourseCoverFallback courseId="course-abc" title="Romans" />)
+    const second = render(<CourseCoverFallback courseId="course-abc" title="Romans" />)
+    const tintClass = (el: HTMLElement) =>
+      Array.from(el.firstElementChild!.classList).find((c) => c.startsWith("course-cover-tint-"))
+    expect(tintClass(first.container)).toBe(tintClass(second.container))
+  })
+
+  it("picks different tints across different course ids (spread, not identical for a small sample)", () => {
+    const ids = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    const tints = new Set(
+      ids.map((id) => {
+        const { container } = render(<CourseCoverFallback courseId={id} title="X" />)
+        return Array.from(container.firstElementChild!.classList).find((c) => c.startsWith("course-cover-tint-"))
+      }),
+    )
+    expect(tints.size).toBeGreaterThan(1)
+  })
+
+  it("falls back to a placeholder glyph for a blank title", () => {
+    const { getByText } = render(<CourseCoverFallback courseId="course-2" title="   " />)
+    expect(getByText("?")).toBeInTheDocument()
+  })
+
+  it("is purely decorative (aria-hidden) since the real title renders as text elsewhere", () => {
+    const { container } = render(<CourseCoverFallback courseId="course-3" title="Exodus" />)
+    expect(container.firstElementChild).toHaveAttribute("aria-hidden", "true")
+  })
+
+  it("renders without a11y violations", async () => {
+    const { container } = render(
+      <div>
+        <h2>Exodus</h2>
+        <CourseCoverFallback courseId="course-4" title="Exodus" />
+      </div>,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -425,6 +425,58 @@
   .border-l-stripe {
     border-left-width: 3px;
   }
+
+  /* Auto-generated course cover art (``<CourseCoverFallback>``). A
+     course that hasn't had a cover uploaded gets a deterministic
+     gradient + monogram instead of a flat muted rectangle with a
+     generic icon — the catalog/dashboard shouldn't look empty just
+     because a teacher hasn't uploaded art yet. Each tint is picked
+     from the existing ``--chart-{1..5}`` categorical palette (already
+     tuned for both themes), so this adds no new colour tokens. Each
+     variant sets its own background + letter colour directly (rather
+     than indirecting through a shared custom property) so the rule
+     order/inheritance is trivial to reason about. */
+  .course-cover-tint-1,
+  .course-cover-tint-2,
+  .course-cover-tint-3,
+  .course-cover-tint-4,
+  .course-cover-tint-5 {
+    background-color: hsl(var(--muted));
+  }
+  .course-cover-tint-1 {
+    background-image: linear-gradient(135deg, hsl(var(--chart-1) / 0.32) 0%, hsl(var(--chart-1) / 0.1) 55%, transparent 100%);
+  }
+  .course-cover-tint-2 {
+    background-image: linear-gradient(135deg, hsl(var(--chart-2) / 0.32) 0%, hsl(var(--chart-2) / 0.1) 55%, transparent 100%);
+  }
+  .course-cover-tint-3 {
+    background-image: linear-gradient(135deg, hsl(var(--chart-3) / 0.32) 0%, hsl(var(--chart-3) / 0.1) 55%, transparent 100%);
+  }
+  .course-cover-tint-4 {
+    background-image: linear-gradient(135deg, hsl(var(--chart-4) / 0.32) 0%, hsl(var(--chart-4) / 0.1) 55%, transparent 100%);
+  }
+  .course-cover-tint-5 {
+    background-image: linear-gradient(135deg, hsl(var(--chart-5) / 0.32) 0%, hsl(var(--chart-5) / 0.1) 55%, transparent 100%);
+  }
+  /* Solid (not blended-into-white) tint at high opacity — reads as a
+     clearly coloured monogram against the quiet wash above, the same
+     way the chart tokens already read clearly against both theme
+     backgrounds in data-viz contexts. */
+  .course-cover-tint-1 .course-cover-letter {
+    color: hsl(var(--chart-1) / 0.82);
+  }
+  .course-cover-tint-2 .course-cover-letter {
+    color: hsl(var(--chart-2) / 0.82);
+  }
+  .course-cover-tint-3 .course-cover-letter {
+    color: hsl(var(--chart-3) / 0.82);
+  }
+  .course-cover-tint-4 .course-cover-letter {
+    color: hsl(var(--chart-4) / 0.82);
+  }
+  .course-cover-tint-5 .course-cover-letter {
+    color: hsl(var(--chart-5) / 0.82);
+  }
 }
 
 @layer components {

--- a/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
+++ b/frontend/src/pages/Teacher/dashboard/CourseCard.tsx
@@ -2,7 +2,6 @@ import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import {
   BarChart3,
-  BookOpen,
   ClipboardList,
   Copy,
   Eye,
@@ -24,6 +23,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { CourseCoverFallback } from "@/components/course/CourseCoverFallback"
 import { toProxyImage } from "@/lib/images"
 import { formatDate } from "@/i18n/format"
 import type { Course } from "@/types"
@@ -63,8 +63,8 @@ export function CourseCard({
             className="h-16 w-16 shrink-0 rounded-lg object-cover sm:h-20 sm:w-20"
           />
         ) : (
-          <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg bg-muted sm:h-20 sm:w-20">
-            <BookOpen className="h-7 w-7 text-ink-muted/40 sm:h-8 sm:w-8" strokeWidth={1.75} aria-hidden />
+          <div className="h-16 w-16 shrink-0 overflow-hidden rounded-lg sm:h-20 sm:w-20">
+            <CourseCoverFallback courseId={course.id} title={course.title} size="sm" />
           </div>
         )}
         <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary

Part 1 of a 3-part design polish pass ("design trio": course covers →
dashboard density → landing page) aimed at the biggest "looks
vibe-coded" tells in the product.

Courses without an uploaded `image_url` fell back to a flat gray
rectangle with a generic `BookOpen` icon — repeated identically on
every card — so the catalog and teacher dashboard read as empty/
generic whenever a teacher hadn't uploaded cover art yet.

- Adds `<CourseCoverFallback>` (`frontend/src/components/course/`): a
  deterministic gradient + monogram cover. The same course id always
  renders the same look (hashed, not random), and the tint is picked
  from the **existing** `--chart-{1..5}` categorical palette — no new
  color tokens introduced, per `docs/DESIGN.md`.
- Wired into the public/catalog `CourseCard` and the teacher
  dashboard's compact `CourseCard` (both previously rendered the same
  static `BookOpen`-on-`bg-muted` placeholder).
- Purely decorative (`aria-hidden`) — the real course title is always
  rendered as text elsewhere on the card, so no new translation keys
  were needed and `i18n:check` stays green untouched.

## Test plan

- [x] `npm run lint` — 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds, bundle sizes within budget
- [x] `npm run test:run` — 565/565 tests pass (added
      `CourseCoverFallback.test.tsx`: deterministic hashing, tint
      spread across ids, blank-title fallback, `aria-hidden`, axe a11y)
- [x] `npm run i18n:check` — locale bundles stay in parity (no new keys)
- [x] Visually verified in light **and** dark themes via a local dev
      server + Playwright screenshots — confirmed distinct, legible
      tints and monograms in both themes at the catalog-card and
      teacher-dashboard-thumbnail sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
