### PR TITLE
feat(frontend): add admin invitation UI and accept-invite flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useRef } from "react"
-import { BrowserRouter, Route, Navigate, useLocation } from "react-router-dom"
+import { BrowserRouter, Route, Navigate, useLocation, useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { Routes } from "@datadog/browser-rum-react/react-router-v6"
 import { AuthProvider } from "./context/AuthContext"
@@ -17,6 +17,7 @@ import PageSpinner from "./components/ui/PageSpinner"
 import ScrollToTop from "./components/layout/ScrollToTop";
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { useGrandTour } from "@/hooks/useGrandTour"
+import { takePendingInviteToken } from "@/lib/pendingInvite"
 
 // Lazy: FirstRunFlow renders null until a brand-new user's privacy/setup gate
 // activates, so it never needs to be on the critical path — its component code
@@ -37,6 +38,7 @@ const Register = lazy(() => import("./pages/Auth/Register"))
 const ForgotPassword = lazy(() => import("./pages/Auth/ForgotPassword"))
 const ResetPassword = lazy(() => import("./pages/Auth/ResetPassword"))
 const AuthCallback = lazy(() => import("./pages/Auth/AuthCallback"))
+const AcceptInvite = lazy(() => import("./pages/Invite/AcceptInvite"))
 const DashboardPage = lazy(() => import("./pages/Dashboard/DashboardPage"))
 const CoursesPage = lazy(() => import("./pages/Courses/CoursesPage"))
 const ProfilePage = lazy(() => import("./pages/Profile/ProfilePage"))
@@ -99,7 +101,38 @@ function Gate({ mode, children }: { mode: RouteMode; children: React.ReactNode }
   return <>{children}</>
 }
 
-const AUTH_PATHS = ["/login", "/register", "/forgot-password", "/auth/reset-password", "/auth/callback", "/auth/confirm"]
+const AUTH_PATHS = [
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/auth/reset-password",
+  "/auth/callback",
+  "/auth/confirm",
+  "/invite/accept",
+]
+
+/**
+ * Resumes an in-progress invite redemption after a full-page redirect
+ * (Google OAuth, or clicking the "confirm your email" link) lands the
+ * visitor back on the app authenticated but on an unrelated route.
+ * AcceptInvite persists the token via `setPendingInviteToken` right
+ * before either redirect kicks off; this picks it up once `user`
+ * becomes non-null and finishes the trip back to `/invite/accept`.
+ * `takePendingInviteToken` clears the stored value on read, so this is
+ * naturally a no-op on every render after the first.
+ */
+function useResumePendingInvite() {
+  const { user } = useAuth()
+  const location = useLocation()
+  const navigate = useNavigate()
+  useEffect(() => {
+    if (!user) return
+    if (location.pathname === "/invite/accept") return
+    const token = takePendingInviteToken()
+    if (token) navigate(`/invite/accept?token=${encodeURIComponent(token)}`, { replace: true })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id])
+}
 
 function AppRoutes() {
   const { loading } = useAuth()
@@ -109,6 +142,7 @@ function AppRoutes() {
   usePageTitle()
   useLocaleSync()
   useRouteFocus()
+  useResumePendingInvite()
   // Grand tour lives here so it has access to React Router (for
   // programmatic navigation between steps) and AuthContext (for the
   // role gate). Mounts after auth is resolved; the hook itself gates
@@ -131,6 +165,10 @@ function AppRoutes() {
             <Route path="/auth/reset-password" element={<ResetPassword />} />
             <Route path="/auth/callback" element={<AuthCallback />} />
             <Route path="/auth/confirm" element={<AuthCallback />} />
+            {/* No <Gate> -- must render correctly for both an anonymous
+                visitor (fresh invite link) and an authenticated one
+                (bounced back here after Google OAuth / email confirm). */}
+            <Route path="/invite/accept" element={<AcceptInvite />} />
             <Route path="*" element={<Navigate to="/login" replace />} />
           </Routes>
         </Suspense>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2030,6 +2030,38 @@
       "pageSizeLabel": "Rows per page",
       "detailsEmpty": "No details",
       "summaryLabel": "On this page"
+    },
+    "tabInvitations": "Invitations",
+    "invitations": {
+      "title": "Invitations",
+      "loadError": "Failed to load invitations",
+      "inviteButton": "Generate invite",
+      "filterRole": "Role",
+      "allRoles": "All roles",
+      "filterStatus": "Status",
+      "allStatuses": "All statuses",
+      "statusPending": "Pending",
+      "statusAccepted": "Accepted",
+      "statusRevoked": "Revoked",
+      "statusExpired": "Expired",
+      "emptyTitle": "No invitations sent yet",
+      "thEmail": "Email",
+      "thRole": "Role",
+      "thStatus": "Status",
+      "thSent": "Sent",
+      "resend": "Resend",
+      "createTitle": "Generate invite",
+      "fieldEmail": "Email",
+      "emailPlaceholder": "person@example.com",
+      "fieldRole": "Role",
+      "sending": "Sending…",
+      "send": "Send invite",
+      "toast": {
+        "created": "Invitation sent",
+        "createFailed": "Failed to send invitation",
+        "resent": "Invitation resent",
+        "resendFailed": "Failed to resend invitation"
+      }
     }
   },
   "roles": {
@@ -2171,5 +2203,25 @@
     "placeholder": "Pick date + time",
     "hourAria": "Hour",
     "minuteAria": "Minute"
+  },
+  "invite": {
+    "heading": "Join Equip",
+    "formSubheading": "You've been invited to join Equip as a {{role}}",
+    "readyBody": "You're signed in as <strong>{{email}}</strong>. Accept this invitation to join Equip as a {{role}}.",
+    "acceptButton": "Accept invitation",
+    "createAccountButton": "Create account",
+    "confirmThenReturn": "Click the link in the email, then come back to this page to finish joining.",
+    "accepted": "You're all set.",
+    "acceptedAs": "You're all set — you've joined Equip as a {{role}}.",
+    "goToDashboard": "Go to dashboard",
+    "logOutAndSwitch": "Log out and switch accounts",
+    "errors": {
+      "notFound": "This invitation link isn't valid. Double-check the link or ask the admin who invited you to resend it.",
+      "unusable": "This invitation has already been used, was revoked, or has expired. Ask the admin who invited you for a new one.",
+      "emailMismatch": "This invitation was sent to a different email address.",
+      "emailMismatchDetail": "This invitation was sent to <strong>{{invited}}</strong>, but you're signed in as <strong>{{current}}</strong>.",
+      "acceptFailed": "Couldn't accept this invitation. Please try again.",
+      "accountExists": "You already have an Equip account with this email. Log in, then reopen this invite link to accept it."
+    }
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1652,6 +1652,38 @@
       "pageSizeLabel": "Строк на странице",
       "detailsEmpty": "Нет деталей",
       "summaryLabel": "На этой странице"
+    },
+    "tabInvitations": "Приглашения",
+    "invitations": {
+      "title": "Приглашения",
+      "loadError": "Не удалось загрузить приглашения",
+      "inviteButton": "Создать приглашение",
+      "filterRole": "Роль",
+      "allRoles": "Все роли",
+      "filterStatus": "Статус",
+      "allStatuses": "Все статусы",
+      "statusPending": "Ожидает",
+      "statusAccepted": "Принято",
+      "statusRevoked": "Отозвано",
+      "statusExpired": "Истекло",
+      "emptyTitle": "Приглашений пока нет",
+      "thEmail": "Email",
+      "thRole": "Роль",
+      "thStatus": "Статус",
+      "thSent": "Отправлено",
+      "resend": "Отправить снова",
+      "createTitle": "Создать приглашение",
+      "fieldEmail": "Email",
+      "emailPlaceholder": "person@example.com",
+      "fieldRole": "Роль",
+      "sending": "Отправка…",
+      "send": "Отправить приглашение",
+      "toast": {
+        "created": "Приглашение отправлено",
+        "createFailed": "Не удалось отправить приглашение",
+        "resent": "Приглашение отправлено повторно",
+        "resendFailed": "Не удалось отправить приглашение повторно"
+      }
     }
   },
   "roles": {
@@ -2229,5 +2261,25 @@
     "placeholder": "Выберите дату и время",
     "hourAria": "Часы",
     "minuteAria": "Минуты"
+  },
+  "invite": {
+    "heading": "Присоединиться к Equip",
+    "formSubheading": "Вас пригласили присоединиться к Equip в роли: {{role}}",
+    "readyBody": "Вы вошли как <strong>{{email}}</strong>. Примите приглашение, чтобы присоединиться к Equip в роли: {{role}}.",
+    "acceptButton": "Принять приглашение",
+    "createAccountButton": "Создать аккаунт",
+    "confirmThenReturn": "Перейдите по ссылке в письме, а затем вернитесь на эту страницу, чтобы завершить регистрацию.",
+    "accepted": "Готово.",
+    "acceptedAs": "Готово — вы присоединились к Equip в роли: {{role}}.",
+    "goToDashboard": "Перейти в кабинет",
+    "logOutAndSwitch": "Выйти и сменить аккаунт",
+    "errors": {
+      "notFound": "Эта ссылка-приглашение недействительна. Проверьте ссылку или попросите администратора отправить её снова.",
+      "unusable": "Это приглашение уже использовано, отозвано или истекло. Попросите администратора создать новое.",
+      "emailMismatch": "Это приглашение отправлено на другой email.",
+      "emailMismatchDetail": "Это приглашение отправлено на <strong>{{invited}}</strong>, но вы вошли как <strong>{{current}}</strong>.",
+      "acceptFailed": "Не удалось принять приглашение. Попробуйте ещё раз.",
+      "accountExists": "У вас уже есть аккаунт Equip с этим email. Войдите в систему, затем снова откройте эту ссылку-приглашение, чтобы принять его."
+    }
   }
 }

--- a/frontend/src/lib/errorCode.ts
+++ b/frontend/src/lib/errorCode.ts
@@ -53,6 +53,11 @@ export type ErrorCode =
   | "daily_challenge.already_attempted"
   | "daily_challenge.invalid_option"
   | "daily_challenge.archive_date_not_allowed"
+  // invitations
+  | "invitation.not_found"
+  | "invitation.expired"
+  | "invitation.already_used"
+  | "invitation.email_mismatch"
   // validation
   | "validation.failed"
 

--- a/frontend/src/lib/pendingInvite.ts
+++ b/frontend/src/lib/pendingInvite.ts
@@ -1,0 +1,31 @@
+const STORAGE_KEY = "equip.pendingInviteToken"
+
+/**
+ * Bridges an invite token across a full-page redirect (Google OAuth,
+ * or the "confirm your email" link for a fresh email/password signup)
+ * back to the accept-invite page.
+ *
+ * AcceptInvite calls `setPendingInviteToken` right before either
+ * redirect kicks off. Once the user comes back authenticated -- to ANY
+ * route, since OAuth/email-confirm both land on "/" -- App.tsx's resume
+ * effect calls `takePendingInviteToken` and navigates to
+ * `/invite/accept?token=...` to finish the promotion.
+ */
+export function setPendingInviteToken(token: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, token)
+  } catch {
+    /* localStorage unavailable (private mode / blocked) -- the resume
+       step just won't fire; the invite link still works if revisited. */
+  }
+}
+
+export function takePendingInviteToken(): string | null {
+  try {
+    const token = localStorage.getItem(STORAGE_KEY)
+    if (token) localStorage.removeItem(STORAGE_KEY)
+    return token
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/lib/validations/auth.ts
+++ b/frontend/src/lib/validations/auth.ts
@@ -35,6 +35,22 @@ export function makeRegisterSchema() {
     })
 }
 
+// Same shape as makeRegisterSchema minus `email` -- the accept-invite
+// page fixes the email to whatever the invite was issued to, so there's
+// no editable email field to validate.
+export function makeAcceptInviteSchema() {
+  return z
+    .object({
+      full_name: z.string().min(2, t("authRegister.errors.fullNameTooShort")),
+      password: z.string().min(6, t("authRegister.errors.passwordTooShort")),
+      confirmPassword: z.string(),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: t("authRegister.errors.passwordsDoNotMatch"),
+      path: ["confirmPassword"],
+    })
+}
+
 // Static snapshots removed — every caller now invokes the factory
 // inside the submit handler so error messages match the active
 // locale (see ``Login.tsx`` / ``useRegister.ts`` / ``ResetPassword.tsx``).

--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -25,6 +25,9 @@ const AuditLogTab = lazy(() =>
 const CohortsTab = lazy(() =>
   import("./cohorts/CohortsTab").then((m) => ({ default: m.CohortsTab })),
 )
+const InvitationsTab = lazy(() =>
+  import("./invitations/InvitationsTab").then((m) => ({ default: m.InvitationsTab })),
+)
 
 /**
  * Admin dashboard orchestrator. Delegates every piece of state to
@@ -156,6 +159,18 @@ export default function AdminDashboard() {
         >
           <Suspense fallback={<PageSpinner />}>
             <CohortsTab />
+          </Suspense>
+        </div>
+      )}
+
+      {tab === "invitations" && (
+        <div
+          role="tabpanel"
+          id={ADMIN_TAB_PANEL_ID.invitations}
+          aria-labelledby={ADMIN_TAB_TRIGGER_ID.invitations}
+        >
+          <Suspense fallback={<PageSpinner />}>
+            <InvitationsTab />
           </Suspense>
         </div>
       )}

--- a/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
+++ b/frontend/src/pages/Admin/dashboard/AdminTabs.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next"
-import { Users, GraduationCap, FileText } from "lucide-react"
+import { Users, GraduationCap, Mail, FileText } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ADMIN_TAB_PANEL_ID, ADMIN_TAB_TRIGGER_ID, type AdminTab } from "./constants"
 
@@ -33,6 +33,13 @@ export function AdminTabs({ active, onChange }: Props) {
         onClick={() => onChange("cohorts")}
         icon={<GraduationCap className="h-4 w-4" strokeWidth={1.75} aria-hidden />}
         label={t("admin.tabCohorts")}
+      />
+      <TabButton
+        name="invitations"
+        active={active === "invitations"}
+        onClick={() => onChange("invitations")}
+        icon={<Mail className="h-4 w-4" strokeWidth={1.75} aria-hidden />}
+        label={t("admin.tabInvitations")}
       />
       <TabButton
         name="audit"

--- a/frontend/src/pages/Admin/dashboard/constants.ts
+++ b/frontend/src/pages/Admin/dashboard/constants.ts
@@ -4,8 +4,8 @@ import type { UserRole } from "@/types"
 // reach into ``@/lib/roles`` directly for the i18n mapping.
 export { ROLE_I18N_KEY } from "@/lib/roles"
 
-export type AdminTab = "overview" | "cohorts" | "audit"
-export const ADMIN_TABS: readonly AdminTab[] = ["overview", "cohorts", "audit"]
+export type AdminTab = "overview" | "cohorts" | "invitations" | "audit"
+export const ADMIN_TABS: readonly AdminTab[] = ["overview", "cohorts", "invitations", "audit"]
 
 /** Stable DOM ids for each admin tab's trigger button. Mirrors of these
  *  live on the corresponding ``role="tabpanel"`` wrappers in
@@ -17,12 +17,14 @@ export const ADMIN_TABS: readonly AdminTab[] = ["overview", "cohorts", "audit"]
 export const ADMIN_TAB_TRIGGER_ID = {
   overview: "admin-tab-overview",
   cohorts: "admin-tab-cohorts",
+  invitations: "admin-tab-invitations",
   audit: "admin-tab-audit",
 } as const
 
 export const ADMIN_TAB_PANEL_ID = {
   overview: "admin-tabpanel-overview",
   cohorts: "admin-tabpanel-cohorts",
+  invitations: "admin-tabpanel-invitations",
   audit: "admin-tabpanel-audit",
 } as const
 

--- a/frontend/src/pages/Admin/invitations/CreateInvitationDialog.tsx
+++ b/frontend/src/pages/Admin/invitations/CreateInvitationDialog.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Modal } from "@/components/patterns"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { invitationsService } from "@/services/invitations"
+import { toast } from "@/lib/toast"
+import { getErrorDetail } from "@/lib/errorDetail"
+import type { InvitationRole } from "@/types"
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onCreated: () => void
+}
+
+const EMAIL_MAX_LENGTH = 254
+
+/** Invite-by-email form. Admin-only can invite the 'teacher' or
+ *  'student' role -- 'admin' is deliberately not selectable, mirroring
+ *  the backend schema Literal that makes admin un-invitable. */
+export function CreateInvitationDialog({ open, onClose, onCreated }: Props) {
+  const { t } = useTranslation()
+  const [email, setEmail] = useState("")
+  const [role, setRole] = useState<InvitationRole>("student")
+  const [saving, setSaving] = useState(false)
+
+  const reset = () => {
+    setEmail("")
+    setRole("student")
+  }
+
+  const handleClose = () => {
+    if (saving) return
+    reset()
+    onClose()
+  }
+
+  const isValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
+
+  const submit = async () => {
+    if (!isValid) return
+    setSaving(true)
+    try {
+      await invitationsService.createInvitation(email.trim(), role)
+      toast({ title: t("admin.invitations.toast.created"), variant: "success" })
+      reset()
+      onCreated()
+    } catch (err) {
+      toast({
+        title: getErrorDetail(err, t("admin.invitations.toast.createFailed")),
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={handleClose} title={t("admin.invitations.createTitle")}>
+      <div className="space-y-4">
+        <div className="space-y-1.5">
+          <Label className="text-xs">{t("admin.invitations.fieldEmail")}</Label>
+          <Input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value.slice(0, EMAIL_MAX_LENGTH))}
+            maxLength={EMAIL_MAX_LENGTH}
+            placeholder={t("admin.invitations.emailPlaceholder")}
+            autoFocus
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs">{t("admin.invitations.fieldRole")}</Label>
+          <Select value={role} onValueChange={(v) => setRole(v as InvitationRole)}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="student">{t("roles.student")}</SelectItem>
+              <SelectItem value="teacher">{t("roles.teacher")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={handleClose} disabled={saving}>
+            {t("common.cancel")}
+          </Button>
+          <Button onClick={submit} disabled={!isValid || saving}>
+            {saving ? t("admin.invitations.sending") : t("admin.invitations.send")}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/pages/Admin/invitations/InvitationsTab.tsx
+++ b/frontend/src/pages/Admin/invitations/InvitationsTab.tsx
@@ -1,0 +1,330 @@
+import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Mail, Plus, RefreshCw } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import { EmptyState, ErrorState } from "@/components/patterns"
+import { invitationsService } from "@/services/invitations"
+import { toast } from "@/lib/toast"
+import { getErrorDetail } from "@/lib/errorDetail"
+import { formatDate } from "@/i18n/format"
+import { ROLE_I18N_KEY, ROLE_BADGE_VARIANT } from "@/lib/roles"
+import type { Invitation, InvitationRole, InvitationStatus } from "@/types"
+import { CreateInvitationDialog } from "./CreateInvitationDialog"
+
+// Status shown to the admin is derived: a 'pending' row with is_expired
+// renders as its own "Expired" state rather than a misleading "Pending".
+type DisplayStatus = InvitationStatus | "expired"
+
+function displayStatus(inv: Invitation): DisplayStatus {
+  if (inv.status === "pending" && inv.is_expired) return "expired"
+  return inv.status
+}
+
+const STATUS_BADGE: Record<DisplayStatus, "successSubtle" | "warningSubtle" | "muted" | "destructiveSubtle"> = {
+  pending: "warningSubtle",
+  accepted: "successSubtle",
+  revoked: "destructiveSubtle",
+  expired: "muted",
+}
+
+const STATUS_LABEL_KEYS: Record<DisplayStatus, string> = {
+  pending: "admin.invitations.statusPending",
+  accepted: "admin.invitations.statusAccepted",
+  revoked: "admin.invitations.statusRevoked",
+  expired: "admin.invitations.statusExpired",
+}
+
+type RoleFilterValue = "" | InvitationRole
+type StatusFilterValue = "" | "pending" | "accepted" | "revoked"
+
+/** Admin "Invitations" tab: send + track one-time email invites for the
+ *  teacher/student roles. Mirrors CohortsTab's card/filter/table shape. */
+export function InvitationsTab() {
+  const { t } = useTranslation()
+  const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [roleFilter, setRoleFilter] = useState<RoleFilterValue>("")
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("")
+  const [resendingId, setResendingId] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    invitationsService
+      .listInvitations({
+        role: roleFilter || undefined,
+        status: statusFilter || undefined,
+      })
+      .then((data) => {
+        if (cancelled) return
+        setInvitations(data)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setError(t("admin.invitations.loadError"))
+      })
+      .finally(() => {
+        if (cancelled) return
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [roleFilter, statusFilter, reloadKey, t])
+
+  // Re-inviting the same (email, role) is a safe, idempotent resend --
+  // see create_or_resend_invitation on the backend. Reuses the same
+  // create-invite call; no separate "resend" endpoint exists.
+  const handleResend = async (inv: Invitation) => {
+    setResendingId(inv.id)
+    try {
+      await invitationsService.createInvitation(inv.email, inv.role)
+      toast({ title: t("admin.invitations.toast.resent"), variant: "success" })
+      reload()
+    } catch (err) {
+      toast({
+        title: getErrorDetail(err, t("admin.invitations.toast.resendFailed")),
+        variant: "destructive",
+      })
+    } finally {
+      setResendingId(null)
+    }
+  }
+
+  return (
+    <Card className="flex max-h-[calc(100dvh-240px)] flex-col md:max-h-[calc(100dvh-200px)] md:min-h-[420px]">
+      <CardHeader className="shrink-0 gap-3 space-y-0 border-b">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-xl">{t("admin.invitations.title")}</CardTitle>
+          <Button size="sm" onClick={() => setCreateOpen(true)} className="h-9 shrink-0">
+            <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
+            {t("admin.invitations.inviteButton")}
+          </Button>
+        </div>
+        <div className="flex flex-wrap items-end gap-3">
+          <Select
+            value={roleFilter || "all"}
+            onValueChange={(v) => setRoleFilter((v === "all" ? "" : v) as InvitationRole)}
+          >
+            <SelectTrigger size="sm" className="h-9 w-full sm:w-40">
+              <SelectValue placeholder={t("admin.invitations.filterRole")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("admin.invitations.allRoles")}</SelectItem>
+              <SelectItem value="teacher">{t("roles.teacher")}</SelectItem>
+              <SelectItem value="student">{t("roles.student")}</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select
+            value={statusFilter || "all"}
+            onValueChange={(v) => setStatusFilter((v === "all" ? "" : v) as InvitationStatus)}
+          >
+            <SelectTrigger size="sm" className="h-9 w-full sm:w-40">
+              <SelectValue placeholder={t("admin.invitations.filterStatus")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("admin.invitations.allStatuses")}</SelectItem>
+              <SelectItem value="pending">{t("admin.invitations.statusPending")}</SelectItem>
+              <SelectItem value="accepted">{t("admin.invitations.statusAccepted")}</SelectItem>
+              <SelectItem value="revoked">{t("admin.invitations.statusRevoked")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col p-0">
+        {loading ? (
+          <InvitationsTableSkeleton />
+        ) : error ? (
+          <ErrorState
+            title={error}
+            action={
+              <Button size="sm" variant="outline" onClick={reload}>
+                {t("common.tryAgain")}
+              </Button>
+            }
+          />
+        ) : invitations.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center px-5 py-10">
+            <EmptyState
+              variant="compact"
+              icon={<Mail strokeWidth={1.75} aria-hidden />}
+              title={t("admin.invitations.emptyTitle")}
+              action={
+                <Button size="sm" onClick={() => setCreateOpen(true)}>
+                  <Plus className="mr-1.5 h-4 w-4" strokeWidth={1.75} aria-hidden />
+                  {t("admin.invitations.inviteButton")}
+                </Button>
+              }
+            />
+          </div>
+        ) : (
+          <InvitationsTable
+            items={invitations}
+            resendingId={resendingId}
+            onResend={handleResend}
+          />
+        )}
+      </CardContent>
+
+      <CreateInvitationDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => {
+          setCreateOpen(false)
+          reload()
+        }}
+      />
+    </Card>
+  )
+}
+
+function InvitationsTable({
+  items,
+  resendingId,
+  onResend,
+}: {
+  items: Invitation[]
+  resendingId: string | null
+  onResend: (inv: Invitation) => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <>
+      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto px-4 py-3 sm:hidden">
+        {items.map((inv) => {
+          const status = displayStatus(inv)
+          return (
+            <div
+              key={inv.id}
+              className="rounded-md border border-edge dark:border-transparent bg-card p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-ink">{inv.email}</p>
+                  <p className="mt-1 text-xs text-ink-muted">{formatDate(inv.created_at ?? inv.expires_at)}</p>
+                </div>
+                <div className="flex shrink-0 flex-col items-end gap-1.5">
+                  <Badge variant={ROLE_BADGE_VARIANT[inv.role]}>{t(ROLE_I18N_KEY[inv.role])}</Badge>
+                  <Badge variant={STATUS_BADGE[status]}>{t(STATUS_LABEL_KEYS[status])}</Badge>
+                </div>
+              </div>
+              {(status === "pending" || status === "expired") && (
+                <div className="mt-3 flex justify-end">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={resendingId === inv.id}
+                    onClick={() => onResend(inv)}
+                  >
+                    <RefreshCw className="mr-1.5 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+                    {t("admin.invitations.resend")}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="hidden min-h-0 flex-1 overflow-y-auto sm:block">
+        <table className="w-full table-fixed text-sm">
+          <colgroup>
+            <col className="w-[34%]" />
+            <col className="w-[14%]" />
+            <col className="w-[16%]" />
+            <col className="w-[20%]" />
+            <col className="w-[16%]" />
+          </colgroup>
+          <thead className="sticky top-0 z-10 bg-card">
+            <tr className="border-b text-left">
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.invitations.thEmail")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.invitations.thRole")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.invitations.thStatus")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted">{t("admin.invitations.thSent")}</th>
+              <th className="px-5 py-3 font-medium text-ink-muted" />
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {items.map((inv) => {
+              const status = displayStatus(inv)
+              return (
+                <tr key={inv.id} className="transition-colors hover:bg-muted/40">
+                  <td className="truncate px-5 py-3 font-medium" title={inv.email}>
+                    {inv.email}
+                  </td>
+                  <td className="px-5 py-3">
+                    <Badge variant={ROLE_BADGE_VARIANT[inv.role]}>{t(ROLE_I18N_KEY[inv.role])}</Badge>
+                  </td>
+                  <td className="px-5 py-3">
+                    <Badge variant={STATUS_BADGE[status]}>{t(STATUS_LABEL_KEYS[status])}</Badge>
+                  </td>
+                  <td className="px-5 py-3 text-xs text-ink-muted">
+                    {formatDate(inv.created_at ?? inv.expires_at)}
+                  </td>
+                  <td className="px-5 py-3 text-right">
+                    {(status === "pending" || status === "expired") && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={resendingId === inv.id}
+                        onClick={() => onResend(inv)}
+                      >
+                        <RefreshCw className="mr-1.5 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+                        {t("admin.invitations.resend")}
+                      </Button>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
+  )
+}
+
+function InvitationsTableSkeleton() {
+  return (
+    <div aria-busy="true">
+      <div className="space-y-2 px-4 py-3 sm:hidden">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-md bg-card p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="hidden max-h-[60vh] overflow-y-auto sm:block">
+        {Array.from({ length: 6 }).map((_, row) => (
+          <div key={row} className="flex items-center gap-4 border-b px-5 py-3">
+            {Array.from({ length: 5 }).map((_, col) => (
+              <Skeleton key={col} className="h-4 flex-1" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Auth/register/RegisterForm.tsx
+++ b/frontend/src/pages/Auth/register/RegisterForm.tsx
@@ -20,8 +20,10 @@ interface Props {
 }
 
 /**
- * The actual registration form — role toggle, four text inputs,
- * Google OAuth shortcut, submit button. Receives state and handlers from
+ * The actual registration form — four text inputs, Google OAuth
+ * shortcut, submit button. Self-signup is student-only (no role
+ * selector); teacher accounts are granted via an admin-issued invite
+ * (see pages/Invite/AcceptInvite.tsx). Receives state and handlers from
  * `useRegister`; nothing in here owns mutable state.
  */
 export function RegisterForm({

--- a/frontend/src/pages/Invite/AcceptInvite.tsx
+++ b/frontend/src/pages/Invite/AcceptInvite.tsx
@@ -1,0 +1,297 @@
+import { Link, Navigate } from "react-router-dom"
+import { Trans, useTranslation } from "react-i18next"
+import { CheckCircle2, Loader2, MailCheck, XCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import AuthLayout from "@/components/layout/AuthLayout"
+import { GoogleIcon } from "@/pages/Auth/register/GoogleIcon"
+import { ROLE_I18N_KEY } from "@/lib/roles"
+import { useAcceptInvite } from "./useAcceptInvite"
+
+/**
+ * Public /invite/accept?token=... route -- reads the token, previews the
+ * invite (email/role/validity), then either shows a signup form (not
+ * authenticated), an "Accept" button (already signed in under the
+ * matching email), or a terminal state (invalid/expired/mismatch/done).
+ */
+export default function AcceptInvite() {
+  const { t } = useTranslation()
+  const {
+    phase,
+    preview,
+    form,
+    errors,
+    serverError,
+    submitting,
+    googleLoading,
+    acceptedRole,
+    currentUserEmail,
+    handleChange,
+    handleSubmit,
+    handleGoogleSignUp,
+    acceptNow,
+    logout,
+  } = useAcceptInvite()
+
+  if (phase === "loading") {
+    return (
+      <AuthLayout heading={t("invite.heading")}>
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-ink-muted" aria-hidden />
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  if (phase === "invalid" || phase === "unusable") {
+    return (
+      <AuthLayout heading={t("invite.heading")}>
+        <div className="flex flex-col items-center gap-4 py-4 text-center animate-fade-in">
+          <div className="flex h-16 w-16 items-center justify-center rounded-md bg-destructive/10">
+            <XCircle className="h-8 w-8 text-destructive" strokeWidth={1.75} aria-hidden />
+          </div>
+          <p className="text-sm text-ink-muted leading-relaxed">
+            {phase === "invalid" ? t("invite.errors.notFound") : t("invite.errors.unusable")}
+          </p>
+          <Link to="/login" className="block w-full">
+            <Button variant="outline" size="lg" className="w-full">
+              {t("authRegister.duplicate.goToSignIn")}
+            </Button>
+          </Link>
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  if (phase === "awaitingConfirmation") {
+    return (
+      <AuthLayout heading={t("invite.heading")}>
+        <div className="flex flex-col items-center gap-4 py-4 text-center animate-fade-in">
+          <div className="flex h-16 w-16 items-center justify-center rounded-md bg-brand/10">
+            <MailCheck className="h-8 w-8 text-brand" strokeWidth={1.75} aria-hidden />
+          </div>
+          <p className="text-sm text-ink-muted leading-relaxed">
+            <Trans
+              i18nKey="authRegister.success.body"
+              values={{ email: preview?.email }}
+              components={{ strong: <strong className="text-ink" /> }}
+            />
+            <br />
+            {t("invite.confirmThenReturn")}
+          </p>
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  if (phase === "done") {
+    return (
+      <AuthLayout heading={t("invite.heading")}>
+        <div className="flex flex-col items-center gap-4 py-4 text-center animate-fade-in">
+          <div className="flex h-16 w-16 items-center justify-center rounded-md bg-success/10">
+            <CheckCircle2 className="h-8 w-8 text-success" strokeWidth={1.75} aria-hidden />
+          </div>
+          <p className="text-sm text-ink-muted leading-relaxed">
+            {acceptedRole
+              ? t("invite.acceptedAs", { role: t(ROLE_I18N_KEY[acceptedRole as "teacher" | "student"]) })
+              : t("invite.accepted")}
+          </p>
+          <Link to="/" className="block w-full">
+            <Button size="lg" className="w-full">
+              {t("invite.goToDashboard")}
+            </Button>
+          </Link>
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  if (phase === "mismatch") {
+    return (
+      <AuthLayout heading={t("invite.heading")}>
+        <div className="flex flex-col items-center gap-4 py-4 text-center animate-fade-in">
+          <div className="flex h-16 w-16 items-center justify-center rounded-md bg-warning/10">
+            <XCircle className="h-8 w-8 text-warning" strokeWidth={1.75} aria-hidden />
+          </div>
+          <p className="text-sm text-ink-muted leading-relaxed">
+            <Trans
+              i18nKey="invite.errors.emailMismatchDetail"
+              values={{ invited: preview?.email, current: currentUserEmail }}
+              components={{ strong: <strong className="text-ink" /> }}
+            />
+          </p>
+          <Button variant="outline" size="lg" className="w-full" onClick={() => void logout()}>
+            {t("invite.logOutAndSwitch")}
+          </Button>
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  if (phase === "ready" && preview) {
+    return (
+      <AuthLayout heading={t("invite.heading")}>
+        <div className="flex flex-col items-center gap-4 py-4 text-center animate-fade-in">
+          {serverError && (
+            <div role="alert" className="w-full text-sm text-destructive bg-destructive/10 border border-destructive/20 p-3 rounded-lg">
+              {serverError}
+            </div>
+          )}
+          <p className="text-sm text-ink-muted leading-relaxed">
+            <Trans
+              i18nKey="invite.readyBody"
+              values={{ email: currentUserEmail, role: t(ROLE_I18N_KEY[preview.role]) }}
+              components={{ strong: <strong className="text-ink" /> }}
+            />
+          </p>
+          <Button size="lg" className="w-full" onClick={() => void acceptNow()} disabled={phase !== "ready"}>
+            {t("invite.acceptButton")}
+          </Button>
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  if (phase === "accepting") {
+    return (
+      <AuthLayout heading={t("invite.heading")}>
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-ink-muted" aria-hidden />
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  // phase === "form": not authenticated -- signup form bound to the
+  // invited email + role.
+  if (!preview) return <Navigate to="/login" replace />
+
+  return (
+    <AuthLayout
+      heading={t("invite.heading")}
+      subheading={t("invite.formSubheading", { role: t(ROLE_I18N_KEY[preview.role]) })}
+    >
+      <div className="space-y-6 animate-fade-in">
+        {serverError && (
+          <div role="alert" className="text-sm text-destructive bg-destructive/10 border border-destructive/20 p-3 rounded-lg">
+            {serverError}
+          </div>
+        )}
+
+        <Button
+          type="button"
+          variant="outline"
+          size="lg"
+          className="w-full font-medium rounded-md"
+          onClick={() => void handleGoogleSignUp()}
+          disabled={googleLoading || submitting}
+        >
+          {googleLoading ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" strokeWidth={1.75} />
+              {t("auth.connecting")}
+            </>
+          ) : (
+            <>
+              <GoogleIcon className="h-4 w-4 mr-2.5" />
+              {t("auth.continueWithGoogle")}
+            </>
+          )}
+        </Button>
+
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t" />
+          </div>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-surface px-3 text-ink-muted">{t("authRegister.orRegisterEmail")}</span>
+          </div>
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            void handleSubmit()
+          }}
+          className="space-y-4"
+        >
+          <div className="space-y-2">
+            <Label htmlFor="inviteEmail">{t("auth.email")}</Label>
+            <Input id="inviteEmail" type="email" value={preview.email} disabled readOnly fieldSize="lg" />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="fullName">{t("authRegister.fullName")}</Label>
+            <Input
+              id="fullName"
+              placeholder={t("authRegister.fullNamePlaceholder")}
+              autoComplete="name"
+              fieldSize="lg"
+              value={form.full_name}
+              onChange={(e) => handleChange("full_name", e.target.value)}
+              aria-invalid={!!errors.full_name}
+              aria-describedby={errors.full_name ? "invite-fullName-error" : undefined}
+              autoFocus
+            />
+            {errors.full_name && (
+              <p id="invite-fullName-error" role="alert" className="text-xs text-destructive mt-1">
+                {errors.full_name}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="password">{t("auth.password")}</Label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="new-password"
+                fieldSize="lg"
+                value={form.password}
+                onChange={(e) => handleChange("password", e.target.value)}
+                aria-invalid={!!errors.password}
+                aria-describedby={errors.password ? "invite-password-error" : undefined}
+              />
+              {errors.password && (
+                <p id="invite-password-error" role="alert" className="text-xs text-destructive mt-1">
+                  {errors.password}
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">{t("authRegister.confirmPasswordShort")}</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                autoComplete="new-password"
+                fieldSize="lg"
+                value={form.confirmPassword}
+                onChange={(e) => handleChange("confirmPassword", e.target.value)}
+                aria-invalid={!!errors.confirmPassword}
+                aria-describedby={errors.confirmPassword ? "invite-confirmPassword-error" : undefined}
+              />
+              {errors.confirmPassword && (
+                <p id="invite-confirmPassword-error" role="alert" className="text-xs text-destructive mt-1">
+                  {errors.confirmPassword}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <Button type="submit" size="lg" className="w-full" disabled={submitting}>
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" strokeWidth={1.75} />
+                {t("common.loading")}
+              </>
+            ) : (
+              t("invite.createAccountButton")
+            )}
+          </Button>
+        </form>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/pages/Invite/useAcceptInvite.ts
+++ b/frontend/src/pages/Invite/useAcceptInvite.ts
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+import { useAuth } from "@/context/useAuth"
+import { invitationsService, type InvitationPreview } from "@/services/invitations"
+import { makeAcceptInviteSchema } from "@/lib/validations/auth"
+import { setPendingInviteToken, takePendingInviteToken } from "@/lib/pendingInvite"
+import { getErrorCode } from "@/lib/errorCode"
+import i18n, { DEFAULT_LOCALE, isSupportedLocale } from "@/i18n/config"
+
+export type FormState = {
+  full_name: string
+  password: string
+  confirmPassword: string
+}
+
+const EMPTY_FORM: FormState = { full_name: "", password: "", confirmPassword: "" }
+
+// A 404/410/409 from the preview or accept call all mean "this link
+// can't be used" -- distinguished only by which copy to show.
+export type AcceptInvitePhase =
+  | "loading"
+  | "invalid" // token doesn't exist
+  | "unusable" // expired, already accepted, or revoked
+  | "form" // pending + valid, caller not authenticated yet -- show signup form
+  | "mismatch" // pending + valid, but signed in under a different email
+  | "ready" // pending + valid, signed in under the matching email -- show Accept button
+  | "accepting"
+  | "done" // accepted this session
+  | "awaitingConfirmation" // email/password signup submitted, waiting on email confirm
+
+export function useAcceptInvite() {
+  const [params] = useSearchParams()
+  const token = params.get("token") ?? ""
+  const { user, register, signInWithGoogle, logout, refreshUser } = useAuth()
+
+  const [preview, setPreview] = useState<InvitationPreview | null>(null)
+  const [previewFailed, setPreviewFailed] = useState(false)
+  const [phase, setPhase] = useState<AcceptInvitePhase>("loading")
+  const [form, setForm] = useState<FormState>(EMPTY_FORM)
+  const [errors, setErrors] = useState<Partial<Record<string, string>>>({})
+  const [serverError, setServerError] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [googleLoading, setGoogleLoading] = useState(false)
+  const [acceptedRole, setAcceptedRole] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) {
+      setPreviewFailed(true)
+      setPhase("invalid")
+      return
+    }
+    let cancelled = false
+    invitationsService
+      .previewInvitation(token)
+      .then((data) => {
+        if (cancelled) return
+        setPreview(data)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setPreviewFailed(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [token])
+
+  // Derive the phase from (preview, previewFailed, user) whenever any of
+  // them change -- keeps the state machine in one place instead of
+  // scattered across the fetch handler and the auth-watching effect.
+  useEffect(() => {
+    if (phase === "accepting" || phase === "done" || phase === "awaitingConfirmation") return
+    if (previewFailed) {
+      setPhase("invalid")
+      return
+    }
+    if (!preview) {
+      setPhase("loading")
+      return
+    }
+    if (preview.status !== "pending" || preview.is_expired) {
+      setPhase("unusable")
+      return
+    }
+    if (!user) {
+      setPhase("form")
+      return
+    }
+    setPhase(user.email.trim().toLowerCase() === preview.email.trim().toLowerCase() ? "ready" : "mismatch")
+  }, [preview, previewFailed, user, phase])
+
+  const acceptNow = useCallback(async () => {
+    setPhase("accepting")
+    setServerError("")
+    try {
+      const result = await invitationsService.acceptInvitation(token)
+      setAcceptedRole(result.role)
+      await refreshUser()
+      setPhase("done")
+    } catch (err) {
+      const code = getErrorCode(err)
+      setServerError(
+        code === "invitation.email_mismatch"
+          ? i18n.t("invite.errors.emailMismatch")
+          : i18n.t("invite.errors.acceptFailed"),
+      )
+      setPhase("ready")
+    }
+  }, [token, refreshUser])
+
+  const handleChange = useCallback((field: keyof FormState, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    setErrors((prev) => ({ ...prev, [field]: undefined }))
+  }, [])
+
+  const handleSubmit = useCallback(async () => {
+    if (!preview) return
+    setServerError("")
+    const result = makeAcceptInviteSchema().safeParse(form)
+    if (!result.success) {
+      const fieldErrors: Partial<Record<string, string>> = {}
+      for (const issue of result.error.issues) {
+        const key = String(issue.path[0])
+        if (!fieldErrors[key]) fieldErrors[key] = issue.message
+      }
+      setErrors(fieldErrors)
+      return
+    }
+    setSubmitting(true)
+    try {
+      const preferredLocale = isSupportedLocale(i18n.resolvedLanguage) ? i18n.resolvedLanguage : DEFAULT_LOCALE
+      // Persisted BEFORE register() -- email confirmation is required
+      // (see SuccessView), so there's no active session yet to redeem
+      // the token with. App.tsx's resume effect picks this up once the
+      // user comes back signed in after confirming.
+      setPendingInviteToken(token)
+      await register(preview.email, result.data.password, result.data.full_name, preferredLocale)
+      setPhase("awaitingConfirmation")
+    } catch (err: unknown) {
+      // register() failed -- there's no pending redirect coming, so drop
+      // the stashed token rather than leaving it to misfire on some
+      // unrelated later sign-in.
+      takePendingInviteToken()
+      const supaErr = err as { message?: string }
+      setServerError(
+        supaErr.message === "DUPLICATE_EMAIL"
+          ? i18n.t("invite.errors.accountExists")
+          : supaErr.message || i18n.t("auth.errors.registrationFailed"),
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }, [form, preview, register, token])
+
+  const handleGoogleSignUp = useCallback(async () => {
+    setGoogleLoading(true)
+    try {
+      setPendingInviteToken(token)
+      await signInWithGoogle()
+    } catch (err: unknown) {
+      takePendingInviteToken()
+      const supaErr = err as { message?: string }
+      setServerError(supaErr.message || i18n.t("auth.errors.googleSignUpFailed"))
+      setGoogleLoading(false)
+    }
+  }, [signInWithGoogle, token])
+
+  return {
+    phase,
+    preview,
+    form,
+    errors,
+    serverError,
+    submitting,
+    googleLoading,
+    acceptedRole,
+    currentUserEmail: user?.email ?? null,
+    handleChange,
+    handleSubmit,
+    handleGoogleSignUp,
+    acceptNow,
+    logout,
+  }
+}

--- a/frontend/src/services/invitations.ts
+++ b/frontend/src/services/invitations.ts
@@ -1,0 +1,41 @@
+import api from "./api"
+import type { Invitation, InvitationRole, InvitationStatus } from "@/types"
+
+export interface InvitationPreview {
+  email: string
+  role: InvitationRole
+  status: InvitationStatus
+  is_expired: boolean
+}
+
+/**
+ * Admin invite-by-email endpoints at /invitations/*, plus the two
+ * routes the accept-invite page uses (public preview, authenticated
+ * accept). Kept separate from adminUsersService the same way that
+ * module is separate from usersService -- different auth scope
+ * (admin-only create/list vs. public/self-serve accept).
+ */
+export const invitationsService = {
+  async createInvitation(email: string, role: InvitationRole): Promise<Invitation> {
+    const response = await api.post<Invitation>("/invitations", { email, role })
+    return response.data
+  },
+
+  async listInvitations(params?: {
+    role?: InvitationRole
+    status?: InvitationStatus
+  }): Promise<Invitation[]> {
+    const response = await api.get<Invitation[]>("/invitations", { params })
+    return response.data
+  },
+
+  async previewInvitation(token: string): Promise<InvitationPreview> {
+    const response = await api.get<InvitationPreview>(`/invitations/token/${encodeURIComponent(token)}`)
+    return response.data
+  },
+
+  async acceptInvitation(token: string): Promise<{ role: InvitationRole }> {
+    const response = await api.post<{ role: InvitationRole }>("/invitations/accept", { token })
+    return response.data
+  },
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -301,6 +301,26 @@ export interface Cohort {
   student_count: number
 }
 
+// InvitationRole deliberately excludes 'admin' -- mirrors the backend
+// Pydantic Literal["teacher", "student"] and the Postgres CHECK
+// constraint on invitations.role. An invite can never grant admin.
+export type InvitationRole = 'teacher' | 'student'
+export type InvitationStatus = 'pending' | 'accepted' | 'revoked'
+
+export interface Invitation {
+  id: string
+  email: string
+  role: InvitationRole
+  status: InvitationStatus
+  invited_by: string | null
+  created_at: string | null
+  accepted_at: string | null
+  expires_at: string
+  // Derived server-side: a 'pending' row past expires_at. Only
+  // meaningful when status === 'pending'.
+  is_expired: boolean
+}
+
 export type NotificationType =
   | 'certificate_approved'
   | 'certificate_rejected'


### PR DESCRIPTION
## Summary
- Admin "Invitations" tab (`/admin?tab=invitations`): generate a single-use email invite for `teacher`/`student`, list with role/status filters, resend a pending/expired one
- Public `/invite/accept?token=...` page: previews the invite, then lets the invitee either register with email/password or continue with Google, resuming correctly after either redirect round-trip via a small `localStorage` handoff (`lib/pendingInvite.ts`) since email confirmation and Google OAuth both land back on an unrelated route first
- Builds on the backend from #862 (already merged) — `services/invitations.ts` talks to `/api/v1/invitations/*`, `lib/errorCode.ts` gained the 4 matching `invitation.*` codes
- Fixed a stale doc-comment in `RegisterForm.tsx` claiming a "role toggle" that hasn't existed since self-signup went student-only

## Test plan
- [x] `npm run lint` — 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds, bundle-size sentinel OK
- [x] `npm run i18n:check` — EN/RU parity OK (added `admin.tabInvitations`, `admin.invitations.*`, `invite.*`)
- [x] `npm run test:run` — 74 files / 559 tests pass
- [ ] CI green on this PR

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
